### PR TITLE
Dose rappel et 1ere dose

### DIFF
--- a/public/sitemaps/sitemap-01.xml
+++ b/public/sitemaps/sitemap-01.xml
@@ -5,808 +5,1612 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01001-01400-l_abergement_clemenciat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01001-01400-l_abergement_clemenciat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01001-01400-l_abergement_clemenciat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01001-01400-l_abergement_clemenciat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01002-01640-l_abergement_de_varey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01002-01640-l_abergement_de_varey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01002-01640-l_abergement_de_varey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01002-01640-l_abergement_de_varey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01004-01500-amberieu_en_bugey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01004-01500-amberieu_en_bugey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01004-01500-amberieu_en_bugey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01004-01500-amberieu_en_bugey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01005-01330-amberieux_en_dombes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01005-01330-amberieux_en_dombes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01005-01330-amberieux_en_dombes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01005-01330-amberieux_en_dombes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01006-01300-ambleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01006-01300-ambleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01006-01300-ambleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01006-01300-ambleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01007-01500-ambronay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01007-01500-ambronay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01007-01500-ambronay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01007-01500-ambronay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01008-01500-ambutrix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01008-01500-ambutrix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01008-01500-ambutrix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01008-01500-ambutrix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01009-01300-andert_et_condon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01009-01300-andert_et_condon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01009-01300-andert_et_condon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01009-01300-andert_et_condon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01010-01350-anglefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01010-01350-anglefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01010-01350-anglefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01010-01350-anglefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01011-01100-apremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01011-01100-apremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01011-01100-apremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01011-01100-apremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01012-01110-aranc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01012-01110-aranc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01012-01110-aranc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01012-01110-aranc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01013-01230-arandas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01013-01230-arandas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01013-01230-arandas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01013-01230-arandas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01014-01100-arbent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01014-01100-arbent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01014-01100-arbent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01014-01100-arbent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01015-01300-arboys_en_bugey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01015-01300-arboys_en_bugey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01015-01300-arboys_en_bugey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01015-01300-arboys_en_bugey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01016-01190-arbigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01016-01190-arbigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01016-01190-arbigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01016-01190-arbigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01017-01230-argis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01017-01230-argis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01017-01230-argis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01017-01230-argis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01019-01510-armix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01019-01510-armix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01019-01510-armix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01019-01510-armix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01021-01480-ars_sur_formans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01021-01480-ars_sur_formans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01021-01480-ars_sur_formans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01021-01480-ars_sur_formans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01022-01510-artemare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01022-01510-artemare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01022-01510-artemare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01022-01510-artemare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01023-01570-asnieres_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01023-01570-asnieres_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01023-01570-asnieres_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01023-01570-asnieres_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01024-01340-attignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01024-01340-attignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01024-01340-attignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01024-01340-attignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01025-01380-bage_dommartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01025-01380-bage_dommartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01025-01380-bage_dommartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01025-01380-bage_dommartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01026-01380-bage_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01026-01380-bage_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01026-01380-bage_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01026-01380-bage_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01027-01360-balan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01027-01360-balan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01027-01360-balan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01027-01360-balan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01028-01990-baneins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01028-01990-baneins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01028-01990-baneins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01028-01990-baneins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01029-01270-beaupont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01029-01270-beaupont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01029-01270-beaupont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01029-01270-beaupont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01030-01480-beauregard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01030-01480-beauregard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01030-01480-beauregard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01030-01480-beauregard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01031-01100-bellignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01031-01100-bellignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01031-01100-bellignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01031-01100-bellignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01032-01360-beligneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01032-01360-beligneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01032-01360-beligneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01032-01360-beligneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01033-01200-valserhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01033-01200-valserhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01033-01200-valserhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01033-01200-valserhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01034-01300-belley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01034-01300-belley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01034-01300-belley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01034-01300-belley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01035-01130-belleydoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01035-01130-belleydoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01035-01130-belleydoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01035-01130-belleydoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01036-01260-valromey_sur_seran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01036-01260-valromey_sur_seran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01036-01260-valromey_sur_seran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01036-01260-valromey_sur_seran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01037-01470-benonces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01037-01470-benonces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01037-01470-benonces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01037-01470-benonces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01038-01370-beny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01038-01370-beny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01038-01370-beny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01038-01370-beny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01039-01350-beon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01039-01350-beon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01039-01350-beon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01039-01350-beon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01040-01340-bereziat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01040-01340-bereziat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01040-01340-bereziat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01040-01340-bereziat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01041-01500-bettant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01041-01500-bettant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01041-01500-bettant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01041-01500-bettant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01042-01290-bey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01042-01290-bey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01042-01290-bey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01042-01290-bey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01043-01700-beynost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01043-01700-beynost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01043-01700-beynost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01043-01700-beynost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01044-01200-billiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01044-01200-billiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01044-01200-billiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01044-01200-billiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01045-01330-birieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01045-01330-birieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01045-01330-birieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01045-01330-birieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01046-01290-biziat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01046-01290-biziat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01046-01290-biziat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01046-01290-biziat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01047-01150-blyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01047-01150-blyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01047-01150-blyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01047-01150-blyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01049-01120-la_boisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01049-01120-la_boisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01049-01120-la_boisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01049-01120-la_boisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01050-01190-boissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01050-01190-boissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01050-01190-boissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01050-01190-boissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01050-01380-boissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01050-01380-boissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01050-01380-boissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01050-01380-boissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01051-01450-bolozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01051-01450-bolozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01051-01450-bolozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01051-01450-bolozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01052-01330-bouligneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01052-01330-bouligneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01052-01330-bouligneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01052-01330-bouligneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01053-01000-bourg_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01053-01000-bourg_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01053-01000-bourg_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01053-01000-bourg_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01054-01800-bourg_saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01054-01800-bourg_saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01054-01800-bourg_saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01054-01800-bourg_saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01056-01640-boyeux_saint_jerome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01056-01640-boyeux_saint_jerome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01056-01640-boyeux_saint_jerome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01056-01640-boyeux_saint_jerome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01057-01190-boz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01057-01190-boz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01057-01190-boz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01057-01190-boz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01058-01300-bregnier_cordon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01058-01300-bregnier_cordon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01058-01300-bregnier_cordon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01058-01300-bregnier_cordon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01060-01110-brenod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01060-01110-brenod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01060-01110-brenod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01060-01110-brenod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01061-01300-brens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01061-01300-brens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01061-01300-brens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01061-01300-brens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01062-01360-bressolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01062-01360-bressolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01062-01360-bressolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01062-01360-bressolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01063-01460-brion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01063-01460-brion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01063-01460-brion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01063-01460-brion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01064-01470-briord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01064-01470-briord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01064-01470-briord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01064-01470-briord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01065-01310-buellas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01065-01310-buellas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01065-01310-buellas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01065-01310-buellas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01066-01510-la_burbanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01066-01510-la_burbanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01066-01510-la_burbanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01066-01510-la_burbanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01067-01430-ceignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01067-01430-ceignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01067-01430-ceignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01067-01430-ceignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01068-01450-cerdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01068-01450-cerdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01068-01450-cerdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01068-01450-cerdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01069-01240-certines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01069-01240-certines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01069-01240-certines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01069-01240-certines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01071-01170-cessy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01071-01170-cessy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01071-01170-cessy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01071-01170-cessy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01072-01250-ceyzeriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01072-01250-ceyzeriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01072-01250-ceyzeriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01072-01250-ceyzeriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01073-01350-ceyzerieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01073-01350-ceyzerieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01073-01350-ceyzerieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01073-01350-ceyzerieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01074-01320-chalamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01074-01320-chalamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01074-01320-chalamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01074-01320-chalamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01075-01480-chaleins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01075-01480-chaleins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01075-01480-chaleins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01075-01480-chaleins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01076-01230-chaley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01076-01230-chaley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01076-01230-chaley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01076-01230-chaley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01077-01450-challes_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01077-01450-challes_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01077-01450-challes_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01077-01450-challes_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01078-01630-challex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01078-01630-challex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01078-01630-challex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01078-01630-challex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01079-01260-champagne_en_valromey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01079-01260-champagne_en_valromey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01079-01260-champagne_en_valromey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01079-01260-champagne_en_valromey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01080-01110-champdor_corcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01080-01110-champdor_corcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01080-01110-champdor_corcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01080-01110-champdor_corcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01081-01410-champfromier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01081-01410-champfromier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01081-01410-champfromier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01081-01410-champfromier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01082-01420-chanay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01082-01420-chanay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01082-01420-chanay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01082-01420-chanay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01083-01990-chaneins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01083-01990-chaneins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01083-01990-chaneins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01083-01990-chaneins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01084-01400-chanoz_chatenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01084-01400-chanoz_chatenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01084-01400-chanoz_chatenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01084-01400-chanoz_chatenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01085-01240-la_chapelle_du_chatelard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01085-01240-la_chapelle_du_chatelard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01085-01240-la_chapelle_du_chatelard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01085-01240-la_chapelle_du_chatelard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01087-01130-charix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01087-01130-charix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01087-01130-charix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01087-01130-charix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01088-01800-charnoz_sur_ain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01088-01800-charnoz_sur_ain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01088-01800-charnoz_sur_ain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01088-01800-charnoz_sur_ain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01089-01500-chateau_gaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01089-01500-chateau_gaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01089-01500-chateau_gaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01089-01500-chateau_gaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01090-01320-chatenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01090-01320-chatenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01090-01320-chatenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01090-01320-chatenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01092-01320-chatillon_la_palud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01092-01320-chatillon_la_palud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01092-01320-chatillon_la_palud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01092-01320-chatillon_la_palud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01093-01400-chatillon_sur_chalaronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01093-01400-chatillon_sur_chalaronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01093-01400-chatillon_sur_chalaronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01093-01400-chatillon_sur_chalaronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01094-01190-chavannes_sur_reyssouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01094-01190-chavannes_sur_reyssouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01094-01190-chavannes_sur_reyssouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01094-01190-chavannes_sur_reyssouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01095-01250-nivigne_et_suran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01095-01250-nivigne_et_suran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01095-01250-nivigne_et_suran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01095-01250-nivigne_et_suran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01096-01660-chaveyriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01096-01660-chaveyriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01096-01660-chaveyriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01096-01660-chaveyriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01098-01300-chazey_bons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01098-01300-chazey_bons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01098-01300-chazey_bons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01098-01300-chazey_bons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01098-01510-chazey_bons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01098-01510-chazey_bons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01098-01510-chazey_bons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01098-01510-chazey_bons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01099-01150-chazey_sur_ain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01099-01150-chazey_sur_ain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01099-01150-chazey_sur_ain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01099-01150-chazey_sur_ain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01100-01510-cheignieu_la_balme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01100-01510-cheignieu_la_balme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01100-01510-cheignieu_la_balme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01100-01510-cheignieu_la_balme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01101-01430-chevillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01101-01430-chevillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01101-01430-chevillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01101-01430-chevillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01102-01190-chevroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01102-01190-chevroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01102-01190-chevroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01102-01190-chevroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01103-01170-chevry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01103-01170-chevry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01103-01170-chevry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01103-01170-chevry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01104-01410-chezery_forens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01104-01410-chezery_forens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01104-01410-chezery_forens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01104-01410-chezery_forens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01104-01200-chezery_forens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01104-01200-chezery_forens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01104-01200-chezery_forens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01104-01200-chezery_forens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01105-01390-civrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01105-01390-civrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01105-01390-civrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01105-01390-civrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01106-01250-cize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01106-01250-cize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01106-01250-cize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01106-01250-cize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01107-01230-cleyzieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01107-01230-cleyzieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01107-01230-cleyzieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01107-01230-cleyzieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01108-01270-coligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01108-01270-coligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01108-01270-coligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01108-01270-coligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01109-01550-collonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01109-01550-collonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01109-01550-collonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01109-01550-collonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01110-01300-colomieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01110-01300-colomieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01110-01300-colomieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01110-01300-colomieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01111-01230-conand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01111-01230-conand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01111-01230-conand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01111-01230-conand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01112-01430-condamine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01112-01430-condamine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01112-01430-condamine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01112-01430-condamine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01113-01400-condeissiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01113-01400-condeissiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01113-01400-condeissiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01113-01400-condeissiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01114-01200-confort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01114-01200-confort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01114-01200-confort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01114-01200-confort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01115-01310-confrancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01115-01310-confrancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01115-01310-confrancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01115-01310-confrancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01116-01300-contrevoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01116-01300-contrevoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01116-01300-contrevoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01116-01300-contrevoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01117-01300-conzieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01117-01300-conzieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01117-01300-conzieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01117-01300-conzieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01118-01420-corbonod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01118-01420-corbonod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01118-01420-corbonod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01118-01420-corbonod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01121-01110-corlier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01121-01110-corlier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01121-01110-corlier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01121-01110-corlier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01123-01290-cormoranche_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01123-01290-cormoranche_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01123-01290-cormoranche_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01123-01290-cormoranche_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01124-01560-cormoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01124-01560-cormoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01124-01560-cormoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01124-01560-cormoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01125-01250-corveissiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01125-01250-corveissiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01125-01250-corveissiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01125-01250-corveissiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01127-01370-courmangoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01127-01370-courmangoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01127-01370-courmangoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01127-01370-courmangoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01128-01560-courtes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01128-01560-courtes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01128-01560-courtes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01128-01560-courtes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01129-01320-crans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01129-01320-crans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01129-01320-crans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01129-01320-crans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01130-01340-bresse_vallons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01130-01340-bresse_vallons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01130-01340-bresse_vallons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01130-01340-bresse_vallons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01133-01350-cressin_rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01133-01350-cressin_rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01133-01350-cressin_rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01133-01350-cressin_rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01134-01290-crottet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01134-01290-crottet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01134-01290-crottet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01134-01290-crottet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01134-01750-crottet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01134-01750-crottet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01134-01750-crottet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01134-01750-crottet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01135-01170-crozet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01135-01170-crozet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01135-01170-crozet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01135-01170-crozet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01136-01290-cruzilles_les_mepillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01136-01290-cruzilles_les_mepillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01136-01290-cruzilles_les_mepillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01136-01290-cruzilles_les_mepillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01138-01350-culoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01138-01350-culoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01138-01350-culoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01138-01350-culoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01139-01560-curciat_dongalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01139-01560-curciat_dongalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01139-01560-curciat_dongalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01139-01560-curciat_dongalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01140-01310-curtafond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01140-01310-curtafond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01140-01310-curtafond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01140-01310-curtafond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01141-01300-cuzieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01141-01300-cuzieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01141-01300-cuzieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01141-01300-cuzieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01142-01120-dagneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01142-01120-dagneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01142-01120-dagneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01142-01120-dagneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01143-01220-divonne_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01143-01220-divonne_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01143-01220-divonne_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01143-01220-divonne_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01145-01240-dompierre_sur_veyle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01145-01240-dompierre_sur_veyle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01145-01240-dompierre_sur_veyle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01145-01240-dompierre_sur_veyle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01146-01400-dompierre_sur_chalaronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01146-01400-dompierre_sur_chalaronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01146-01400-dompierre_sur_chalaronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01146-01400-dompierre_sur_chalaronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01147-01270-domsure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01147-01270-domsure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01147-01270-domsure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01147-01270-domsure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01148-01590-dortan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01148-01590-dortan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01148-01590-dortan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01148-01590-dortan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01149-01500-douvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01149-01500-douvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01149-01500-douvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01149-01500-douvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01150-01250-drom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01150-01250-drom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01150-01250-drom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01150-01250-drom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01151-01160-druillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01151-01160-druillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01151-01160-druillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01151-01160-druillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01152-01130-echallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01152-01130-echallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01152-01130-echallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01152-01130-echallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01153-01170-echenevex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01153-01170-echenevex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01153-01170-echenevex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01153-01170-echenevex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01155-01230-evosges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01155-01230-evosges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01155-01230-evosges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01155-01230-evosges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01156-01800-faramans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01156-01800-faramans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01156-01800-faramans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01156-01800-faramans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01157-01480-fareins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01157-01480-fareins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01157-01480-fareins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01157-01480-fareins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01158-01550-farges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01158-01550-farges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01158-01550-farges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01158-01550-farges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01159-01570-feillens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01159-01570-feillens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01159-01570-feillens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01159-01570-feillens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01160-01210-ferney_voltaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01160-01210-ferney_voltaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01160-01210-ferney_voltaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01160-01210-ferney_voltaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01162-01350-flaxieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01162-01350-flaxieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01162-01350-flaxieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01162-01350-flaxieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01163-01340-foissiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01163-01340-foissiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01163-01340-foissiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01163-01340-foissiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01165-01090-francheleins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01165-01090-francheleins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01165-01090-francheleins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01165-01090-francheleins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01166-01480-frans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01166-01480-frans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01166-01480-frans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01166-01480-frans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01167-01140-garnerans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01167-01140-garnerans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01167-01140-garnerans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01167-01140-garnerans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01169-01090-genouilleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01169-01090-genouilleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01169-01090-genouilleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01169-01090-genouilleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01170-01460-beard_geovreissiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01170-01460-beard_geovreissiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01170-01460-beard_geovreissiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01170-01460-beard_geovreissiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01171-01100-geovreisset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01171-01100-geovreisset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01171-01100-geovreisset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01171-01100-geovreisset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01173-01170-gex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01173-01170-gex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01173-01170-gex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01173-01170-gex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01174-01130-giron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01174-01130-giron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01174-01130-giron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01174-01130-giron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01175-01190-gorrevod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01175-01190-gorrevod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01175-01190-gorrevod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01175-01190-gorrevod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01177-01250-grand_corent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01177-01250-grand_corent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01177-01250-grand_corent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01177-01250-grand_corent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01179-01290-grieges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01179-01290-grieges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01179-01290-grieges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01179-01290-grieges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01180-01220-grilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01180-01220-grilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01180-01220-grilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01180-01220-grilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01181-01100-groissiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01181-01100-groissiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01181-01100-groissiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01181-01100-groissiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01183-01090-guereins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01183-01090-guereins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01183-01090-guereins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01183-01090-guereins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01184-01250-hautecourt_romaneche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01184-01250-hautecourt_romaneche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01184-01250-hautecourt_romaneche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01184-01250-hautecourt_romaneche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01185-01110-plateau_d’hauteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01185-01110-plateau_d’hauteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01185-01110-plateau_d’hauteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01185-01110-plateau_d’hauteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01187-01260-haut_valromey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01187-01260-haut_valromey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01187-01260-haut_valromey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01187-01260-haut_valromey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01188-01140-illiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01188-01140-illiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01188-01140-illiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01188-01140-illiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01189-01200-injoux_genissiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01189-01200-injoux_genissiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01189-01200-injoux_genissiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01189-01200-injoux_genissiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01190-01680-innimond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01190-01680-innimond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01190-01680-innimond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01190-01680-innimond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01191-01430-izenave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01191-01430-izenave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01191-01430-izenave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01191-01430-izenave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01192-01580-izernore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01192-01580-izernore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01192-01580-izernore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01192-01580-izernore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01193-01300-izieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01193-01300-izieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01193-01300-izieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01193-01300-izieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01194-01480-jassans_riottier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01194-01480-jassans_riottier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01194-01480-jassans_riottier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01194-01480-jassans_riottier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01195-01250-jasseron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01195-01250-jasseron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01195-01250-jasseron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01195-01250-jasseron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01196-01340-jayat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01196-01340-jayat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01196-01340-jayat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01196-01340-jayat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01197-01250-journans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01197-01250-journans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01197-01250-journans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01197-01250-journans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01198-01800-joyeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01198-01800-joyeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01198-01800-joyeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01198-01800-joyeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01199-01640-jujurieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01199-01640-jujurieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01199-01640-jujurieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01199-01640-jujurieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01200-01450-labalme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01200-01450-labalme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01200-01450-labalme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01200-01450-labalme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01202-01150-lagnieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01202-01150-lagnieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01202-01150-lagnieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01202-01150-lagnieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01203-01290-laiz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01203-01290-laiz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01203-01290-laiz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01203-01290-laiz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01204-01130-le_poizat_lalleyriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01204-01130-le_poizat_lalleyriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01204-01130-le_poizat_lalleyriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01204-01130-le_poizat_lalleyriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01206-01430-lantenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01206-01430-lantenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01206-01430-lantenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01206-01430-lantenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01207-01330-lapeyrouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01207-01330-lapeyrouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01207-01330-lapeyrouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01207-01330-lapeyrouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01208-01350-lavours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01208-01350-lavours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01208-01350-lavours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01208-01350-lavours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01209-01200-leaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01209-01200-leaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01209-01200-leaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01209-01200-leaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01210-01410-lelex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01210-01410-lelex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01210-01410-lelex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01210-01410-lelex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01211-01240-lent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01211-01240-lent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01211-01240-lent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01211-01240-lent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01212-01560-lescheroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01212-01560-lescheroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01212-01560-lescheroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01212-01560-lescheroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01213-01150-leyment/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01213-01150-leyment/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01213-01150-leyment/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01213-01150-leyment/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01214-01450-leyssard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01214-01450-leyssard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01214-01450-leyssard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01214-01450-leyssard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01215-01420-surjoux_lhopital/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01215-01420-surjoux_lhopital/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01215-01420-surjoux_lhopital/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01215-01420-surjoux_lhopital/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01216-01680-lhuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01216-01680-lhuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01216-01680-lhuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01216-01680-lhuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01219-01680-lompnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01219-01680-lompnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01219-01680-lompnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01219-01680-lompnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01224-01360-loyettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01224-01360-loyettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01224-01360-loyettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01224-01360-loyettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01225-01090-lurcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01225-01090-lurcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01225-01090-lurcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01225-01090-lurcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01227-01300-magnieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01227-01300-magnieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01227-01300-magnieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01227-01300-magnieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01228-01430-maillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01228-01430-maillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01228-01430-maillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01228-01430-maillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01229-01340-malafretaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01229-01340-malafretaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01229-01340-malafretaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01229-01340-malafretaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01230-01560-mantenay_montlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01230-01560-mantenay_montlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01230-01560-mantenay_montlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01230-01560-mantenay_montlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01231-01570-manziat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01231-01570-manziat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01231-01570-manziat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01231-01570-manziat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01232-01851-marboz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01232-01851-marboz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01232-01851-marboz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01232-01851-marboz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01233-01680-marchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01233-01680-marchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01233-01680-marchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01233-01680-marchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01234-01300-marignieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01234-01300-marignieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01234-01300-marignieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01234-01300-marignieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01235-01240-marlieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01235-01240-marlieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01235-01240-marlieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01235-01240-marlieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01236-01340-marsonnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01236-01340-marsonnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01236-01340-marsonnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01236-01340-marsonnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01237-01100-martignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01237-01100-martignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01237-01100-martignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01237-01100-martignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01238-01600-massieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01238-01600-massieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01238-01600-massieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01238-01600-massieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01239-01300-massignieu_de_rives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01239-01300-massignieu_de_rives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01239-01300-massignieu_de_rives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01239-01300-massignieu_de_rives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01240-01580-matafelon_granges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01240-01580-matafelon_granges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01240-01580-matafelon_granges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01240-01580-matafelon_granges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01241-01370-meillonnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01241-01370-meillonnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01241-01370-meillonnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01241-01370-meillonnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01242-01450-merignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01242-01450-merignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01242-01450-merignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01242-01450-merignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01243-01480-messimy_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01243-01480-messimy_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01243-01480-messimy_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01243-01480-messimy_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01244-01800-meximieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01244-01800-meximieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01244-01800-meximieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01244-01800-meximieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01245-01250-bohas_meyriat_rignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01245-01250-bohas_meyriat_rignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01245-01250-bohas_meyriat_rignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01245-01250-bohas_meyriat_rignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01246-01660-mezeriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01246-01660-mezeriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01246-01660-mezeriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01246-01660-mezeriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01247-01410-mijoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01247-01410-mijoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01247-01410-mijoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01247-01410-mijoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01247-01170-mijoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01247-01170-mijoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01247-01170-mijoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01247-01170-mijoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01248-01390-mionnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01248-01390-mionnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01248-01390-mionnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01248-01390-mionnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01249-01700-miribel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01249-01700-miribel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01249-01700-miribel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01249-01700-miribel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01250-01600-miserieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01250-01600-miserieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01250-01600-miserieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01250-01600-miserieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01252-01140-mogneneins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01252-01140-mogneneins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01252-01140-mogneneins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01252-01140-mogneneins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01254-01250-montagnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01254-01250-montagnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01254-01250-montagnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01254-01250-montagnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01255-01470-montagnieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01255-01470-montagnieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01255-01470-montagnieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01255-01470-montagnieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01257-01200-montanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01257-01200-montanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01257-01200-montanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01257-01200-montanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01258-01090-montceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01258-01090-montceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01258-01090-montceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01258-01090-montceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01259-01310-montcet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01259-01310-montcet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01259-01310-montcet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01259-01310-montcet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01260-01800-le_montellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01260-01800-le_montellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01260-01800-le_montellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01260-01800-le_montellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01261-01390-monthieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01261-01390-monthieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01261-01390-monthieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01261-01390-monthieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01262-01120-montluel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01262-01120-montluel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01262-01120-montluel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01262-01120-montluel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01263-01090-montmerle_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01263-01090-montmerle_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01263-01090-montmerle_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01263-01090-montmerle_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01264-01310-montracol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01264-01310-montracol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01264-01310-montracol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01264-01310-montracol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01265-01460-montreal_la_cluse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01265-01460-montreal_la_cluse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01265-01460-montreal_la_cluse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01265-01460-montreal_la_cluse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01266-01340-montrevel_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01266-01340-montrevel_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01266-01340-montrevel_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01266-01340-montrevel_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01267-01460-nurieux_volognat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01267-01460-nurieux_volognat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01267-01460-nurieux_volognat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01267-01460-nurieux_volognat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01268-01300-murs_et_gelignieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01268-01300-murs_et_gelignieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01268-01300-murs_et_gelignieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01268-01300-murs_et_gelignieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01269-01130-nantua/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01269-01130-nantua/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01269-01130-nantua/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01269-01130-nantua/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01269-01460-nantua/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01269-01460-nantua/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01269-01460-nantua/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01269-01460-nantua/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01272-01400-neuville_les_dames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01272-01400-neuville_les_dames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01272-01400-neuville_les_dames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01272-01400-neuville_les_dames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01273-01160-neuville_sur_ain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01273-01160-neuville_sur_ain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01273-01160-neuville_sur_ain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01273-01160-neuville_sur_ain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01274-01130-les_neyrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01274-01130-les_neyrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01274-01130-les_neyrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01274-01130-les_neyrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01275-01700-neyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01275-01700-neyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01275-01700-neyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01275-01700-neyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01276-01120-nievroz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01276-01120-nievroz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01276-01120-nievroz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01276-01120-nievroz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01277-01230-nivollet_montgriffon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01277-01230-nivollet_montgriffon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01277-01230-nivollet_montgriffon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01277-01230-nivollet_montgriffon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01279-01230-oncieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01279-01230-oncieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01279-01230-oncieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01279-01230-oncieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01280-01510-ordonnaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01280-01510-ordonnaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01280-01510-ordonnaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01280-01510-ordonnaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01281-01210-ornex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01281-01210-ornex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01281-01210-ornex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01281-01210-ornex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01282-01430-outriaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01282-01430-outriaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01282-01430-outriaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01282-01430-outriaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01283-01100-oyonnax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01283-01100-oyonnax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01283-01100-oyonnax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01283-01100-oyonnax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01284-01190-ozan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01284-01190-ozan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01284-01190-ozan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01284-01190-ozan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01285-01600-parcieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01285-01600-parcieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01285-01600-parcieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01285-01600-parcieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01286-01300-parves_et_nattages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01286-01300-parves_et_nattages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01286-01300-parves_et_nattages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01286-01300-parves_et_nattages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01288-01630-peron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01288-01630-peron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01288-01630-peron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01288-01630-peron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01289-01960-peronnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01289-01960-peronnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01289-01960-peronnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01289-01960-peronnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01290-01800-perouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01290-01800-perouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01290-01800-perouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01290-01800-perouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01291-01540-perrex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01291-01540-perrex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01291-01540-perrex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01291-01540-perrex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01293-01430-peyriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01293-01430-peyriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01293-01430-peyriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01293-01430-peyriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01294-01300-peyrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01294-01300-peyrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01294-01300-peyrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01294-01300-peyrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01295-01140-peyzieux_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01295-01140-peyzieux_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01295-01140-peyzieux_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01295-01140-peyzieux_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01296-01270-pirajoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01296-01270-pirajoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01296-01270-pirajoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01296-01270-pirajoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01297-01120-pizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01297-01120-pizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01297-01120-pizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01297-01120-pizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01298-01130-plagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01298-01130-plagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01298-01130-plagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01298-01130-plagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01299-01330-le_plantay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01299-01330-le_plantay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01299-01330-le_plantay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01299-01330-le_plantay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01301-01310-polliat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01301-01310-polliat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01301-01310-polliat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01301-01310-polliat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01302-01350-pollieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01302-01350-pollieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01302-01350-pollieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01302-01350-pollieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01303-01450-poncin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01303-01450-poncin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01303-01450-poncin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01303-01450-poncin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01304-01160-pont_d_ain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01304-01160-pont_d_ain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01304-01160-pont_d_ain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01304-01160-pont_d_ain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01305-01190-pont_de_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01305-01190-pont_de_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01305-01190-pont_de_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01305-01190-pont_de_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01306-01290-pont_de_veyle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01306-01290-pont_de_veyle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01306-01290-pont_de_veyle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01306-01290-pont_de_veyle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01307-01460-port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01307-01460-port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01307-01460-port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01307-01460-port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01308-01550-pougny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01308-01550-pougny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01308-01550-pougny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01308-01550-pougny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01309-01250-pouillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01309-01250-pouillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01309-01250-pouillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01309-01250-pouillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01310-01300-premeyzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01310-01300-premeyzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01310-01300-premeyzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01310-01300-premeyzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01311-01110-premillieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01311-01110-premillieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01311-01110-premillieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01311-01110-premillieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01313-01280-prevessin_moens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01313-01280-prevessin_moens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01313-01280-prevessin_moens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01313-01280-prevessin_moens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01314-01160-priay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01314-01160-priay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01314-01160-priay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01314-01160-priay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01317-01250-ramasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01317-01250-ramasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01317-01250-ramasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01317-01250-ramasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01318-01390-rance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01318-01390-rance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01318-01390-rance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01318-01390-rance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01319-01990-relevant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01319-01990-relevant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01319-01990-relevant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01319-01990-relevant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01320-01750-replonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01320-01750-replonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01320-01750-replonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01320-01750-replonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01321-01250-revonnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01321-01250-revonnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01321-01250-revonnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01321-01250-revonnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01322-01600-reyrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01322-01600-reyrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01322-01600-reyrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01322-01600-reyrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01323-01190-reyssouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01323-01190-reyssouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01323-01190-reyssouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01323-01190-reyssouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01325-01800-rignieux_le_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01325-01800-rignieux_le_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01325-01800-rignieux_le_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01325-01800-rignieux_le_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01328-01400-romans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01328-01400-romans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01328-01400-romans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01328-01400-romans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01329-01510-rossillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01329-01510-rossillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01329-01510-rossillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01329-01510-rossillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01330-01260-ruffieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01330-01260-ruffieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01330-01260-ruffieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01330-01260-ruffieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01331-01450-saint_alban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01331-01450-saint_alban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01331-01450-saint_alban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01331-01450-saint_alban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01332-01380-saint_andre_de_bage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01332-01380-saint_andre_de_bage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01332-01380-saint_andre_de_bage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01332-01380-saint_andre_de_bage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01333-01390-saint_andre_de_corcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01333-01390-saint_andre_de_corcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01333-01390-saint_andre_de_corcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01333-01390-saint_andre_de_corcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01334-01290-saint_andre_d_huiriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01334-01290-saint_andre_d_huiriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01334-01290-saint_andre_d_huiriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01334-01290-saint_andre_d_huiriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01335-01240-saint_andre_le_bouchoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01335-01240-saint_andre_le_bouchoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01335-01240-saint_andre_le_bouchoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01335-01240-saint_andre_le_bouchoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01336-01960-saint_andre_sur_vieux_jonc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01336-01960-saint_andre_sur_vieux_jonc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01336-01960-saint_andre_sur_vieux_jonc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01336-01960-saint_andre_sur_vieux_jonc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01337-01190-saint_benigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01337-01190-saint_benigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01337-01190-saint_benigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01337-01190-saint_benigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01338-01680-groslee_saint_benoit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01338-01680-groslee_saint_benoit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01338-01680-groslee_saint_benoit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01338-01680-groslee_saint_benoit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01338-01300-groslee_saint_benoit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01338-01300-groslee_saint_benoit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01338-01300-groslee_saint_benoit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01338-01300-groslee_saint_benoit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01339-01600-saint_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01339-01600-saint_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01339-01600-saint_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01339-01600-saint_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01342-01120-sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01342-01120-sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01342-01120-sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01342-01120-sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01343-01380-saint_cyr_sur_menthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01343-01380-saint_cyr_sur_menthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01343-01380-saint_cyr_sur_menthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01343-01380-saint_cyr_sur_menthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01344-01000-saint_denis_les_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01344-01000-saint_denis_les_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01344-01000-saint_denis_les_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01344-01000-saint_denis_les_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01345-01500-saint_denis_en_bugey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01345-01500-saint_denis_en_bugey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01345-01500-saint_denis_en_bugey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01345-01500-saint_denis_en_bugey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01346-01340-saint_didier_d_aussiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01346-01340-saint_didier_d_aussiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01346-01340-saint_didier_d_aussiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01346-01340-saint_didier_d_aussiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01347-01600-saint_didier_de_formans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01347-01600-saint_didier_de_formans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01347-01600-saint_didier_de_formans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01347-01600-saint_didier_de_formans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01348-01140-saint_didier_sur_chalaronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01348-01140-saint_didier_sur_chalaronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01348-01140-saint_didier_sur_chalaronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01348-01140-saint_didier_sur_chalaronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01349-01800-saint_eloi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01349-01800-saint_eloi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01349-01800-saint_eloi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01349-01800-saint_eloi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01350-01370-saint_etienne_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01350-01370-saint_etienne_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01350-01370-saint_etienne_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01350-01370-saint_etienne_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01351-01140-saint_etienne_sur_chalaronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01351-01140-saint_etienne_sur_chalaronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01351-01140-saint_etienne_sur_chalaronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01351-01140-saint_etienne_sur_chalaronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01352-01190-saint_etienne_sur_reyssouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01352-01190-saint_etienne_sur_reyssouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01352-01190-saint_etienne_sur_reyssouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01352-01190-saint_etienne_sur_reyssouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01353-01600-sainte_euphemie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01353-01600-sainte_euphemie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01353-01600-sainte_euphemie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01353-01600-sainte_euphemie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01354-01630-saint_genis_pouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01354-01630-saint_genis_pouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01354-01630-saint_genis_pouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01354-01630-saint_genis_pouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01355-01380-saint_genis_sur_menthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01355-01380-saint_genis_sur_menthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01355-01380-saint_genis_sur_menthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01355-01380-saint_genis_sur_menthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01356-01400-saint_georges_sur_renon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01356-01400-saint_georges_sur_renon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01356-01400-saint_georges_sur_renon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01356-01400-saint_georges_sur_renon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01357-01130-saint_germain_de_joux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01357-01130-saint_germain_de_joux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01357-01130-saint_germain_de_joux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01357-01130-saint_germain_de_joux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01358-01300-saint_germain_les_paroisses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01358-01300-saint_germain_les_paroisses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01358-01300-saint_germain_les_paroisses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01358-01300-saint_germain_les_paroisses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01359-01240-saint_germain_sur_renon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01359-01240-saint_germain_sur_renon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01359-01240-saint_germain_sur_renon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01359-01240-saint_germain_sur_renon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01360-01630-saint_jean_de_gonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01360-01630-saint_jean_de_gonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01360-01630-saint_jean_de_gonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01360-01630-saint_jean_de_gonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01361-01800-saint_jean_de_niost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01361-01800-saint_jean_de_niost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01361-01800-saint_jean_de_niost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01361-01800-saint_jean_de_niost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01362-01390-saint_jean_de_thurigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01362-01390-saint_jean_de_thurigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01362-01390-saint_jean_de_thurigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01362-01390-saint_jean_de_thurigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01363-01640-saint_jean_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01363-01640-saint_jean_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01363-01640-saint_jean_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01363-01640-saint_jean_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01364-01560-saint_jean_sur_reyssouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01364-01560-saint_jean_sur_reyssouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01364-01560-saint_jean_sur_reyssouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01364-01560-saint_jean_sur_reyssouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01365-01290-saint_jean_sur_veyle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01365-01290-saint_jean_sur_veyle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01365-01290-saint_jean_sur_veyle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01365-01290-saint_jean_sur_veyle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01366-01150-sainte_julie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01366-01150-sainte_julie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01366-01150-sainte_julie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01366-01150-sainte_julie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01367-01560-saint_julien_sur_reyssouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01367-01560-saint_julien_sur_reyssouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01367-01560-saint_julien_sur_reyssouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01367-01560-saint_julien_sur_reyssouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01368-01540-saint_julien_sur_veyle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01368-01540-saint_julien_sur_veyle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01368-01540-saint_julien_sur_veyle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01368-01540-saint_julien_sur_veyle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01369-01250-saint_just/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01369-01250-saint_just/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01369-01250-saint_just/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01369-01250-saint_just/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01370-01750-saint_laurent_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01370-01750-saint_laurent_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01370-01750-saint_laurent_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01370-01750-saint_laurent_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01371-01390-saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01371-01390-saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01371-01390-saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01371-01390-saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01372-01510-saint_martin_de_bavel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01372-01510-saint_martin_de_bavel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01372-01510-saint_martin_de_bavel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01372-01510-saint_martin_de_bavel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01373-01430-saint_martin_du_frene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01373-01430-saint_martin_du_frene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01373-01430-saint_martin_du_frene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01373-01430-saint_martin_du_frene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01374-01160-saint_martin_du_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01374-01160-saint_martin_du_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01374-01160-saint_martin_du_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01374-01160-saint_martin_du_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01375-01310-saint_martin_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01375-01310-saint_martin_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01375-01310-saint_martin_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01375-01310-saint_martin_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01376-01700-saint_maurice_de_beynost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01376-01700-saint_maurice_de_beynost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01376-01700-saint_maurice_de_beynost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01376-01700-saint_maurice_de_beynost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01378-01800-saint_maurice_de_gourdans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01378-01800-saint_maurice_de_gourdans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01378-01800-saint_maurice_de_gourdans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01378-01800-saint_maurice_de_gourdans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01379-01500-saint_maurice_de_remens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01379-01500-saint_maurice_de_remens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01379-01500-saint_maurice_de_remens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01379-01500-saint_maurice_de_remens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01380-01560-saint_nizier_le_bouchoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01380-01560-saint_nizier_le_bouchoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01380-01560-saint_nizier_le_bouchoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01380-01560-saint_nizier_le_bouchoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01381-01320-saint_nizier_le_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01381-01320-saint_nizier_le_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01381-01320-saint_nizier_le_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01381-01320-saint_nizier_le_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01382-01330-sainte_olive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01382-01330-sainte_olive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01382-01330-sainte_olive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01382-01330-sainte_olive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01383-01240-saint_paul_de_varax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01383-01240-saint_paul_de_varax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01383-01240-saint_paul_de_varax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01383-01240-saint_paul_de_varax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01384-01230-saint_rambert_en_bugey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01384-01230-saint_rambert_en_bugey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01384-01230-saint_rambert_en_bugey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01384-01230-saint_rambert_en_bugey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01385-01310-saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01385-01310-saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01385-01310-saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01385-01310-saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01386-01150-saint_sorlin_en_bugey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01386-01150-saint_sorlin_en_bugey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01386-01150-saint_sorlin_en_bugey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01386-01150-saint_sorlin_en_bugey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01387-01340-saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01387-01340-saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01387-01340-saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01387-01340-saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01388-01560-saint_trivier_de_courtes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01388-01560-saint_trivier_de_courtes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01388-01560-saint_trivier_de_courtes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01388-01560-saint_trivier_de_courtes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01389-01990-saint_trivier_sur_moignans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01389-01990-saint_trivier_sur_moignans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01389-01990-saint_trivier_sur_moignans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01389-01990-saint_trivier_sur_moignans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01390-01150-saint_vulbas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01390-01150-saint_vulbas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01390-01150-saint_vulbas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01390-01150-saint_vulbas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01391-01270-salavre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01391-01270-salavre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01391-01270-salavre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01391-01270-salavre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01392-01580-samognat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01392-01580-samognat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01392-01580-samognat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01392-01580-samognat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01393-01400-sandrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01393-01400-sandrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01393-01400-sandrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01393-01400-sandrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01396-01150-sault_brenaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01396-01150-sault_brenaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01396-01150-sault_brenaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01396-01150-sault_brenaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01397-01220-sauverny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01397-01220-sauverny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01397-01220-sauverny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01397-01220-sauverny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01398-01480-savigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01398-01480-savigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01398-01480-savigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01398-01480-savigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01399-01170-segny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01399-01170-segny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01399-01170-segny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01399-01170-segny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01400-01470-seillonnaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01400-01470-seillonnaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01400-01470-seillonnaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01400-01470-seillonnaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01401-01630-sergy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01401-01630-sergy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01401-01630-sergy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01401-01630-sergy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01402-01190-sermoyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01402-01190-sermoyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01402-01190-sermoyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01402-01190-sermoyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01403-01470-serrieres_de_briord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01403-01470-serrieres_de_briord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01403-01470-serrieres_de_briord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01403-01470-serrieres_de_briord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01404-01450-serrieres_sur_ain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01404-01450-serrieres_sur_ain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01404-01450-serrieres_sur_ain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01404-01450-serrieres_sur_ain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01405-01960-servas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01405-01960-servas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01405-01960-servas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01405-01960-servas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01406-01560-servignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01406-01560-servignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01406-01560-servignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01406-01560-servignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01407-01420-seyssel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01407-01420-seyssel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01407-01420-seyssel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01407-01420-seyssel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01408-01250-simandre_sur_suran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01408-01250-simandre_sur_suran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01408-01250-simandre_sur_suran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01408-01250-simandre_sur_suran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01410-01580-sonthonnax_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01410-01580-sonthonnax_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01410-01580-sonthonnax_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01410-01580-sonthonnax_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01411-01150-souclin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01411-01150-souclin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01411-01150-souclin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01411-01150-souclin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01412-01400-sulignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01412-01400-sulignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01412-01400-sulignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01412-01400-sulignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01415-01510-talissieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01415-01510-talissieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01415-01510-talissieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01415-01510-talissieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01416-01230-tenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01416-01230-tenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01416-01230-tenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01416-01230-tenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01418-01120-thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01418-01120-thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01418-01120-thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01418-01120-thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01419-01710-thoiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01419-01710-thoiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01419-01710-thoiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01419-01710-thoiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01420-01140-thoissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01420-01140-thoissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01420-01140-thoissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01420-01140-thoissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01421-01230-torcieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01421-01230-torcieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01421-01230-torcieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01421-01230-torcieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01422-01250-tossiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01422-01250-tossiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01422-01250-tossiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01422-01250-tossiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01423-01600-toussieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01423-01600-toussieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01423-01600-toussieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01423-01600-toussieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01424-01390-tramoyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01424-01390-tramoyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01424-01390-tramoyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01424-01390-tramoyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01425-01160-la_trancliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01425-01160-la_trancliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01425-01160-la_trancliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01425-01160-la_trancliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01426-01370-val_revermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01426-01370-val_revermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01426-01370-val_revermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01426-01370-val_revermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01427-01600-trevoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01427-01600-trevoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01427-01600-trevoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01427-01600-trevoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01428-01140-valeins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01428-01140-valeins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01428-01140-valeins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01428-01140-valeins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01429-01660-vandeins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01429-01660-vandeins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01429-01660-vandeins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01429-01660-vandeins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01430-01160-varambon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01430-01160-varambon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01430-01160-varambon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01430-01160-varambon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01431-01150-vaux_en_bugey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01431-01150-vaux_en_bugey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01431-01150-vaux_en_bugey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01431-01150-vaux_en_bugey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01432-01270-verjon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01432-01270-verjon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01432-01270-verjon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01432-01270-verjon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01433-01560-vernoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01433-01560-vernoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01433-01560-vernoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01433-01560-vernoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01434-01330-versailleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01434-01330-versailleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01434-01330-versailleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01434-01330-versailleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01435-01210-versonnex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01435-01210-versonnex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01435-01210-versonnex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01435-01210-versonnex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01436-01170-vesancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01436-01170-vesancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01436-01170-vesancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01436-01170-vesancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01437-01560-vescours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01437-01560-vescours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01437-01560-vescours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01437-01560-vescours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01439-01570-vesines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01439-01570-vesines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01439-01570-vesines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01439-01570-vesines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01441-01430-vieu_d_izenave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01441-01430-vieu_d_izenave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01441-01430-vieu_d_izenave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01441-01430-vieu_d_izenave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01443-01330-villars_les_dombes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01443-01330-villars_les_dombes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01443-01330-villars_les_dombes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01443-01330-villars_les_dombes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01444-01150-villebois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01444-01150-villebois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01444-01150-villebois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01444-01150-villebois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01445-01270-villemotier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01445-01270-villemotier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01445-01270-villemotier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01445-01270-villemotier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01446-01480-villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01446-01480-villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01446-01480-villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01446-01480-villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01447-01250-villereversure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01447-01250-villereversure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01447-01250-villereversure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01447-01250-villereversure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01448-01200-villes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01448-01200-villes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01448-01200-villes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01448-01200-villes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01449-01320-villette_sur_ain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01449-01320-villette_sur_ain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01449-01320-villette_sur_ain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01449-01320-villette_sur_ain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01450-01800-villieu_loyes_mollon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01450-01800-villieu_loyes_mollon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01450-01800-villieu_loyes_mollon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01450-01800-villieu_loyes_mollon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01451-01440-viriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01451-01440-viriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01451-01440-viriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01451-01440-viriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01452-01510-virieu_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01452-01510-virieu_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01452-01510-virieu_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01452-01510-virieu_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01453-01260-arviere_en_valromey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01453-01260-arviere_en_valromey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01453-01260-arviere_en_valromey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01453-01260-arviere_en_valromey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01453-01510-arviere_en_valromey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01453-01510-arviere_en_valromey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01453-01510-arviere_en_valromey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01453-01510-arviere_en_valromey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01454-01300-virignin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01454-01300-virignin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01454-01300-virignin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01454-01300-virignin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01456-01350-vongnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01456-01350-vongnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01456-01350-vongnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01456-01350-vongnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01457-01540-vonnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01457-01540-vonnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01457-01540-vonnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt01-ain/commune01457-01540-vonnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-02.xml
+++ b/public/sitemaps/sitemap-02.xml
@@ -5,1608 +5,3212 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02001-02300-abbecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02001-02300-abbecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02001-02300-abbecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02001-02300-abbecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02002-02800-achery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02002-02800-achery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02002-02800-achery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02002-02800-achery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02003-02200-acy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02003-02200-acy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02003-02200-acy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02003-02200-acy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02004-02340-agnicourt_et_sechelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02004-02340-agnicourt_et_sechelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02004-02340-agnicourt_et_sechelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02004-02340-agnicourt_et_sechelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02005-02190-aguilcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02005-02190-aguilcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02005-02190-aguilcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02005-02190-aguilcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02006-02110-aisonville_et_bernoville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02006-02110-aisonville_et_bernoville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02006-02110-aisonville_et_bernoville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02006-02110-aisonville_et_bernoville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02007-02820-aizelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02007-02820-aizelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02007-02820-aizelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02007-02820-aizelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02008-02370-aizy_jouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02008-02370-aizy_jouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02008-02370-aizy_jouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02008-02370-aizy_jouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02009-02240-alaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02009-02240-alaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02009-02240-alaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02009-02240-alaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02010-02320-allemant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02010-02320-allemant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02010-02320-allemant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02010-02320-allemant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02011-02290-ambleny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02011-02290-ambleny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02011-02290-ambleny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02011-02290-ambleny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02012-02200-ambrief/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02012-02200-ambrief/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02012-02200-ambrief/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02012-02200-ambrief/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02013-02190-amifontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02013-02190-amifontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02013-02190-amifontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02013-02190-amifontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02014-02700-amigny_rouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02014-02700-amigny_rouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02014-02700-amigny_rouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02014-02700-amigny_rouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02015-02600-ancienville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02015-02600-ancienville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02015-02600-ancienville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02015-02600-ancienville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02016-02800-andelain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02016-02800-andelain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02016-02800-andelain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02016-02800-andelain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02017-02800-anguilcourt_le_sart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02017-02800-anguilcourt_le_sart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02017-02800-anguilcourt_le_sart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02017-02800-anguilcourt_le_sart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02018-02320-anizy_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02018-02320-anizy_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02018-02320-anizy_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02018-02320-anizy_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02019-02480-annois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02019-02480-annois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02019-02480-annois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02019-02480-annois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02020-02500-any_martin_rieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02020-02500-any_martin_rieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02020-02500-any_martin_rieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02020-02500-any_martin_rieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02021-02360-archon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02021-02360-archon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02021-02360-archon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02021-02360-archon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02022-02130-arcy_sainte_restitue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02022-02130-arcy_sainte_restitue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02022-02130-arcy_sainte_restitue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02022-02130-arcy_sainte_restitue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02023-02210-armentieres_sur_ourcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02023-02210-armentieres_sur_ourcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02023-02210-armentieres_sur_ourcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02023-02210-armentieres_sur_ourcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02024-02860-arrancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02024-02860-arrancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02024-02860-arrancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02024-02860-arrancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02025-02480-artemps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02025-02480-artemps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02025-02480-artemps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02025-02480-artemps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02027-02270-assis_sur_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02027-02270-assis_sur_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02027-02270-assis_sur_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02027-02270-assis_sur_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02028-02840-athies_sous_laon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02028-02840-athies_sous_laon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02028-02840-athies_sous_laon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02028-02840-athies_sous_laon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02029-02490-attilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02029-02490-attilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02029-02490-attilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02029-02490-attilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02030-02420-aubencheul_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02030-02420-aubencheul_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02030-02420-aubencheul_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02030-02420-aubencheul_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02031-02500-aubenton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02031-02500-aubenton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02031-02500-aubenton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02031-02500-aubenton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02032-02590-aubigny_aux_kaisnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02032-02590-aubigny_aux_kaisnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02032-02590-aubigny_aux_kaisnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02032-02590-aubigny_aux_kaisnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02033-02820-aubigny_en_laonnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02033-02820-aubigny_en_laonnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02033-02820-aubigny_en_laonnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02033-02820-aubigny_en_laonnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02034-02300-audignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02034-02300-audignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02034-02300-audignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02034-02300-audignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02035-02120-audigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02035-02120-audigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02035-02120-audigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02035-02120-audigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02036-02220-augy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02036-02220-augy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02036-02220-augy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02036-02220-augy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02037-02000-aulnois_sous_laon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02037-02000-aulnois_sous_laon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02037-02000-aulnois_sous_laon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02037-02000-aulnois_sous_laon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02038-02360-les_autels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02038-02360-les_autels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02038-02360-les_autels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02038-02360-les_autels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02039-02250-autremencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02039-02250-autremencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02039-02250-autremencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02039-02250-autremencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02040-02580-autreppes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02040-02580-autreppes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02040-02580-autreppes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02040-02580-autreppes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02041-02300-autreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02041-02300-autreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02041-02300-autreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02041-02300-autreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02042-02400-azy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02042-02400-azy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02042-02400-azy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02042-02400-azy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02043-02290-bagneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02043-02290-bagneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02043-02290-bagneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02043-02290-bagneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02044-02140-bancigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02044-02140-bancigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02044-02140-bancigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02044-02140-bancigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02046-02000-barenton_bugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02046-02000-barenton_bugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02046-02000-barenton_bugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02046-02000-barenton_bugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02047-02000-barenton_cel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02047-02000-barenton_cel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02047-02000-barenton_cel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02047-02000-barenton_cel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02048-02270-barenton_sur_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02048-02270-barenton_sur_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02048-02270-barenton_sur_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02048-02270-barenton_sur_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02049-02700-barisis_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02049-02700-barisis_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02049-02700-barisis_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02049-02700-barisis_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02050-02170-barzy_en_thierache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02050-02170-barzy_en_thierache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02050-02170-barzy_en_thierache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02050-02170-barzy_en_thierache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02051-02850-barzy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02051-02850-barzy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02051-02850-barzy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02051-02850-barzy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02052-02380-bassoles_aulers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02052-02380-bassoles_aulers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02052-02380-bassoles_aulers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02052-02380-bassoles_aulers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02053-02330-vallees_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02053-02330-vallees_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02053-02330-vallees_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02053-02330-vallees_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02054-02220-bazoches_sur_vesles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02054-02220-bazoches_sur_vesles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02054-02220-bazoches_sur_vesles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02054-02220-bazoches_sur_vesles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02055-02500-beaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02055-02500-beaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02055-02500-beaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02055-02500-beaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02056-02300-beaumont_en_beine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02056-02300-beaumont_en_beine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02056-02300-beaumont_en_beine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02056-02300-beaumont_en_beine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02057-02110-beaurevoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02057-02110-beaurevoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02057-02110-beaurevoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02057-02110-beaurevoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02058-02160-beaurieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02058-02160-beaurieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02058-02160-beaurieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02058-02160-beaurieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02059-02800-beautor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02059-02800-beautor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02059-02800-beautor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02059-02800-beautor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02060-02590-beauvois_en_vermandois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02060-02590-beauvois_en_vermandois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02060-02590-beauvois_en_vermandois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02060-02590-beauvois_en_vermandois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02061-02110-becquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02061-02110-becquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02061-02110-becquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02061-02110-becquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02062-02400-belleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02062-02400-belleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02062-02400-belleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02062-02400-belleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02063-02420-bellenglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02063-02420-bellenglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02063-02420-bellenglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02063-02420-bellenglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02064-02200-belleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02064-02200-belleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02064-02200-belleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02064-02200-belleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02065-02420-bellicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02065-02420-bellicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02065-02420-bellicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02065-02420-bellicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02066-02440-benay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02066-02440-benay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02066-02440-benay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02066-02440-benay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02067-02450-bergues_sur_sambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02067-02450-bergues_sur_sambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02067-02450-bergues_sur_sambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02067-02450-bergues_sur_sambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02068-02250-berlancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02068-02250-berlancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02068-02250-berlancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02068-02250-berlancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02069-02340-berlise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02069-02340-berlise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02069-02340-berlise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02069-02340-berlise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02070-02120-bernot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02070-02120-bernot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02070-02120-bernot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02070-02120-bernot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02071-02290-berny_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02071-02290-berny_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02071-02290-berny_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02071-02290-berny_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02072-02820-berrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02072-02820-berrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02072-02820-berrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02072-02820-berrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02073-02190-berry_au_bac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02073-02190-berry_au_bac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02073-02190-berry_au_bac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02073-02190-berry_au_bac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02074-02800-bertaucourt_epourdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02074-02800-bertaucourt_epourdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02074-02800-bertaucourt_epourdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02074-02800-bertaucourt_epourdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02075-02240-berthenicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02075-02240-berthenicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02075-02240-berthenicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02075-02240-berthenicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02076-02190-bertricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02076-02190-bertricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02076-02190-bertricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02076-02190-bertricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02077-02200-berzy_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02077-02200-berzy_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02077-02200-berzy_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02077-02200-berzy_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02078-02300-besme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02078-02300-besme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02078-02300-besme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02078-02300-besme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02079-02500-besmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02079-02500-besmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02079-02500-besmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02079-02500-besmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02080-02870-besny_et_loizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02080-02870-besny_et_loizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02080-02870-besny_et_loizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02080-02870-besny_et_loizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02081-02300-bethancourt_en_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02081-02300-bethancourt_en_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02081-02300-bethancourt_en_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02081-02300-bethancourt_en_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02082-02210-beugneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02082-02210-beugneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02082-02210-beugneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02082-02210-beugneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02083-02130-beuvardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02083-02130-beuvardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02083-02130-beuvardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02083-02130-beuvardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02084-02310-bezu_le_guery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02084-02310-bezu_le_guery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02084-02310-bezu_le_guery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02084-02310-bezu_le_guery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02085-02400-bezu_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02085-02400-bezu_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02085-02400-bezu_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02085-02400-bezu_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02086-02300-bichancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02086-02300-bichancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02086-02300-bichancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02086-02300-bichancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02087-02290-bieuxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02087-02290-bieuxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02087-02290-bieuxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02087-02290-bieuxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02088-02860-bievres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02088-02860-bievres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02088-02860-bievres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02088-02860-bievres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02089-02200-billy_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02089-02200-billy_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02089-02200-billy_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02089-02200-billy_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02090-02210-billy_sur_ourcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02090-02210-billy_sur_ourcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02090-02210-billy_sur_ourcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02090-02210-billy_sur_ourcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02091-02160-blanzy_les_fismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02091-02160-blanzy_les_fismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02091-02160-blanzy_les_fismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02091-02160-blanzy_les_fismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02093-02300-blerancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02093-02300-blerancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02093-02300-blerancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02093-02300-blerancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02094-02400-blesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02094-02400-blesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02094-02400-blesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02094-02400-blesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02095-02110-bohain_en_vermandois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02095-02110-bohain_en_vermandois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02095-02110-bohain_en_vermandois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02095-02110-bohain_en_vermandois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02096-02270-bois_les_pargny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02096-02270-bois_les_pargny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02096-02270-bois_les_pargny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02096-02270-bois_les_pargny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02097-02350-boncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02097-02350-boncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02097-02350-boncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02097-02350-boncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02098-02400-bonneil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02098-02400-bonneil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02098-02400-bonneil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02098-02400-bonneil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02099-02400-bonnesvalyn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02099-02400-bonnesvalyn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02099-02400-bonnesvalyn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02099-02400-bonnesvalyn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02100-02420-bony/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02100-02420-bony/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02100-02420-bony/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02100-02420-bony/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02101-02250-bosmont_sur_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02101-02250-bosmont_sur_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02101-02250-bosmont_sur_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02101-02250-bosmont_sur_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02102-02860-bouconville_vauclair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02102-02860-bouconville_vauclair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02102-02860-bouconville_vauclair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02102-02860-bouconville_vauclair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02103-02450-boue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02103-02450-boue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02103-02450-boue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02103-02450-boue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02104-02160-bouffignereux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02104-02160-bouffignereux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02104-02160-bouffignereux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02104-02160-bouffignereux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02105-02400-bouresches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02105-02400-bouresches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02105-02400-bouresches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02105-02400-bouresches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02106-02160-bourg_et_comin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02106-02160-bourg_et_comin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02106-02160-bourg_et_comin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02106-02160-bourg_et_comin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02107-02300-bourguignon_sous_coucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02107-02300-bourguignon_sous_coucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02107-02300-bourguignon_sous_coucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02107-02300-bourguignon_sous_coucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02108-02000-bourguignon_sous_montbavin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02108-02000-bourguignon_sous_montbavin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02108-02000-bourguignon_sous_montbavin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02108-02000-bourguignon_sous_montbavin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02109-02140-la_bouteille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02109-02140-la_bouteille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02109-02140-la_bouteille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02109-02140-la_bouteille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02110-02220-braine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02110-02220-braine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02110-02220-braine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02110-02220-braine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02111-02320-brancourt_en_laonnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02111-02320-brancourt_en_laonnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02111-02320-brancourt_en_laonnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02111-02320-brancourt_en_laonnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02112-02110-brancourt_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02112-02110-brancourt_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02112-02110-brancourt_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02112-02110-brancourt_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02114-02400-brasles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02114-02400-brasles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02114-02400-brasles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02114-02400-brasles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02115-02000-braye_en_laonnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02115-02000-braye_en_laonnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02115-02000-braye_en_laonnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02115-02000-braye_en_laonnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02116-02140-braye_en_thierache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02116-02140-braye_en_thierache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02116-02140-braye_en_thierache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02116-02140-braye_en_thierache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02117-02480-bray_saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02117-02480-bray_saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02117-02480-bray_saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02117-02480-bray_saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02118-02880-braye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02118-02880-braye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02118-02880-braye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02118-02880-braye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02119-02210-brecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02119-02210-brecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02119-02210-brecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02119-02210-brecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02120-02220-brenelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02120-02220-brenelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02120-02220-brenelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02120-02220-brenelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02121-02210-breny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02121-02210-breny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02121-02210-breny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02121-02210-breny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02122-02870-brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02122-02870-brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02122-02870-brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02122-02870-brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02123-02240-brissay_choigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02123-02240-brissay_choigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02123-02240-brissay_choigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02123-02240-brissay_choigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02124-02240-brissy_hamegicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02124-02240-brissy_hamegicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02124-02240-brissy_hamegicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02124-02240-brissy_hamegicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02125-02810-brumetz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02125-02810-brumetz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02125-02810-brumetz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02125-02810-brumetz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02126-02360-brunehamel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02126-02360-brunehamel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02126-02360-brunehamel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02126-02360-brunehamel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02127-02130-bruyeres_sur_fere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02127-02130-bruyeres_sur_fere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02127-02130-bruyeres_sur_fere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02127-02130-bruyeres_sur_fere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02128-02860-bruyeres_et_montberault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02128-02860-bruyeres_et_montberault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02128-02860-bruyeres_et_montberault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02128-02860-bruyeres_et_montberault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02129-02220-bruys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02129-02220-bruys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02129-02220-bruys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02129-02220-bruys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02130-02500-bucilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02130-02500-bucilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02130-02500-bucilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02130-02500-bucilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02131-02880-bucy_le_long/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02131-02880-bucy_le_long/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02131-02880-bucy_le_long/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02131-02880-bucy_le_long/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02132-02870-bucy_les_cerny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02132-02870-bucy_les_cerny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02132-02870-bucy_les_cerny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02132-02870-bucy_les_cerny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02133-02350-bucy_les_pierrepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02133-02350-bucy_les_pierrepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02133-02350-bucy_les_pierrepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02133-02350-bucy_les_pierrepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02134-02500-buire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02134-02500-buire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02134-02500-buire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02134-02500-buire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02135-02620-buironfosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02135-02620-buironfosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02135-02620-buironfosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02135-02620-buironfosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02136-02140-burelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02136-02140-burelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02136-02140-burelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02136-02140-burelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02137-02810-bussiares/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02137-02810-bussiares/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02137-02810-bussiares/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02137-02810-bussiares/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02138-02200-buzancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02138-02200-buzancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02138-02200-buzancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02138-02200-buzancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02139-02300-caillouel_crepigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02139-02300-caillouel_crepigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02139-02300-caillouel_crepigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02139-02300-caillouel_crepigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02140-02300-camelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02140-02300-camelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02140-02300-camelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02140-02300-camelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02141-02260-la_capelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02141-02260-la_capelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02141-02260-la_capelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02141-02260-la_capelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02142-02680-castres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02142-02680-castres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02142-02680-castres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02142-02680-castres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02143-02420-le_catelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02143-02420-le_catelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02143-02420-le_catelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02143-02420-le_catelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02144-02490-caulaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02144-02490-caulaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02144-02490-caulaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02144-02490-caulaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02145-02300-caumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02145-02300-caumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02145-02300-caumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02145-02300-caumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02146-02330-celles_les_conde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02146-02330-celles_les_conde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02146-02330-celles_les_conde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02146-02330-celles_les_conde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02148-02370-celles_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02148-02370-celles_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02148-02370-celles_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02148-02370-celles_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02149-02240-cerizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02149-02240-cerizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02149-02240-cerizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02149-02240-cerizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02150-02860-cerny_en_laonnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02150-02860-cerny_en_laonnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02150-02860-cerny_en_laonnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02150-02860-cerny_en_laonnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02151-02870-cerny_les_bucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02151-02870-cerny_les_bucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02151-02870-cerny_les_bucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02151-02870-cerny_les_bucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02152-02220-cerseuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02152-02220-cerseuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02152-02220-cerseuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02152-02220-cerseuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02153-02320-cessieres_suzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02153-02320-cessieres_suzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02153-02320-cessieres_suzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02153-02320-cessieres_suzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02154-02200-chacrise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02154-02200-chacrise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02154-02200-chacrise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02154-02200-chacrise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02155-02000-chaillevois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02155-02000-chaillevois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02155-02000-chaillevois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02155-02000-chaillevois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02156-02270-chalandry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02156-02270-chalandry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02156-02270-chalandry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02156-02270-chalandry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02157-02000-chambry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02157-02000-chambry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02157-02000-chambry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02157-02000-chambry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02158-02860-chamouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02158-02860-chamouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02158-02860-chamouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02158-02860-chamouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02159-02670-champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02159-02670-champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02159-02670-champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02159-02670-champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02160-02340-chaourse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02160-02340-chaourse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02160-02340-chaourse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02160-02340-chaourse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02162-02570-la_chapelle_sur_chezy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02162-02570-la_chapelle_sur_chezy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02162-02570-la_chapelle_sur_chezy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02162-02570-la_chapelle_sur_chezy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02163-02310-charly_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02163-02310-charly_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02163-02310-charly_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02163-02310-charly_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02164-02850-le_charmel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02164-02850-le_charmel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02164-02850-le_charmel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02164-02850-le_charmel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02165-02800-charmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02165-02800-charmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02165-02800-charmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02165-02800-charmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02166-02400-charteves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02166-02400-charteves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02166-02400-charteves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02166-02400-charteves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02167-02370-chassemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02167-02370-chassemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02167-02370-chassemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02167-02370-chassemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02168-02400-chateau_thierry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02168-02400-chateau_thierry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02168-02400-chateau_thierry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02168-02400-chateau_thierry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02169-02270-chatillon_les_sons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02169-02270-chatillon_les_sons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02169-02270-chatillon_les_sons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02169-02270-chatillon_les_sons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02170-02240-chatillon_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02170-02240-chatillon_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02170-02240-chatillon_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02170-02240-chatillon_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02171-02160-chaudardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02171-02160-chaudardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02171-02160-chaudardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02171-02160-chaudardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02172-02200-chaudun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02172-02200-chaudun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02172-02200-chaudun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02172-02200-chaudun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02173-02300-chauny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02173-02300-chauny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02173-02300-chauny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02173-02300-chauny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02174-02000-chavignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02174-02000-chavignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02174-02000-chavignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02174-02000-chavignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02175-02880-chavigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02175-02880-chavigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02175-02880-chavigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02175-02880-chavigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02176-02370-chavonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02176-02370-chavonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02176-02370-chavonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02176-02370-chavonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02177-02860-cheret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02177-02860-cheret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02177-02860-cheret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02177-02860-cheret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02178-02860-chermizy_ailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02178-02860-chermizy_ailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02178-02860-chermizy_ailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02178-02860-chermizy_ailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02179-02220-chery_chartreuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02179-02220-chery_chartreuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02179-02220-chery_chartreuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02179-02220-chery_chartreuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02180-02000-chery_les_pouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02180-02000-chery_les_pouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02180-02000-chery_les_pouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02180-02000-chery_les_pouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02181-02360-chery_les_rozoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02181-02360-chery_les_rozoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02181-02360-chery_les_rozoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02181-02360-chery_les_rozoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02182-02250-chevennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02182-02250-chevennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02182-02250-chevennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02182-02250-chevennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02183-02000-chevregny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02183-02000-chevregny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02183-02000-chevregny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02183-02000-chevregny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02184-02270-chevresis_monceau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02184-02270-chevresis_monceau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02184-02270-chevresis_monceau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02184-02270-chevresis_monceau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02185-02810-chezy_en_orxois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02185-02810-chezy_en_orxois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02185-02810-chezy_en_orxois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02185-02810-chezy_en_orxois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02186-02570-chezy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02186-02570-chezy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02186-02570-chezy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02186-02570-chezy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02187-02400-chierry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02187-02400-chierry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02187-02400-chierry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02187-02400-chierry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02188-02120-chigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02188-02120-chigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02188-02120-chigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02188-02120-chigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02189-02350-chivres_en_laonnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02189-02350-chivres_en_laonnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02189-02350-chivres_en_laonnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02189-02350-chivres_en_laonnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02190-02880-chivres_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02190-02880-chivres_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02190-02880-chivres_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02190-02880-chivres_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02191-02000-chivy_les_etouvelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02191-02000-chivy_les_etouvelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02191-02000-chivy_les_etouvelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02191-02000-chivy_les_etouvelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02192-02210-chouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02192-02210-chouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02192-02210-chouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02192-02210-chouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02193-02130-cierges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02193-02130-cierges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02193-02130-cierges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02193-02130-cierges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02194-02250-cilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02194-02250-cilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02194-02250-cilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02194-02250-cilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02195-02220-ciry_salsogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02195-02220-ciry_salsogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02195-02220-ciry_salsogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02195-02220-ciry_salsogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02196-02000-clacy_et_thierret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02196-02000-clacy_et_thierret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02196-02000-clacy_et_thierret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02196-02000-clacy_et_thierret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02197-02260-clairfontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02197-02260-clairfontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02197-02260-clairfontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02197-02260-clairfontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02198-02880-clamecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02198-02880-clamecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02198-02880-clamecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02198-02880-clamecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02199-02440-clastres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02199-02440-clastres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02199-02440-clastres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02199-02440-clastres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02200-02340-clermont_les_fermes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02200-02340-clermont_les_fermes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02200-02340-clermont_les_fermes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02200-02340-clermont_les_fermes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02201-02600-coeuvres_et_valsery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02201-02600-coeuvres_et_valsery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02201-02600-coeuvres_et_valsery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02201-02600-coeuvres_et_valsery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02203-02210-coincy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02203-02210-coincy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02203-02210-coincy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02203-02210-coincy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02204-02360-coingt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02204-02360-coingt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02204-02360-coingt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02204-02360-coingt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02205-02860-colligis_crandelain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02205-02860-colligis_crandelain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02205-02860-colligis_crandelain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02205-02860-colligis_crandelain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02206-02120-colonfay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02206-02120-colonfay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02206-02120-colonfay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02206-02120-colonfay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02207-02300-commenchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02207-02300-commenchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02207-02300-commenchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02207-02300-commenchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02208-02160-concevreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02208-02160-concevreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02208-02160-concevreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02208-02160-concevreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02209-02330-conde_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02209-02330-conde_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02209-02330-conde_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02209-02330-conde_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02210-02370-conde_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02210-02370-conde_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02210-02370-conde_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02210-02370-conde_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02211-02190-conde_sur_suippe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02211-02190-conde_sur_suippe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02211-02190-conde_sur_suippe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02211-02190-conde_sur_suippe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02212-02700-condren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02212-02700-condren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02212-02700-condren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02212-02700-condren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02213-02330-connigis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02213-02330-connigis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02213-02330-connigis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02213-02330-connigis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02214-02680-contescourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02214-02680-contescourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02214-02680-contescourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02214-02680-contescourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02215-02820-corbeny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02215-02820-corbeny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02215-02820-corbeny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02215-02820-corbeny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02216-02600-corcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02216-02600-corcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02216-02600-corcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02216-02600-corcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02217-02380-coucy_le_chateau_auffrique/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02217-02380-coucy_le_chateau_auffrique/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02217-02380-coucy_le_chateau_auffrique/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02217-02380-coucy_le_chateau_auffrique/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02218-02840-coucy_les_eppes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02218-02840-coucy_les_eppes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02218-02840-coucy_les_eppes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02218-02840-coucy_les_eppes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02219-02380-coucy_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02219-02380-coucy_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02219-02380-coucy_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02219-02380-coucy_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02220-02130-coulonges_cohan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02220-02130-coulonges_cohan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02220-02130-coulonges_cohan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02220-02130-coulonges_cohan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02221-02310-coupru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02221-02310-coupru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02221-02310-coupru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02221-02310-coupru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02222-02800-courbes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02222-02800-courbes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02222-02800-courbes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02222-02800-courbes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02223-02330-courboin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02223-02330-courboin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02223-02330-courboin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02223-02330-courboin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02224-02220-courcelles_sur_vesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02224-02220-courcelles_sur_vesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02224-02220-courcelles_sur_vesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02224-02220-courcelles_sur_vesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02225-02810-courchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02225-02810-courchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02225-02810-courchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02225-02810-courchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02226-02200-courmelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02226-02200-courmelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02226-02200-courmelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02226-02200-courmelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02227-02130-courmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02227-02130-courmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02227-02130-courmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02227-02130-courmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02228-02850-courtemont_varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02228-02850-courtemont_varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02228-02850-courtemont_varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02228-02850-courtemont_varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02229-02820-courtrizy_et_fussigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02229-02820-courtrizy_et_fussigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02229-02820-courtrizy_et_fussigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02229-02820-courtrizy_et_fussigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02230-02220-couvrelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02230-02220-couvrelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02230-02220-couvrelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02230-02220-couvrelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02231-02270-couvron_et_aumencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02231-02270-couvron_et_aumencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02231-02270-couvron_et_aumencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02231-02270-couvron_et_aumencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02232-02600-coyolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02232-02600-coyolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02232-02600-coyolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02232-02600-coyolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02233-02130-cramaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02233-02130-cramaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02233-02130-cramaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02233-02130-cramaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02234-02160-craonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02234-02160-craonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02234-02160-craonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02234-02160-craonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02235-02160-craonnelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02235-02160-craonnelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02235-02160-craonnelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02235-02160-craonnelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02236-02380-crecy_au_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02236-02380-crecy_au_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02236-02380-crecy_au_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02236-02380-crecy_au_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02237-02270-crecy_sur_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02237-02270-crecy_sur_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02237-02270-crecy_sur_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02237-02270-crecy_sur_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02238-02870-crepy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02238-02870-crepy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02238-02870-crepy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02238-02870-crepy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02239-02650-crezancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02239-02650-crezancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02239-02650-crezancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02239-02650-crezancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02240-02110-croix_fonsomme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02240-02110-croix_fonsomme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02240-02110-croix_fonsomme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02240-02110-croix_fonsomme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02241-02210-la_croix_sur_ourcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02241-02210-la_croix_sur_ourcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02241-02210-la_croix_sur_ourcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02241-02210-la_croix_sur_ourcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02242-02310-crouttes_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02242-02310-crouttes_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02242-02310-crouttes_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02242-02310-crouttes_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02243-02880-crouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02243-02880-crouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02243-02880-crouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02243-02880-crouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02244-02120-crupilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02244-02120-crupilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02244-02120-crupilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02244-02120-crupilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02245-02880-cuffies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02245-02880-cuffies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02245-02880-cuffies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02245-02880-cuffies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02246-02480-cugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02246-02480-cugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02246-02480-cugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02246-02480-cugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02248-02350-cuirieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02248-02350-cuirieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02248-02350-cuirieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02248-02350-cuirieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02249-02220-cuiry_housse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02249-02220-cuiry_housse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02249-02220-cuiry_housse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02249-02220-cuiry_housse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02250-02160-cuiry_les_chaudardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02250-02160-cuiry_les_chaudardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02250-02160-cuiry_les_chaudardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02250-02160-cuiry_les_chaudardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02251-02360-cuiry_les_iviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02251-02360-cuiry_les_iviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02251-02360-cuiry_les_iviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02251-02360-cuiry_les_iviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02252-02160-cuissy_et_geny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02252-02160-cuissy_et_geny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02252-02160-cuissy_et_geny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02252-02160-cuissy_et_geny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02253-02200-cuisy_en_almont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02253-02200-cuisy_en_almont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02253-02200-cuisy_en_almont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02253-02200-cuisy_en_almont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02254-02600-cutry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02254-02600-cutry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02254-02600-cutry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02254-02600-cutry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02255-02220-cys_la_commune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02255-02220-cys_la_commune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02255-02220-cys_la_commune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02255-02220-cys_la_commune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02256-02140-dagny_lambercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02256-02140-dagny_lambercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02256-02140-dagny_lambercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02256-02140-dagny_lambercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02257-02680-dallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02257-02680-dallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02257-02680-dallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02257-02680-dallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02258-02470-dammard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02258-02470-dammard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02258-02470-dammard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02258-02470-dammard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02259-02600-dampleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02259-02600-dampleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02259-02600-dampleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02259-02600-dampleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02260-02800-danizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02260-02800-danizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02260-02800-danizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02260-02800-danizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02261-02270-dercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02261-02270-dercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02261-02270-dercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02261-02270-dercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02262-02700-deuillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02262-02700-deuillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02262-02700-deuillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02262-02700-deuillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02263-02220-dhuizel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02263-02220-dhuizel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02263-02220-dhuizel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02263-02220-dhuizel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02264-02340-dizy_le_gros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02264-02340-dizy_le_gros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02264-02340-dizy_le_gros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02264-02340-dizy_le_gros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02265-02360-dohis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02265-02360-dohis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02265-02360-dohis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02265-02360-dohis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02266-02360-dolignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02266-02360-dolignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02266-02360-dolignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02266-02360-dolignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02267-02600-dommiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02267-02600-dommiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02267-02600-dommiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02267-02600-dommiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02268-02310-domptin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02268-02310-domptin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02268-02310-domptin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02268-02310-domptin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02269-02450-dorengt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02269-02450-dorengt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02269-02450-dorengt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02269-02450-dorengt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02270-02590-douchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02270-02590-douchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02270-02590-douchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02270-02590-douchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02271-02130-dravegny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02271-02130-dravegny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02271-02130-dravegny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02271-02130-dravegny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02272-02210-droizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02272-02210-droizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02272-02210-droizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02272-02210-droizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02273-02480-dury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02273-02480-dury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02273-02480-dury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02273-02480-dury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02274-02350-ebouleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02274-02350-ebouleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02274-02350-ebouleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02274-02350-ebouleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02275-02500-effry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02275-02500-effry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02275-02500-effry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02275-02500-effry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02276-02260-englancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02276-02260-englancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02276-02260-englancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02276-02260-englancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02277-02290-epagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02277-02290-epagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02277-02290-epagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02277-02290-epagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02278-02500-eparcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02278-02500-eparcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02278-02500-eparcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02278-02500-eparcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02279-02400-epaux_bezu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02279-02400-epaux_bezu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02279-02400-epaux_bezu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02279-02400-epaux_bezu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02280-02400-epieds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02280-02400-epieds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02280-02400-epieds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02280-02400-epieds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02281-02540-l_epine_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02281-02540-l_epine_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02281-02540-l_epine_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02281-02540-l_epine_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02282-02840-eppes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02282-02840-eppes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02282-02840-eppes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02282-02840-eppes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02283-02250-erlon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02283-02250-erlon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02283-02250-erlon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02283-02250-erlon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02284-02260-erloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02284-02260-erloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02284-02260-erloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02284-02260-erloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02286-02170-esqueheries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02286-02170-esqueheries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02286-02170-esqueheries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02286-02170-esqueheries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02287-02690-essigny_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02287-02690-essigny_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02287-02690-essigny_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02287-02690-essigny_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02288-02100-essigny_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02288-02100-essigny_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02288-02100-essigny_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02288-02100-essigny_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02289-02570-essises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02289-02570-essises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02289-02570-essises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02289-02570-essises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02290-02400-essomes_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02290-02400-essomes_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02290-02400-essomes_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02290-02400-essomes_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02291-02420-estrees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02291-02420-estrees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02291-02420-estrees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02291-02420-estrees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02292-02400-etampes_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02292-02400-etampes_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02292-02400-etampes_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02292-02400-etampes_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02293-02110-etaves_et_bocquiaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02293-02110-etaves_et_bocquiaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02293-02110-etaves_et_bocquiaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02293-02110-etaves_et_bocquiaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02294-02000-etouvelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02294-02000-etouvelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02294-02000-etouvelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02294-02000-etouvelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02295-02580-etreaupont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02295-02580-etreaupont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02295-02580-etreaupont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02295-02580-etreaupont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02296-02590-etreillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02296-02590-etreillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02296-02590-etreillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02296-02590-etreillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02297-02400-etrepilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02297-02400-etrepilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02297-02400-etrepilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02297-02400-etrepilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02298-02510-etreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02298-02510-etreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02298-02510-etreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02298-02510-etreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02299-02190-evergnicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02299-02190-evergnicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02299-02190-evergnicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02299-02190-evergnicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02302-02600-faverolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02302-02600-faverolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02302-02600-faverolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02302-02600-faverolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02303-02100-fayet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02303-02100-fayet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02303-02100-fayet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02303-02100-fayet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02304-02800-la_fere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02304-02800-la_fere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02304-02800-la_fere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02304-02800-la_fere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02305-02130-fere_en_tardenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02305-02130-fere_en_tardenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02305-02130-fere_en_tardenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02305-02130-fere_en_tardenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02306-02270-la_ferte_chevresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02306-02270-la_ferte_chevresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02306-02270-la_ferte_chevresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02306-02270-la_ferte_chevresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02307-02460-la_ferte_milon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02307-02460-la_ferte_milon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02307-02460-la_ferte_milon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02307-02460-la_ferte_milon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02308-02450-fesmy_le_sart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02308-02450-fesmy_le_sart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02308-02450-fesmy_le_sart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02308-02450-fesmy_le_sart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02309-02840-festieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02309-02840-festieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02309-02840-festieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02309-02840-festieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02310-02110-fieulaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02310-02110-fieulaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02310-02110-fieulaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02310-02110-fieulaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02311-02000-filain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02311-02000-filain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02311-02000-filain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02311-02000-filain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02312-02260-la_flamengrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02312-02260-la_flamengrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02312-02260-la_flamengrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02312-02260-la_flamengrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02313-02120-flavigny_le_grand_et_beaurain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02313-02120-flavigny_le_grand_et_beaurain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02313-02120-flavigny_le_grand_et_beaurain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02313-02120-flavigny_le_grand_et_beaurain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02315-02520-flavy_le_martel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02315-02520-flavy_le_martel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02315-02520-flavy_le_martel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02315-02520-flavy_le_martel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02316-02600-fleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02316-02600-fleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02316-02600-fleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02316-02600-fleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02317-02590-fluquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02317-02590-fluquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02317-02590-fluquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02317-02590-fluquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02318-02670-folembray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02318-02670-folembray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02318-02670-folembray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02318-02670-folembray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02319-02110-fonsomme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02319-02110-fonsomme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02319-02110-fonsomme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02319-02110-fonsomme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02320-02680-fontaine_les_clercs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02320-02680-fontaine_les_clercs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02320-02680-fontaine_les_clercs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02320-02680-fontaine_les_clercs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02321-02140-fontaine_les_vervins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02321-02140-fontaine_les_vervins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02321-02140-fontaine_les_vervins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02321-02140-fontaine_les_vervins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02322-02110-fontaine_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02322-02110-fontaine_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02322-02110-fontaine_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02322-02110-fontaine_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02323-02110-fontaine_uterte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02323-02110-fontaine_uterte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02323-02110-fontaine_uterte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02323-02110-fontaine_uterte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02324-02170-fontenelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02324-02170-fontenelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02324-02170-fontenelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02324-02170-fontenelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02326-02290-fontenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02326-02290-fontenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02326-02290-fontenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02326-02290-fontenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02327-02590-foreste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02327-02590-foreste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02327-02590-foreste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02327-02590-foreste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02328-02650-fossoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02328-02650-fossoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02328-02650-fossoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02328-02650-fossoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02329-02870-fourdrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02329-02870-fourdrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02329-02870-fourdrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02329-02870-fourdrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02330-02760-francilly_selency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02330-02760-francilly_selency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02330-02760-francilly_selency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02330-02760-francilly_selency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02331-02140-franqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02331-02140-franqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02331-02140-franqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02331-02140-franqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02332-02130-fresnes_en_tardenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02332-02130-fresnes_en_tardenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02332-02130-fresnes_en_tardenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02332-02130-fresnes_en_tardenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02333-02380-fresnes_sous_coucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02333-02380-fresnes_sous_coucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02333-02380-fresnes_sous_coucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02333-02380-fresnes_sous_coucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02334-02230-fresnoy_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02334-02230-fresnoy_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02334-02230-fresnoy_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02334-02230-fresnoy_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02335-02800-fressancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02335-02800-fressancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02335-02800-fressancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02335-02800-fressancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02336-02700-frieres_faillouel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02336-02700-frieres_faillouel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02336-02700-frieres_faillouel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02336-02700-frieres_faillouel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02337-02260-froidestrees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02337-02260-froidestrees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02337-02260-froidestrees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02337-02260-froidestrees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02338-02270-froidmont_cohartille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02338-02270-froidmont_cohartille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02338-02270-froidmont_cohartille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02338-02270-froidmont_cohartille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02339-02810-gandelu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02339-02810-gandelu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02339-02810-gandelu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02339-02810-gandelu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02340-02430-gauchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02340-02430-gauchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02340-02430-gauchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02340-02430-gauchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02341-02140-gercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02341-02140-gercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02341-02140-gercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02341-02140-gercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02342-02260-gergny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02342-02260-gergny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02342-02260-gergny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02342-02260-gergny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02343-02590-germaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02343-02590-germaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02343-02590-germaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02343-02590-germaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02345-02440-gibercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02345-02440-gibercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02345-02440-gibercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02345-02440-gibercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02346-02350-gizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02346-02350-gizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02346-02350-gizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02346-02350-gizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02347-02400-gland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02347-02400-gland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02347-02400-gland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02347-02400-gland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02349-02820-goudelancourt_les_berrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02349-02820-goudelancourt_les_berrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02349-02820-goudelancourt_les_berrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02349-02820-goudelancourt_les_berrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02350-02350-goudelancourt_les_pierrepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02350-02350-goudelancourt_les_pierrepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02350-02350-goudelancourt_les_pierrepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02350-02350-goudelancourt_les_pierrepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02351-02130-goussancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02351-02130-goussancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02351-02130-goussancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02351-02130-goussancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02352-02420-gouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02352-02420-gouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02352-02420-gouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02352-02420-gouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02353-02350-grandlup_et_fay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02353-02350-grandlup_et_fay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02353-02350-grandlup_et_fay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02353-02350-grandlup_et_fay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02354-02360-grandrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02354-02360-grandrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02354-02360-grandrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02354-02360-grandrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02355-02100-gricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02355-02100-gricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02355-02100-gricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02355-02100-gricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02356-02210-grisolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02356-02210-grisolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02356-02210-grisolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02356-02210-grisolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02357-02140-gronard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02357-02140-gronard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02357-02140-gronard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02357-02140-gronard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02358-02110-grougis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02358-02110-grougis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02358-02110-grougis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02358-02110-grougis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02359-02680-grugies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02359-02680-grugies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02359-02680-grugies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02359-02680-grugies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02360-02190-villeneuve_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02360-02190-villeneuve_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02360-02190-villeneuve_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02360-02190-villeneuve_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02361-02120-guise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02361-02120-guise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02361-02120-guise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02361-02120-guise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02362-02300-guivry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02362-02300-guivry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02362-02300-guivry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02362-02300-guivry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02363-02300-guny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02363-02300-guny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02363-02300-guny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02363-02300-guny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02364-02160-guyencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02364-02160-guyencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02364-02160-guyencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02364-02160-guyencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02366-02510-hannapes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02366-02510-hannapes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02366-02510-hannapes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02366-02510-hannapes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02367-02480-happencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02367-02480-happencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02367-02480-happencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02367-02480-happencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02368-02600-haramont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02368-02600-haramont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02368-02600-haramont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02368-02600-haramont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02369-02140-harcigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02369-02140-harcigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02369-02140-harcigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02369-02140-harcigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02370-02420-hargicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02370-02420-hargicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02370-02420-hargicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02370-02420-hargicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02371-02100-harly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02371-02100-harly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02371-02100-harly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02371-02100-harly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02372-02210-hartennes_et_taux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02372-02210-hartennes_et_taux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02372-02210-hartennes_et_taux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02372-02210-hartennes_et_taux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02373-02140-hary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02373-02140-hary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02373-02140-hary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02373-02140-hary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02374-02420-lehaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02374-02420-lehaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02374-02420-lehaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02374-02420-lehaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02375-02810-hautevesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02375-02810-hautevesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02375-02810-hautevesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02375-02810-hautevesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02376-02120-hauteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02376-02120-hauteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02376-02120-hauteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02376-02120-hauteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02377-02140-haution/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02377-02140-haution/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02377-02140-haution/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02377-02140-haution/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02378-02500-la_herie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02378-02500-la_herie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02378-02500-la_herie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02378-02500-la_herie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02379-02120-le_herie_la_vieville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02379-02120-le_herie_la_vieville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02379-02120-le_herie_la_vieville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02379-02120-le_herie_la_vieville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02380-02440-hinacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02380-02440-hinacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02380-02440-hinacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02380-02440-hinacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02381-02500-hirson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02381-02500-hirson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02381-02500-hirson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02381-02500-hirson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02382-02760-holnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02382-02760-holnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02382-02760-holnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02382-02760-holnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02383-02720-homblieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02383-02720-homblieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02383-02720-homblieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02383-02720-homblieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02384-02140-houry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02384-02140-houry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02384-02140-houry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02384-02140-houry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02385-02250-housset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02385-02250-housset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02385-02250-housset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02385-02250-housset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02386-02510-iron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02386-02510-iron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02386-02510-iron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02386-02510-iron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02387-02240-itancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02387-02240-itancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02387-02240-itancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02387-02240-itancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02388-02360-iviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02388-02360-iviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02388-02360-iviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02388-02360-iviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02389-02850-jaulgonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02389-02850-jaulgonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02389-02850-jaulgonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02389-02850-jaulgonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02390-02490-jeancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02390-02490-jeancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02390-02490-jeancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02390-02490-jeancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02391-02140-jeantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02391-02140-jeantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02391-02140-jeantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02391-02140-jeantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02392-02420-joncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02392-02420-joncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02392-02420-joncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02392-02420-joncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02393-02220-jouaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02393-02220-jouaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02393-02220-jouaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02393-02220-jouaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02395-02380-jumencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02395-02380-jumencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02395-02380-jumencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02395-02380-jumencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02396-02160-jumigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02396-02160-jumigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02396-02160-jumigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02396-02160-jumigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02397-02480-jussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02397-02480-jussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02397-02480-jussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02397-02480-jussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02398-02880-juvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02398-02880-juvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02398-02880-juvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02398-02880-juvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02399-02190-juvincourt_et_damary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02399-02190-juvincourt_et_damary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02399-02190-juvincourt_et_damary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02399-02190-juvincourt_et_damary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02400-02880-laffaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02400-02880-laffaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02400-02880-laffaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02400-02880-laffaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02401-02140-laigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02401-02140-laigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02401-02140-laigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02401-02140-laigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02402-02590-lanchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02402-02590-lanchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02402-02590-lanchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02402-02590-lanchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02403-02120-landifay_et_bertaignemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02403-02120-landifay_et_bertaignemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02403-02120-landifay_et_bertaignemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02403-02120-landifay_et_bertaignemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02404-02140-landouzy_la_cour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02404-02140-landouzy_la_cour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02404-02140-landouzy_la_cour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02404-02140-landouzy_la_cour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02405-02140-landouzy_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02405-02140-landouzy_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02405-02140-landouzy_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02405-02140-landouzy_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02406-02380-landricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02406-02380-landricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02406-02380-landricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02406-02380-landricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02407-02000-laniscourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02407-02000-laniscourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02407-02000-laniscourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02407-02000-laniscourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02408-02000-laon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02408-02000-laon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02408-02000-laon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02408-02000-laon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02409-02150-lappion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02409-02150-lappion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02409-02150-lappion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02409-02150-lappion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02410-02600-largny_sur_automne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02410-02600-largny_sur_automne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02410-02600-largny_sur_automne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02410-02600-largny_sur_automne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02411-02210-latilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02411-02210-latilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02411-02210-latilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02411-02210-latilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02412-02210-launoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02412-02210-launoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02412-02210-launoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02412-02210-launoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02413-02860-laval_en_laonnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02413-02860-laval_en_laonnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02413-02860-laval_en_laonnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02413-02860-laval_en_laonnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02414-02450-lavaqueresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02414-02450-lavaqueresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02414-02450-lavaqueresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02414-02450-lavaqueresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02415-02600-laversine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02415-02600-laversine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02415-02600-laversine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02415-02600-laversine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02416-02140-leme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02416-02140-leme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02416-02140-leme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02416-02140-leme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02417-02420-lempire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02417-02420-lempire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02417-02420-lempire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02417-02420-lempire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02418-02260-lerzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02418-02260-lerzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02418-02260-lerzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02418-02260-lerzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02419-02170-leschelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02419-02170-leschelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02419-02170-leschelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02419-02170-leschelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02420-02100-lesdins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02420-02100-lesdins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02420-02100-lesdins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02420-02100-lesdins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02421-02220-lesges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02421-02220-lesges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02421-02220-lesges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02421-02220-lesges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02422-02120-lesquielles_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02422-02120-lesquielles_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02422-02120-lesquielles_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02422-02120-lesquielles_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02423-02380-leuilly_sous_coucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02423-02380-leuilly_sous_coucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02423-02380-leuilly_sous_coucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02423-02380-leuilly_sous_coucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02424-02880-leury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02424-02880-leury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02424-02880-leury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02424-02880-leury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02425-02500-leuze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02425-02500-leuze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02425-02500-leuze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02425-02500-leuze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02426-02420-levergies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02426-02420-levergies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02426-02420-levergies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02426-02420-levergies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02427-02220-lhuys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02427-02220-lhuys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02427-02220-lhuys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02427-02220-lhuys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02428-02810-licy_clignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02428-02810-licy_clignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02428-02810-licy_clignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02428-02810-licy_clignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02429-02860-lierval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02429-02860-lierval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02429-02860-lierval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02429-02860-lierval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02430-02350-liesse_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02430-02350-liesse_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02430-02350-liesse_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02430-02350-liesse_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02431-02700-liez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02431-02700-liez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02431-02700-liez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02431-02700-liez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02432-02220-lime/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02432-02220-lime/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02432-02220-lime/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02432-02220-lime/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02433-02340-lislet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02433-02340-lislet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02433-02340-lislet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02433-02340-lislet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02435-02500-logny_les_aubenton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02435-02500-logny_les_aubenton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02435-02500-logny_les_aubenton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02435-02500-logny_les_aubenton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02438-02600-longpont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02438-02600-longpont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02438-02600-longpont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02438-02600-longpont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02439-02160-les_septvallons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02439-02160-les_septvallons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02439-02160-les_septvallons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02439-02160-les_septvallons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02440-02190-lor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02440-02190-lor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02440-02190-lor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02440-02190-lor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02441-02600-louatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02441-02600-louatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02441-02600-louatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02441-02600-louatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02442-02130-loupeigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02442-02130-loupeigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02442-02130-loupeigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02442-02130-loupeigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02443-02400-lucy_le_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02443-02400-lucy_le_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02443-02400-lucy_le_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02443-02400-lucy_le_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02444-02140-lugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02444-02140-lugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02444-02140-lugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02444-02140-lugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02445-02500-luzoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02445-02500-luzoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02445-02500-luzoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02445-02500-luzoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02446-02440-ly_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02446-02440-ly_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02446-02440-ly_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02446-02440-ly_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02447-02220-maast_et_violaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02447-02220-maast_et_violaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02447-02220-maast_et_violaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02447-02220-maast_et_violaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02448-02350-machecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02448-02350-machecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02448-02350-machecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02448-02350-machecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02449-02470-macogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02449-02470-macogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02449-02470-macogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02449-02470-macogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02450-02120-macquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02450-02120-macquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02450-02120-macquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02450-02120-macquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02451-02420-magny_la_fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02451-02420-magny_la_fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02451-02420-magny_la_fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02451-02420-magny_la_fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02452-02490-maissemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02452-02490-maissemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02452-02490-maissemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02452-02490-maissemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02453-02160-maizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02453-02160-maizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02453-02160-maizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02453-02160-maizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02454-02190-la_malmaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02454-02190-la_malmaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02454-02190-la_malmaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02454-02190-la_malmaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02455-02120-malzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02455-02120-malzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02455-02120-malzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02455-02120-malzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02456-02300-manicamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02456-02300-manicamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02456-02300-manicamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02456-02300-manicamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02457-02350-marchais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02457-02350-marchais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02457-02350-marchais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02457-02350-marchais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02458-02540-dhuys_et_morin_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02458-02540-dhuys_et_morin_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02458-02540-dhuys_et_morin_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02458-02540-dhuys_et_morin_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02458-02330-dhuys_et_morin_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02458-02330-dhuys_et_morin_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02458-02330-dhuys_et_morin_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02458-02330-dhuys_et_morin_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02459-02720-marcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02459-02720-marcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02459-02720-marcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02459-02720-marcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02460-02250-marcy_sous_marle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02460-02250-marcy_sous_marle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02460-02250-marcy_sous_marle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02460-02250-marcy_sous_marle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02461-02300-marest_dampcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02461-02300-marest_dampcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02461-02300-marest_dampcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02461-02300-marest_dampcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02462-02130-mareuil_en_dole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02462-02130-mareuil_en_dole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02462-02130-mareuil_en_dole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02462-02130-mareuil_en_dole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02463-02140-marfontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02463-02140-marfontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02463-02140-marfontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02463-02140-marfontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02464-02880-margival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02464-02880-margival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02464-02880-margival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02464-02880-margival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02465-02810-marigny_en_orxois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02465-02810-marigny_en_orxois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02465-02810-marigny_en_orxois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02465-02810-marigny_en_orxois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02466-02470-marizy_sainte_genevieve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02466-02470-marizy_sainte_genevieve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02466-02470-marizy_sainte_genevieve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02466-02470-marizy_sainte_genevieve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02467-02470-marizy_saint_mard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02467-02470-marizy_saint_mard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02467-02470-marizy_saint_mard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02467-02470-marizy_saint_mard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02468-02250-marle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02468-02250-marle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02468-02250-marle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02468-02250-marle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02469-02120-marly_gomont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02469-02120-marly_gomont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02469-02120-marly_gomont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02469-02120-marly_gomont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02470-02500-martigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02470-02500-martigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02470-02500-martigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02470-02500-martigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02471-02860-martigny_courpierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02471-02860-martigny_courpierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02471-02860-martigny_courpierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02471-02860-martigny_courpierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02472-02820-mauregny_en_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02472-02820-mauregny_en_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02472-02820-mauregny_en_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02472-02820-mauregny_en_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02473-02800-mayot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02473-02800-mayot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02473-02800-mayot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02473-02800-mayot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02474-02700-mennessis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02474-02700-mennessis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02474-02700-mennessis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02474-02700-mennessis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02476-02630-mennevret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02476-02630-mennevret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02476-02630-mennevret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02476-02630-mennevret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02477-02200-mercin_et_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02477-02200-mercin_et_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02477-02200-mercin_et_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02477-02200-mercin_et_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02478-02000-merlieux_et_fouquerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02478-02000-merlieux_et_fouquerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02478-02000-merlieux_et_fouquerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02478-02000-merlieux_et_fouquerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02480-02270-mesbrecourt_richecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02480-02270-mesbrecourt_richecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02480-02270-mesbrecourt_richecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02480-02270-mesbrecourt_richecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02481-02720-mesnil_saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02481-02720-mesnil_saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02481-02720-mesnil_saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02481-02720-mesnil_saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02482-02160-meurival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02482-02160-meurival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02482-02160-meurival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02482-02160-meurival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02483-02240-mezieres_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02483-02240-mezieres_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02483-02240-mezieres_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02483-02240-mezieres_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02484-02650-mezy_moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02484-02650-mezy_moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02484-02650-mezy_moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02484-02650-mezy_moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02485-02200-missy_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02485-02200-missy_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02485-02200-missy_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02485-02200-missy_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02486-02350-missy_les_pierrepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02486-02350-missy_les_pierrepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02486-02350-missy_les_pierrepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02486-02350-missy_les_pierrepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02487-02880-missy_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02487-02880-missy_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02487-02880-missy_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02487-02880-missy_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02488-02110-molain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02488-02110-molain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02488-02110-molain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02488-02110-molain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02489-02000-molinchart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02489-02000-molinchart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02489-02000-molinchart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02489-02000-molinchart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02490-02000-monampteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02490-02000-monampteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02490-02000-monampteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02490-02000-monampteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02491-02270-monceau_le_neuf_et_faucouzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02491-02270-monceau_le_neuf_et_faucouzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02491-02270-monceau_le_neuf_et_faucouzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02491-02270-monceau_le_neuf_et_faucouzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02492-02270-monceau_les_leups/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02492-02270-monceau_les_leups/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02492-02270-monceau_les_leups/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02492-02270-monceau_les_leups/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02493-02840-monceau_le_waast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02493-02840-monceau_le_waast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02493-02840-monceau_le_waast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02493-02840-monceau_le_waast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02494-02120-monceau_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02494-02120-monceau_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02494-02120-monceau_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02494-02120-monceau_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02495-02500-mondrepuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02495-02500-mondrepuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02495-02500-mondrepuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02495-02500-mondrepuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02496-02470-monnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02496-02470-monnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02496-02470-monnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02496-02470-monnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02497-02000-mons_en_laonnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02497-02000-mons_en_laonnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02497-02000-mons_en_laonnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02497-02000-mons_en_laonnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02498-02820-montaigu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02498-02820-montaigu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02498-02820-montaigu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02498-02820-montaigu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02499-02000-montbavin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02499-02000-montbavin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02499-02000-montbavin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02499-02000-montbavin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02500-02110-montbrehain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02500-02110-montbrehain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02500-02110-montbrehain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02500-02110-montbrehain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02501-02860-montchalons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02501-02860-montchalons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02501-02860-montchalons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02501-02860-montchalons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02502-02340-montcornet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02502-02340-montcornet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02502-02340-montcornet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02502-02340-montcornet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02503-02390-mont_d_origny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02503-02390-mont_d_origny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02503-02390-mont_d_origny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02503-02390-mont_d_origny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02504-02440-montescourt_lizerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02504-02440-montescourt_lizerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02504-02440-montescourt_lizerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02504-02440-montescourt_lizerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02505-02540-montfaucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02505-02540-montfaucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02505-02540-montfaucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02505-02540-montfaucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02506-02600-montgobert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02506-02600-montgobert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02506-02600-montgobert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02506-02600-montgobert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02507-02210-montgru_saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02507-02210-montgru_saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02507-02210-montgru_saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02507-02210-montgru_saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02508-02860-monthenault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02508-02860-monthenault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02508-02860-monthenault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02508-02860-monthenault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02509-02400-monthiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02509-02400-monthiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02509-02400-monthiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02509-02400-monthiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02510-02330-monthurel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02510-02330-monthurel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02510-02330-monthurel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02510-02330-monthurel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02511-02110-montigny_en_arrouaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02511-02110-montigny_en_arrouaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02511-02110-montigny_en_arrouaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02511-02110-montigny_en_arrouaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02512-02810-montigny_l_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02512-02810-montigny_l_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02512-02810-montigny_l_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02512-02810-montigny_l_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02513-02250-montigny_le_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02513-02250-montigny_le_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02513-02250-montigny_le_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02513-02250-montigny_le_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02514-02290-montigny_lengrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02514-02290-montigny_lengrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02514-02290-montigny_lengrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02514-02290-montigny_lengrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02515-02330-montigny_les_conde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02515-02330-montigny_les_conde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02515-02330-montigny_les_conde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02515-02330-montigny_les_conde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02516-02250-montigny_sous_marle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02516-02250-montigny_sous_marle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02516-02250-montigny_sous_marle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02516-02250-montigny_sous_marle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02517-02270-montigny_sur_crecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02517-02270-montigny_sur_crecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02517-02270-montigny_sur_crecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02517-02270-montigny_sur_crecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02518-02330-montlevon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02518-02330-montlevon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02518-02330-montlevon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02518-02330-montlevon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02519-02340-montloue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02519-02340-montloue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02519-02340-montloue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02519-02340-montloue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02520-02220-mont_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02520-02220-mont_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02520-02220-mont_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02520-02220-mont_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02521-02310-montreuil_aux_lions/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02521-02310-montreuil_aux_lions/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02521-02310-montreuil_aux_lions/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02521-02310-montreuil_aux_lions/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02522-02360-mont_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02522-02360-mont_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02522-02360-mont_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02522-02360-mont_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02523-02220-mont_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02523-02220-mont_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02523-02220-mont_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02523-02220-mont_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02524-02400-mont_saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02524-02400-mont_saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02524-02400-mont_saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02524-02400-mont_saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02525-02100-morcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02525-02100-morcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02525-02100-morcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02525-02100-morcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02526-02360-morgny_en_thierache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02526-02360-morgny_en_thierache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02526-02360-morgny_en_thierache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02526-02360-morgny_en_thierache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02527-02290-morsain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02527-02290-morsain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02527-02290-morsain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02527-02290-morsain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02528-02600-mortefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02528-02600-mortefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02528-02600-mortefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02528-02600-mortefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02529-02270-mortiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02529-02270-mortiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02529-02270-mortiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02529-02270-mortiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02530-02160-moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02530-02160-moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02530-02160-moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02530-02160-moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02531-02160-moussy_verneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02531-02160-moussy_verneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02531-02160-moussy_verneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02531-02160-moussy_verneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02532-02610-moÿ_de_l_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02532-02610-moÿ_de_l_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02532-02610-moÿ_de_l_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02532-02610-moÿ_de_l_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02533-02210-muret_et_crouttes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02533-02210-muret_et_crouttes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02533-02210-muret_et_crouttes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02533-02210-muret_et_crouttes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02534-02160-muscourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02534-02160-muscourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02534-02160-muscourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02534-02160-muscourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02535-02140-nampcelles_la_cour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02535-02140-nampcelles_la_cour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02535-02140-nampcelles_la_cour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02535-02140-nampcelles_la_cour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02536-02200-nampteuil_sous_muret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02536-02200-nampteuil_sous_muret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02536-02200-nampteuil_sous_muret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02536-02200-nampteuil_sous_muret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02537-02880-nanteuil_la_fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02537-02880-nanteuil_la_fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02537-02880-nanteuil_la_fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02537-02880-nanteuil_la_fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02538-02210-nanteuil_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02538-02210-nanteuil_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02538-02210-nanteuil_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02538-02210-nanteuil_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02539-02420-nauroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02539-02420-nauroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02539-02420-nauroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02539-02420-nauroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02540-02400-nesles_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02540-02400-nesles_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02540-02400-nesles_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02540-02400-nesles_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02541-02190-neufchatel_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02541-02190-neufchatel_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02541-02190-neufchatel_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02541-02190-neufchatel_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02542-02300-neuflieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02542-02300-neuflieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02542-02300-neuflieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02542-02300-neuflieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02543-02470-neuilly_saint_front/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02543-02470-neuilly_saint_front/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02543-02470-neuilly_saint_front/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02543-02470-neuilly_saint_front/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02544-02500-neuve_maison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02544-02500-neuve_maison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02544-02500-neuve_maison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02544-02500-neuve_maison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02545-02250-la_neuville_bosmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02545-02250-la_neuville_bosmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02545-02250-la_neuville_bosmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02545-02250-la_neuville_bosmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02546-02300-la_neuville_en_beine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02546-02300-la_neuville_en_beine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02546-02300-la_neuville_en_beine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02546-02300-la_neuville_en_beine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02547-02250-la_neuville_housset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02547-02250-la_neuville_housset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02547-02250-la_neuville_housset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02547-02250-la_neuville_housset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02548-02450-la_neuville_les_dorengt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02548-02450-la_neuville_les_dorengt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02548-02450-la_neuville_les_dorengt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02548-02450-la_neuville_les_dorengt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02549-02100-neuville_saint_amand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02549-02100-neuville_saint_amand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02549-02100-neuville_saint_amand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02549-02100-neuville_saint_amand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02550-02860-neuville_sur_ailette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02550-02860-neuville_sur_ailette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02550-02860-neuville_sur_ailette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02550-02860-neuville_sur_ailette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02551-02880-neuville_sur_margival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02551-02880-neuville_sur_margival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02551-02880-neuville_sur_margival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02551-02880-neuville_sur_margival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02552-02390-neuvillette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02552-02390-neuvillette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02552-02390-neuvillette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02552-02390-neuvillette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02553-02150-nizy_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02553-02150-nizy_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02553-02150-nizy_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02553-02150-nizy_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02554-02400-nogentel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02554-02400-nogentel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02554-02400-nogentel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02554-02400-nogentel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02555-02310-nogent_l_artaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02555-02310-nogent_l_artaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02555-02310-nogent_l_artaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02555-02310-nogent_l_artaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02556-02340-noircourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02556-02340-noircourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02556-02340-noircourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02556-02340-noircourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02557-02600-noroy_sur_ourcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02557-02600-noroy_sur_ourcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02557-02600-noroy_sur_ourcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02557-02600-noroy_sur_ourcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02558-02170-le_nouvion_en_thierache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02558-02170-le_nouvion_en_thierache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02558-02170-le_nouvion_en_thierache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02558-02170-le_nouvion_en_thierache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02559-02270-nouvion_et_catillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02559-02270-nouvion_et_catillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02559-02270-nouvion_et_catillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02559-02270-nouvion_et_catillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02560-02800-nouvion_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02560-02800-nouvion_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02560-02800-nouvion_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02560-02800-nouvion_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02561-02860-nouvion_le_vineux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02561-02860-nouvion_le_vineux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02561-02860-nouvion_le_vineux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02561-02860-nouvion_le_vineux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02562-02290-nouvron_vingre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02562-02290-nouvron_vingre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02562-02290-nouvron_vingre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02562-02290-nouvron_vingre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02563-02120-noyales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02563-02120-noyales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02563-02120-noyales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02563-02120-noyales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02564-02200-noyant_et_aconin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02564-02200-noyant_et_aconin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02564-02200-noyant_et_aconin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02564-02200-noyant_et_aconin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02565-02160-oeuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02565-02160-oeuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02565-02160-oeuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02565-02160-oeuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02566-02300-ognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02566-02300-ognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02566-02300-ognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02566-02300-ognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02567-02500-ohis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02567-02500-ohis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02567-02500-ohis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02567-02500-ohis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02568-02600-oigny_en_valois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02568-02600-oigny_en_valois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02568-02600-oigny_en_valois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02568-02600-oigny_en_valois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02569-02450-oisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02569-02450-oisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02569-02450-oisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02569-02450-oisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02570-02480-ollezy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02570-02480-ollezy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02570-02480-ollezy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02570-02480-ollezy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02571-02100-omissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02571-02100-omissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02571-02100-omissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02571-02100-omissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02572-02190-orainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02572-02190-orainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02572-02190-orainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02572-02190-orainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02573-02860-orgeval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02573-02860-orgeval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02573-02860-orgeval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02573-02860-orgeval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02574-02550-origny_en_thierache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02574-02550-origny_en_thierache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02574-02550-origny_en_thierache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02574-02550-origny_en_thierache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02575-02390-origny_sainte_benoite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02575-02390-origny_sainte_benoite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02575-02390-origny_sainte_benoite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02575-02390-origny_sainte_benoite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02576-02290-osly_courtil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02576-02290-osly_courtil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02576-02290-osly_courtil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02576-02290-osly_courtil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02577-02370-ostel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02577-02370-ostel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02577-02370-ostel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02577-02370-ostel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02578-02160-oulches_la_vallee_foulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02578-02160-oulches_la_vallee_foulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02578-02160-oulches_la_vallee_foulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02578-02160-oulches_la_vallee_foulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02579-02210-oulchy_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02579-02210-oulchy_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02579-02210-oulchy_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02579-02210-oulchy_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02580-02210-oulchy_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02580-02210-oulchy_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02580-02210-oulchy_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02580-02210-oulchy_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02581-02220-paars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02581-02220-paars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02581-02220-paars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02581-02220-paars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02582-02160-paissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02582-02160-paissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02582-02160-paissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02582-02160-paissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02583-02860-pancy_courtecon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02583-02860-pancy_courtecon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02583-02860-pancy_courtecon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02583-02860-pancy_courtecon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02584-02260-papleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02584-02260-papleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02584-02260-papleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02584-02260-papleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02585-02210-parcy_et_tigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02585-02210-parcy_et_tigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02585-02210-parcy_et_tigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02585-02210-parcy_et_tigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02586-02360-parfondeval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02586-02360-parfondeval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02586-02360-parfondeval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02586-02360-parfondeval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02587-02840-parfondru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02587-02840-parfondru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02587-02840-parfondru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02587-02840-parfondru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02588-02160-pargnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02588-02160-pargnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02588-02160-pargnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02588-02160-pargnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02589-02000-pargny_filain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02589-02000-pargny_filain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02589-02000-pargny_filain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02589-02000-pargny_filain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02590-02330-pargny_la_dhuys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02590-02330-pargny_la_dhuys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02590-02330-pargny_la_dhuys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02590-02330-pargny_la_dhuys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02591-02270-pargny_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02591-02270-pargny_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02591-02270-pargny_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02591-02270-pargny_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02592-02240-parpeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02592-02240-parpeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02592-02240-parpeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02592-02240-parpeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02593-02200-pasly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02593-02200-pasly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02593-02200-pasly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02593-02200-pasly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02594-02470-passy_en_valois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02594-02470-passy_en_valois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02594-02470-passy_en_valois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02594-02470-passy_en_valois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02595-02850-passy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02595-02850-passy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02595-02850-passy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02595-02850-passy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02596-02310-pavant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02596-02310-pavant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02596-02310-pavant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02596-02310-pavant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02598-02200-pernant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02598-02200-pernant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02598-02200-pernant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02598-02200-pernant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02599-02300-pierremande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02599-02300-pierremande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02599-02300-pierremande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02599-02300-pierremande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02600-02350-pierrepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02600-02350-pierrepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02600-02350-pierrepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02600-02350-pierrepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02601-02190-pignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02601-02190-pignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02601-02190-pignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02601-02190-pignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02602-02320-pinon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02602-02320-pinon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02602-02320-pinon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02602-02320-pinon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02604-02480-pithon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02604-02480-pithon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02604-02480-pithon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02604-02480-pithon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02605-02240-pleine_selve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02605-02240-pleine_selve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02605-02240-pleine_selve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02605-02240-pleine_selve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02606-02210-le_plessier_huleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02606-02210-le_plessier_huleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02606-02210-le_plessier_huleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02606-02210-le_plessier_huleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02607-02200-ploisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02607-02200-ploisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02607-02200-ploisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02607-02200-ploisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02608-02140-plomion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02608-02140-plomion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02608-02140-plomion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02608-02140-plomion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02609-02860-ployart_et_vaurseine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02609-02860-ployart_et_vaurseine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02609-02860-ployart_et_vaurseine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02609-02860-ployart_et_vaurseine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02610-02200-pommiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02610-02200-pommiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02610-02200-pommiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02610-02200-pommiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02612-02160-pont_arcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02612-02160-pont_arcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02612-02160-pont_arcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02612-02160-pont_arcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02613-02160-pontavert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02613-02160-pontavert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02613-02160-pontavert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02613-02160-pontavert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02614-02490-pontru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02614-02490-pontru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02614-02490-pontru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02614-02490-pontru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02615-02490-pontruet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02615-02490-pontruet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02615-02490-pontruet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02615-02490-pontruet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02616-02380-pont_saint_mard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02616-02380-pont_saint_mard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02616-02380-pont_saint_mard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02616-02380-pont_saint_mard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02617-02270-pouilly_sur_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02617-02270-pouilly_sur_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02617-02270-pouilly_sur_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02617-02270-pouilly_sur_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02618-02110-premont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02618-02110-premont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02618-02110-premont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02618-02110-premont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02619-02320-premontre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02619-02320-premontre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02619-02320-premontre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02619-02320-premontre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02620-02370-presles_et_boves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02620-02370-presles_et_boves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02620-02370-presles_et_boves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02620-02370-presles_et_boves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02621-02860-presles_et_thierny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02621-02860-presles_et_thierny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02621-02860-presles_et_thierny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02621-02860-presles_et_thierny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02622-02470-priez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02622-02470-priez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02622-02470-priez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02622-02470-priez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02623-02140-prisces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02623-02140-prisces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02623-02140-prisces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02623-02140-prisces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02624-02120-proisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02624-02120-proisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02624-02120-proisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02624-02120-proisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02625-02120-proix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02625-02120-proix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02625-02120-proix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02625-02120-proix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02626-02190-prouvais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02626-02190-prouvais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02626-02190-prouvais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02626-02190-prouvais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02627-02190-proviseux_et_plesnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02627-02190-proviseux_et_plesnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02627-02190-proviseux_et_plesnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02627-02190-proviseux_et_plesnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02628-02600-puiseux_en_retz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02628-02600-puiseux_en_retz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02628-02600-puiseux_en_retz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02628-02600-puiseux_en_retz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02629-02120-puisieux_et_clanlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02629-02120-puisieux_et_clanlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02629-02120-puisieux_et_clanlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02629-02120-puisieux_et_clanlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02631-02300-quierzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02631-02300-quierzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02631-02300-quierzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02631-02300-quierzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02632-02380-quincy_basse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02632-02380-quincy_basse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02632-02380-quincy_basse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02632-02380-quincy_basse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02633-02220-quincy_sous_le_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02633-02220-quincy_sous_le_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02633-02220-quincy_sous_le_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02633-02220-quincy_sous_le_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02634-02360-raillimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02634-02360-raillimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02634-02360-raillimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02634-02360-raillimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02635-02110-ramicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02635-02110-ramicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02635-02110-ramicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02635-02110-ramicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02636-02240-regny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02636-02240-regny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02636-02240-regny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02636-02240-regny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02637-02100-remaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02637-02100-remaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02637-02100-remaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02637-02100-remaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02638-02270-remies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02638-02270-remies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02638-02270-remies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02638-02270-remies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02639-02440-remigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02639-02440-remigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02639-02440-remigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02639-02440-remigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02640-02240-renansart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02640-02240-renansart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02640-02240-renansart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02640-02240-renansart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02641-02340-renneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02641-02340-renneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02641-02340-renneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02641-02340-renneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02642-02360-resigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02642-02360-resigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02642-02360-resigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02642-02360-resigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02643-02290-ressons_le_long/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02643-02290-ressons_le_long/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02643-02290-ressons_le_long/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02643-02290-ressons_le_long/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02644-02600-retheuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02644-02600-retheuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02644-02600-retheuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02644-02600-retheuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02645-02850-reuilly_sauvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02645-02850-reuilly_sauvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02645-02850-reuilly_sauvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02645-02850-reuilly_sauvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02647-02110-ribeauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02647-02110-ribeauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02647-02110-ribeauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02647-02110-ribeauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02648-02240-ribemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02648-02240-ribemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02648-02240-ribemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02648-02240-ribemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02649-02210-rocourt_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02649-02210-rocourt_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02649-02210-rocourt_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02649-02210-rocourt_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02650-02260-rocquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02650-02260-rocquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02650-02260-rocquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02650-02260-rocquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02651-02800-rogecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02651-02800-rogecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02651-02800-rogecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02651-02800-rogecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02652-02140-rogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02652-02140-rogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02652-02140-rogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02652-02140-rogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02653-02310-romeny_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02653-02310-romeny_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02653-02310-romeny_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02653-02310-romeny_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02654-02120-romery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02654-02120-romery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02654-02120-romery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02654-02120-romery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02655-02130-roncheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02655-02130-roncheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02655-02130-roncheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02655-02130-roncheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02656-02160-roucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02656-02160-roucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02656-02160-roucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02656-02160-roucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02657-02140-rougeries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02657-02140-rougeries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02657-02140-rougeries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02657-02140-rougeries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02658-02590-roupy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02658-02590-roupy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02658-02590-roupy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02658-02590-roupy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02659-02100-rouvroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02659-02100-rouvroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02659-02100-rouvroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02659-02100-rouvroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02660-02360-rouvroy_sur_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02660-02360-rouvroy_sur_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02660-02360-rouvroy_sur_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02660-02360-rouvroy_sur_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02661-02000-royaucourt_et_chailvet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02661-02000-royaucourt_et_chailvet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02661-02000-royaucourt_et_chailvet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02661-02000-royaucourt_et_chailvet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02662-02210-rozet_saint_albin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02662-02210-rozet_saint_albin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02662-02210-rozet_saint_albin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02662-02210-rozet_saint_albin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02663-02200-rozieres_sur_crise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02663-02200-rozieres_sur_crise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02663-02200-rozieres_sur_crise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02663-02200-rozieres_sur_crise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02664-02540-rozoy_bellevalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02664-02540-rozoy_bellevalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02664-02540-rozoy_bellevalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02664-02540-rozoy_bellevalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02665-02210-grand_rozoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02665-02210-grand_rozoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02665-02210-grand_rozoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02665-02210-grand_rozoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02666-02360-rozoy_sur_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02666-02360-rozoy_sur_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02666-02360-rozoy_sur_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02666-02360-rozoy_sur_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02667-02200-saconin_et_breuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02667-02200-saconin_et_breuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02667-02200-saconin_et_breuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02667-02200-saconin_et_breuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02668-02120-sains_richaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02668-02120-sains_richaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02668-02120-sains_richaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02668-02120-sains_richaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02670-02260-saint_algis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02670-02260-saint_algis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02670-02260-saint_algis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02670-02260-saint_algis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02671-02300-saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02671-02300-saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02671-02300-saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02671-02300-saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02672-02290-saint_bandry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02672-02290-saint_bandry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02672-02290-saint_bandry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02672-02290-saint_bandry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02673-02290-saint_christophe_a_berry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02673-02290-saint_christophe_a_berry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02673-02290-saint_christophe_a_berry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02673-02290-saint_christophe_a_berry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02674-02360-saint_clement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02674-02360-saint_clement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02674-02360-saint_clement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02674-02360-saint_clement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02675-02820-sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02675-02820-sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02675-02820-sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02675-02820-sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02676-02820-saint_erme_outre_et_ramecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02676-02820-saint_erme_outre_et_ramecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02676-02820-saint_erme_outre_et_ramecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02676-02820-saint_erme_outre_et_ramecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02677-02330-saint_eugene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02677-02330-saint_eugene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02677-02330-saint_eugene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02677-02330-saint_eugene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02678-02340-sainte_genevieve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02678-02340-sainte_genevieve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02678-02340-sainte_genevieve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02678-02340-sainte_genevieve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02679-02810-saint_gengoulph/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02679-02810-saint_gengoulph/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02679-02810-saint_gengoulph/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02679-02810-saint_gengoulph/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02680-02410-saint_gobain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02680-02410-saint_gobain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02680-02410-saint_gobain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02680-02410-saint_gobain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02681-02140-saint_gobert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02681-02140-saint_gobert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02681-02140-saint_gobert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02681-02140-saint_gobert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02682-02220-saint_mard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02682-02220-saint_mard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02682-02220-saint_mard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02682-02220-saint_mard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02683-02110-saint_martin_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02683-02110-saint_martin_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02683-02110-saint_martin_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02683-02110-saint_martin_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02684-02830-saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02684-02830-saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02684-02830-saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02684-02830-saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02685-02410-saint_nicolas_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02685-02410-saint_nicolas_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02685-02410-saint_nicolas_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02685-02410-saint_nicolas_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02686-02300-saint_paul_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02686-02300-saint_paul_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02686-02300-saint_paul_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02686-02300-saint_paul_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02687-02600-saint_pierre_aigle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02687-02600-saint_pierre_aigle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02687-02600-saint_pierre_aigle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02687-02600-saint_pierre_aigle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02688-02140-saint_pierre_les_franqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02688-02140-saint_pierre_les_franqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02688-02140-saint_pierre_les_franqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02688-02140-saint_pierre_les_franqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02689-02250-saint_pierremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02689-02250-saint_pierremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02689-02250-saint_pierremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02689-02250-saint_pierremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02690-02350-sainte_preuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02690-02350-sainte_preuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02690-02350-sainte_preuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02690-02350-sainte_preuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02691-02100-saint_quentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02691-02100-saint_quentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02691-02100-saint_quentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02691-02100-saint_quentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02693-02210-saint_remy_blanzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02693-02210-saint_remy_blanzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02693-02210-saint_remy_blanzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02693-02210-saint_remy_blanzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02694-02640-saint_simon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02694-02640-saint_simon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02694-02640-saint_simon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02694-02640-saint_simon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02695-02220-saint_thibaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02695-02220-saint_thibaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02695-02220-saint_thibaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02695-02220-saint_thibaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02696-02820-saint_thomas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02696-02820-saint_thomas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02696-02820-saint_thomas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02696-02820-saint_thomas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02697-02840-samoussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02697-02840-samoussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02697-02840-samoussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02697-02840-samoussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02698-02880-sancy_les_cheminots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02698-02880-sancy_les_cheminots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02698-02880-sancy_les_cheminots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02698-02880-sancy_les_cheminots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02699-02130-saponay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02699-02130-saponay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02699-02130-saponay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02699-02130-saponay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02701-02310-saulchery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02701-02310-saulchery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02701-02310-saulchery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02701-02310-saulchery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02702-02590-savy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02702-02590-savy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02702-02590-savy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02702-02590-savy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02703-02110-seboncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02703-02110-seboncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02703-02110-seboncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02703-02110-seboncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02704-02300-selens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02704-02300-selens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02704-02300-selens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02704-02300-selens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02705-02150-la_selve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02705-02150-la_selve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02705-02150-la_selve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02705-02150-la_selve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02706-02200-septmonts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02706-02200-septmonts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02706-02200-septmonts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02706-02200-septmonts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02707-02410-septvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02707-02410-septvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02707-02410-septvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02707-02410-septvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02708-02420-sequehart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02708-02420-sequehart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02708-02420-sequehart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02708-02420-sequehart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02709-02110-serain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02709-02110-serain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02709-02110-serain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02709-02110-serain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02710-02790-seraucourt_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02710-02790-seraucourt_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02710-02790-seraucourt_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02710-02790-seraucourt_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02711-02220-serches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02711-02220-serches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02711-02220-serches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02711-02220-serches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02712-02130-sergy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02712-02130-sergy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02712-02130-sergy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02712-02130-sergy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02713-02130-seringes_et_nesles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02713-02130-seringes_et_nesles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02713-02130-seringes_et_nesles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02713-02130-seringes_et_nesles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02714-02220-sermoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02714-02220-sermoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02714-02220-sermoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02714-02220-sermoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02715-02160-serval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02715-02160-serval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02715-02160-serval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02715-02160-serval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02716-02700-servais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02716-02700-servais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02716-02700-servais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02716-02700-servais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02717-02240-sery_les_mezieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02717-02240-sery_les_mezieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02717-02240-sery_les_mezieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02717-02240-sery_les_mezieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02718-02460-silly_la_poterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02718-02460-silly_la_poterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02718-02460-silly_la_poterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02718-02460-silly_la_poterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02719-02300-sinceny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02719-02300-sinceny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02719-02300-sinceny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02719-02300-sinceny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02720-02150-sissonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02720-02150-sissonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02720-02150-sissonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02720-02150-sissonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02721-02240-sissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02721-02240-sissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02721-02240-sissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02721-02240-sissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02722-02200-soissons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02722-02200-soissons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02722-02200-soissons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02722-02200-soissons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02723-02340-soize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02723-02340-soize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02723-02340-soize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02723-02340-soize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02724-02470-sommelans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02724-02470-sommelans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02724-02470-sommelans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02724-02470-sommelans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02725-02260-sommeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02725-02260-sommeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02725-02260-sommeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02725-02260-sommeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02726-02480-sommette_eaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02726-02480-sommette_eaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02726-02480-sommette_eaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02726-02480-sommette_eaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02727-02270-sons_et_roncheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02727-02270-sons_et_roncheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02727-02270-sons_et_roncheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02727-02270-sons_et_roncheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02728-02580-sorbais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02728-02580-sorbais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02728-02580-sorbais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02728-02580-sorbais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02729-02600-soucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02729-02600-soucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02729-02600-soucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02729-02600-soucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02730-02160-soupir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02730-02160-soupir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02730-02160-soupir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02730-02160-soupir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02731-02140-le_sourd/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02731-02140-le_sourd/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02731-02140-le_sourd/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02731-02140-le_sourd/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02732-02240-surfontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02732-02240-surfontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02732-02240-surfontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02732-02240-surfontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02734-02600-taillefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02734-02600-taillefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02734-02600-taillefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02734-02600-taillefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02735-02220-tannieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02735-02220-tannieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02735-02220-tannieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02735-02220-tannieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02736-02290-tartiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02736-02290-tartiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02736-02290-tartiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02736-02290-tartiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02737-02250-tavaux_et_pontsericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02737-02250-tavaux_et_pontsericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02737-02250-tavaux_et_pontsericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02737-02250-tavaux_et_pontsericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02738-02700-tergnier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02738-02700-tergnier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02738-02700-tergnier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02738-02700-tergnier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02739-02880-terny_sorny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02739-02880-terny_sorny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02739-02880-terny_sorny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02739-02880-terny_sorny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02740-02140-thenailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02740-02140-thenailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02740-02140-thenailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02740-02140-thenailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02741-02390-thenelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02741-02390-thenelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02741-02390-thenelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02741-02390-thenelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02742-02250-thiernu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02742-02250-thiernu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02742-02250-thiernu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02742-02250-thiernu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02743-02340-le_thuel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02743-02340-le_thuel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02743-02340-le_thuel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02743-02340-le_thuel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02744-02810-torcy_en_valois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02744-02810-torcy_en_valois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02744-02810-torcy_en_valois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02744-02810-torcy_en_valois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02745-02250-toulis_et_attencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02745-02250-toulis_et_attencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02745-02250-toulis_et_attencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02745-02250-toulis_et_attencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02746-02800-travecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02746-02800-travecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02746-02800-travecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02746-02800-travecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02747-02490-trefcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02747-02490-trefcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02747-02490-trefcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02747-02490-trefcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02748-02850-trelou_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02748-02850-trelou_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02748-02850-trelou_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02748-02850-trelou_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02749-02460-troesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02749-02460-troesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02749-02460-troesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02749-02460-troesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02750-02300-trosly_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02750-02300-trosly_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02750-02300-trosly_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02750-02300-trosly_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02751-02860-trucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02751-02860-trucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02751-02860-trucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02751-02860-trucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02752-02640-tugny_et_pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02752-02640-tugny_et_pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02752-02640-tugny_et_pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02752-02640-tugny_et_pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02753-02120-tupigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02753-02120-tupigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02753-02120-tupigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02753-02120-tupigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02754-02300-ugny_le_gay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02754-02300-ugny_le_gay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02754-02300-ugny_le_gay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02754-02300-ugny_le_gay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02755-02000-urcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02755-02000-urcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02755-02000-urcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02755-02000-urcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02756-02690-urvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02756-02690-urvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02756-02690-urvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02756-02690-urvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02757-02120-vadencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02757-02120-vadencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02757-02120-vadencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02757-02120-vadencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02758-02370-vailly_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02758-02370-vailly_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02758-02370-vailly_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02758-02370-vailly_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02759-02140-la_vallee_au_ble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02759-02140-la_vallee_au_ble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02759-02140-la_vallee_au_ble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02759-02140-la_vallee_au_ble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02760-02110-la_vallee_mulatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02760-02110-la_vallee_mulatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02760-02110-la_vallee_mulatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02760-02110-la_vallee_mulatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02761-02190-variscourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02761-02190-variscourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02761-02190-variscourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02761-02190-variscourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02762-02290-vassens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02762-02290-vassens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02762-02290-vassens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02762-02290-vassens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02763-02220-vasseny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02763-02220-vasseny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02763-02220-vasseny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02763-02220-vasseny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02764-02160-vassogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02764-02160-vassogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02764-02160-vassogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02764-02160-vassogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02765-02000-vaucelles_et_beffecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02765-02000-vaucelles_et_beffecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02765-02000-vaucelles_et_beffecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02765-02000-vaucelles_et_beffecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02766-02320-vaudesson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02766-02320-vaudesson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02766-02320-vaudesson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02766-02320-vaudesson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02767-02200-vauxrezis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02767-02200-vauxrezis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02767-02200-vauxrezis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02767-02200-vauxrezis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02768-02320-vauxaillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02768-02320-vauxaillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02768-02320-vauxaillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02768-02320-vauxaillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02769-02110-vaux_andigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02769-02110-vaux_andigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02769-02110-vaux_andigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02769-02110-vaux_andigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02770-02200-vauxbuin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02770-02200-vauxbuin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02770-02200-vauxbuin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02770-02200-vauxbuin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02772-02590-vaux_en_vermandois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02772-02590-vaux_en_vermandois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02772-02590-vaux_en_vermandois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02772-02590-vaux_en_vermandois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02773-02220-vauxtin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02773-02220-vauxtin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02773-02220-vauxtin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02773-02220-vauxtin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02774-02490-vendelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02774-02490-vendelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02774-02490-vendelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02774-02490-vendelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02775-02800-vendeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02775-02800-vendeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02775-02800-vendeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02775-02800-vendeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02776-02420-vendhuile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02776-02420-vendhuile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02776-02420-vendhuile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02776-02420-vendhuile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02777-02540-vendieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02777-02540-vendieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02777-02540-vendieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02777-02540-vendieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02778-02160-vendresse_beaulne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02778-02160-vendresse_beaulne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02778-02160-vendresse_beaulne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02778-02160-vendresse_beaulne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02779-02510-venerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02779-02510-venerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02779-02510-venerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02779-02510-venerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02780-02200-venizel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02780-02200-venizel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02780-02200-venizel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02780-02200-venizel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02781-02400-verdilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02781-02400-verdilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02781-02400-verdilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02781-02400-verdilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02782-02490-le_verguier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02782-02490-le_verguier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02782-02490-le_verguier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02782-02490-le_verguier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02783-02120-grand_verly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02783-02120-grand_verly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02783-02120-grand_verly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02783-02120-grand_verly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02784-02630-petit_verly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02784-02630-petit_verly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02784-02630-petit_verly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02784-02630-petit_verly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02785-02490-vermand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02785-02490-vermand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02785-02490-vermand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02785-02490-vermand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02786-02380-verneuil_sous_coucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02786-02380-verneuil_sous_coucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02786-02380-verneuil_sous_coucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02786-02380-verneuil_sous_coucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02787-02000-verneuil_sur_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02787-02000-verneuil_sur_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02787-02000-verneuil_sur_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02787-02000-verneuil_sur_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02788-02800-versigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02788-02800-versigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02788-02800-versigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02788-02800-versigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02789-02140-vervins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02789-02140-vervins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02789-02140-vervins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02789-02140-vervins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02790-02350-vesles_et_caumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02790-02350-vesles_et_caumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02790-02350-vesles_et_caumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02790-02350-vesles_et_caumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02791-02840-veslud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02791-02840-veslud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02791-02840-veslud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02791-02840-veslud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02792-02810-veuilly_la_poterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02792-02810-veuilly_la_poterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02792-02810-veuilly_la_poterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02792-02810-veuilly_la_poterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02793-02290-vezaponin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02793-02290-vezaponin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02793-02290-vezaponin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02793-02290-vezaponin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02794-02130-vezilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02794-02130-vezilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02794-02130-vezilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02794-02130-vezilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02795-02290-vic_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02795-02290-vic_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02795-02290-vic_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02795-02290-vic_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02796-02210-vichel_nanteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02796-02210-vichel_nanteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02796-02210-vichel_nanteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02796-02210-vichel_nanteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02797-02160-viel_arcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02797-02160-viel_arcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02797-02160-viel_arcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02797-02160-viel_arcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02798-02540-viels_maisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02798-02540-viels_maisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02798-02540-viels_maisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02798-02540-viels_maisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02799-02210-vierzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02799-02210-vierzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02799-02210-vierzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02799-02210-vierzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02800-02540-viffort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02800-02540-viffort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02800-02540-viffort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02800-02540-viffort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02801-02340-vigneux_hocquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02801-02340-vigneux_hocquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02801-02340-vigneux_hocquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02801-02340-vigneux_hocquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02802-02340-la_ville_aux_bois_les_dizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02802-02340-la_ville_aux_bois_les_dizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02802-02340-la_ville_aux_bois_les_dizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02802-02340-la_ville_aux_bois_les_dizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02803-02160-la_ville_aux_bois_les_pontavert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02803-02160-la_ville_aux_bois_les_pontavert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02803-02160-la_ville_aux_bois_les_pontavert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02803-02160-la_ville_aux_bois_les_pontavert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02804-02210-villemontoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02804-02210-villemontoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02804-02210-villemontoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02804-02210-villemontoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02805-02200-villeneuve_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02805-02200-villeneuve_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02805-02200-villeneuve_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02805-02200-villeneuve_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02806-02130-villeneuve_sur_fere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02806-02130-villeneuve_sur_fere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02806-02130-villeneuve_sur_fere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02806-02130-villeneuve_sur_fere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02807-02300-villequier_aumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02807-02300-villequier_aumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02807-02300-villequier_aumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02807-02300-villequier_aumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02808-02420-villeret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02808-02420-villeret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02808-02420-villeret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02808-02420-villeret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02809-02130-villers_agron_aiguizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02809-02130-villers_agron_aiguizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02809-02130-villers_agron_aiguizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02809-02130-villers_agron_aiguizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02810-02600-villers_cotterets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02810-02600-villers_cotterets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02810-02600-villers_cotterets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02810-02600-villers_cotterets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02812-02600-villers_helon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02812-02600-villers_helon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02812-02600-villers_helon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02812-02600-villers_helon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02813-02240-villers_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02813-02240-villers_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02813-02240-villers_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02813-02240-villers_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02814-02120-villers_les_guise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02814-02120-villers_les_guise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02814-02120-villers_les_guise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02814-02120-villers_les_guise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02815-02590-villers_saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02815-02590-villers_saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02815-02590-villers_saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02815-02590-villers_saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02816-02130-villers_sur_fere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02816-02130-villers_sur_fere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02816-02130-villers_sur_fere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02816-02130-villers_sur_fere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02817-02220-ville_savoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02817-02220-ville_savoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02817-02220-ville_savoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02817-02220-ville_savoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02818-02310-villiers_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02818-02310-villiers_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02818-02310-villiers_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02818-02310-villiers_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02819-02340-vincy_reuil_et_magny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02819-02340-vincy_reuil_et_magny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02819-02340-vincy_reuil_et_magny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02819-02340-vincy_reuil_et_magny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02820-02300-viry_noureuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02820-02300-viry_noureuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02820-02300-viry_noureuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02820-02300-viry_noureuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02821-02870-vivaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02821-02870-vivaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02821-02870-vivaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02821-02870-vivaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02822-02600-vivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02822-02600-vivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02822-02600-vivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02822-02600-vivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02823-02140-voharies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02823-02140-voharies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02823-02140-voharies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02823-02140-voharies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02824-02860-vorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02824-02860-vorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02824-02860-vorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02824-02860-vorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02826-02140-voulpaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02826-02140-voulpaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02826-02140-voulpaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02826-02140-voulpaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02827-02250-voyenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02827-02250-voyenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02827-02250-voyenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02827-02250-voyenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02828-02880-vregny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02828-02880-vregny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02828-02880-vregny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02828-02880-vregny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02829-02880-vuillery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02829-02880-vuillery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02829-02880-vuillery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02829-02880-vuillery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02830-02630-wassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02830-02630-wassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02830-02630-wassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02830-02630-wassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02831-02830-watigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02831-02830-watigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02831-02830-watigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02831-02830-watigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02832-02120-wiege_faty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02832-02120-wiege_faty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02832-02120-wiege_faty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02832-02120-wiege_faty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02833-02500-wimy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02833-02500-wimy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02833-02500-wimy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02833-02500-wimy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02834-02320-wissignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02834-02320-wissignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02834-02320-wissignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt02-aisne/commune02834-02320-wissignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-03.xml
+++ b/public/sitemaps/sitemap-03.xml
@@ -5,646 +5,1288 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03001-03200-abrest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03001-03200-abrest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03001-03200-abrest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03001-03200-abrest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03002-03210-agonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03002-03210-agonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03002-03210-agonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03002-03210-agonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03003-03360-ainay_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03003-03360-ainay_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03003-03360-ainay_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03003-03360-ainay_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03004-03120-andelaroche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03004-03120-andelaroche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03004-03120-andelaroche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03004-03120-andelaroche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03005-03380-archignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03005-03380-archignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03005-03380-archignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03005-03380-archignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03006-03120-arfeuilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03006-03120-arfeuilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03006-03120-arfeuilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03006-03120-arfeuilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03007-03420-arpheuilles_saint_priest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03007-03420-arpheuilles_saint_priest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03007-03420-arpheuilles_saint_priest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03007-03420-arpheuilles_saint_priest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03008-03250-arronnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03008-03250-arronnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03008-03250-arronnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03008-03250-arronnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03009-03460-aubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03009-03460-aubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03009-03460-aubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03009-03460-aubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03010-03190-audes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03010-03190-audes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03010-03190-audes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03010-03190-audes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03011-03460-aurouer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03011-03460-aurouer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03011-03460-aurouer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03011-03460-aurouer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03012-03210-autry_issards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03012-03210-autry_issards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03012-03210-autry_issards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03012-03210-autry_issards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03013-03000-avermes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03013-03000-avermes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03013-03000-avermes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03013-03000-avermes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03014-03130-avrilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03014-03130-avrilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03014-03130-avrilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03014-03130-avrilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03015-03460-bagneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03015-03460-bagneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03015-03460-bagneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03015-03460-bagneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03016-03140-barberier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03016-03140-barberier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03016-03140-barberier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03016-03140-barberier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03017-03120-barrais_bussolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03017-03120-barrais_bussolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03017-03120-barrais_bussolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03017-03120-barrais_bussolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03018-03500-bayet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03018-03500-bayet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03018-03500-bayet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03018-03500-bayet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03019-03230-beaulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03019-03230-beaulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03019-03230-beaulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03019-03230-beaulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03020-03390-beaune_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03020-03390-beaune_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03020-03390-beaune_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03020-03390-beaune_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03021-03800-begues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03021-03800-begues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03021-03800-begues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03021-03800-begues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03022-03330-bellenaves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03022-03330-bellenaves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03022-03330-bellenaves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03022-03330-bellenaves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03023-03700-bellerive_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03023-03700-bellerive_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03023-03700-bellerive_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03023-03700-bellerive_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03024-03130-bert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03024-03130-bert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03024-03130-bert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03024-03130-bert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03025-03340-bessay_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03025-03340-bessay_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03025-03340-bessay_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03025-03340-bessay_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03026-03210-besson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03026-03210-besson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03026-03210-besson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03026-03210-besson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03027-03170-bezenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03027-03170-bezenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03027-03170-bezenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03027-03170-bezenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03028-03120-billezois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03028-03120-billezois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03028-03120-billezois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03028-03120-billezois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03029-03260-billy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03029-03260-billy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03029-03260-billy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03029-03260-billy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03030-03800-biozat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03030-03800-biozat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03030-03800-biozat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03030-03800-biozat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03031-03170-bizeneuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03031-03170-bizeneuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03031-03170-bizeneuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03031-03170-bizeneuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03032-03390-blomard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03032-03390-blomard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03032-03390-blomard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03032-03390-blomard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03033-03300-bost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03033-03300-bost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03033-03300-bost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03033-03300-bost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03034-03150-bouce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03034-03150-bouce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03034-03150-bouce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03034-03150-bouce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03035-03130-le_bouchaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03035-03130-le_bouchaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03035-03130-le_bouchaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03035-03130-le_bouchaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03036-03160-bourbon_l_archambault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03036-03160-bourbon_l_archambault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03036-03160-bourbon_l_archambault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03036-03160-bourbon_l_archambault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03037-03360-braize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03037-03360-braize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03037-03360-braize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03037-03360-braize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03038-03500-bransat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03038-03500-bransat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03038-03500-bransat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03038-03500-bransat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03039-03210-bresnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03039-03210-bresnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03039-03210-bresnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03039-03210-bresnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03040-03000-bressolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03040-03000-bressolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03040-03000-bressolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03040-03000-bressolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03041-03350-le_brethon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03041-03350-le_brethon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03041-03350-le_brethon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03041-03350-le_brethon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03042-03120-le_breuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03042-03120-le_breuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03042-03120-le_breuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03042-03120-le_breuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03043-03110-brout_vernet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03043-03110-brout_vernet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03043-03110-brout_vernet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03043-03110-brout_vernet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03044-03700-brugheas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03044-03700-brugheas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03044-03700-brugheas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03044-03700-brugheas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03045-03270-busset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03045-03270-busset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03045-03270-busset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03045-03270-busset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03046-03440-buxieres_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03046-03440-buxieres_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03046-03440-buxieres_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03046-03440-buxieres_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03047-03600-la_celle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03047-03600-la_celle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03047-03600-la_celle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03047-03600-la_celle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03048-03350-cerilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03048-03350-cerilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03048-03350-cerilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03048-03350-cerilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03049-03500-cesset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03049-03500-cesset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03049-03500-cesset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03049-03500-cesset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03050-03250-la_chabanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03050-03250-la_chabanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03050-03250-la_chabanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03050-03250-la_chabanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03051-03370-chamberat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03051-03370-chamberat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03051-03370-chamberat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03051-03370-chamberat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03052-03170-chamblet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03052-03170-chamblet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03052-03170-chamblet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03052-03170-chamblet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03053-03140-chantelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03053-03140-chantelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03053-03140-chantelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03053-03140-chantelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03054-03340-chapeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03054-03340-chapeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03054-03340-chapeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03054-03340-chapeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03055-03380-la_chapelaude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03055-03380-la_chapelaude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03055-03380-la_chapelaude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03055-03380-la_chapelaude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03056-03300-la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03056-03300-la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03056-03300-la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03056-03300-la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03057-03230-la_chapelle_aux_chasses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03057-03230-la_chapelle_aux_chasses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03057-03230-la_chapelle_aux_chasses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03057-03230-la_chapelle_aux_chasses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03058-03390-chappes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03058-03390-chappes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03058-03390-chappes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03058-03390-chappes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03059-03140-chareil_cintrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03059-03140-chareil_cintrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03059-03140-chareil_cintrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03059-03140-chareil_cintrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03060-03110-charmeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03060-03110-charmeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03060-03110-charmeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03060-03110-charmeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03061-03800-charmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03061-03800-charmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03061-03800-charmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03061-03800-charmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03062-03140-charroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03062-03140-charroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03062-03140-charroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03062-03140-charroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03063-03510-chassenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03063-03510-chassenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03063-03510-chassenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03063-03510-chassenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03064-03320-chateau_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03064-03320-chateau_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03064-03320-chateau_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03064-03320-chateau_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03065-03500-chatel_de_neuvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03065-03500-chatel_de_neuvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03065-03500-chatel_de_neuvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03065-03500-chatel_de_neuvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03066-03250-chatel_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03066-03250-chatel_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03066-03250-chatel_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03066-03250-chatel_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03067-03220-chatelperron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03067-03220-chatelperron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03067-03220-chatelperron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03067-03220-chatelperron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03068-03120-chatelus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03068-03120-chatelus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03068-03120-chatelus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03068-03120-chatelus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03069-03210-chatillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03069-03210-chatillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03069-03210-chatillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03069-03210-chatillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03070-03440-chavenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03070-03440-chavenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03070-03440-chavenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03070-03440-chavenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03071-03220-chavroches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03071-03220-chavroches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03071-03220-chavroches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03071-03220-chavroches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03072-03370-chazemais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03072-03370-chazemais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03072-03370-chazemais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03072-03370-chazemais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03073-03210-chemilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03073-03210-chemilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03073-03210-chemilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03073-03210-chemilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03074-03230-chevagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03074-03230-chevagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03074-03230-chevagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03074-03230-chevagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03075-03140-chezelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03075-03140-chezelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03075-03140-chezelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03075-03140-chezelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03076-03230-chezy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03076-03230-chezy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03076-03230-chezy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03076-03230-chezy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03077-03330-chirat_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03077-03330-chirat_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03077-03330-chirat_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03077-03330-chirat_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03078-03450-chouvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03078-03450-chouvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03078-03450-chouvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03078-03450-chouvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03079-03220-cindre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03079-03220-cindre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03079-03220-cindre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03079-03220-cindre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03080-03110-cognat_lyonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03080-03110-cognat_lyonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03080-03110-cognat_lyonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03080-03110-cognat_lyonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03081-03600-colombier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03081-03600-colombier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03081-03600-colombier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03081-03600-colombier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03082-03600-commentry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03082-03600-commentry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03082-03600-commentry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03082-03600-commentry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03083-03500-contigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03083-03500-contigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03083-03500-contigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03083-03500-contigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03084-03430-cosne_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03084-03430-cosne_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03084-03430-cosne_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03084-03430-cosne_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03085-03000-coulandon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03085-03000-coulandon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03085-03000-coulandon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03085-03000-coulandon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03086-03470-coulanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03086-03470-coulanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03086-03470-coulanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03086-03470-coulanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03087-03320-couleuvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03087-03320-couleuvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03087-03320-couleuvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03087-03320-couleuvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03088-03370-courcais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03088-03370-courcais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03088-03370-courcais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03088-03370-courcais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03089-03330-coutansouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03089-03330-coutansouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03089-03330-coutansouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03089-03330-coutansouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03090-03160-couzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03090-03160-couzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03090-03160-couzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03090-03160-couzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03091-03150-crechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03091-03150-crechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03091-03150-crechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03091-03150-crechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03092-03240-cressanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03092-03240-cressanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03092-03240-cressanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03092-03240-cressanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03093-03300-creuzier_le_neuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03093-03300-creuzier_le_neuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03093-03300-creuzier_le_neuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03093-03300-creuzier_le_neuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03094-03300-creuzier_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03094-03300-creuzier_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03094-03300-creuzier_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03094-03300-creuzier_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03095-03300-cusset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03095-03300-cusset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03095-03300-cusset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03095-03300-cusset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03096-03140-deneuille_les_chantelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03096-03140-deneuille_les_chantelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03096-03140-deneuille_les_chantelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03096-03140-deneuille_les_chantelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03097-03170-deneuille_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03097-03170-deneuille_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03097-03170-deneuille_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03097-03170-deneuille_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03098-03630-desertines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03098-03630-desertines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03098-03630-desertines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03098-03630-desertines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03099-03240-deux_chaises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03099-03240-deux_chaises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03099-03240-deux_chaises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03099-03240-deux_chaises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03100-03290-diou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03100-03290-diou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03100-03290-diou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03100-03290-diou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03101-03410-domerat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03101-03410-domerat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03101-03410-domerat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03101-03410-domerat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03102-03290-dompierre_sur_besbre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03102-03290-dompierre_sur_besbre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03102-03290-dompierre_sur_besbre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03102-03290-dompierre_sur_besbre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03103-03130-le_donjon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03103-03130-le_donjon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03103-03130-le_donjon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03103-03130-le_donjon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03104-03170-doyet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03104-03170-doyet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03104-03170-doyet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03104-03170-doyet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03105-03120-droiturier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03105-03120-droiturier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03105-03120-droiturier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03105-03120-droiturier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03106-03310-durdat_larequille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03106-03310-durdat_larequille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03106-03310-durdat_larequille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03106-03310-durdat_larequille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03107-03450-ebreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03107-03450-ebreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03107-03450-ebreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03107-03450-ebreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03108-03330-echassieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03108-03330-echassieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03108-03330-echassieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03108-03330-echassieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03109-03110-escurolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03109-03110-escurolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03109-03110-escurolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03109-03110-escurolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03110-03110-espinasse_vozelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03110-03110-espinasse_vozelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03110-03110-espinasse_vozelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03110-03110-espinasse_vozelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03111-03190-estivareilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03111-03190-estivareilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03111-03190-estivareilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03111-03190-estivareilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03112-03140-etroussat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03112-03140-etroussat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03112-03140-etroussat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03112-03140-etroussat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03113-03250-ferrieres_sur_sichon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03113-03250-ferrieres_sur_sichon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03113-03250-ferrieres_sur_sichon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03113-03250-ferrieres_sur_sichon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03114-03340-la_ferte_hauterive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03114-03340-la_ferte_hauterive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03114-03340-la_ferte_hauterive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03114-03340-la_ferte_hauterive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03115-03140-fleuriel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03115-03140-fleuriel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03115-03140-fleuriel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03115-03140-fleuriel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03116-03140-fourilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03116-03140-fourilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03116-03140-fourilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03116-03140-fourilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03117-03160-franchesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03117-03160-franchesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03117-03160-franchesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03117-03160-franchesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03118-03800-gannat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03118-03800-gannat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03118-03800-gannat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03118-03800-gannat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03119-03230-gannay_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03119-03230-gannay_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03119-03230-gannay_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03119-03230-gannay_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03120-03230-garnat_sur_engievre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03120-03230-garnat_sur_engievre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03120-03230-garnat_sur_engievre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03120-03230-garnat_sur_engievre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03121-03400-gennetines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03121-03400-gennetines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03121-03400-gennetines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03121-03400-gennetines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03122-03210-gipcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03122-03210-gipcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03122-03210-gipcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03122-03210-gipcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03124-03340-gouise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03124-03340-gouise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03124-03340-gouise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03124-03340-gouise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03125-03250-la_guillermie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03125-03250-la_guillermie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03125-03250-la_guillermie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03125-03250-la_guillermie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03126-03270-hauterive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03126-03270-hauterive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03126-03270-hauterive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03126-03270-hauterive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03127-03190-herisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03127-03190-herisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03127-03190-herisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03127-03190-herisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03128-03380-huriel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03128-03380-huriel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03128-03380-huriel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03128-03380-huriel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03129-03600-hyds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03129-03600-hyds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03129-03600-hyds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03129-03600-hyds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03130-03360-isle_et_bardais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03130-03360-isle_et_bardais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03130-03360-isle_et_bardais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03130-03360-isle_et_bardais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03131-03120-isserpent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03131-03120-isserpent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03131-03120-isserpent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03131-03120-isserpent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03132-03220-jaligny_sur_besbre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03132-03220-jaligny_sur_besbre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03132-03220-jaligny_sur_besbre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03132-03220-jaligny_sur_besbre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03133-03800-jenzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03133-03800-jenzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03133-03800-jenzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03133-03800-jenzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03134-03500-lafeline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03134-03500-lafeline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03134-03500-lafeline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03134-03500-lafeline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03135-03450-lalizolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03135-03450-lalizolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03135-03450-lalizolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03135-03450-lalizolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03136-03380-lamaids/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03136-03380-lamaids/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03136-03380-lamaids/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03136-03380-lamaids/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03137-03150-langy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03137-03150-langy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03137-03150-langy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03137-03150-langy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03138-03120-lapalisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03138-03120-lapalisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03138-03120-lapalisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03138-03120-lapalisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03139-03250-laprugne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03139-03250-laprugne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03139-03250-laprugne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03139-03250-laprugne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03140-03100-lavault_sainte_anne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03140-03100-lavault_sainte_anne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03140-03100-lavault_sainte_anne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03140-03100-lavault_sainte_anne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03141-03250-lavoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03141-03250-lavoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03141-03250-lavoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03141-03250-lavoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03142-03130-lenax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03142-03130-lenax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03142-03130-lenax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03142-03130-lenax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03143-03360-letelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03143-03360-letelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03143-03360-letelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03143-03360-letelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03144-03130-liernolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03144-03130-liernolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03144-03130-liernolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03144-03130-liernolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03145-03410-lignerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03145-03410-lignerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03145-03410-lignerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03145-03410-lignerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03146-03320-limoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03146-03320-limoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03146-03320-limoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03146-03320-limoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03147-03130-loddes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03147-03130-loddes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03147-03130-loddes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03147-03130-loddes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03148-03500-loriges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03148-03500-loriges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03148-03500-loriges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03148-03500-loriges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03149-03500-louchy_montfand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03149-03500-louchy_montfand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03149-03500-louchy_montfand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03149-03500-louchy_montfand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03150-03350-louroux_bourbonnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03150-03350-louroux_bourbonnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03150-03350-louroux_bourbonnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03150-03350-louroux_bourbonnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03151-03600-louroux_de_beaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03151-03600-louroux_de_beaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03151-03600-louroux_de_beaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03151-03600-louroux_de_beaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03151-03170-louroux_de_beaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03151-03170-louroux_de_beaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03151-03170-louroux_de_beaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03151-03170-louroux_de_beaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03152-03330-louroux_de_bouble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03152-03330-louroux_de_bouble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03152-03330-louroux_de_bouble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03152-03330-louroux_de_bouble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03154-03130-luneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03154-03130-luneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03154-03130-luneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03154-03130-luneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03155-03320-lurcy_levis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03155-03320-lurcy_levis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03155-03320-lurcy_levis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03155-03320-lurcy_levis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03156-03230-lusigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03156-03230-lusigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03156-03230-lusigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03156-03230-lusigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03157-03260-magnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03157-03260-magnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03157-03260-magnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03157-03260-magnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03158-03190-haut_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03158-03190-haut_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03158-03190-haut_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03158-03190-haut_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03159-03600-malicorne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03159-03600-malicorne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03159-03600-malicorne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03159-03600-malicorne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03160-03260-marcenat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03160-03260-marcenat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03160-03260-marcenat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03160-03260-marcenat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03161-03420-marcillat_en_combraille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03161-03420-marcillat_en_combraille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03161-03420-marcillat_en_combraille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03161-03420-marcillat_en_combraille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03162-03210-marigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03162-03210-marigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03162-03210-marigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03162-03210-marigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03163-03270-mariol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03163-03270-mariol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03163-03270-mariol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03163-03270-mariol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03164-03800-le_mayet_d_ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03164-03800-le_mayet_d_ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03164-03800-le_mayet_d_ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03164-03800-le_mayet_d_ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03165-03250-le_mayet_de_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03165-03250-le_mayet_de_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03165-03250-le_mayet_de_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03165-03250-le_mayet_de_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03166-03800-mazerier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03166-03800-mazerier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03166-03800-mazerier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03166-03800-mazerier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03167-03420-mazirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03167-03420-mazirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03167-03420-mazirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03167-03420-mazirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03168-03360-meaulne_vitray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03168-03360-meaulne_vitray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03168-03360-meaulne_vitray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03168-03360-meaulne_vitray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03169-03500-meillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03169-03500-meillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03169-03500-meillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03169-03500-meillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03170-03210-meillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03170-03210-meillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03170-03210-meillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03170-03210-meillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03171-03340-mercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03171-03340-mercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03171-03340-mercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03171-03340-mercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03172-03370-mesples/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03172-03370-mesples/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03172-03370-mesples/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03172-03370-mesples/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03173-03510-molinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03173-03510-molinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03173-03510-molinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03173-03510-molinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03174-03300-molles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03174-03300-molles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03174-03300-molles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03174-03300-molles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03175-03140-monestier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03175-03140-monestier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03175-03140-monestier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03175-03140-monestier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03176-03500-monetay_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03176-03500-monetay_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03176-03500-monetay_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03176-03500-monetay_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03177-03470-monetay_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03177-03470-monetay_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03177-03470-monetay_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03177-03470-monetay_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03178-03130-montaiguet_en_forez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03178-03130-montaiguet_en_forez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03178-03130-montaiguet_en_forez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03178-03130-montaiguet_en_forez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03179-03150-montaigu_le_blin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03179-03150-montaigu_le_blin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03179-03150-montaigu_le_blin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03179-03150-montaigu_le_blin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03180-03340-montbeugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03180-03340-montbeugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03180-03340-montbeugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03180-03340-montbeugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03181-03130-montcombroux_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03181-03130-montcombroux_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03181-03130-montcombroux_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03181-03130-montcombroux_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03182-03800-monteignet_sur_l_andelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03182-03800-monteignet_sur_l_andelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03182-03800-monteignet_sur_l_andelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03182-03800-monteignet_sur_l_andelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03183-03240-le_montet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03183-03240-le_montet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03183-03240-le_montet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03183-03240-le_montet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03184-03000-montilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03184-03000-montilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03184-03000-montilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03184-03000-montilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03185-03100-montlucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03185-03100-montlucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03185-03100-montlucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03185-03100-montlucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03186-03390-montmarault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03186-03390-montmarault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03186-03390-montmarault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03186-03390-montmarault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03187-03150-montoldre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03187-03150-montoldre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03187-03150-montoldre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03187-03150-montoldre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03188-03500-montord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03188-03500-montord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03188-03500-montord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03188-03500-montord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03189-03170-montvicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03189-03170-montvicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03189-03170-montvicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03189-03170-montvicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03190-03000-moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03190-03000-moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03190-03000-moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03190-03000-moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03191-03390-murat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03191-03390-murat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03191-03390-murat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03191-03390-murat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03191-03430-murat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03191-03430-murat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03191-03430-murat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03191-03430-murat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03192-03450-nades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03192-03450-nades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03192-03450-nades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03192-03450-nades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03193-03190-nassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03193-03190-nassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03193-03190-nassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03193-03190-nassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03194-03330-naves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03194-03330-naves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03194-03330-naves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03194-03330-naves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03195-03310-neris_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03195-03310-neris_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03195-03310-neris_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03195-03310-neris_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03196-03130-neuilly_en_donjon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03196-03130-neuilly_en_donjon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03196-03130-neuilly_en_donjon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03196-03130-neuilly_en_donjon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03197-03340-neuilly_le_real/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03197-03340-neuilly_le_real/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03197-03340-neuilly_le_real/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03197-03340-neuilly_le_real/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03198-03320-neure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03198-03320-neure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03198-03320-neure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03198-03320-neure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03200-03000-neuvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03200-03000-neuvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03200-03000-neuvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03200-03000-neuvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03201-03250-nizerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03201-03250-nizerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03201-03250-nizerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03201-03250-nizerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03202-03210-noyant_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03202-03210-noyant_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03202-03210-noyant_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03202-03210-noyant_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03203-03230-paray_le_fresil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03203-03230-paray_le_fresil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03203-03230-paray_le_fresil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03203-03230-paray_le_fresil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03204-03500-paray_sous_briailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03204-03500-paray_sous_briailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03204-03500-paray_sous_briailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03204-03500-paray_sous_briailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03205-03120-perigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03205-03120-perigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03205-03120-perigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03205-03120-perigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03206-03420-la_petite_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03206-03420-la_petite_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03206-03420-la_petite_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03206-03420-la_petite_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03207-03470-pierrefitte_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03207-03470-pierrefitte_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03207-03470-pierrefitte_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03207-03470-pierrefitte_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03208-03130-le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03208-03130-le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03208-03130-le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03208-03130-le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03209-03800-poezat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03209-03800-poezat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03209-03800-poezat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03209-03800-poezat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03210-03320-pouzy_mesangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03210-03320-pouzy_mesangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03210-03320-pouzy_mesangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03210-03320-pouzy_mesangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03211-03410-premilhat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03211-03410-premilhat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03211-03410-premilhat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03211-03410-premilhat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03212-03380-quinssaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03212-03380-quinssaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03212-03380-quinssaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03212-03380-quinssaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03213-03190-reugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03213-03190-reugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03213-03190-reugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03213-03190-reugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03214-03240-rocles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03214-03240-rocles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03214-03240-rocles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03214-03240-rocles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03215-03150-rongeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03215-03150-rongeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03215-03150-rongeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03215-03150-rongeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03216-03420-ronnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03216-03420-ronnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03216-03420-ronnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03216-03420-ronnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03217-03170-saint_angel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03217-03170-saint_angel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03217-03170-saint_angel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03217-03170-saint_angel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03218-03160-saint_aubin_le_monial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03218-03160-saint_aubin_le_monial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03218-03160-saint_aubin_le_monial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03218-03160-saint_aubin_le_monial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03219-03390-saint_bonnet_de_four/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03219-03390-saint_bonnet_de_four/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03219-03390-saint_bonnet_de_four/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03219-03390-saint_bonnet_de_four/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03220-03800-saint_bonnet_de_rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03220-03800-saint_bonnet_de_rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03220-03800-saint_bonnet_de_rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03220-03800-saint_bonnet_de_rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03221-03360-saint_bonnet_troncais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03221-03360-saint_bonnet_troncais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03221-03360-saint_bonnet_troncais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03221-03360-saint_bonnet_troncais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03222-03190-saint_caprais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03222-03190-saint_caprais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03222-03190-saint_caprais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03222-03190-saint_caprais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03223-03120-saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03223-03120-saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03223-03120-saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03223-03120-saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03224-03250-saint_clement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03224-03250-saint_clement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03224-03250-saint_clement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03224-03250-saint_clement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03225-03370-saint_desire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03225-03370-saint_desire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03225-03370-saint_desire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03225-03370-saint_desire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03226-03130-saint_didier_en_donjon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03226-03130-saint_didier_en_donjon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03226-03130-saint_didier_en_donjon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03226-03130-saint_didier_en_donjon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03227-03110-saint_didier_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03227-03110-saint_didier_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03227-03110-saint_didier_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03227-03110-saint_didier_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03228-03370-saint_eloy_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03228-03370-saint_eloy_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03228-03370-saint_eloy_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03228-03370-saint_eloy_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03229-03400-saint_ennemond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03229-03400-saint_ennemond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03229-03400-saint_ennemond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03229-03400-saint_ennemond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03230-03300-saint_etienne_de_vicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03230-03300-saint_etienne_de_vicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03230-03300-saint_etienne_de_vicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03230-03300-saint_etienne_de_vicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03231-03420-saint_fargeol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03231-03420-saint_fargeol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03231-03420-saint_fargeol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03231-03420-saint_fargeol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03232-03260-saint_felix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03232-03260-saint_felix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03232-03260-saint_felix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03232-03260-saint_felix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03233-03310-saint_genest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03233-03310-saint_genest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03233-03310-saint_genest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03233-03310-saint_genest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03234-03340-saint_gerand_de_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03234-03340-saint_gerand_de_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03234-03340-saint_gerand_de_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03234-03340-saint_gerand_de_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03235-03150-saint_gerand_le_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03235-03150-saint_gerand_le_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03235-03150-saint_gerand_le_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03235-03150-saint_gerand_le_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03236-03260-saint_germain_des_fosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03236-03260-saint_germain_des_fosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03236-03260-saint_germain_des_fosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03236-03260-saint_germain_des_fosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03237-03140-saint_germain_de_salles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03237-03140-saint_germain_de_salles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03237-03140-saint_germain_de_salles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03237-03140-saint_germain_de_salles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03238-03440-saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03238-03440-saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03238-03440-saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03238-03440-saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03239-03130-saint_leger_sur_vouzance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03239-03130-saint_leger_sur_vouzance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03239-03130-saint_leger_sur_vouzance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03239-03130-saint_leger_sur_vouzance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03240-03220-saint_leon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03240-03220-saint_leon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03240-03220-saint_leon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03240-03220-saint_leon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03241-03160-saint_leopardin_d_augy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03241-03160-saint_leopardin_d_augy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03241-03160-saint_leopardin_d_augy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03241-03160-saint_leopardin_d_augy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03242-03150-saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03242-03150-saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03242-03150-saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03242-03150-saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03243-03390-saint_marcel_en_murat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03243-03390-saint_marcel_en_murat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03243-03390-saint_marcel_en_murat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03243-03390-saint_marcel_en_murat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03244-03420-saint_marcel_en_marcillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03244-03420-saint_marcel_en_marcillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03244-03420-saint_marcel_en_marcillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03244-03420-saint_marcel_en_marcillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03245-03230-saint_martin_des_lais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03245-03230-saint_martin_des_lais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03245-03230-saint_martin_des_lais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03245-03230-saint_martin_des_lais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03246-03380-saint_martinien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03246-03380-saint_martinien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03246-03380-saint_martinien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03246-03380-saint_martinien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03247-03210-saint_menoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03247-03210-saint_menoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03247-03210-saint_menoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03247-03210-saint_menoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03248-03250-saint_nicolas_des_biefs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03248-03250-saint_nicolas_des_biefs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03248-03250-saint_nicolas_des_biefs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03248-03250-saint_nicolas_des_biefs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03249-03370-saint_palais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03249-03370-saint_palais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03249-03370-saint_palais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03249-03370-saint_palais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03250-42620-saint_pierre_laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03250-42620-saint_pierre_laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03250-42620-saint_pierre_laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03250-42620-saint_pierre_laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03251-03160-saint_plaisir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03251-03160-saint_plaisir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03251-03160-saint_plaisir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03251-03160-saint_plaisir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03252-03110-saint_pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03252-03110-saint_pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03252-03110-saint_pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03252-03110-saint_pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03253-03290-saint_pourcain_sur_besbre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03253-03290-saint_pourcain_sur_besbre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03253-03290-saint_pourcain_sur_besbre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03253-03290-saint_pourcain_sur_besbre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03254-03500-saint_pourcain_sur_sioule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03254-03500-saint_pourcain_sur_sioule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03254-03500-saint_pourcain_sur_sioule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03254-03500-saint_pourcain_sur_sioule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03255-03800-saint_priest_d_andelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03255-03800-saint_priest_d_andelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03255-03800-saint_priest_d_andelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03255-03800-saint_priest_d_andelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03256-03390-saint_priest_en_murat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03256-03390-saint_priest_en_murat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03256-03390-saint_priest_en_murat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03256-03390-saint_priest_en_murat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03256-03170-saint_priest_en_murat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03256-03170-saint_priest_en_murat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03256-03170-saint_priest_en_murat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03256-03170-saint_priest_en_murat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03257-03120-saint_prix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03257-03120-saint_prix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03257-03120-saint_prix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03257-03120-saint_prix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03258-03110-saint_remy_en_rollat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03258-03110-saint_remy_en_rollat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03258-03110-saint_remy_en_rollat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03258-03110-saint_remy_en_rollat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03259-03370-saint_sauvier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03259-03370-saint_sauvier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03259-03370-saint_sauvier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03259-03370-saint_sauvier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03260-03240-saint_sornin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03260-03240-saint_sornin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03260-03240-saint_sornin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03260-03240-saint_sornin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03261-03420-sainte_therence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03261-03420-sainte_therence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03261-03420-sainte_therence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03261-03420-sainte_therence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03262-03410-saint_victor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03262-03410-saint_victor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03262-03410-saint_victor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03262-03410-saint_victor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03263-03220-saint_voir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03263-03220-saint_voir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03263-03220-saint_voir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03263-03220-saint_voir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03264-03270-saint_yorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03264-03270-saint_yorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03264-03270-saint_yorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03264-03270-saint_yorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03265-03470-saligny_sur_roudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03265-03470-saligny_sur_roudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03265-03470-saligny_sur_roudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03265-03470-saligny_sur_roudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03266-03150-sanssat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03266-03150-sanssat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03266-03150-sanssat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03266-03150-sanssat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03267-03500-saulcet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03267-03500-saulcet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03267-03500-saulcet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03267-03500-saulcet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03268-03800-saulzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03268-03800-saulzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03268-03800-saulzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03268-03800-saulzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03269-03430-sauvagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03269-03430-sauvagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03269-03430-sauvagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03269-03430-sauvagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03270-03390-sazeret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03270-03390-sazeret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03270-03390-sazeret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03270-03390-sazeret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03271-03700-serbannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03271-03700-serbannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03271-03700-serbannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03271-03700-serbannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03272-03120-servilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03272-03120-servilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03272-03120-servilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03272-03120-servilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03273-03260-seuillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03273-03260-seuillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03273-03260-seuillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03273-03260-seuillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03274-03220-sorbier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03274-03220-sorbier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03274-03220-sorbier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03274-03220-sorbier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03275-03210-souvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03275-03210-souvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03275-03210-souvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03275-03210-souvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03276-03450-sussat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03276-03450-sussat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03276-03450-sussat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03276-03450-sussat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03277-03140-target/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03277-03140-target/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03277-03140-target/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03277-03140-target/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03278-03140-taxat_senat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03278-03140-taxat_senat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03278-03140-taxat_senat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03278-03140-taxat_senat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03279-03410-teillet_argenty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03279-03410-teillet_argenty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03279-03410-teillet_argenty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03279-03410-teillet_argenty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03280-03420-terjat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03280-03420-terjat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03280-03420-terjat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03280-03420-terjat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03281-03240-le_theil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03281-03240-le_theil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03281-03240-le_theil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03281-03240-le_theil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03282-03350-theneuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03282-03350-theneuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03282-03350-theneuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03282-03350-theneuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03283-03230-thiel_sur_acolin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03283-03230-thiel_sur_acolin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03283-03230-thiel_sur_acolin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03283-03230-thiel_sur_acolin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03284-03220-thionne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03284-03220-thionne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03284-03220-thionne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03284-03220-thionne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03285-03430-tortezais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03285-03430-tortezais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03285-03430-tortezais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03285-03430-tortezais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03286-03400-toulon_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03286-03400-toulon_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03286-03400-toulon_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03286-03400-toulon_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03287-03240-treban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03287-03240-treban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03287-03240-treban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03287-03240-treban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03288-03380-treignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03288-03380-treignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03288-03380-treignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03288-03380-treignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03289-03220-treteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03289-03220-treteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03289-03220-treteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03289-03220-treteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03290-03460-trevol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03290-03460-trevol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03290-03460-trevol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03290-03460-trevol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03291-03220-trezelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03291-03220-trezelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03291-03220-trezelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03291-03220-trezelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03292-03240-tronget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03292-03240-tronget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03292-03240-tronget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03292-03240-tronget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03293-03360-urcay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03293-03360-urcay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03293-03360-urcay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03293-03360-urcay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03294-03140-ussel_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03294-03140-ussel_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03294-03140-ussel_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03294-03140-ussel_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03295-03330-valignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03295-03330-valignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03295-03330-valignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03295-03330-valignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03296-03360-valigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03296-03360-valigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03296-03360-valigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03296-03360-valigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03297-03190-vallon_en_sully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03297-03190-vallon_en_sully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03297-03190-vallon_en_sully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03297-03190-vallon_en_sully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03298-03150-varennes_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03298-03150-varennes_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03298-03150-varennes_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03298-03150-varennes_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03299-03220-varennes_sur_teche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03299-03220-varennes_sur_teche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03299-03220-varennes_sur_teche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03299-03220-varennes_sur_teche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03300-03220-vaumas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03300-03220-vaumas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03300-03220-vaumas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03300-03220-vaumas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03301-03190-vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03301-03190-vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03301-03190-vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03301-03190-vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03302-03450-veauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03302-03450-veauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03302-03450-veauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03302-03450-veauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03303-03190-venas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03303-03190-venas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03303-03190-venas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03303-03190-venas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03304-03110-vendat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03304-03110-vendat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03304-03110-vendat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03304-03110-vendat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03305-03190-verneix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03305-03190-verneix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03305-03190-verneix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03305-03190-verneix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03306-03200-le_vernet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03306-03200-le_vernet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03306-03200-le_vernet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03306-03200-le_vernet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03307-03500-verneuil_en_bourbonnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03307-03500-verneuil_en_bourbonnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03307-03500-verneuil_en_bourbonnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03307-03500-verneuil_en_bourbonnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03308-03390-vernusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03308-03390-vernusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03308-03390-vernusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03308-03390-vernusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03309-03320-le_veurdre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03309-03320-le_veurdre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03309-03320-le_veurdre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03309-03320-le_veurdre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03310-03200-vichy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03310-03200-vichy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03310-03200-vichy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03310-03200-vichy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03311-03450-vicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03311-03450-vicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03311-03450-vicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03311-03450-vicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03312-03430-vieure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03312-03430-vieure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03312-03430-vieure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03312-03430-vieure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03313-03350-le_vilhain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03313-03350-le_vilhain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03313-03350-le_vilhain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03313-03350-le_vilhain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03314-03310-villebret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03314-03310-villebret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03314-03310-villebret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03314-03310-villebret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03315-03430-villefranche_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03315-03430-villefranche_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03315-03430-villefranche_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03315-03430-villefranche_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03316-03460-villeneuve_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03316-03460-villeneuve_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03316-03460-villeneuve_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03316-03460-villeneuve_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03317-03370-viplaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03317-03370-viplaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03317-03370-viplaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03317-03370-viplaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03319-03140-voussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03319-03140-voussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03319-03140-voussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03319-03140-voussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03320-03160-ygrande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03320-03160-ygrande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03320-03160-ygrande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03320-03160-ygrande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03321-03400-yzeure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03321-03400-yzeure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03321-03400-yzeure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt03-allier/commune03321-03400-yzeure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-04.xml
+++ b/public/sitemaps/sitemap-04.xml
@@ -5,406 +5,808 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04001-04510-aiglun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04001-04510-aiglun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04001-04510-aiglun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04001-04510-aiglun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04004-04500-allemagne_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04004-04500-allemagne_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04004-04500-allemagne_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04004-04500-allemagne_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04005-04170-allons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04005-04170-allons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04005-04170-allons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04005-04170-allons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04006-04260-allos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04006-04260-allos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04006-04260-allos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04006-04260-allos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04007-04170-angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04007-04170-angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04007-04170-angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04007-04170-angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04008-04240-annot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04008-04240-annot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04008-04240-annot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04008-04240-annot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04009-04420-archail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04009-04420-archail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04009-04420-archail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04009-04420-archail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04012-04110-aubenas_les_alpes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04012-04110-aubenas_les_alpes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04012-04110-aubenas_les_alpes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04012-04110-aubenas_les_alpes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04013-04200-aubignosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04013-04200-aubignosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04013-04200-aubignosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04013-04200-aubignosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04016-04200-authon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04016-04200-authon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04016-04200-authon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04016-04200-authon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04017-04140-auzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04017-04140-auzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04017-04140-auzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04017-04140-auzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04018-04150-banon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04018-04150-banon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04018-04150-banon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04018-04150-banon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04019-04400-barcelonnette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04019-04400-barcelonnette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04019-04400-barcelonnette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04019-04400-barcelonnette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04020-04140-barles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04020-04140-barles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04020-04140-barles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04020-04140-barles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04021-04380-barras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04021-04380-barras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04021-04380-barras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04021-04380-barras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04022-04330-barreme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04022-04330-barreme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04022-04330-barreme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04022-04330-barreme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04023-04250-bayons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04023-04250-bayons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04023-04250-bayons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04023-04250-bayons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04024-04420-beaujeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04024-04420-beaujeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04024-04420-beaujeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04024-04420-beaujeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04025-04370-beauvezer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04025-04370-beauvezer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04025-04370-beauvezer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04025-04370-beauvezer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04026-04250-bellaffaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04026-04250-bellaffaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04026-04250-bellaffaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04026-04250-bellaffaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04027-04200-bevons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04027-04200-bevons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04027-04200-bevons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04027-04200-bevons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04028-04270-beynes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04028-04270-beynes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04028-04270-beynes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04028-04270-beynes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04030-04330-blieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04030-04330-blieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04030-04330-blieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04030-04330-blieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04031-04270-bras_d_asse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04031-04270-bras_d_asse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04031-04270-bras_d_asse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04031-04270-bras_d_asse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04032-04240-braux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04032-04240-braux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04032-04240-braux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04032-04240-braux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04033-04340-ubaye_serre_poncon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04033-04340-ubaye_serre_poncon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04033-04340-ubaye_serre_poncon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04033-04340-ubaye_serre_poncon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04034-04700-la_brillanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04034-04700-la_brillanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04034-04700-la_brillanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04034-04700-la_brillanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04035-04210-brunet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04035-04210-brunet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04035-04210-brunet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04035-04210-brunet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04036-04420-le_brusquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04036-04420-le_brusquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04036-04420-le_brusquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04036-04420-le_brusquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04037-04250-le_caire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04037-04250-le_caire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04037-04250-le_caire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04037-04250-le_caire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04039-04120-castellane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04039-04120-castellane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04039-04120-castellane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04039-04120-castellane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04040-04380-le_castellard_melan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04040-04380-le_castellard_melan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04040-04380-le_castellard_melan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04040-04380-le_castellard_melan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04041-04700-le_castellet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04041-04700-le_castellet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04041-04700-le_castellet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04041-04700-le_castellet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04042-04320-castellet_les_sausses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04042-04320-castellet_les_sausses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04042-04320-castellet_les_sausses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04042-04320-castellet_les_sausses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04043-04320-val_de_chalvagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04043-04320-val_de_chalvagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04043-04320-val_de_chalvagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04043-04320-val_de_chalvagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04045-04280-cereste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04045-04280-cereste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04045-04280-cereste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04045-04280-cereste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04046-04510-le_chaffaut_saint_jurson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04046-04510-le_chaffaut_saint_jurson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04046-04510-le_chaffaut_saint_jurson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04046-04510-le_chaffaut_saint_jurson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04047-04660-champtercier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04047-04660-champtercier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04047-04660-champtercier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04047-04660-champtercier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04049-04600-chateau_arnoux_saint_auban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04049-04600-chateau_arnoux_saint_auban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04049-04600-chateau_arnoux_saint_auban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04049-04600-chateau_arnoux_saint_auban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04049-04160-chateau_arnoux_saint_auban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04049-04160-chateau_arnoux_saint_auban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04049-04160-chateau_arnoux_saint_auban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04049-04160-chateau_arnoux_saint_auban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04050-04250-chateaufort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04050-04250-chateaufort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04050-04250-chateaufort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04050-04250-chateaufort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04051-04200-chateauneuf_miravail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04051-04200-chateauneuf_miravail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04051-04200-chateauneuf_miravail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04051-04200-chateauneuf_miravail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04053-04200-chateauneuf_val_saint_donat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04053-04200-chateauneuf_val_saint_donat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04053-04200-chateauneuf_val_saint_donat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04053-04200-chateauneuf_val_saint_donat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04054-04270-chateauredon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04054-04270-chateauredon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04054-04270-chateauredon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04054-04270-chateauredon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04055-04330-chaudon_norante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04055-04330-chaudon_norante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04055-04330-chaudon_norante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04055-04330-chaudon_norante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04057-04250-clamensane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04057-04250-clamensane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04057-04250-clamensane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04057-04250-clamensane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04058-05110-claret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04058-05110-claret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04058-05110-claret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04058-05110-claret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04059-04330-clumanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04059-04330-clumanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04059-04330-clumanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04059-04330-clumanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04061-04370-colmars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04061-04370-colmars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04061-04370-colmars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04061-04370-colmars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04062-04530-la_condamine_chatelard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04062-04530-la_condamine_chatelard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04062-04530-la_condamine_chatelard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04062-04530-la_condamine_chatelard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04063-04220-corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04063-04220-corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04063-04220-corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04063-04220-corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04065-04230-cruis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04065-04230-cruis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04065-04230-cruis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04065-04230-cruis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04066-05110-curbans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04066-05110-curbans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04066-05110-curbans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04066-05110-curbans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04067-04200-curel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04067-04200-curel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04067-04200-curel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04067-04200-curel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04068-04300-dauphin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04068-04300-dauphin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04068-04300-dauphin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04068-04300-dauphin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04069-04120-demandolx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04069-04120-demandolx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04069-04120-demandolx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04069-04120-demandolx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04070-04000-digne_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04070-04000-digne_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04070-04000-digne_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04070-04000-digne_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04072-04420-draix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04072-04420-draix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04072-04420-draix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04072-04420-draix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04073-04400-enchastrayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04073-04400-enchastrayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04073-04400-enchastrayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04073-04400-enchastrayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04074-04000-entrages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04074-04000-entrages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04074-04000-entrages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04074-04000-entrages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04074-04270-entrages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04074-04270-entrages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04074-04270-entrages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04074-04270-entrages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04075-04200-entrepierres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04075-04200-entrepierres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04075-04200-entrepierres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04075-04200-entrepierres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04076-04320-entrevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04076-04320-entrevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04076-04320-entrevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04076-04320-entrevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04077-04700-entrevennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04077-04700-entrevennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04077-04700-entrevennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04077-04700-entrevennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04079-04160-l_escale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04079-04160-l_escale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04079-04160-l_escale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04079-04160-l_escale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04081-04800-esparron_de_verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04081-04800-esparron_de_verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04081-04800-esparron_de_verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04081-04800-esparron_de_verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04084-04270-estoublon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04084-04270-estoublon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04084-04270-estoublon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04084-04270-estoublon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04085-04250-faucon_du_caire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04085-04250-faucon_du_caire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04085-04250-faucon_du_caire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04085-04250-faucon_du_caire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04086-04400-faucon_de_barcelonnette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04086-04400-faucon_de_barcelonnette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04086-04400-faucon_de_barcelonnette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04086-04400-faucon_de_barcelonnette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04087-04230-fontienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04087-04230-fontienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04087-04230-fontienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04087-04230-fontienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04088-04300-forcalquier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04088-04300-forcalquier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04088-04300-forcalquier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04088-04300-forcalquier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04090-04240-le_fugeret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04090-04240-le_fugeret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04090-04240-le_fugeret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04090-04240-le_fugeret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04091-04310-ganagobie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04091-04310-ganagobie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04091-04310-ganagobie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04091-04310-ganagobie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04092-04120-la_garde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04092-04120-la_garde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04092-04120-la_garde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04092-04120-la_garde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04093-04250-gigors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04093-04250-gigors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04093-04250-gigors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04093-04250-gigors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04094-04800-greoux_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04094-04800-greoux_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04094-04800-greoux_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04094-04800-greoux_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04095-04150-l_hospitalet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04095-04150-l_hospitalet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04095-04150-l_hospitalet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04095-04150-l_hospitalet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04096-04850-jausiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04096-04850-jausiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04096-04850-jausiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04096-04850-jausiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04097-04420-la_javie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04097-04420-la_javie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04097-04420-la_javie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04097-04420-la_javie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04099-04170-lambruisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04099-04170-lambruisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04099-04170-lambruisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04099-04170-lambruisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04101-04230-lardiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04101-04230-lardiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04101-04230-lardiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04101-04230-lardiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04102-04340-le_lauzet_ubaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04102-04340-le_lauzet_ubaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04102-04340-le_lauzet_ubaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04102-04340-le_lauzet_ubaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04104-04300-limans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04104-04300-limans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04104-04300-limans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04104-04300-limans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04106-04700-lurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04106-04700-lurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04106-04700-lurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04106-04700-lurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04107-04270-majastres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04107-04270-majastres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04107-04270-majastres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04107-04270-majastres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04108-04350-malijai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04108-04350-malijai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04108-04350-malijai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04108-04350-malijai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04109-04230-mallefougasse_auges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04109-04230-mallefougasse_auges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04109-04230-mallefougasse_auges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04109-04230-mallefougasse_auges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04110-04510-mallemoisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04110-04510-mallemoisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04110-04510-mallemoisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04110-04510-mallemoisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04111-04300-mane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04111-04300-mane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04111-04300-mane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04111-04300-mane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04112-04100-manosque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04112-04100-manosque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04112-04100-manosque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04112-04100-manosque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04113-04420-marcoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04113-04420-marcoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04113-04420-marcoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04113-04420-marcoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04115-04240-meailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04115-04240-meailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04115-04240-meailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04115-04240-meailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04116-04190-les_mees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04116-04190-les_mees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04116-04190-les_mees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04116-04190-les_mees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04118-04250-melve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04118-04250-melve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04118-04250-melve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04118-04250-melve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04120-04530-val_d_oronaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04120-04530-val_d_oronaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04120-04530-val_d_oronaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04120-04530-val_d_oronaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04121-04270-mezel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04121-04270-mezel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04121-04270-mezel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04121-04270-mezel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04122-04510-mirabeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04122-04510-mirabeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04122-04510-mirabeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04122-04510-mirabeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04123-04200-mison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04123-04200-mison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04123-04200-mison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04123-04200-mison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04124-04500-montagnac_montpezat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04124-04500-montagnac_montpezat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04124-04500-montagnac_montpezat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04124-04500-montagnac_montpezat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04126-04140-montclar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04126-04140-montclar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04126-04140-montclar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04126-04140-montclar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04127-04600-montfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04127-04600-montfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04127-04600-montfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04127-04600-montfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04128-04110-montfuron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04128-04110-montfuron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04128-04110-montfuron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04128-04110-montfuron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04129-04110-montjustin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04129-04110-montjustin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04129-04110-montjustin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04129-04110-montjustin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04130-04230-montlaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04130-04230-montlaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04130-04230-montlaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04130-04230-montlaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04132-04150-montsalier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04132-04150-montsalier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04132-04150-montsalier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04132-04150-montsalier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04133-04170-moriez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04133-04170-moriez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04133-04170-moriez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04133-04170-moriez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04134-04250-la_motte_du_caire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04134-04250-la_motte_du_caire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04134-04250-la_motte_du_caire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04134-04250-la_motte_du_caire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04135-04360-moustiers_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04135-04360-moustiers_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04135-04360-moustiers_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04135-04360-moustiers_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04136-04170-la_mure_argens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04136-04170-la_mure_argens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04136-04170-la_mure_argens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04136-04170-la_mure_argens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04137-04250-nibles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04137-04250-nibles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04137-04250-nibles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04137-04250-nibles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04138-04300-niozelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04138-04300-niozelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04138-04300-niozelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04138-04300-niozelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04139-04200-noyers_sur_jabron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04139-04200-noyers_sur_jabron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04139-04200-noyers_sur_jabron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04139-04200-noyers_sur_jabron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04140-04200-les_omergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04140-04200-les_omergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04140-04200-les_omergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04140-04200-les_omergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04141-04230-ongles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04141-04230-ongles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04141-04230-ongles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04141-04230-ongles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04142-04110-oppedette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04142-04110-oppedette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04142-04110-oppedette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04142-04110-oppedette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04143-04700-oraison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04143-04700-oraison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04143-04700-oraison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04143-04700-oraison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04144-04120-la_palud_sur_verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04144-04120-la_palud_sur_verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04144-04120-la_palud_sur_verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04144-04120-la_palud_sur_verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04145-04200-peipin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04145-04200-peipin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04145-04200-peipin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04145-04200-peipin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04148-04120-peyroules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04148-04120-peyroules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04148-04120-peyroules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04148-04120-peyroules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04149-04310-peyruis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04149-04310-peyruis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04149-04310-peyruis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04149-04310-peyruis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04150-05130-piegut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04150-05130-piegut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04150-05130-piegut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04150-05130-piegut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04151-04300-pierrerue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04151-04300-pierrerue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04151-04300-pierrerue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04151-04300-pierrerue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04152-04860-pierrevert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04152-04860-pierrevert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04152-04860-pierrevert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04152-04860-pierrevert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04154-05160-pontis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04154-05160-pontis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04154-05160-pontis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04154-05160-pontis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04155-04420-prads_haute_bleone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04155-04420-prads_haute_bleone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04155-04420-prads_haute_bleone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04155-04420-prads_haute_bleone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04156-04700-puimichel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04156-04700-puimichel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04156-04700-puimichel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04156-04700-puimichel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04157-04410-puimoisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04157-04410-puimoisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04157-04410-puimoisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04157-04410-puimoisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04158-04500-quinson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04158-04500-quinson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04158-04500-quinson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04158-04500-quinson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04159-04150-redortiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04159-04150-redortiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04159-04150-redortiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04159-04150-redortiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04160-04110-reillanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04160-04110-reillanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04160-04110-reillanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04160-04110-reillanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04161-04340-meolans_revel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04161-04340-meolans_revel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04161-04340-meolans_revel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04161-04340-meolans_revel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04162-04150-revest_des_brousses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04162-04150-revest_des_brousses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04162-04150-revest_des_brousses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04162-04150-revest_des_brousses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04163-04150-revest_du_bion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04163-04150-revest_du_bion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04163-04150-revest_du_bion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04163-04150-revest_du_bion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04164-04230-revest_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04164-04230-revest_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04164-04230-revest_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04164-04230-revest_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04166-04500-riez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04166-04500-riez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04166-04500-riez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04166-04500-riez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04167-04000-la_robine_sur_galabre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04167-04000-la_robine_sur_galabre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04167-04000-la_robine_sur_galabre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04167-04000-la_robine_sur_galabre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04169-04150-la_rochegiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04169-04150-la_rochegiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04169-04150-la_rochegiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04169-04150-la_rochegiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04170-06260-la_rochette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04170-06260-la_rochette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04170-06260-la_rochette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04170-06260-la_rochette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04171-04120-rougon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04171-04120-rougon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04171-04120-rougon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04171-04120-rougon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04172-04500-roumoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04172-04500-roumoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04172-04500-roumoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04172-04500-roumoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04173-04170-saint_andre_les_alpes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04173-04170-saint_andre_les_alpes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04173-04170-saint_andre_les_alpes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04173-04170-saint_andre_les_alpes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04174-04240-saint_benoit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04174-04240-saint_benoit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04174-04240-saint_benoit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04174-04240-saint_benoit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04175-04110-sainte_croix_a_lauze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04175-04110-sainte_croix_a_lauze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04175-04110-sainte_croix_a_lauze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04175-04110-sainte_croix_a_lauze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04176-04500-sainte_croix_du_verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04176-04500-sainte_croix_du_verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04176-04500-sainte_croix_du_verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04176-04500-sainte_croix_du_verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04177-04380-hautes_duyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04177-04380-hautes_duyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04177-04380-hautes_duyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04177-04380-hautes_duyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04178-04230-saint_etienne_les_orgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04178-04230-saint_etienne_les_orgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04178-04230-saint_etienne_les_orgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04178-04230-saint_etienne_les_orgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04179-04200-saint_geniez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04179-04200-saint_geniez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04179-04200-saint_geniez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04179-04200-saint_geniez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04180-04330-saint_jacques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04180-04330-saint_jacques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04180-04330-saint_jacques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04180-04330-saint_jacques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04181-04270-saint_jeannet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04181-04270-saint_jeannet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04181-04270-saint_jeannet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04181-04270-saint_jeannet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04182-04270-saint_julien_d_asse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04182-04270-saint_julien_d_asse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04182-04270-saint_julien_d_asse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04182-04270-saint_julien_d_asse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04183-04170-saint_julien_du_verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04183-04170-saint_julien_du_verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04183-04170-saint_julien_du_verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04183-04170-saint_julien_du_verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04184-04410-saint_jurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04184-04410-saint_jurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04184-04410-saint_jurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04184-04410-saint_jurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04186-04500-saint_laurent_du_verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04186-04500-saint_laurent_du_verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04186-04500-saint_laurent_du_verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04186-04500-saint_laurent_du_verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04187-04330-saint_lions/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04187-04330-saint_lions/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04187-04330-saint_lions/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04187-04330-saint_lions/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04188-04300-saint_maime/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04188-04300-saint_maime/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04188-04300-saint_maime/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04188-04300-saint_maime/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04189-04800-saint_martin_de_bromes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04189-04800-saint_martin_de_bromes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04189-04800-saint_martin_de_bromes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04189-04800-saint_martin_de_bromes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04190-04300-saint_martin_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04190-04300-saint_martin_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04190-04300-saint_martin_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04190-04300-saint_martin_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04191-04140-saint_martin_les_seyne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04191-04140-saint_martin_les_seyne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04191-04140-saint_martin_les_seyne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04191-04140-saint_martin_les_seyne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04192-04870-saint_michel_l_observatoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04192-04870-saint_michel_l_observatoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04192-04870-saint_michel_l_observatoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04192-04870-saint_michel_l_observatoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04193-04530-saint_paul_sur_ubaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04193-04530-saint_paul_sur_ubaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04193-04530-saint_paul_sur_ubaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04193-04530-saint_paul_sur_ubaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04194-06260-saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04194-06260-saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04194-06260-saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04194-06260-saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04195-04400-saint_pons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04195-04400-saint_pons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04195-04400-saint_pons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04195-04400-saint_pons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04197-04220-sainte_tulle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04197-04220-sainte_tulle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04197-04220-sainte_tulle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04197-04220-sainte_tulle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04199-04200-saint_vincent_sur_jabron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04199-04200-saint_vincent_sur_jabron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04199-04200-saint_vincent_sur_jabron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04199-04200-saint_vincent_sur_jabron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04200-04290-salignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04200-04290-salignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04200-04290-salignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04200-04290-salignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04201-04150-saumane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04201-04150-saumane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04201-04150-saumane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04201-04150-saumane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04202-04320-sausses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04202-04320-sausses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04202-04320-sausses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04202-04320-sausses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04203-04140-selonnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04203-04140-selonnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04203-04140-selonnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04203-04140-selonnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04204-04330-senez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04204-04330-senez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04204-04330-senez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04204-04330-senez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04205-04140-seyne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04205-04140-seyne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04205-04140-seyne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04205-04140-seyne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04206-04300-sigonce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04206-04300-sigonce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04206-04300-sigonce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04206-04300-sigonce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04207-04200-sigoyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04207-04200-sigoyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04207-04200-sigoyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04207-04200-sigoyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04208-04150-simiane_la_rotonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04208-04150-simiane_la_rotonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04208-04150-simiane_la_rotonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04208-04150-simiane_la_rotonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04209-04200-sisteron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04209-04200-sisteron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04209-04200-sisteron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04209-04200-sisteron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04210-04120-soleilhas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04210-04120-soleilhas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04210-04120-soleilhas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04210-04120-soleilhas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04211-04290-sourribes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04211-04290-sourribes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04211-04290-sourribes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04211-04290-sourribes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04214-04330-tartonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04214-04330-tartonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04214-04330-tartonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04214-04330-tartonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04216-04200-theze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04216-04200-theze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04216-04200-theze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04216-04200-theze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04217-04380-thoard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04217-04380-thoard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04217-04380-thoard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04217-04380-thoard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04218-04170-thorame_basse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04218-04170-thorame_basse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04218-04170-thorame_basse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04218-04170-thorame_basse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04219-04170-thorame_haute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04219-04170-thorame_haute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04219-04170-thorame_haute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04219-04170-thorame_haute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04220-04400-les_thuiles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04220-04400-les_thuiles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04220-04400-les_thuiles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04220-04400-les_thuiles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04222-04250-turriers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04222-04250-turriers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04222-04250-turriers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04222-04250-turriers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04224-04240-ubraye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04224-04240-ubraye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04224-04240-ubraye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04224-04240-ubraye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04226-04400-uvernet_fours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04226-04400-uvernet_fours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04226-04400-uvernet_fours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04226-04400-uvernet_fours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04227-04110-vacheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04227-04110-vacheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04227-04110-vacheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04227-04110-vacheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04228-04250-valavoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04228-04250-valavoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04228-04250-valavoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04228-04250-valavoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04229-04200-valbelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04229-04200-valbelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04229-04200-valbelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04229-04200-valbelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04230-04210-valensole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04230-04210-valensole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04230-04210-valensole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04230-04210-valensole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04231-04200-valernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04231-04200-valernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04231-04200-valernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04231-04200-valernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04233-04200-vaumeilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04233-04200-vaumeilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04233-04200-vaumeilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04233-04200-vaumeilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04234-05130-venterol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04234-05130-venterol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04234-05130-venterol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04234-05130-venterol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04235-04140-verdaches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04235-04140-verdaches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04235-04140-verdaches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04235-04140-verdaches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04236-04170-vergons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04236-04170-vergons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04236-04170-vergons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04236-04170-vergons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04237-04140-le_vernet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04237-04140-le_vernet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04237-04140-le_vernet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04237-04140-le_vernet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04240-04370-villars_colmars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04240-04370-villars_colmars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04240-04370-villars_colmars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04240-04370-villars_colmars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04241-04110-villemus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04241-04110-villemus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04241-04110-villemus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04241-04110-villemus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04242-04180-villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04242-04180-villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04242-04180-villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04242-04180-villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04244-04290-volonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04244-04290-volonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04244-04290-volonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04244-04290-volonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04245-04130-volx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04245-04130-volx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04245-04130-volx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt04-alpes_de_haute_provence/commune04245-04130-volx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-05.xml
+++ b/public/sitemaps/sitemap-05.xml
@@ -5,330 +5,656 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05001-05460-abries_ristolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05001-05460-abries_ristolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05001-05460-abries_ristolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05001-05460-abries_ristolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05003-05470-aiguilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05003-05470-aiguilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05003-05470-aiguilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05003-05470-aiguilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05004-05260-ancelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05004-05260-ancelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05004-05260-ancelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05004-05260-ancelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05006-05120-l_argentiere_la_bessee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05006-05120-l_argentiere_la_bessee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05006-05120-l_argentiere_la_bessee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05006-05120-l_argentiere_la_bessee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05007-05350-arvieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05007-05350-arvieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05007-05350-arvieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05007-05350-arvieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05008-05140-aspremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05008-05140-aspremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05008-05140-aspremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05008-05140-aspremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05009-05800-aspres_les_corps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05009-05800-aspres_les_corps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05009-05800-aspres_les_corps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05009-05800-aspres_les_corps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05010-05140-aspres_sur_buech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05010-05140-aspres_sur_buech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05010-05140-aspres_sur_buech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05010-05140-aspres_sur_buech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05011-05230-avancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05011-05230-avancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05011-05230-avancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05011-05230-avancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05012-05200-baratier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05012-05200-baratier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05012-05200-baratier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05012-05200-baratier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05013-05110-barcillonnette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05013-05110-barcillonnette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05013-05110-barcillonnette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05013-05110-barcillonnette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05014-05300-barret_sur_meouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05014-05300-barret_sur_meouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05014-05300-barret_sur_meouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05014-05300-barret_sur_meouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05016-05700-la_batie_montsaleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05016-05700-la_batie_montsaleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05016-05700-la_batie_montsaleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05016-05700-la_batie_montsaleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05017-05230-la_batie_neuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05017-05230-la_batie_neuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05017-05230-la_batie_neuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05017-05230-la_batie_neuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05018-05000-la_batie_vieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05018-05000-la_batie_vieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05018-05000-la_batie_vieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05018-05000-la_batie_vieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05019-05140-la_beaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05019-05140-la_beaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05019-05140-la_beaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05019-05140-la_beaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05021-05700-le_bersac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05021-05700-le_bersac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05021-05700-le_bersac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05021-05700-le_bersac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05022-05190-breziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05022-05190-breziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05022-05190-breziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05022-05190-breziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05023-05100-briancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05023-05100-briancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05023-05100-briancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05023-05100-briancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05024-05150-valdoule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05024-05150-valdoule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05024-05150-valdoule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05024-05150-valdoule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05025-05500-buissard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05025-05500-buissard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05025-05500-buissard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05025-05500-buissard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05026-05600-ceillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05026-05600-ceillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05026-05600-ceillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05026-05600-ceillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05027-05100-cervieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05027-05100-cervieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05027-05100-cervieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05027-05100-cervieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05028-05400-chabestan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05028-05400-chabestan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05028-05400-chabestan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05028-05400-chabestan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05029-05260-chabottes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05029-05260-chabottes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05029-05260-chabottes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05029-05260-chabottes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05031-05310-champcella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05031-05310-champcella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05031-05310-champcella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05031-05310-champcella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05032-05260-champoleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05032-05260-champoleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05032-05260-champoleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05032-05260-champoleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05033-05700-chanousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05033-05700-chanousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05033-05700-chanousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05033-05700-chanousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05035-05400-chateauneuf_d_oze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05035-05400-chateauneuf_d_oze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05035-05400-chateauneuf_d_oze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05035-05400-chateauneuf_d_oze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05036-05380-chateauroux_les_alpes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05036-05380-chateauroux_les_alpes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05036-05380-chateauroux_les_alpes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05036-05380-chateauroux_les_alpes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05037-05000-chateauvieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05037-05000-chateauvieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05037-05000-chateauvieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05037-05000-chateauvieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05038-05350-chateau_ville_vieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05038-05350-chateau_ville_vieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05038-05350-chateau_ville_vieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05038-05350-chateau_ville_vieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05039-05800-aubessagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05039-05800-aubessagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05039-05800-aubessagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05039-05800-aubessagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05040-05230-chorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05040-05230-chorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05040-05230-chorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05040-05230-chorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05044-05200-crevoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05044-05200-crevoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05044-05200-crevoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05044-05200-crevoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05045-05200-crots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05045-05200-crots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05045-05200-crots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05045-05200-crots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05046-05200-embrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05046-05200-embrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05046-05200-embrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05046-05200-embrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05047-05300-eourres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05047-05300-eourres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05047-05300-eourres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05047-05300-eourres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05048-05700-l_epine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05048-05700-l_epine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05048-05700-l_epine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05048-05700-l_epine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05049-05110-esparron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05049-05110-esparron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05049-05110-esparron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05049-05110-esparron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05050-05190-espinasses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05050-05190-espinasses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05050-05190-espinasses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05050-05190-espinasses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05051-05700-etoile_saint_cyrice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05051-05700-etoile_saint_cyrice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05051-05700-etoile_saint_cyrice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05051-05700-etoile_saint_cyrice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05052-05600-eygliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05052-05600-eygliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05052-05600-eygliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05052-05600-eygliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05053-05300-garde_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05053-05300-garde_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05053-05300-garde_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05053-05300-garde_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05054-05500-la_fare_en_champsaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05054-05500-la_fare_en_champsaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05054-05500-la_fare_en_champsaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05054-05500-la_fare_en_champsaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05055-05140-la_faurie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05055-05140-la_faurie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05055-05140-la_faurie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05055-05140-la_faurie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05056-05260-forest_saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05056-05260-forest_saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05056-05260-forest_saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05056-05260-forest_saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05057-05130-fouillouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05057-05130-fouillouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05057-05130-fouillouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05057-05130-fouillouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05058-05310-freissinieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05058-05310-freissinieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05058-05310-freissinieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05058-05310-freissinieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05059-05000-la_freissinouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05059-05000-la_freissinouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05059-05000-la_freissinouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05059-05000-la_freissinouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05060-05400-furmeyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05060-05400-furmeyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05060-05400-furmeyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05060-05400-furmeyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05061-05000-gap/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05061-05000-gap/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05061-05000-gap/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05061-05000-gap/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05062-05800-le_glaizil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05062-05800-le_glaizil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05062-05800-le_glaizil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05062-05800-le_glaizil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05063-05320-la_grave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05063-05320-la_grave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05063-05320-la_grave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05063-05320-la_grave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05064-05800-la_chapelle_en_valgaudemar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05064-05800-la_chapelle_en_valgaudemar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05064-05800-la_chapelle_en_valgaudemar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05064-05800-la_chapelle_en_valgaudemar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05065-05600-guillestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05065-05600-guillestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05065-05600-guillestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05065-05600-guillestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05066-05140-la_haute_beaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05066-05140-la_haute_beaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05066-05140-la_haute_beaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05066-05140-la_haute_beaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05068-05130-jarjayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05068-05130-jarjayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05068-05130-jarjayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05068-05130-jarjayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05070-05300-laragne_monteglin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05070-05300-laragne_monteglin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05070-05300-laragne_monteglin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05070-05300-laragne_monteglin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05071-05110-lardier_et_valenca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05071-05110-lardier_et_valenca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05071-05110-lardier_et_valenca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05071-05110-lardier_et_valenca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05072-05500-laye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05072-05500-laye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05072-05500-laye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05072-05500-laye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05073-05300-lazer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05073-05300-lazer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05073-05300-lazer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05073-05300-lazer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05074-05130-lettret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05074-05130-lettret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05074-05130-lettret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05074-05130-lettret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05075-05400-manteyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05075-05400-manteyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05075-05400-manteyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05075-05400-manteyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05076-05700-mereuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05076-05700-mereuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05076-05700-mereuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05076-05700-mereuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05077-05350-molines_en_queyras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05077-05350-molines_en_queyras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05077-05350-molines_en_queyras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05077-05350-molines_en_queyras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05078-05110-monetier_allemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05078-05110-monetier_allemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05078-05110-monetier_allemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05078-05110-monetier_allemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05079-05220-le_monetier_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05079-05220-le_monetier_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05079-05220-le_monetier_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05079-05220-le_monetier_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05080-05140-montbrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05080-05140-montbrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05080-05140-montbrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05080-05140-montbrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05081-05700-montclus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05081-05700-montclus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05081-05700-montclus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05081-05700-montclus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05082-05600-mont_dauphin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05082-05600-mont_dauphin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05082-05600-mont_dauphin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05082-05600-mont_dauphin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05084-05230-montgardin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05084-05230-montgardin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05084-05230-montgardin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05084-05230-montgardin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05085-05100-montgenevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05085-05100-montgenevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05085-05100-montgenevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05085-05100-montgenevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05086-05150-montjay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05086-05150-montjay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05086-05150-montjay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05086-05150-montjay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05087-05400-montmaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05087-05400-montmaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05087-05400-montmaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05087-05400-montmaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05089-05700-montrond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05089-05700-montrond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05089-05700-montrond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05089-05700-montrond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05090-05500-la_motte_en_champsaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05090-05500-la_motte_en_champsaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05090-05500-la_motte_en_champsaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05090-05500-la_motte_en_champsaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05091-05150-moydans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05091-05150-moydans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05091-05150-moydans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05091-05150-moydans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05092-05000-neffes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05092-05000-neffes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05092-05000-neffes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05092-05000-neffes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05093-05100-nevache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05093-05100-nevache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05093-05100-nevache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05093-05100-nevache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05094-05700-nossage_et_benevent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05094-05700-nossage_et_benevent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05094-05700-nossage_et_benevent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05094-05700-nossage_et_benevent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05095-05500-le_noyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05095-05500-le_noyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05095-05500-le_noyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05095-05500-le_noyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05096-05170-orcieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05096-05170-orcieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05096-05170-orcieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05096-05170-orcieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05097-05700-orpierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05097-05700-orpierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05097-05700-orpierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05097-05700-orpierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05098-05200-les_orres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05098-05200-les_orres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05098-05200-les_orres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05098-05200-les_orres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05099-05400-oze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05099-05400-oze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05099-05400-oze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05099-05400-oze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05100-05000-pelleautier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05100-05000-pelleautier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05100-05000-pelleautier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05100-05000-pelleautier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05101-05340-vallouise_pelvoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05101-05340-vallouise_pelvoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05101-05340-vallouise_pelvoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05101-05340-vallouise_pelvoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05102-05700-la_piarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05102-05700-la_piarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05102-05700-la_piarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05102-05700-la_piarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05103-05300-le_poet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05103-05300-le_poet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05103-05300-le_poet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05103-05300-le_poet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05104-05500-poligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05104-05500-poligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05104-05500-poligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05104-05500-poligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05106-05230-prunieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05106-05230-prunieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05106-05230-prunieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05106-05230-prunieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05107-05100-puy_saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05107-05100-puy_saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05107-05100-puy_saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05107-05100-puy_saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05108-05200-puy_saint_eusebe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05108-05200-puy_saint_eusebe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05108-05200-puy_saint_eusebe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05108-05200-puy_saint_eusebe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05109-05100-puy_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05109-05100-puy_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05109-05100-puy_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05109-05100-puy_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05110-05290-puy_saint_vincent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05110-05290-puy_saint_vincent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05110-05290-puy_saint_vincent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05110-05290-puy_saint_vincent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05111-05200-puy_sanieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05111-05200-puy_sanieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05111-05200-puy_sanieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05111-05200-puy_sanieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05112-05400-rabou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05112-05400-rabou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05112-05400-rabou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05112-05400-rabou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05113-05000-rambaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05113-05000-rambaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05113-05000-rambaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05113-05000-rambaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05114-05160-reallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05114-05160-reallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05114-05160-reallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05114-05160-reallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05115-05190-remollon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05115-05190-remollon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05115-05190-remollon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05115-05190-remollon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05116-05600-reotier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05116-05600-reotier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05116-05600-reotier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05116-05600-reotier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05117-05150-ribeyret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05117-05150-ribeyret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05117-05150-ribeyret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05117-05150-ribeyret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05118-05300-val_buech_meouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05118-05300-val_buech_meouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05118-05300-val_buech_meouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05118-05300-val_buech_meouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05119-05600-risoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05119-05600-risoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05119-05600-risoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05119-05600-risoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05121-05190-rochebrune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05121-05190-rochebrune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05121-05190-rochebrune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05121-05190-rochebrune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05122-05310-la_roche_de_rame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05122-05310-la_roche_de_rame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05122-05310-la_roche_de_rame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05122-05310-la_roche_de_rame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05123-05400-la_roche_des_arnauds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05123-05400-la_roche_des_arnauds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05123-05400-la_roche_des_arnauds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05123-05400-la_roche_des_arnauds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05124-05000-la_rochette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05124-05000-la_rochette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05124-05000-la_rochette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05124-05000-la_rochette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05126-05150-rosans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05126-05150-rosans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05126-05150-rosans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05126-05150-rosans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05127-05190-rousset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05127-05190-rousset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05127-05190-rousset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05127-05190-rousset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05128-05200-saint_andre_d_embrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05128-05200-saint_andre_d_embrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05128-05200-saint_andre_d_embrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05128-05200-saint_andre_d_embrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05129-05150-saint_andre_de_rosans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05129-05150-saint_andre_de_rosans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05129-05150-saint_andre_de_rosans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05129-05150-saint_andre_de_rosans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05130-05160-saint_apollinaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05130-05160-saint_apollinaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05130-05160-saint_apollinaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05130-05160-saint_apollinaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05131-05400-saint_auban_d_oze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05131-05400-saint_auban_d_oze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05131-05400-saint_auban_d_oze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05131-05400-saint_auban_d_oze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05132-05500-saint_bonnet_en_champsaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05132-05500-saint_bonnet_en_champsaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05132-05500-saint_bonnet_en_champsaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05132-05500-saint_bonnet_en_champsaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05133-05330-saint_chaffrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05133-05330-saint_chaffrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05133-05330-saint_chaffrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05133-05330-saint_chaffrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05134-05600-saint_clement_sur_durance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05134-05600-saint_clement_sur_durance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05134-05600-saint_clement_sur_durance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05134-05600-saint_clement_sur_durance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05135-05700-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05135-05700-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05135-05700-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05135-05700-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05136-05600-saint_crepin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05136-05600-saint_crepin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05136-05600-saint_crepin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05136-05600-saint_crepin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05139-05250-devoluy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05139-05250-devoluy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05139-05250-devoluy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05139-05250-devoluy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05140-05130-saint_etienne_le_laus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05140-05130-saint_etienne_le_laus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05140-05130-saint_etienne_le_laus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05140-05130-saint_etienne_le_laus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05142-05800-saint_firmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05142-05800-saint_firmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05142-05800-saint_firmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05142-05800-saint_firmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05144-05800-saint_jacques_en_valgodemard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05144-05800-saint_jacques_en_valgodemard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05144-05800-saint_jacques_en_valgodemard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05144-05800-saint_jacques_en_valgodemard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05145-05260-saint_jean_saint_nicolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05145-05260-saint_jean_saint_nicolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05145-05260-saint_jean_saint_nicolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05145-05260-saint_jean_saint_nicolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05146-05140-saint_julien_en_beauchene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05146-05140-saint_julien_en_beauchene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05146-05140-saint_julien_en_beauchene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05146-05140-saint_julien_en_beauchene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05147-05500-saint_julien_en_champsaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05147-05500-saint_julien_en_champsaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05147-05500-saint_julien_en_champsaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05147-05500-saint_julien_en_champsaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05148-05500-saint_laurent_du_cros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05148-05500-saint_laurent_du_cros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05148-05500-saint_laurent_du_cros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05148-05500-saint_laurent_du_cros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05149-05260-saint_leger_les_melezes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05149-05260-saint_leger_les_melezes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05149-05260-saint_leger_les_melezes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05149-05260-saint_leger_les_melezes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05151-05120-saint_martin_de_queyrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05151-05120-saint_martin_de_queyrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05151-05120-saint_martin_de_queyrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05151-05120-saint_martin_de_queyrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05152-05800-saint_maurice_en_valgodemard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05152-05800-saint_maurice_en_valgodemard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05152-05800-saint_maurice_en_valgodemard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05152-05800-saint_maurice_en_valgodemard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05153-05260-saint_michel_de_chaillol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05153-05260-saint_michel_de_chaillol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05153-05260-saint_michel_de_chaillol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05153-05260-saint_michel_de_chaillol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05154-05140-saint_pierre_d_argencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05154-05140-saint_pierre_d_argencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05154-05140-saint_pierre_d_argencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05154-05140-saint_pierre_d_argencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05155-05300-saint_pierre_avez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05155-05300-saint_pierre_avez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05155-05300-saint_pierre_avez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05155-05300-saint_pierre_avez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05156-05200-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05156-05200-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05156-05200-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05156-05200-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05157-05350-saint_veran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05157-05350-saint_veran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05157-05350-saint_veran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05157-05350-saint_veran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05158-05400-le_saix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05158-05400-le_saix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05158-05400-le_saix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05158-05400-le_saix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05159-05300-saleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05159-05300-saleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05159-05300-saleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05159-05300-saleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05160-05300-salerans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05160-05300-salerans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05160-05300-salerans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05160-05300-salerans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05161-05240-la_salle_les_alpes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05161-05240-la_salle_les_alpes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05161-05240-la_salle_les_alpes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05161-05240-la_salle_les_alpes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05162-05110-la_saulce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05162-05110-la_saulce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05162-05110-la_saulce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05162-05110-la_saulce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05163-05160-le_sauze_du_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05163-05160-le_sauze_du_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05163-05160-le_sauze_du_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05163-05160-le_sauze_du_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05164-05160-savines_le_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05164-05160-savines_le_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05164-05160-savines_le_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05164-05160-savines_le_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05165-05700-savournon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05165-05700-savournon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05165-05700-savournon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05165-05700-savournon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05166-05700-serres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05166-05700-serres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05166-05700-serres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05166-05700-serres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05167-05700-sigottier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05167-05700-sigottier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05167-05700-sigottier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05167-05700-sigottier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05168-05130-sigoyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05168-05130-sigoyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05168-05130-sigoyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05168-05130-sigoyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05169-05150-sorbiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05169-05150-sorbiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05169-05150-sorbiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05169-05150-sorbiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05170-05130-tallard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05170-05130-tallard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05170-05130-tallard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05170-05130-tallard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05171-05190-theus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05171-05190-theus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05171-05190-theus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05171-05190-theus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05172-05700-trescleoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05172-05700-trescleoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05172-05700-trescleoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05172-05700-trescleoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05173-05300-upaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05173-05300-upaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05173-05300-upaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05173-05300-upaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05174-05100-val_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05174-05100-val_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05174-05100-val_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05174-05100-val_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05176-05130-valserres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05176-05130-valserres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05176-05130-valserres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05176-05130-valserres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05177-05560-vars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05177-05560-vars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05177-05560-vars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05177-05560-vars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05178-05300-ventavon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05178-05300-ventavon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05178-05300-ventavon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05178-05300-ventavon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05179-05400-veynes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05179-05400-veynes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05179-05400-veynes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05179-05400-veynes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05180-05120-les_vigneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05180-05120-les_vigneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05180-05120-les_vigneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05180-05120-les_vigneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05181-05480-villar_d_arene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05181-05480-villar_d_arene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05181-05480-villar_d_arene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05181-05480-villar_d_arene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05182-05800-villar_loubiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05182-05800-villar_loubiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05182-05800-villar_loubiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05182-05800-villar_loubiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05183-05100-villar_saint_pancrace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05183-05100-villar_saint_pancrace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05183-05100-villar_saint_pancrace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05183-05100-villar_saint_pancrace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05184-05110-vitrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05184-05110-vitrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05184-05110-vitrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt05-hautes_alpes/commune05184-05110-vitrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-06.xml
+++ b/public/sitemaps/sitemap-06.xml
@@ -5,344 +5,684 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06001-06910-aiglun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06001-06910-aiglun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06001-06910-aiglun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06001-06910-aiglun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06002-06910-amirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06002-06910-amirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06002-06910-amirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06002-06910-amirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06003-06750-andon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06003-06750-andon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06003-06750-andon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06003-06750-andon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06004-06600-antibes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06004-06600-antibes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06004-06600-antibes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06004-06600-antibes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06004-06160-antibes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06004-06160-antibes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06004-06160-antibes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06004-06160-antibes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06005-06260-ascros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06005-06260-ascros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06005-06260-ascros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06005-06260-ascros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06006-06790-aspremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06006-06790-aspremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06006-06790-aspremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06006-06790-aspremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06007-06810-auribeau_sur_siagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06007-06810-auribeau_sur_siagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06007-06810-auribeau_sur_siagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06007-06810-auribeau_sur_siagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06008-06260-auvare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06008-06260-auvare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06008-06260-auvare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06008-06260-auvare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06009-06420-bairols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06009-06420-bairols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06009-06420-bairols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06009-06420-bairols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06010-06620-le_bar_sur_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06010-06620-le_bar_sur_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06010-06620-le_bar_sur_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06010-06620-le_bar_sur_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06011-06310-beaulieu_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06011-06310-beaulieu_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06011-06310-beaulieu_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06011-06310-beaulieu_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06012-06240-beausoleil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06012-06240-beausoleil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06012-06240-beausoleil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06012-06240-beausoleil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06013-06450-belvedere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06013-06450-belvedere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06013-06450-belvedere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06013-06450-belvedere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06014-06390-bendejun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06014-06390-bendejun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06014-06390-bendejun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06014-06390-bendejun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06015-06390-berre_les_alpes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06015-06390-berre_les_alpes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06015-06390-berre_les_alpes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06015-06390-berre_les_alpes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06016-06470-beuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06016-06470-beuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06016-06470-beuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06016-06470-beuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06017-06510-bezaudun_les_alpes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06017-06510-bezaudun_les_alpes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06017-06510-bezaudun_les_alpes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06017-06510-bezaudun_les_alpes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06018-06410-biot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06018-06410-biot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06018-06410-biot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06018-06410-biot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06019-06440-blausasc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06019-06440-blausasc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06019-06440-blausasc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06019-06440-blausasc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06020-06450-la_bollene_vesubie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06020-06450-la_bollene_vesubie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06020-06450-la_bollene_vesubie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06020-06450-la_bollene_vesubie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06021-06830-bonson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06021-06830-bonson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06021-06830-bonson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06021-06830-bonson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06022-06510-bouyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06022-06510-bouyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06022-06510-bouyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06022-06510-bouyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06023-06540-breil_sur_roya/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06023-06540-breil_sur_roya/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06023-06540-breil_sur_roya/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06023-06540-breil_sur_roya/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06024-06850-brianconnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06024-06850-brianconnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06024-06850-brianconnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06024-06850-brianconnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06025-06510-le_broc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06025-06510-le_broc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06025-06510-le_broc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06025-06510-le_broc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06026-06530-cabris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06026-06530-cabris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06026-06530-cabris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06026-06530-cabris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06027-06800-cagnes_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06027-06800-cagnes_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06027-06800-cagnes_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06027-06800-cagnes_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06028-06750-caille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06028-06750-caille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06028-06750-caille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06028-06750-caille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06029-06150-cannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06029-06150-cannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06029-06150-cannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06029-06150-cannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06029-06400-cannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06029-06400-cannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06029-06400-cannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06029-06400-cannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06030-06110-le_cannet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06030-06110-le_cannet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06030-06110-le_cannet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06030-06110-le_cannet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06031-06340-cantaron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06031-06340-cantaron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06031-06340-cantaron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06031-06340-cantaron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06032-06320-cap_d_ail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06032-06320-cap_d_ail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06032-06320-cap_d_ail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06032-06320-cap_d_ail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06033-06510-carros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06033-06510-carros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06033-06510-carros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06033-06510-carros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06034-06670-castagniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06034-06670-castagniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06034-06670-castagniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06034-06670-castagniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06035-06500-castellar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06035-06500-castellar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06035-06500-castellar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06035-06500-castellar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06036-06500-castillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06036-06500-castillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06036-06500-castillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06036-06500-castillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06037-06460-caussols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06037-06460-caussols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06037-06460-caussols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06037-06460-caussols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06038-06740-chateauneuf_grasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06038-06740-chateauneuf_grasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06038-06740-chateauneuf_grasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06038-06740-chateauneuf_grasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06039-06390-chateauneuf_villevieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06039-06390-chateauneuf_villevieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06039-06390-chateauneuf_villevieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06039-06390-chateauneuf_villevieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06040-06470-chateauneuf_d_entraunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06040-06470-chateauneuf_d_entraunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06040-06470-chateauneuf_d_entraunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06040-06470-chateauneuf_d_entraunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06041-06620-cipieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06041-06620-cipieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06041-06620-cipieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06041-06620-cipieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06042-06420-clans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06042-06420-clans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06042-06420-clans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06042-06420-clans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06043-06390-coaraze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06043-06390-coaraze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06043-06390-coaraze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06043-06390-coaraze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06044-06480-la_colle_sur_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06044-06480-la_colle_sur_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06044-06480-la_colle_sur_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06044-06480-la_colle_sur_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06045-06910-collongues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06045-06910-collongues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06045-06910-collongues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06045-06910-collongues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06046-06670-colomars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06046-06670-colomars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06046-06670-colomars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06046-06670-colomars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06047-06510-consegudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06047-06510-consegudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06047-06510-consegudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06047-06510-consegudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06048-06390-contes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06048-06390-contes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06048-06390-contes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06048-06390-contes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06049-06620-courmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06049-06620-courmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06049-06620-courmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06049-06620-courmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06050-06140-coursegoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06050-06140-coursegoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06050-06140-coursegoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06050-06140-coursegoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06051-06260-la_croix_sur_roudoule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06051-06260-la_croix_sur_roudoule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06051-06260-la_croix_sur_roudoule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06051-06260-la_croix_sur_roudoule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06052-06910-cuebris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06052-06910-cuebris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06052-06910-cuebris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06052-06910-cuebris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06053-06470-daluis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06053-06470-daluis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06053-06470-daluis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06053-06470-daluis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06054-06340-drap/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06054-06340-drap/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06054-06340-drap/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06054-06340-drap/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06055-06670-duranus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06055-06670-duranus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06055-06670-duranus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06055-06670-duranus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06056-06470-entraunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06056-06470-entraunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06056-06470-entraunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06056-06470-entraunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06057-06440-l_escarene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06057-06440-l_escarene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06057-06440-l_escarene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06057-06440-l_escarene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06058-06460-escragnolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06058-06460-escragnolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06058-06460-escragnolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06058-06460-escragnolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06059-06360-eze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06059-06360-eze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06059-06360-eze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06059-06360-eze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06060-06950-falicon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06060-06950-falicon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06060-06950-falicon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06060-06950-falicon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06061-06510-les_ferres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06061-06510-les_ferres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06061-06510-les_ferres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06061-06510-les_ferres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06062-06540-fontan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06062-06540-fontan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06062-06540-fontan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06062-06540-fontan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06063-06850-gars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06063-06850-gars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06063-06850-gars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06063-06850-gars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06064-06510-gattieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06064-06510-gattieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06064-06510-gattieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06064-06510-gattieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06065-06610-la_gaude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06065-06610-la_gaude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06065-06610-la_gaude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06065-06610-la_gaude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06066-06830-gilette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06066-06830-gilette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06066-06830-gilette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06066-06830-gilette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06067-06500-gorbio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06067-06500-gorbio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06067-06500-gorbio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06067-06500-gorbio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06068-06620-gourdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06068-06620-gourdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06068-06620-gourdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06068-06620-gourdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06069-06520-grasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06069-06520-grasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06069-06520-grasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06069-06520-grasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06069-06130-grasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06069-06130-grasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06069-06130-grasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06069-06130-grasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06070-06620-greolieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06070-06620-greolieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06070-06620-greolieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06070-06620-greolieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06071-06470-guillaumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06071-06470-guillaumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06071-06470-guillaumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06071-06470-guillaumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06072-06420-ilonse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06072-06420-ilonse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06072-06420-ilonse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06072-06420-ilonse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06073-06420-isola/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06073-06420-isola/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06073-06420-isola/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06073-06420-isola/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06074-06450-lantosque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06074-06450-lantosque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06074-06450-lantosque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06074-06450-lantosque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06075-06670-levens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06075-06670-levens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06075-06670-levens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06075-06670-levens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06076-06260-lieuche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06076-06260-lieuche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06076-06260-lieuche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06076-06260-lieuche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06077-06440-luceram/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06077-06440-luceram/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06077-06440-luceram/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06077-06440-luceram/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06078-06710-malaussene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06078-06710-malaussene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06078-06710-malaussene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06078-06710-malaussene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06079-06210-mandelieu_la_napoule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06079-06210-mandelieu_la_napoule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06079-06210-mandelieu_la_napoule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06079-06210-mandelieu_la_napoule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06080-06420-marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06080-06420-marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06080-06420-marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06080-06420-marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06081-06910-le_mas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06081-06910-le_mas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06081-06910-le_mas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06081-06910-le_mas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06082-06710-massoins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06082-06710-massoins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06082-06710-massoins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06082-06710-massoins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06083-06500-menton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06083-06500-menton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06083-06500-menton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06083-06500-menton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06084-06370-mouans_sartoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06084-06370-mouans_sartoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06084-06370-mouans_sartoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06084-06370-mouans_sartoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06085-06250-mougins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06085-06250-mougins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06085-06250-mougins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06085-06250-mougins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06086-06380-moulinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06086-06380-moulinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06086-06380-moulinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06086-06380-moulinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06087-06910-les_mujouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06087-06910-les_mujouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06087-06910-les_mujouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06087-06910-les_mujouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06300-nice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06300-nice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06300-nice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06300-nice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06000-nice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06000-nice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06000-nice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06000-nice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06100-nice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06100-nice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06100-nice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06100-nice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06200-nice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06200-nice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06200-nice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06088-06200-nice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06089-06650-opio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06089-06650-opio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06089-06650-opio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06089-06650-opio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06090-06580-pegomas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06090-06580-pegomas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06090-06580-pegomas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06090-06580-pegomas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06091-06440-peille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06091-06440-peille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06091-06440-peille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06091-06440-peille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06092-06440-peillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06092-06440-peillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06092-06440-peillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06092-06440-peillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06093-06260-la_penne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06093-06260-la_penne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06093-06260-la_penne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06093-06260-la_penne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06094-06470-peone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06094-06470-peone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06094-06470-peone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06094-06470-peone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06095-06530-peymeinade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06095-06530-peymeinade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06095-06530-peymeinade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06095-06530-peymeinade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06096-06260-pierlas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06096-06260-pierlas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06096-06260-pierlas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06096-06260-pierlas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06097-06910-pierrefeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06097-06910-pierrefeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06097-06910-pierrefeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06097-06910-pierrefeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06098-06260-puget_rostang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06098-06260-puget_rostang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06098-06260-puget_rostang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06098-06260-puget_rostang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06099-06260-puget_theniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06099-06260-puget_theniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06099-06260-puget_theniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06099-06260-puget_theniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06100-06830-revest_les_roches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06100-06830-revest_les_roches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06100-06830-revest_les_roches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06100-06830-revest_les_roches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06101-06260-rigaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06101-06260-rigaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06101-06260-rigaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06101-06260-rigaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06102-06420-rimplas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06102-06420-rimplas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06102-06420-rimplas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06102-06420-rimplas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06103-06450-roquebilliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06103-06450-roquebilliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06103-06450-roquebilliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06103-06450-roquebilliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06104-06190-roquebrune_cap_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06104-06190-roquebrune_cap_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06104-06190-roquebrune_cap_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06104-06190-roquebrune_cap_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06105-06330-roquefort_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06105-06330-roquefort_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06105-06330-roquefort_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06105-06330-roquefort_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06106-06910-roquesteron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06106-06910-roquesteron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06106-06910-roquesteron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06106-06910-roquesteron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06107-06910-la_roque_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06107-06910-la_roque_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06107-06910-la_roque_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06107-06910-la_roque_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06108-06550-la_roquette_sur_siagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06108-06550-la_roquette_sur_siagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06108-06550-la_roquette_sur_siagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06108-06550-la_roquette_sur_siagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06109-06670-la_roquette_sur_var/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06109-06670-la_roquette_sur_var/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06109-06670-la_roquette_sur_var/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06109-06670-la_roquette_sur_var/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06110-06420-roubion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06110-06420-roubion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06110-06420-roubion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06110-06420-roubion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06111-06420-roure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06111-06420-roure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06111-06420-roure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06111-06420-roure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06112-06650-le_rouret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06112-06650-le_rouret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06112-06650-le_rouret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06112-06650-le_rouret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06113-06500-sainte_agnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06113-06500-sainte_agnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06113-06500-sainte_agnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06113-06500-sainte_agnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06114-06730-saint_andre_de_la_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06114-06730-saint_andre_de_la_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06114-06730-saint_andre_de_la_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06114-06730-saint_andre_de_la_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06115-06260-saint_antonin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06115-06260-saint_antonin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06115-06260-saint_antonin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06115-06260-saint_antonin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06116-06850-saint_auban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06116-06850-saint_auban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06116-06850-saint_auban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06116-06850-saint_auban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06117-06670-saint_blaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06117-06670-saint_blaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06117-06670-saint_blaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06117-06670-saint_blaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06118-06530-saint_cezaire_sur_siagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06118-06530-saint_cezaire_sur_siagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06118-06530-saint_cezaire_sur_siagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06118-06530-saint_cezaire_sur_siagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06119-06660-saint_dalmas_le_selvage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06119-06660-saint_dalmas_le_selvage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06119-06660-saint_dalmas_le_selvage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06119-06660-saint_dalmas_le_selvage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06120-06660-saint_etienne_de_tinee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06120-06660-saint_etienne_de_tinee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06120-06660-saint_etienne_de_tinee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06120-06660-saint_etienne_de_tinee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06121-06230-saint_jean_cap_ferrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06121-06230-saint_jean_cap_ferrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06121-06230-saint_jean_cap_ferrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06121-06230-saint_jean_cap_ferrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06122-06640-saint_jeannet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06122-06640-saint_jeannet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06122-06640-saint_jeannet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06122-06640-saint_jeannet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06123-06700-saint_laurent_du_var/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06123-06700-saint_laurent_du_var/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06123-06700-saint_laurent_du_var/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06123-06700-saint_laurent_du_var/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06124-06260-saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06124-06260-saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06124-06260-saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06124-06260-saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06125-06470-saint_martin_d_entraunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06125-06470-saint_martin_d_entraunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06125-06470-saint_martin_d_entraunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06125-06470-saint_martin_d_entraunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06126-06670-saint_martin_du_var/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06126-06670-saint_martin_du_var/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06126-06670-saint_martin_du_var/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06126-06670-saint_martin_du_var/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06127-06450-saint_martin_vesubie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06127-06450-saint_martin_vesubie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06127-06450-saint_martin_vesubie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06127-06450-saint_martin_vesubie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06128-06570-saint_paul_de_vence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06128-06570-saint_paul_de_vence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06128-06570-saint_paul_de_vence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06128-06570-saint_paul_de_vence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06129-06420-saint_sauveur_sur_tinee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06129-06420-saint_sauveur_sur_tinee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06129-06420-saint_sauveur_sur_tinee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06129-06420-saint_sauveur_sur_tinee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06130-06460-saint_vallier_de_thiey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06130-06460-saint_vallier_de_thiey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06130-06460-saint_vallier_de_thiey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06130-06460-saint_vallier_de_thiey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06131-06910-sallagriffon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06131-06910-sallagriffon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06131-06910-sallagriffon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06131-06910-sallagriffon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06132-06540-saorge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06132-06540-saorge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06132-06540-saorge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06132-06540-saorge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06133-06470-sauze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06133-06470-sauze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06133-06470-sauze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06133-06470-sauze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06134-06750-seranon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06134-06750-seranon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06134-06750-seranon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06134-06750-seranon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06135-06910-sigale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06135-06910-sigale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06135-06910-sigale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06135-06910-sigale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06136-06380-sospel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06136-06380-sospel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06136-06380-sospel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06136-06380-sospel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06137-06530-speracedes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06137-06530-speracedes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06137-06530-speracedes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06137-06530-speracedes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06138-06590-theoule_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06138-06590-theoule_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06138-06590-theoule_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06138-06590-theoule_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06139-06710-thiery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06139-06710-thiery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06139-06710-thiery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06139-06710-thiery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06140-06530-le_tignet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06140-06530-le_tignet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06140-06530-le_tignet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06140-06530-le_tignet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06141-06830-toudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06141-06830-toudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06141-06830-toudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06141-06830-toudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06142-06440-touet_de_l_escarene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06142-06440-touet_de_l_escarene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06142-06440-touet_de_l_escarene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06142-06440-touet_de_l_escarene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06143-06710-touet_sur_var/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06143-06710-touet_sur_var/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06143-06710-touet_sur_var/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06143-06710-touet_sur_var/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06144-06420-la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06144-06420-la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06144-06420-la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06144-06420-la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06145-06830-tourette_du_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06145-06830-tourette_du_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06145-06830-tourette_du_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06145-06830-tourette_du_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06146-06420-tournefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06146-06420-tournefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06146-06420-tournefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06146-06420-tournefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06147-06690-tourrette_levens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06147-06690-tourrette_levens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06147-06690-tourrette_levens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06147-06690-tourrette_levens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06148-06140-tourrettes_sur_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06148-06140-tourrettes_sur_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06148-06140-tourrettes_sur_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06148-06140-tourrettes_sur_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06149-06340-la_trinite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06149-06340-la_trinite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06149-06340-la_trinite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06149-06340-la_trinite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06150-06320-la_turbie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06150-06320-la_turbie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06150-06320-la_turbie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06150-06320-la_turbie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06151-06450-utelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06151-06450-utelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06151-06450-utelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06151-06450-utelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06152-06560-valbonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06152-06560-valbonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06152-06560-valbonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06152-06560-valbonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06153-06420-valdeblore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06153-06420-valdeblore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06153-06420-valdeblore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06153-06420-valdeblore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06154-06750-valderoure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06154-06750-valderoure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06154-06750-valderoure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06154-06750-valderoure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06155-06220-vallauris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06155-06220-vallauris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06155-06220-vallauris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06155-06220-vallauris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06156-06450-venanson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06156-06450-venanson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06156-06450-venanson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06156-06450-venanson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06157-06140-vence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06157-06140-vence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06157-06140-vence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06157-06140-vence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06158-06710-villars_sur_var/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06158-06710-villars_sur_var/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06158-06710-villars_sur_var/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06158-06710-villars_sur_var/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06159-06230-villefranche_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06159-06230-villefranche_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06159-06230-villefranche_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06159-06230-villefranche_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06160-06470-villeneuve_d_entraunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06160-06470-villeneuve_d_entraunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06160-06470-villeneuve_d_entraunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06160-06470-villeneuve_d_entraunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06161-06270-villeneuve_loubet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06161-06270-villeneuve_loubet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06161-06270-villeneuve_loubet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06161-06270-villeneuve_loubet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06162-06430-la_brigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06162-06430-la_brigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06162-06430-la_brigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06162-06430-la_brigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06163-06430-tende/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06163-06430-tende/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06163-06430-tende/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt06-alpes_maritimes/commune06163-06430-tende/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-07.xml
+++ b/public/sitemaps/sitemap-07.xml
@@ -5,730 +5,1456 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07001-07160-accons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07001-07160-accons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07001-07160-accons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07001-07160-accons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07002-07200-ailhon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07002-07200-ailhon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07002-07200-ailhon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07002-07200-ailhon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07003-07530-aizac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07003-07530-aizac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07003-07530-aizac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07003-07530-aizac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07004-07000-ajoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07004-07000-ajoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07004-07000-ajoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07004-07000-ajoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07005-07400-alba_la_romaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07005-07400-alba_la_romaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07005-07400-alba_la_romaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07005-07400-alba_la_romaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07006-07190-albon_d_ardeche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07006-07190-albon_d_ardeche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07006-07190-albon_d_ardeche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07006-07190-albon_d_ardeche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07007-07440-alboussiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07007-07440-alboussiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07007-07440-alboussiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07007-07440-alboussiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07008-07210-alissas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07008-07210-alissas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07008-07210-alissas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07008-07210-alissas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07009-07340-andance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07009-07340-andance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07009-07340-andance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07009-07340-andance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07010-07100-annonay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07010-07100-annonay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07010-07100-annonay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07010-07100-annonay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07011-07530-vallees_d’antraigues_asperjoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07011-07530-vallees_d’antraigues_asperjoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07011-07530-vallees_d’antraigues_asperjoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07011-07530-vallees_d’antraigues_asperjoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07011-07600-vallees_d’antraigues_asperjoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07011-07600-vallees_d’antraigues_asperjoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07011-07600-vallees_d’antraigues_asperjoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07011-07600-vallees_d’antraigues_asperjoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07012-07310-arcens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07012-07310-arcens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07012-07310-arcens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07012-07310-arcens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07013-07290-ardoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07013-07290-ardoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07013-07290-ardoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07013-07290-ardoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07014-07410-arlebosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07014-07410-arlebosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07014-07410-arlebosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07014-07410-arlebosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07015-07370-arras_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07015-07370-arras_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07015-07370-arras_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07015-07370-arras_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07017-07140-les_assions/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07017-07140-les_assions/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07017-07140-les_assions/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07017-07140-les_assions/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07330-astet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07330-astet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07330-astet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07330-astet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07660-astet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07660-astet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07660-astet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07660-astet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07510-astet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07510-astet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07510-astet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07510-astet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07590-astet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07590-astet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07590-astet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07018-07590-astet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07019-07200-aubenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07019-07200-aubenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07019-07200-aubenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07019-07200-aubenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07020-07400-aubignas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07020-07400-aubignas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07020-07400-aubignas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07020-07400-aubignas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07022-07210-baix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07022-07210-baix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07022-07210-baix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07022-07210-baix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07023-07120-balazuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07023-07120-balazuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07023-07120-balazuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07023-07120-balazuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07024-07460-banne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07024-07460-banne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07024-07460-banne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07024-07460-banne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07024-07140-banne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07024-07140-banne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07024-07140-banne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07024-07140-banne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07025-07330-barnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07025-07330-barnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07025-07330-barnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07025-07330-barnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07026-07630-le_beage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07026-07630-le_beage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07026-07630-le_beage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07026-07630-le_beage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07027-07800-beauchastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07027-07800-beauchastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07027-07800-beauchastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07027-07800-beauchastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07028-07460-beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07028-07460-beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07028-07460-beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07028-07460-beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07029-07110-beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07029-07110-beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07029-07110-beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07029-07110-beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07029-07260-beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07029-07260-beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07029-07260-beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07029-07260-beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07030-07190-beauvene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07030-07190-beauvene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07030-07190-beauvene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07030-07190-beauvene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07031-07460-berrias_et_casteljau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07031-07460-berrias_et_casteljau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07031-07460-berrias_et_casteljau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07031-07460-berrias_et_casteljau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07032-07580-berzeme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07032-07580-berzeme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07032-07580-berzeme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07032-07580-berzeme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07033-07150-bessas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07033-07150-bessas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07033-07150-bessas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07033-07150-bessas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07034-07700-bidon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07034-07700-bidon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07034-07700-bidon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07034-07700-bidon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07035-07440-boffres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07035-07440-boffres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07035-07440-boffres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07035-07440-boffres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07036-07340-bogy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07036-07340-bogy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07036-07340-bogy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07036-07340-bogy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07037-07310-boree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07037-07310-boree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07037-07310-boree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07037-07310-boree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07038-07590-borne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07038-07590-borne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07038-07590-borne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07038-07590-borne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07039-07410-bozas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07039-07410-bozas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07039-07410-bozas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07039-07410-bozas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07040-07270-boucieu_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07040-07270-boucieu_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07040-07270-boucieu_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07040-07270-boucieu_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07041-07100-boulieu_les_annonay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07041-07100-boulieu_les_annonay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07041-07100-boulieu_les_annonay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07041-07100-boulieu_les_annonay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07042-07700-bourg_saint_andeol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07042-07700-bourg_saint_andeol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07042-07700-bourg_saint_andeol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07042-07700-bourg_saint_andeol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07044-07340-brossainc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07044-07340-brossainc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07044-07340-brossainc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07044-07340-brossainc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07045-07450-burzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07045-07450-burzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07045-07450-burzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07045-07450-burzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07047-07590-cellier_du_luc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07047-07590-cellier_du_luc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07047-07590-cellier_du_luc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07047-07590-cellier_du_luc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07048-07240-chalencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07048-07240-chalencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07048-07240-chalencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07048-07240-chalencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07049-07160-le_chambon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07049-07160-le_chambon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07049-07160-le_chambon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07049-07160-le_chambon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07050-07140-chambonas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07050-07140-chambonas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07050-07140-chambonas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07050-07140-chambonas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07051-07340-champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07051-07340-champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07051-07340-champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07051-07340-champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07052-07440-champis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07052-07440-champis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07052-07440-champis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07052-07440-champis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07053-07230-chandolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07053-07230-chandolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07053-07230-chandolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07053-07230-chandolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07054-07310-chaneac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07054-07310-chaneac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07054-07310-chaneac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07054-07310-chaneac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07055-07800-charmes_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07055-07800-charmes_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07055-07800-charmes_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07055-07800-charmes_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07056-07340-charnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07056-07340-charnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07056-07340-charnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07056-07340-charnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07058-07110-chassiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07058-07110-chassiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07058-07110-chassiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07058-07110-chassiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07059-07130-chateaubourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07059-07130-chateaubourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07059-07130-chateaubourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07059-07130-chateaubourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07060-07240-chateauneuf_de_vernoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07060-07240-chateauneuf_de_vernoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07060-07240-chateauneuf_de_vernoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07060-07240-chateauneuf_de_vernoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07061-07120-chauzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07061-07120-chauzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07061-07120-chauzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07061-07120-chauzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07062-07110-chazeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07062-07110-chazeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07062-07110-chazeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07062-07110-chazeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07063-07300-cheminas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07063-07300-cheminas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07063-07300-cheminas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07063-07300-cheminas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07064-07160-le_cheylard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07064-07160-le_cheylard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07064-07160-le_cheylard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07064-07160-le_cheylard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07065-07380-chirols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07065-07380-chirols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07065-07380-chirols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07065-07380-chirols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07066-07210-chomerac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07066-07210-chomerac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07066-07210-chomerac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07066-07210-chomerac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07067-07430-colombier_le_cardinal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07067-07430-colombier_le_cardinal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07067-07430-colombier_le_cardinal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07067-07430-colombier_le_cardinal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07068-07270-colombier_le_jeune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07068-07270-colombier_le_jeune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07068-07270-colombier_le_jeune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07068-07270-colombier_le_jeune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07069-07410-colombier_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07069-07410-colombier_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07069-07410-colombier_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07069-07410-colombier_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07070-07130-cornas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07070-07130-cornas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07070-07130-cornas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07070-07130-cornas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07071-07470-coucouron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07071-07470-coucouron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07071-07470-coucouron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07071-07470-coucouron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07072-07000-coux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07072-07000-coux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07072-07000-coux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07072-07000-coux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07073-07270-le_crestet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07073-07270-le_crestet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07073-07270-le_crestet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07073-07270-le_crestet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07074-07000-creysseilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07074-07000-creysseilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07074-07000-creysseilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07074-07000-creysseilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07075-07510-cros_de_georand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07075-07510-cros_de_georand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07075-07510-cros_de_georand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07075-07510-cros_de_georand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07075-07630-cros_de_georand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07075-07630-cros_de_georand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07075-07630-cros_de_georand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07075-07630-cros_de_georand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07076-07350-cruas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07076-07350-cruas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07076-07350-cruas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07076-07350-cruas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07077-07170-darbres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07077-07170-darbres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07077-07170-darbres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07077-07170-darbres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07078-07430-davezieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07078-07430-davezieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07078-07430-davezieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07078-07430-davezieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07079-07570-desaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07079-07570-desaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07079-07570-desaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07079-07570-desaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07079-07320-desaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07079-07320-desaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07079-07320-desaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07079-07320-desaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07080-07320-devesset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07080-07320-devesset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07080-07320-devesset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07080-07320-devesset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07081-07260-dompnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07081-07260-dompnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07081-07260-dompnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07081-07260-dompnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07082-07160-dornas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07082-07160-dornas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07082-07160-dornas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07082-07160-dornas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07083-07360-duniere_sur_eyrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07083-07360-duniere_sur_eyrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07083-07360-duniere_sur_eyrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07083-07360-duniere_sur_eyrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07370-eclassan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07370-eclassan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07370-eclassan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07370-eclassan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07300-eclassan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07300-eclassan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07300-eclassan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07300-eclassan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07290-eclassan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07290-eclassan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07290-eclassan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07084-07290-eclassan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07085-07270-empurany/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07085-07270-empurany/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07085-07270-empurany/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07085-07270-empurany/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07086-07300-etables/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07086-07300-etables/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07086-07300-etables/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07086-07300-etables/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07087-07380-fabras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07087-07380-fabras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07087-07380-fabras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07087-07380-fabras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07088-07230-faugeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07088-07230-faugeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07088-07230-faugeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07088-07230-faugeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07089-07340-felines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07089-07340-felines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07089-07340-felines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07089-07340-felines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07090-07000-flaviac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07090-07000-flaviac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07090-07000-flaviac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07090-07000-flaviac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07091-07200-fons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07091-07200-fons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07091-07200-fons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07091-07200-fons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07092-07000-freyssenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07092-07000-freyssenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07092-07000-freyssenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07092-07000-freyssenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07093-07530-genestelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07093-07530-genestelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07093-07530-genestelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07093-07530-genestelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07094-07800-gilhac_et_bruzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07094-07800-gilhac_et_bruzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07094-07800-gilhac_et_bruzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07094-07800-gilhac_et_bruzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07095-07270-gilhoc_sur_ormeze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07095-07270-gilhoc_sur_ormeze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07095-07270-gilhoc_sur_ormeze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07095-07270-gilhoc_sur_ormeze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07096-07190-gluiras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07096-07190-gluiras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07096-07190-gluiras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07096-07190-gluiras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07097-07300-glun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07097-07300-glun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07097-07300-glun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07097-07300-glun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07098-07000-gourdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07098-07000-gourdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07098-07000-gourdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07098-07000-gourdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07099-07700-gras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07099-07700-gras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07099-07700-gras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07099-07700-gras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07100-07140-gravieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07100-07140-gravieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07100-07140-gravieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07100-07140-gravieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07101-07120-grospierres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07101-07120-grospierres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07101-07120-grospierres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07101-07120-grospierres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07102-07500-guilherand_granges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07102-07500-guilherand_granges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07102-07500-guilherand_granges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07102-07500-guilherand_granges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07310-saint_julien_d’intres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07310-saint_julien_d’intres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07310-saint_julien_d’intres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07310-saint_julien_d’intres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07320-saint_julien_d’intres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07320-saint_julien_d’intres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07320-saint_julien_d’intres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07320-saint_julien_d’intres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07160-saint_julien_d’intres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07160-saint_julien_d’intres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07160-saint_julien_d’intres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07103-07160-saint_julien_d’intres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07104-07190-issamoulenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07104-07190-issamoulenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07104-07190-issamoulenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07104-07190-issamoulenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07105-07660-issanlas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07105-07660-issanlas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07105-07660-issanlas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07105-07660-issanlas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07105-07510-issanlas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07105-07510-issanlas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07105-07510-issanlas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07105-07510-issanlas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07106-07470-issarles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07106-07470-issarles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07106-07470-issarles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07106-07470-issarles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07107-07380-jaujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07107-07380-jaujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07107-07380-jaujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07107-07380-jaujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07108-07160-jaunac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07108-07160-jaunac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07108-07160-jaunac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07108-07160-jaunac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07109-07110-joannas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07109-07110-joannas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07109-07110-joannas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07109-07110-joannas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07110-07260-joyeuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07110-07260-joyeuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07110-07260-joyeuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07110-07260-joyeuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07111-07600-juvinas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07111-07600-juvinas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07111-07600-juvinas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07111-07600-juvinas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07112-07600-labastide_sur_besorgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07112-07600-labastide_sur_besorgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07112-07600-labastide_sur_besorgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07112-07600-labastide_sur_besorgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07113-07150-labastide_de_virac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07113-07150-labastide_de_virac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07113-07150-labastide_de_virac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07113-07150-labastide_de_virac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07114-07570-labatie_d_andaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07114-07570-labatie_d_andaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07114-07570-labatie_d_andaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07114-07570-labatie_d_andaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07114-07270-labatie_d_andaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07114-07270-labatie_d_andaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07114-07270-labatie_d_andaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07114-07270-labatie_d_andaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07115-07120-labeaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07115-07120-labeaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07115-07120-labeaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07115-07120-labeaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07116-07200-labegude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07116-07200-labegude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07116-07200-labegude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07116-07200-labegude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07117-07230-lablachere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07117-07230-lablachere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07117-07230-lablachere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07117-07230-lablachere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07118-07110-laboule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07118-07110-laboule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07118-07110-laboule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07118-07110-laboule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07119-07470-le_lac_d_issarles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07119-07470-le_lac_d_issarles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07119-07470-le_lac_d_issarles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07119-07470-le_lac_d_issarles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07120-07530-lachamp_raphael/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07120-07530-lachamp_raphael/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07120-07530-lachamp_raphael/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07120-07530-lachamp_raphael/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07121-07470-lachapelle_graillouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07121-07470-lachapelle_graillouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07121-07470-lachapelle_graillouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07121-07470-lachapelle_graillouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07122-07200-lachapelle_sous_aubenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07122-07200-lachapelle_sous_aubenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07122-07200-lachapelle_sous_aubenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07122-07200-lachapelle_sous_aubenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07123-07310-lachapelle_sous_chaneac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07123-07310-lachapelle_sous_chaneac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07123-07310-lachapelle_sous_chaneac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07123-07310-lachapelle_sous_chaneac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07124-07520-lafarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07124-07520-lafarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07124-07520-lafarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07124-07520-lafarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07126-07150-lagorce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07126-07150-lagorce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07126-07150-lagorce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07126-07150-lagorce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07127-07380-lalevade_d_ardeche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07127-07380-lalevade_d_ardeche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07127-07380-lalevade_d_ardeche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07127-07380-lalevade_d_ardeche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07128-07520-lalouvesc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07128-07520-lalouvesc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07128-07520-lalouvesc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07128-07520-lalouvesc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07129-07270-lamastre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07129-07270-lamastre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07129-07270-lamastre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07129-07270-lamastre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07130-07660-lanarce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07130-07660-lanarce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07130-07660-lanarce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07130-07660-lanarce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07131-07200-lanas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07131-07200-lanas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07131-07200-lanas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07131-07200-lanas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07132-07110-largentiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07132-07110-largentiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07132-07110-largentiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07132-07110-largentiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07133-07220-larnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07133-07220-larnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07133-07220-larnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07133-07220-larnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07134-07110-laurac_en_vivarais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07134-07110-laurac_en_vivarais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07134-07110-laurac_en_vivarais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07134-07110-laurac_en_vivarais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07136-48250-laveyrune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07136-48250-laveyrune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07136-48250-laveyrune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07136-48250-laveyrune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07137-07660-lavillatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07137-07660-lavillatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07137-07660-lavillatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07137-07660-lavillatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07137-07470-lavillatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07137-07470-lavillatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07137-07470-lavillatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07137-07470-lavillatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07138-07170-lavilledieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07138-07170-lavilledieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07138-07170-lavilledieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07138-07170-lavilledieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07139-07530-laviolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07139-07530-laviolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07139-07530-laviolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07139-07530-laviolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07140-07610-lemps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07140-07610-lemps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07140-07610-lemps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07140-07610-lemps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07140-07300-lemps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07140-07300-lemps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07140-07300-lemps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07140-07300-lemps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07141-07200-lentilleres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07141-07200-lentilleres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07141-07200-lentilleres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07141-07200-lentilleres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07142-07660-lesperon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07142-07660-lesperon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07142-07660-lesperon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07142-07660-lesperon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07143-07340-limony/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07143-07340-limony/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07143-07340-limony/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07143-07340-limony/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07144-07110-loubaresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07144-07110-loubaresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07144-07110-loubaresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07144-07110-loubaresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07145-07170-lussas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07145-07170-lussas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07145-07170-lussas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07145-07170-lussas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07146-07000-lyas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07146-07000-lyas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07146-07000-lyas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07146-07000-lyas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07147-07140-malarce_sur_la_thines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07147-07140-malarce_sur_la_thines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07147-07140-malarce_sur_la_thines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07147-07140-malarce_sur_la_thines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07148-07140-malbosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07148-07140-malbosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07148-07140-malbosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07148-07140-malbosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07149-07190-marcols_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07149-07190-marcols_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07149-07190-marcols_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07149-07190-marcols_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07150-07160-mariac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07150-07160-mariac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07150-07160-mariac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07150-07160-mariac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07151-07320-mars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07151-07320-mars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07151-07320-mars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07151-07320-mars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07152-07300-mauves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07152-07300-mauves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07152-07300-mauves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07152-07300-mauves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07153-07330-mayres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07153-07330-mayres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07153-07330-mayres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07153-07330-mayres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07154-07510-mazan_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07154-07510-mazan_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07154-07510-mazan_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07154-07510-mazan_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07154-07660-mazan_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07154-07660-mazan_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07154-07660-mazan_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07154-07660-mazan_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07155-07200-mercuer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07155-07200-mercuer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07155-07200-mercuer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07155-07200-mercuer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07156-07380-meyras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07156-07380-meyras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07156-07380-meyras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07156-07380-meyras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07157-07400-meysse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07157-07400-meysse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07157-07400-meysse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07157-07400-meysse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07158-07530-mezilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07158-07530-mezilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07158-07530-mezilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07158-07530-mezilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07159-07170-mirabel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07159-07170-mirabel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07159-07170-mirabel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07159-07170-mirabel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07160-07690-monestier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07160-07690-monestier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07160-07690-monestier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07160-07690-monestier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07161-07560-montpezat_sous_bauzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07161-07560-montpezat_sous_bauzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07161-07560-montpezat_sous_bauzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07161-07560-montpezat_sous_bauzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07162-07110-montreal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07162-07110-montreal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07162-07110-montreal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07162-07110-montreal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07163-07140-montselgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07163-07140-montselgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07163-07140-montselgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07163-07140-montselgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07165-07160-belsentes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07165-07160-belsentes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07165-07160-belsentes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07165-07160-belsentes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07166-07270-nozieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07166-07270-nozieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07166-07270-nozieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07166-07270-nozieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07167-07360-les_ollieres_sur_eyrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07167-07360-les_ollieres_sur_eyrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07167-07360-les_ollieres_sur_eyrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07167-07360-les_ollieres_sur_eyrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07167-07190-les_ollieres_sur_eyrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07167-07190-les_ollieres_sur_eyrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07167-07190-les_ollieres_sur_eyrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07167-07190-les_ollieres_sur_eyrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07168-07150-orgnac_l_aven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07168-07150-orgnac_l_aven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07168-07150-orgnac_l_aven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07168-07150-orgnac_l_aven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07169-07370-ozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07169-07370-ozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07169-07370-ozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07169-07370-ozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07170-07410-pailhares/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07170-07410-pailhares/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07170-07410-pailhares/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07170-07410-pailhares/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07171-07230-payzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07171-07230-payzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07171-07230-payzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07171-07230-payzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07172-07340-peaugres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07172-07340-peaugres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07172-07340-peaugres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07172-07340-peaugres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07173-07450-pereyres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07173-07450-pereyres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07173-07450-pereyres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07173-07450-pereyres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07174-07340-peyraud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07174-07340-peyraud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07174-07340-peyraud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07174-07340-peyraud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07175-07590-le_plagnal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07175-07590-le_plagnal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07175-07590-le_plagnal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07175-07590-le_plagnal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07176-07230-planzolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07176-07230-planzolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07176-07230-planzolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07176-07230-planzolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07177-07300-plats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07177-07300-plats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07177-07300-plats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07177-07300-plats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07178-07380-pont_de_labeaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07178-07380-pont_de_labeaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07178-07380-pont_de_labeaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07178-07380-pont_de_labeaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07179-07000-pourcheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07179-07000-pourcheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07179-07000-pourcheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07179-07000-pourcheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07181-07250-le_pouzin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07181-07250-le_pouzin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07181-07250-le_pouzin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07181-07250-le_pouzin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07182-07380-prades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07182-07380-prades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07182-07380-prades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07182-07380-prades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07183-07120-pradons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07183-07120-pradons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07183-07120-pradons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07183-07120-pradons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07184-07000-pranles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07184-07000-pranles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07184-07000-pranles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07184-07000-pranles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07184-07190-pranles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07184-07190-pranles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07184-07190-pranles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07184-07190-pranles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07185-07290-preaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07185-07290-preaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07185-07290-preaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07185-07290-preaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07186-07000-privas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07186-07000-privas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07186-07000-privas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07186-07000-privas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07187-07110-prunet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07187-07110-prunet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07187-07110-prunet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07187-07110-prunet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07188-07290-quintenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07188-07290-quintenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07188-07290-quintenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07188-07290-quintenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07189-07260-ribes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07189-07260-ribes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07189-07260-ribes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07189-07260-ribes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07190-07200-rochecolombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07190-07200-rochecolombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07190-07200-rochecolombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07190-07200-rochecolombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07191-07400-rochemaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07191-07400-rochemaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07191-07400-rochemaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07191-07400-rochemaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07192-07320-rochepaule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07192-07320-rochepaule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07192-07320-rochepaule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07192-07320-rochepaule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07193-07110-rocher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07193-07110-rocher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07193-07110-rocher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07193-07110-rocher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07194-07210-rochessauve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07194-07210-rochessauve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07194-07210-rochessauve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07194-07210-rochessauve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07195-07310-la_rochette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07195-07310-la_rochette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07195-07310-la_rochette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07195-07310-la_rochette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07196-07110-rocles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07196-07110-rocles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07196-07110-rocles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07196-07110-rocles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07197-07100-roiffieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07197-07100-roiffieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07197-07100-roiffieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07197-07100-roiffieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07198-07250-rompon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07198-07250-rompon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07198-07250-rompon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07198-07250-rompon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07199-07260-rosieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07199-07260-rosieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07199-07260-rosieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07199-07260-rosieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07200-07560-le_roux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07200-07560-le_roux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07200-07560-le_roux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07200-07560-le_roux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07201-07120-ruoms/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07201-07120-ruoms/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07201-07120-ruoms/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07201-07120-ruoms/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07202-07260-sablieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07202-07260-sablieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07202-07260-sablieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07202-07260-sablieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07203-07450-sagnes_et_goudoulet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07203-07450-sagnes_et_goudoulet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07203-07450-sagnes_et_goudoulet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07203-07450-sagnes_et_goudoulet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07204-07320-saint_agreve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07204-07320-saint_agreve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07204-07320-saint_agreve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07204-07320-saint_agreve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07205-07790-saint_alban_d_ay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07205-07790-saint_alban_d_ay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07205-07790-saint_alban_d_ay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07205-07790-saint_alban_d_ay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07206-07590-saint_alban_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07206-07590-saint_alban_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07206-07590-saint_alban_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07206-07590-saint_alban_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07207-07120-saint_alban_auriolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07207-07120-saint_alban_auriolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07207-07120-saint_alban_auriolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07207-07120-saint_alban_auriolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07208-07170-saint_andeol_de_berg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07208-07170-saint_andeol_de_berg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07208-07170-saint_andeol_de_berg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07208-07170-saint_andeol_de_berg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07209-07160-saint_andeol_de_fourchades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07209-07160-saint_andeol_de_fourchades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07209-07160-saint_andeol_de_fourchades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07209-07160-saint_andeol_de_fourchades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07210-07600-saint_andeol_de_vals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07210-07600-saint_andeol_de_vals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07210-07600-saint_andeol_de_vals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07210-07600-saint_andeol_de_vals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07211-07460-saint_andre_de_cruzieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07211-07460-saint_andre_de_cruzieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07211-07460-saint_andre_de_cruzieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07211-07460-saint_andre_de_cruzieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07212-07690-saint_andre_en_vivarais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07212-07690-saint_andre_en_vivarais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07212-07690-saint_andre_en_vivarais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07212-07690-saint_andre_en_vivarais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07213-07230-saint_andre_lachamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07213-07230-saint_andre_lachamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07213-07230-saint_andre_lachamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07213-07230-saint_andre_lachamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07214-07240-saint_apollinaire_de_rias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07214-07240-saint_apollinaire_de_rias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07214-07240-saint_apollinaire_de_rias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07214-07240-saint_apollinaire_de_rias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07215-07160-saint_barthelemy_le_meil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07215-07160-saint_barthelemy_le_meil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07215-07160-saint_barthelemy_le_meil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07215-07160-saint_barthelemy_le_meil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07216-07270-saint_barthelemy_grozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07216-07270-saint_barthelemy_grozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07216-07270-saint_barthelemy_grozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07216-07270-saint_barthelemy_grozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07217-07300-saint_barthelemy_le_plain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07217-07300-saint_barthelemy_le_plain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07217-07300-saint_barthelemy_le_plain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07217-07300-saint_barthelemy_le_plain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07218-07270-saint_basile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07218-07270-saint_basile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07218-07270-saint_basile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07218-07270-saint_basile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07219-07210-saint_bauzile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07219-07210-saint_bauzile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07219-07210-saint_bauzile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07219-07210-saint_bauzile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07220-07160-saint_christol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07220-07160-saint_christol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07220-07160-saint_christol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07220-07160-saint_christol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07221-07800-saint_cierge_la_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07221-07800-saint_cierge_la_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07221-07800-saint_cierge_la_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07221-07800-saint_cierge_la_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07222-07160-saint_cierge_sous_le_cheylard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07222-07160-saint_cierge_sous_le_cheylard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07222-07160-saint_cierge_sous_le_cheylard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07222-07160-saint_cierge_sous_le_cheylard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07223-07380-saint_cirgues_de_prades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07223-07380-saint_cirgues_de_prades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07223-07380-saint_cirgues_de_prades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07223-07380-saint_cirgues_de_prades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07224-07510-saint_cirgues_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07224-07510-saint_cirgues_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07224-07510-saint_cirgues_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07224-07510-saint_cirgues_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07225-07430-saint_clair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07225-07430-saint_clair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07225-07430-saint_clair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07225-07430-saint_clair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07226-07310-saint_clement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07226-07310-saint_clement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07226-07310-saint_clement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07226-07310-saint_clement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07227-07430-saint_cyr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07227-07430-saint_cyr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07227-07430-saint_cyr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07227-07430-saint_cyr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07228-07340-saint_desirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07228-07340-saint_desirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07228-07340-saint_desirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07228-07340-saint_desirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07229-07200-saint_didier_sous_aubenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07229-07200-saint_didier_sous_aubenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07229-07200-saint_didier_sous_aubenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07229-07200-saint_didier_sous_aubenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07230-07200-saint_etienne_de_boulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07230-07200-saint_etienne_de_boulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07230-07200-saint_etienne_de_boulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07230-07200-saint_etienne_de_boulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07231-07200-saint_etienne_de_fontbellon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07231-07200-saint_etienne_de_fontbellon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07231-07200-saint_etienne_de_fontbellon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07231-07200-saint_etienne_de_fontbellon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07232-07590-saint_etienne_de_lugdares/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07232-07590-saint_etienne_de_lugdares/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07232-07590-saint_etienne_de_lugdares/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07232-07590-saint_etienne_de_lugdares/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07233-07190-saint_etienne_de_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07233-07190-saint_etienne_de_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07233-07190-saint_etienne_de_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07233-07190-saint_etienne_de_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07234-07340-saint_etienne_de_valoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07234-07340-saint_etienne_de_valoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07234-07340-saint_etienne_de_valoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07234-07340-saint_etienne_de_valoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07235-07510-sainte_eulalie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07235-07510-sainte_eulalie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07235-07510-sainte_eulalie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07235-07510-sainte_eulalie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07236-07410-saint_felicien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07236-07410-saint_felicien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07236-07410-saint_felicien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07236-07410-saint_felicien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07237-07360-saint_fortunat_sur_eyrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07237-07360-saint_fortunat_sur_eyrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07237-07360-saint_fortunat_sur_eyrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07237-07360-saint_fortunat_sur_eyrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07238-07230-saint_genest_de_beauzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07238-07230-saint_genest_de_beauzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07238-07230-saint_genest_de_beauzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07238-07230-saint_genest_de_beauzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07239-07190-saint_genest_lachamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07239-07190-saint_genest_lachamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07239-07190-saint_genest_lachamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07239-07190-saint_genest_lachamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07239-07160-saint_genest_lachamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07239-07160-saint_genest_lachamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07239-07160-saint_genest_lachamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07239-07160-saint_genest_lachamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07240-07800-saint_georges_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07240-07800-saint_georges_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07240-07800-saint_georges_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07240-07800-saint_georges_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07241-07170-saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07241-07170-saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07241-07170-saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07241-07170-saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07242-07580-saint_gineis_en_coiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07242-07580-saint_gineis_en_coiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07242-07580-saint_gineis_en_coiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07242-07580-saint_gineis_en_coiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07243-07340-saint_jacques_d_atticieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07243-07340-saint_jacques_d_atticieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07243-07340-saint_jacques_d_atticieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07243-07340-saint_jacques_d_atticieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07244-07240-saint_jean_chambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07244-07240-saint_jean_chambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07244-07240-saint_jean_chambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07244-07240-saint_jean_chambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07245-07300-saint_jean_de_muzols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07245-07300-saint_jean_de_muzols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07245-07300-saint_jean_de_muzols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07245-07300-saint_jean_de_muzols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07247-07580-saint_jean_le_centenier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07247-07580-saint_jean_le_centenier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07247-07580-saint_jean_le_centenier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07247-07580-saint_jean_le_centenier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07248-07160-saint_jean_roure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07248-07160-saint_jean_roure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07248-07160-saint_jean_roure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07248-07160-saint_jean_roure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07249-07320-saint_jeure_d_andaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07249-07320-saint_jeure_d_andaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07249-07320-saint_jeure_d_andaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07249-07320-saint_jeure_d_andaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07250-07290-saint_jeure_d_ay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07250-07290-saint_jeure_d_ay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07250-07290-saint_jeure_d_ay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07250-07290-saint_jeure_d_ay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07251-07530-saint_joseph_des_bancs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07251-07530-saint_joseph_des_bancs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07251-07530-saint_joseph_des_bancs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07251-07530-saint_joseph_des_bancs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07253-07190-saint_julien_du_gua/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07253-07190-saint_julien_du_gua/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07253-07190-saint_julien_du_gua/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07253-07190-saint_julien_du_gua/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07254-07200-saint_julien_du_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07254-07200-saint_julien_du_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07254-07200-saint_julien_du_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07254-07200-saint_julien_du_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07254-07600-saint_julien_du_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07254-07600-saint_julien_du_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07254-07600-saint_julien_du_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07254-07600-saint_julien_du_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07255-07000-saint_julien_en_saint_alban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07255-07000-saint_julien_en_saint_alban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07255-07000-saint_julien_en_saint_alban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07255-07000-saint_julien_en_saint_alban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07257-07240-saint_julien_le_roux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07257-07240-saint_julien_le_roux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07257-07240-saint_julien_le_roux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07257-07240-saint_julien_le_roux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07258-07690-saint_julien_vocance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07258-07690-saint_julien_vocance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07258-07690-saint_julien_vocance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07258-07690-saint_julien_vocance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07259-07700-saint_just_d_ardeche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07259-07700-saint_just_d_ardeche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07259-07700-saint_just_d_ardeche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07259-07700-saint_just_d_ardeche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07260-07210-saint_lager_bressac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07260-07210-saint_lager_bressac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07260-07210-saint_lager_bressac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07260-07210-saint_lager_bressac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07261-07800-saint_laurent_du_pape/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07261-07800-saint_laurent_du_pape/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07261-07800-saint_laurent_du_pape/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07261-07800-saint_laurent_du_pape/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07262-07590-saint_laurent_les_bains_laval_d_aurelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07262-07590-saint_laurent_les_bains_laval_d_aurelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07262-07590-saint_laurent_les_bains_laval_d_aurelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07262-07590-saint_laurent_les_bains_laval_d_aurelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07263-07170-saint_laurent_sous_coiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07263-07170-saint_laurent_sous_coiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07263-07170-saint_laurent_sous_coiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07263-07170-saint_laurent_sous_coiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07264-07700-saint_marcel_d_ardeche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07264-07700-saint_marcel_d_ardeche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07264-07700-saint_marcel_d_ardeche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07264-07700-saint_marcel_d_ardeche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07265-07100-saint_marcel_les_annonay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07265-07100-saint_marcel_les_annonay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07265-07100-saint_marcel_les_annonay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07265-07100-saint_marcel_les_annonay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07266-07140-sainte_marguerite_lafigere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07266-07140-sainte_marguerite_lafigere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07266-07140-sainte_marguerite_lafigere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07266-07140-sainte_marguerite_lafigere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07267-07310-saint_martial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07267-07310-saint_martial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07267-07310-saint_martial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07267-07310-saint_martial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07268-07700-saint_martin_d_ardeche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07268-07700-saint_martin_d_ardeche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07268-07700-saint_martin_d_ardeche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07268-07700-saint_martin_d_ardeche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07269-07310-saint_martin_de_valamas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07269-07310-saint_martin_de_valamas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07269-07310-saint_martin_de_valamas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07269-07310-saint_martin_de_valamas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07270-07400-saint_martin_sur_lavezon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07270-07400-saint_martin_sur_lavezon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07270-07400-saint_martin_sur_lavezon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07270-07400-saint_martin_sur_lavezon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07272-07200-saint_maurice_d_ardeche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07272-07200-saint_maurice_d_ardeche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07272-07200-saint_maurice_d_ardeche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07272-07200-saint_maurice_d_ardeche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07273-07170-saint_maurice_d_ibie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07273-07170-saint_maurice_d_ibie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07273-07170-saint_maurice_d_ibie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07273-07170-saint_maurice_d_ibie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07190-saint_maurice_en_chalencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07190-saint_maurice_en_chalencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07190-saint_maurice_en_chalencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07190-saint_maurice_en_chalencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07240-saint_maurice_en_chalencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07240-saint_maurice_en_chalencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07240-saint_maurice_en_chalencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07240-saint_maurice_en_chalencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07360-saint_maurice_en_chalencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07360-saint_maurice_en_chalencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07360-saint_maurice_en_chalencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07274-07360-saint_maurice_en_chalencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07275-07260-saint_melany/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07275-07260-saint_melany/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07275-07260-saint_melany/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07275-07260-saint_melany/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07276-07160-saint_michel_d_aurance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07276-07160-saint_michel_d_aurance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07276-07160-saint_michel_d_aurance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07276-07160-saint_michel_d_aurance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07277-07200-saint_michel_de_boulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07277-07200-saint_michel_de_boulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07277-07200-saint_michel_de_boulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07277-07200-saint_michel_de_boulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07277-07000-saint_michel_de_boulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07277-07000-saint_michel_de_boulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07277-07000-saint_michel_de_boulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07277-07000-saint_michel_de_boulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07360-saint_michel_de_chabrillanoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07360-saint_michel_de_chabrillanoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07360-saint_michel_de_chabrillanoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07360-saint_michel_de_chabrillanoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07190-saint_michel_de_chabrillanoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07190-saint_michel_de_chabrillanoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07190-saint_michel_de_chabrillanoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07190-saint_michel_de_chabrillanoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07240-saint_michel_de_chabrillanoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07240-saint_michel_de_chabrillanoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07240-saint_michel_de_chabrillanoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07278-07240-saint_michel_de_chabrillanoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07279-07220-saint_montan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07279-07220-saint_montan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07279-07220-saint_montan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07279-07220-saint_montan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07280-07460-saint_paul_le_jeune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07280-07460-saint_paul_le_jeune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07280-07460-saint_paul_le_jeune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07280-07460-saint_paul_le_jeune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07281-07130-saint_peray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07281-07130-saint_peray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07281-07130-saint_peray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07281-07130-saint_peray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07282-07450-saint_pierre_de_colombier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07282-07450-saint_pierre_de_colombier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07282-07450-saint_pierre_de_colombier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07282-07450-saint_pierre_de_colombier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07283-07400-saint_pierre_la_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07283-07400-saint_pierre_la_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07283-07400-saint_pierre_la_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07283-07400-saint_pierre_la_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07284-07140-saint_pierre_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07284-07140-saint_pierre_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07284-07140-saint_pierre_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07284-07140-saint_pierre_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07285-07520-saint_pierre_sur_doux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07285-07520-saint_pierre_sur_doux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07285-07520-saint_pierre_sur_doux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07285-07520-saint_pierre_sur_doux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07286-07190-saint_pierreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07286-07190-saint_pierreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07286-07190-saint_pierreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07286-07190-saint_pierreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07287-07580-saint_pons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07287-07580-saint_pons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07287-07580-saint_pons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07287-07580-saint_pons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07288-07000-saint_priest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07288-07000-saint_priest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07288-07000-saint_priest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07288-07000-saint_priest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07289-07200-saint_privat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07289-07200-saint_privat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07289-07200-saint_privat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07289-07200-saint_privat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07290-07270-saint_prix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07290-07270-saint_prix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07290-07270-saint_prix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07290-07270-saint_prix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07291-07700-saint_remeze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07291-07700-saint_remeze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07291-07700-saint_remeze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07291-07700-saint_remeze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07292-07290-saint_romain_d_ay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07292-07290-saint_romain_d_ay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07292-07290-saint_romain_d_ay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07292-07290-saint_romain_d_ay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07293-07130-saint_romain_de_lerps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07293-07130-saint_romain_de_lerps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07293-07130-saint_romain_de_lerps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07293-07130-saint_romain_de_lerps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07294-07460-saint_sauveur_de_cruzieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07294-07460-saint_sauveur_de_cruzieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07294-07460-saint_sauveur_de_cruzieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07294-07460-saint_sauveur_de_cruzieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07295-07190-saint_sauveur_de_montagut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07295-07190-saint_sauveur_de_montagut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07295-07190-saint_sauveur_de_montagut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07295-07190-saint_sauveur_de_montagut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07296-07200-saint_sernin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07296-07200-saint_sernin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07296-07200-saint_sernin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07296-07200-saint_sernin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07297-07440-saint_sylvestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07297-07440-saint_sylvestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07297-07440-saint_sylvestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07297-07440-saint_sylvestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07298-07210-saint_symphorien_sous_chomerac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07298-07210-saint_symphorien_sous_chomerac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07298-07210-saint_symphorien_sous_chomerac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07298-07210-saint_symphorien_sous_chomerac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07299-07290-saint_symphorien_de_mahun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07299-07290-saint_symphorien_de_mahun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07299-07290-saint_symphorien_de_mahun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07299-07290-saint_symphorien_de_mahun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07300-07220-saint_thome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07300-07220-saint_thome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07300-07220-saint_thome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07300-07220-saint_thome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07301-07410-saint_victor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07301-07410-saint_victor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07301-07410-saint_victor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07301-07410-saint_victor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07302-07210-saint_vincent_de_barres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07302-07210-saint_vincent_de_barres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07302-07210-saint_vincent_de_barres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07302-07210-saint_vincent_de_barres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07303-07360-saint_vincent_de_durfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07303-07360-saint_vincent_de_durfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07303-07360-saint_vincent_de_durfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07303-07360-saint_vincent_de_durfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07304-07150-salavas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07304-07150-salavas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07304-07150-salavas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07304-07150-salavas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07305-07140-les_salelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07305-07140-les_salelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07305-07140-les_salelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07305-07140-les_salelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07306-07120-sampzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07306-07120-sampzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07306-07120-sampzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07306-07120-sampzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07307-07110-sanilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07307-07110-sanilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07307-07110-sanilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07307-07110-sanilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07308-07370-sarras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07308-07370-sarras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07308-07370-sarras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07308-07370-sarras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07309-07290-satillieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07309-07290-satillieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07309-07290-satillieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07309-07290-satillieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07310-07430-savas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07310-07430-savas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07310-07430-savas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07310-07430-savas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07311-07400-sceautres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07311-07400-sceautres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07311-07400-sceautres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07311-07400-sceautres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07312-07610-secheras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07312-07610-secheras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07312-07610-secheras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07312-07610-secheras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07313-07340-serrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07313-07340-serrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07313-07340-serrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07313-07340-serrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07314-07240-silhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07314-07240-silhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07314-07240-silhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07314-07240-silhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07315-07380-la_souche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07315-07380-la_souche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07315-07380-la_souche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07315-07380-la_souche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07316-07130-soyons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07316-07130-soyons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07316-07130-soyons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07316-07130-soyons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07317-07340-talencieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07317-07340-talencieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07317-07340-talencieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07317-07340-talencieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07318-07110-tauriers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07318-07110-tauriers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07318-07110-tauriers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07318-07110-tauriers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07319-07400-le_teil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07319-07400-le_teil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07319-07400-le_teil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07319-07400-le_teil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07321-07340-thorrenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07321-07340-thorrenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07321-07340-thorrenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07321-07340-thorrenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07321-07100-thorrenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07321-07100-thorrenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07321-07100-thorrenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07321-07100-thorrenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07322-07330-thueyts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07322-07330-thueyts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07322-07330-thueyts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07322-07330-thueyts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07323-07130-toulaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07323-07130-toulaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07323-07130-toulaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07323-07130-toulaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07324-07300-tournon_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07324-07300-tournon_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07324-07300-tournon_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07324-07300-tournon_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07325-07200-ucel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07325-07200-ucel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07325-07200-ucel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07325-07200-ucel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07326-07510-usclades_et_rieutord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07326-07510-usclades_et_rieutord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07326-07510-usclades_et_rieutord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07326-07510-usclades_et_rieutord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07327-07110-uzer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07327-07110-uzer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07327-07110-uzer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07327-07110-uzer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07328-07150-vagnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07328-07150-vagnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07328-07150-vagnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07328-07150-vagnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07329-07110-valgorge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07329-07110-valgorge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07329-07110-valgorge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07329-07110-valgorge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07330-07150-vallon_pont_d_arc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07330-07150-vallon_pont_d_arc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07330-07150-vallon_pont_d_arc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07330-07150-vallon_pont_d_arc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07331-07600-vals_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07331-07600-vals_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07331-07600-vals_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07331-07600-vals_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07332-07400-valvigneres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07332-07400-valvigneres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07332-07400-valvigneres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07332-07400-valvigneres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07333-07690-vanosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07333-07690-vanosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07333-07690-vanosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07333-07690-vanosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07334-07140-les_vans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07334-07140-les_vans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07334-07140-les_vans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07334-07140-les_vans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07335-07410-vaudevant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07335-07410-vaudevant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07335-07410-vaudevant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07335-07410-vaudevant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07336-07260-vernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07336-07260-vernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07336-07260-vernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07336-07260-vernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07337-07430-vernosc_les_annonay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07337-07430-vernosc_les_annonay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07337-07430-vernosc_les_annonay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07337-07430-vernosc_les_annonay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07338-07240-vernoux_en_vivarais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07338-07240-vernoux_en_vivarais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07338-07240-vernoux_en_vivarais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07338-07240-vernoux_en_vivarais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07339-07200-vesseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07339-07200-vesseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07339-07200-vesseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07339-07200-vesseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07340-07000-veyras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07340-07000-veyras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07340-07000-veyras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07340-07000-veyras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07341-07170-villeneuve_de_berg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07341-07170-villeneuve_de_berg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07341-07170-villeneuve_de_berg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07341-07170-villeneuve_de_berg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07342-07690-villevocance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07342-07690-villevocance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07342-07690-villevocance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07342-07690-villevocance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07343-07110-vinezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07343-07110-vinezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07343-07110-vinezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07343-07110-vinezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07344-07340-vinzieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07344-07340-vinzieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07344-07340-vinzieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07344-07340-vinzieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07345-07610-vion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07345-07610-vion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07345-07610-vion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07345-07610-vion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07346-07220-viviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07346-07220-viviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07346-07220-viviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07346-07220-viviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07347-07690-vocance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07347-07690-vocance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07347-07690-vocance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07347-07690-vocance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07348-07200-vogue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07348-07200-vogue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07348-07200-vogue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07348-07200-vogue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07349-07800-la_voulte_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07349-07800-la_voulte_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07349-07800-la_voulte_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt07-ardeche/commune07349-07800-la_voulte_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-08.xml
+++ b/public/sitemaps/sitemap-08.xml
@@ -5,918 +5,1832 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08001-08300-acy_romance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08001-08300-acy_romance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08001-08300-acy_romance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08001-08300-acy_romance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08003-08090-aiglemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08003-08090-aiglemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08003-08090-aiglemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08003-08090-aiglemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08004-08190-aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08004-08190-aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08004-08190-aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08004-08190-aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08005-08310-alincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08005-08310-alincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08005-08310-alincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08005-08310-alincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08006-08130-alland_huy_et_sausseuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08006-08130-alland_huy_et_sausseuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08006-08130-alland_huy_et_sausseuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08006-08130-alland_huy_et_sausseuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08008-08300-amagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08008-08300-amagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08008-08300-amagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08008-08300-amagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08010-08130-ambly_fleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08010-08130-ambly_fleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08010-08130-ambly_fleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08010-08130-ambly_fleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08011-08500-anchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08011-08500-anchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08011-08500-anchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08011-08500-anchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08013-08450-angecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08013-08450-angecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08013-08450-angecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08013-08450-angecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08014-08310-annelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08014-08310-annelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08014-08310-annelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08014-08310-annelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08015-08260-antheny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08015-08260-antheny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08015-08260-antheny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08015-08260-antheny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08016-08290-aouste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08016-08290-aouste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08016-08290-aouste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08016-08290-aouste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08017-08250-apremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08017-08250-apremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08017-08250-apremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08017-08250-apremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08018-08400-ardeuil_et_montfauxelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08018-08400-ardeuil_et_montfauxelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08018-08400-ardeuil_et_montfauxelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08018-08400-ardeuil_et_montfauxelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08019-08390-les_grandes_armoises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08019-08390-les_grandes_armoises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08019-08390-les_grandes_armoises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08019-08390-les_grandes_armoises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08020-08390-les_petites_armoises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08020-08390-les_petites_armoises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08020-08390-les_petites_armoises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08020-08390-les_petites_armoises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08021-08300-arnicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08021-08300-arnicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08021-08300-arnicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08021-08300-arnicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08022-08090-arreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08022-08090-arreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08022-08090-arreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08022-08090-arreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08023-08390-artaise_le_vivier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08023-08390-artaise_le_vivier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08023-08390-artaise_le_vivier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08023-08390-artaise_le_vivier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08024-08190-asfeld/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08024-08190-asfeld/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08024-08190-asfeld/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08024-08190-asfeld/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08025-08130-attigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08025-08130-attigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08025-08130-attigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08025-08130-attigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08026-08150-aubigny_les_pothees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08026-08150-aubigny_les_pothees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08026-08150-aubigny_les_pothees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08026-08150-aubigny_les_pothees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08027-08270-auboncourt_vauzelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08027-08270-auboncourt_vauzelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08027-08270-auboncourt_vauzelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08027-08270-auboncourt_vauzelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08028-08320-aubrives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08028-08320-aubrives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08028-08320-aubrives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08028-08320-aubrives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08029-08370-auflance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08029-08370-auflance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08029-08370-auflance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08029-08370-auflance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08030-08380-auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08030-08380-auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08030-08380-auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08030-08380-auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08031-08400-aure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08031-08400-aure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08031-08400-aure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08031-08400-aure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08032-08310-aussonce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08032-08310-aussonce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08032-08310-aussonce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08032-08310-aussonce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08033-08240-authe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08033-08240-authe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08033-08240-authe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08033-08240-authe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08034-08210-autrecourt_et_pourron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08034-08210-autrecourt_et_pourron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08034-08210-autrecourt_et_pourron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08034-08210-autrecourt_et_pourron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08035-08240-autruche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08035-08240-autruche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08035-08240-autruche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08035-08240-autruche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08036-08250-autry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08036-08250-autry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08036-08250-autry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08036-08250-autry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08037-08260-auvillers_les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08037-08260-auvillers_les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08037-08260-auvillers_les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08037-08260-auvillers_les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08038-08300-avancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08038-08300-avancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08038-08300-avancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08038-08300-avancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08039-08190-avaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08039-08190-avaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08039-08190-avaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08039-08190-avaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08040-08000-les_ayvelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08040-08000-les_ayvelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08040-08000-les_ayvelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08040-08000-les_ayvelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08041-08430-baalons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08041-08430-baalons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08041-08430-baalons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08041-08430-baalons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08043-08200-balan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08043-08200-balan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08043-08200-balan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08043-08200-balan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08044-08190-balham/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08044-08190-balham/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08044-08190-balham/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08044-08190-balham/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08045-08400-ballay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08045-08400-ballay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08045-08400-ballay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08045-08400-ballay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08046-08220-banogne_recouvrance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08046-08220-banogne_recouvrance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08046-08220-banogne_recouvrance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08046-08220-banogne_recouvrance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08047-08430-barbaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08047-08430-barbaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08047-08430-barbaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08047-08430-barbaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08048-08300-barby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08048-08300-barby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08048-08300-barby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08048-08300-barby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08049-08240-bar_les_buzancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08049-08240-bar_les_buzancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08049-08240-bar_les_buzancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08049-08240-bar_les_buzancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08052-08240-bayonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08052-08240-bayonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08052-08240-bayonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08052-08240-bayonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08053-08140-bazeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08053-08140-bazeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08053-08140-bazeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08053-08140-bazeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08055-08210-beaumont_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08055-08210-beaumont_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08055-08210-beaumont_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08055-08210-beaumont_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08056-08250-beffu_et_le_morthomme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08056-08250-beffu_et_le_morthomme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08056-08250-beffu_et_le_morthomme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08056-08250-beffu_et_le_morthomme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08057-08240-belleville_et_chatillon_sur_bar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08057-08240-belleville_et_chatillon_sur_bar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08057-08240-belleville_et_chatillon_sur_bar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08057-08240-belleville_et_chatillon_sur_bar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08058-08090-belval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08058-08090-belval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08058-08090-belval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08058-08090-belval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08059-08240-belval_bois_des_dames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08059-08240-belval_bois_des_dames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08059-08240-belval_bois_des_dames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08059-08240-belval_bois_des_dames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08060-08300-bergnicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08060-08300-bergnicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08060-08300-bergnicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08060-08300-bergnicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08061-08240-la_berliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08061-08240-la_berliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08061-08240-la_berliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08061-08240-la_berliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08062-08300-bertoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08062-08300-bertoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08062-08300-bertoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08062-08300-bertoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08063-08450-la_besace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08063-08450-la_besace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08063-08450-la_besace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08063-08450-la_besace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08064-08300-biermes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08064-08300-biermes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08064-08300-biermes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08064-08300-biermes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08065-08370-bievres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08065-08370-bievres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08065-08370-bievres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08065-08370-bievres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08066-08310-bignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08066-08310-bignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08066-08310-bignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08066-08310-bignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08067-08110-blagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08067-08110-blagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08067-08110-blagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08067-08110-blagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08069-08290-blanchefosse_et_bay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08069-08290-blanchefosse_et_bay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08069-08290-blanchefosse_et_bay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08069-08290-blanchefosse_et_bay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08070-08190-blanzy_la_salonnaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08070-08190-blanzy_la_salonnaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08070-08190-blanzy_la_salonnaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08070-08190-blanzy_la_salonnaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08071-08260-blombay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08071-08260-blombay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08071-08260-blombay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08071-08260-blombay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08073-08290-bossus_les_rumigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08073-08290-bossus_les_rumigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08073-08290-bossus_les_rumigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08073-08290-bossus_les_rumigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08074-08250-bouconville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08074-08250-bouconville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08074-08250-bouconville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08074-08250-bouconville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08075-08240-boult_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08075-08240-boult_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08075-08240-boult_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08075-08240-boult_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08076-08410-boulzicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08076-08410-boulzicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08076-08410-boulzicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08076-08410-boulzicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08077-08400-bourcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08077-08400-bourcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08077-08400-bourcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08077-08400-bourcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08078-08230-bourg_fidele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08078-08230-bourg_fidele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08078-08230-bourg_fidele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08078-08230-bourg_fidele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08080-08430-bouvellemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08080-08430-bouvellemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08080-08430-bouvellemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08080-08430-bouvellemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08081-08120-bogny_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08081-08120-bogny_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08081-08120-bogny_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08081-08120-bogny_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08082-08400-brecy_brieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08082-08400-brecy_brieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08082-08400-brecy_brieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08082-08400-brecy_brieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08083-08140-brevilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08083-08140-brevilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08083-08140-brevilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08083-08140-brevilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08084-08190-brienne_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08084-08190-brienne_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08084-08190-brienne_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08084-08190-brienne_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08085-08240-brieulles_sur_bar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08085-08240-brieulles_sur_bar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08085-08240-brieulles_sur_bar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08085-08240-brieulles_sur_bar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08086-08240-briquenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08086-08240-briquenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08086-08240-briquenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08086-08240-briquenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08087-08380-brognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08087-08380-brognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08087-08380-brognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08087-08380-brognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08088-08450-bulson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08088-08450-bulson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08088-08450-bulson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08088-08450-bulson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08089-08240-buzancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08089-08240-buzancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08089-08240-buzancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08089-08240-buzancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08090-08110-carignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08090-08110-carignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08090-08110-carignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08090-08110-carignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08092-08310-cauroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08092-08310-cauroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08092-08310-cauroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08092-08310-cauroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08094-08260-cernion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08094-08260-cernion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08094-08260-cernion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08094-08260-cernion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08095-08430-chagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08095-08430-chagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08095-08430-chagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08095-08430-chagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08096-08160-chalandry_elaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08096-08160-chalandry_elaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08096-08160-chalandry_elaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08096-08160-chalandry_elaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08097-08400-challerange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08097-08400-challerange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08097-08400-challerange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08097-08400-challerange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08098-08250-champigneulle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08098-08250-champigneulle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08098-08250-champigneulle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08098-08250-champigneulle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08099-08430-champigneul_sur_vence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08099-08430-champigneul_sur_vence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08099-08430-champigneul_sur_vence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08099-08430-champigneul_sur_vence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08100-08260-champlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08100-08260-champlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08100-08260-champlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08100-08260-champlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08101-08200-la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08101-08200-la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08101-08200-la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08101-08200-la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08102-08220-chappes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08102-08220-chappes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08102-08220-chappes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08102-08220-chappes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08103-08130-charbogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08103-08130-charbogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08103-08130-charbogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08103-08130-charbogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08104-08400-chardeny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08104-08400-chardeny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08104-08400-chardeny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08104-08400-chardeny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08105-08000-charleville_mezieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08105-08000-charleville_mezieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08105-08000-charleville_mezieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08105-08000-charleville_mezieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08106-08600-charnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08106-08600-charnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08106-08600-charnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08106-08600-charnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08107-08360-chateau_porcien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08107-08360-chateau_porcien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08107-08360-chateau_porcien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08107-08360-chateau_porcien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08109-08250-chatel_chehery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08109-08250-chatel_chehery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08109-08250-chatel_chehery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08109-08250-chatel_chehery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08110-08150-le_chatelet_sur_sormonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08110-08150-le_chatelet_sur_sormonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08110-08150-le_chatelet_sur_sormonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08110-08150-le_chatelet_sur_sormonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08111-08300-le_chatelet_sur_retourne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08111-08300-le_chatelet_sur_retourne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08111-08300-le_chatelet_sur_retourne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08111-08300-le_chatelet_sur_retourne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08113-08220-chaumont_porcien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08113-08220-chaumont_porcien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08113-08220-chaumont_porcien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08113-08220-chaumont_porcien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08115-08450-chemery_chehery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08115-08450-chemery_chehery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08115-08450-chemery_chehery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08115-08450-chemery_chehery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08115-08350-chemery_chehery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08115-08350-chemery_chehery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08115-08350-chemery_chehery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08115-08350-chemery_chehery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08116-08390-bairon_et_ses_environs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08116-08390-bairon_et_ses_environs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08116-08390-bairon_et_ses_environs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08116-08390-bairon_et_ses_environs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08116-08400-bairon_et_ses_environs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08116-08400-bairon_et_ses_environs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08116-08400-bairon_et_ses_environs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08116-08400-bairon_et_ses_environs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08117-08270-chesnois_auboncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08117-08270-chesnois_auboncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08117-08270-chesnois_auboncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08117-08270-chesnois_auboncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08119-08350-cheveuges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08119-08350-cheveuges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08119-08350-cheveuges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08119-08350-cheveuges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08120-08250-chevieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08120-08250-chevieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08120-08250-chevieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08120-08250-chevieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08121-08260-chilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08121-08260-chilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08121-08260-chilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08121-08260-chilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08122-08600-chooz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08122-08600-chooz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08122-08600-chooz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08122-08600-chooz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08123-08130-chuffilly_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08123-08130-chuffilly_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08123-08130-chuffilly_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08123-08130-chuffilly_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08124-08460-clavy_warby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08124-08460-clavy_warby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08124-08460-clavy_warby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08124-08460-clavy_warby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08125-08090-cliron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08125-08090-cliron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08125-08090-cliron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08125-08090-cliron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08126-08360-conde_les_herpy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08126-08360-conde_les_herpy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08126-08360-conde_les_herpy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08126-08360-conde_les_herpy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08128-08250-conde_les_autry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08128-08250-conde_les_autry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08128-08250-conde_les_autry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08128-08250-conde_les_autry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08130-08400-contreuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08130-08400-contreuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08130-08400-contreuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08130-08400-contreuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08131-08250-cornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08131-08250-cornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08131-08250-cornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08131-08250-cornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08132-08270-corny_macheromenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08132-08270-corny_macheromenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08132-08270-corny_macheromenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08132-08270-corny_macheromenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08133-08300-coucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08133-08300-coucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08133-08300-coucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08133-08300-coucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08134-08130-coulommes_et_marqueny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08134-08130-coulommes_et_marqueny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08134-08130-coulommes_et_marqueny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08134-08130-coulommes_et_marqueny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08135-08400-la_croix_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08135-08400-la_croix_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08135-08400-la_croix_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08135-08400-la_croix_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08136-08140-daigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08136-08140-daigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08136-08140-daigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08136-08140-daigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08137-08090-damouzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08137-08090-damouzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08137-08090-damouzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08137-08090-damouzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08138-08110-les_deux_villes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08138-08110-les_deux_villes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08138-08110-les_deux_villes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08138-08110-les_deux_villes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08139-08800-deville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08139-08800-deville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08139-08800-deville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08139-08800-deville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08140-08160-dom_le_mesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08140-08160-dom_le_mesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08140-08160-dom_le_mesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08140-08160-dom_le_mesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08141-08460-dommery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08141-08460-dommery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08141-08460-dommery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08141-08460-dommery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08142-08350-donchery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08142-08350-donchery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08142-08350-donchery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08142-08350-donchery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08143-08220-doumely_begny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08143-08220-doumely_begny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08143-08220-doumely_begny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08143-08220-doumely_begny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08144-08300-doux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08144-08300-doux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08144-08300-doux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08144-08300-doux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08145-08140-douzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08145-08140-douzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08145-08140-douzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08145-08140-douzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08146-08220-draize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08146-08220-draize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08146-08220-draize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08146-08220-draize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08147-08310-dricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08147-08310-dricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08147-08310-dricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08147-08310-dricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08148-08300-l_ecaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08148-08300-l_ecaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08148-08300-l_ecaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08148-08300-l_ecaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08149-08150-l_echelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08149-08150-l_echelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08149-08150-l_echelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08149-08150-l_echelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08150-08300-ecly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08150-08300-ecly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08150-08300-ecly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08150-08300-ecly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08151-08130-ecordal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08151-08130-ecordal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08151-08130-ecordal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08151-08130-ecordal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08153-08110-escombres_et_le_chesnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08153-08110-escombres_et_le_chesnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08153-08110-escombres_et_le_chesnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08153-08110-escombres_et_le_chesnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08154-08260-estrebay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08154-08260-estrebay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08154-08260-estrebay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08154-08260-estrebay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08155-08260-etalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08155-08260-etalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08155-08260-etalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08155-08260-etalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08156-08260-eteignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08156-08260-eteignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08156-08260-eteignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08156-08260-eteignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08158-08160-etrepigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08158-08160-etrepigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08158-08160-etrepigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08158-08160-etrepigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08159-08210-euilly_et_lombut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08159-08210-euilly_et_lombut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08159-08210-euilly_et_lombut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08159-08210-euilly_et_lombut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08160-08090-evigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08160-08090-evigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08160-08090-evigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08160-08090-evigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08161-08250-exermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08161-08250-exermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08161-08250-exermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08161-08250-exermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08162-08090-fagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08162-08090-fagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08162-08090-fagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08162-08090-fagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08163-08270-faissault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08163-08270-faissault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08163-08270-faissault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08163-08270-faissault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08164-08400-falaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08164-08400-falaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08164-08400-falaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08164-08400-falaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08165-08270-faux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08165-08270-faux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08165-08270-faux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08165-08270-faux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08166-08170-fepin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08166-08170-fepin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08166-08170-fepin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08166-08170-fepin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08167-08290-la_feree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08167-08290-la_feree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08167-08290-la_feree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08167-08290-la_feree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08168-08370-la_ferte_sur_chiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08168-08370-la_ferte_sur_chiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08168-08370-la_ferte_sur_chiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08168-08370-la_ferte_sur_chiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08169-08260-flaignes_havys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08169-08260-flaignes_havys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08169-08260-flaignes_havys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08169-08260-flaignes_havys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08170-08200-fleigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08170-08200-fleigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08170-08200-fleigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08170-08200-fleigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08171-08250-fleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08171-08250-fleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08171-08250-fleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08171-08250-fleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08172-08380-fligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08172-08380-fligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08172-08380-fligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08172-08380-fligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08173-08160-flize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08173-08160-flize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08173-08160-flize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08173-08160-flize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08174-08200-floing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08174-08200-floing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08174-08200-floing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08174-08200-floing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08175-08600-foisches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08175-08600-foisches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08175-08600-foisches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08175-08600-foisches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08176-08240-fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08176-08240-fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08176-08240-fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08176-08240-fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08178-08220-fraillicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08178-08220-fraillicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08178-08220-fraillicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08178-08220-fraillicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08179-08140-francheval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08179-08140-francheval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08179-08140-francheval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08179-08140-francheval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08180-08000-la_francheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08180-08000-la_francheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08180-08000-la_francheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08180-08000-la_francheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08182-08290-le_frety/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08182-08290-le_frety/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08182-08290-le_frety/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08182-08290-le_frety/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08183-08600-fromelennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08183-08600-fromelennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08183-08600-fromelennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08183-08600-fromelennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08184-08370-fromy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08184-08370-fromy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08184-08370-fromy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08184-08370-fromy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08185-08170-fumay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08185-08170-fumay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08185-08170-fumay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08185-08170-fumay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08186-08240-germont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08186-08240-germont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08186-08240-germont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08186-08240-germont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08187-08440-gernelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08187-08440-gernelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08187-08440-gernelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08187-08440-gernelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08188-08700-gespunsart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08188-08700-gespunsart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08188-08700-gespunsart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08188-08700-gespunsart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08189-08260-girondelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08189-08260-girondelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08189-08260-girondelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08189-08260-girondelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08190-08600-givet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08190-08600-givet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08190-08600-givet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08190-08600-givet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08191-08200-givonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08191-08200-givonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08191-08200-givonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08191-08200-givonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08192-08220-givron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08192-08220-givron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08192-08220-givron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08192-08220-givron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08193-08130-givry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08193-08130-givry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08193-08130-givry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08193-08130-givry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08194-08200-glaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08194-08200-glaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08194-08200-glaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08194-08200-glaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08195-08190-gomont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08195-08190-gomont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08195-08190-gomont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08195-08190-gomont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08196-08270-grandchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08196-08270-grandchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08196-08270-grandchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08196-08270-grandchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08197-08250-grandham/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08197-08250-grandham/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08197-08250-grandham/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08197-08250-grandham/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08198-08250-grandpre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08198-08250-grandpre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08198-08250-grandpre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08198-08250-grandpre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08199-08700-la_grandville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08199-08700-la_grandville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08199-08700-la_grandville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08199-08700-la_grandville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08200-08400-grivy_loisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08200-08400-grivy_loisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08200-08400-grivy_loisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08200-08400-grivy_loisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08201-08430-gruyeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08201-08430-gruyeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08201-08430-gruyeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08201-08430-gruyeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08202-08230-gue_d_hossus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08202-08230-gue_d_hossus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08202-08230-gue_d_hossus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08202-08230-gue_d_hossus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08203-08430-guignicourt_sur_vence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08203-08430-guignicourt_sur_vence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08203-08430-guignicourt_sur_vence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08203-08430-guignicourt_sur_vence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08204-08130-guincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08204-08130-guincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08204-08130-guincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08204-08130-guincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08205-08430-hagnicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08205-08430-hagnicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08205-08430-hagnicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08205-08430-hagnicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08206-08090-ham_les_moines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08206-08090-ham_les_moines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08206-08090-ham_les_moines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08206-08090-ham_les_moines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08207-08600-ham_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08207-08600-ham_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08207-08600-ham_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08207-08600-ham_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08208-08290-hannappes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08208-08290-hannappes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08208-08290-hannappes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08208-08290-hannappes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08209-08160-hannogne_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08209-08160-hannogne_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08209-08160-hannogne_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08209-08160-hannogne_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08210-08220-hannogne_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08210-08220-hannogne_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08210-08220-hannogne_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08210-08220-hannogne_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08211-08450-haraucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08211-08450-haraucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08211-08450-haraucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08211-08450-haraucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08212-08150-harcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08212-08150-harcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08212-08150-harcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08212-08150-harcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08214-08170-hargnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08214-08170-hargnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08214-08170-hargnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08214-08170-hargnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08215-08240-harricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08215-08240-harricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08215-08240-harricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08215-08240-harricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08216-08090-haudrecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08216-08090-haudrecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08216-08090-haudrecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08216-08090-haudrecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08217-08800-haulme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08217-08800-haulme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08217-08800-haulme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08217-08800-haulme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08218-08800-les_hautes_rivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08218-08800-les_hautes_rivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08218-08800-les_hautes_rivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08218-08800-les_hautes_rivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08219-08300-hauteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08219-08300-hauteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08219-08300-hauteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08219-08300-hauteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08220-08310-hauvine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08220-08310-hauvine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08220-08310-hauvine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08220-08310-hauvine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08222-08170-haybes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08222-08170-haybes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08222-08170-haybes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08222-08170-haybes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08223-08370-herbeuval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08223-08370-herbeuval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08223-08370-herbeuval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08223-08370-herbeuval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08225-08360-herpy_l_arlesienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08225-08360-herpy_l_arlesienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08225-08360-herpy_l_arlesienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08225-08360-herpy_l_arlesienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08226-08320-hierges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08226-08320-hierges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08226-08320-hierges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08226-08320-hierges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08228-08430-la_horgne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08228-08430-la_horgne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08228-08430-la_horgne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08228-08430-la_horgne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08229-08190-houdilcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08229-08190-houdilcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08229-08190-houdilcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08229-08190-houdilcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08230-08090-houldizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08230-08090-houldizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08230-08090-houldizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08230-08090-houldizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08232-08200-illy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08232-08200-illy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08232-08200-illy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08232-08200-illy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08233-08240-imecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08233-08240-imecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08233-08240-imecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08233-08240-imecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08234-08300-inaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08234-08300-inaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08234-08300-inaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08234-08300-inaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08235-08440-issancourt_et_rumel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08235-08440-issancourt_et_rumel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08235-08440-issancourt_et_rumel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08235-08440-issancourt_et_rumel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08236-08430-jandun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08236-08430-jandun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08236-08430-jandun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08236-08430-jandun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08237-08700-joigny_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08237-08700-joigny_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08237-08700-joigny_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08237-08700-joigny_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08238-08130-jonval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08238-08130-jonval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08238-08130-jonval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08238-08130-jonval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08239-08310-juniville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08239-08310-juniville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08239-08310-juniville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08239-08310-juniville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08240-08270-justine_herbigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08240-08270-justine_herbigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08240-08270-justine_herbigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08240-08270-justine_herbigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08242-08800-laifour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08242-08800-laifour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08242-08800-laifour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08242-08800-laifour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08243-08460-lalobbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08243-08460-lalobbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08243-08460-lalobbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08243-08460-lalobbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08244-08130-lametz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08244-08130-lametz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08244-08130-lametz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08244-08130-lametz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08245-08250-lancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08245-08250-lancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08245-08250-lancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08245-08250-lancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08246-08240-landres_et_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08246-08240-landres_et_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08246-08240-landres_et_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08246-08240-landres_et_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08247-08600-landrichamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08247-08600-landrichamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08247-08600-landrichamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08247-08600-landrichamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08248-08430-launois_sur_vence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08248-08430-launois_sur_vence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08248-08430-launois_sur_vence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08248-08430-launois_sur_vence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08249-08150-laval_morency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08249-08150-laval_morency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08249-08150-laval_morency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08249-08150-laval_morency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08250-08310-leffincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08250-08310-leffincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08250-08310-leffincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08250-08310-leffincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08251-08150-lepron_les_vallees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08251-08150-lepron_les_vallees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08251-08150-lepron_les_vallees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08251-08150-lepron_les_vallees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08252-08210-letanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08252-08210-letanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08252-08210-letanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08252-08210-letanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08254-08290-liart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08254-08290-liart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08254-08290-liart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08254-08290-liart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08255-08110-linay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08255-08110-linay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08255-08110-linay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08255-08110-linay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08256-08400-liry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08256-08400-liry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08256-08400-liry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08256-08400-liry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08257-08150-logny_bogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08257-08150-logny_bogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08257-08150-logny_bogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08257-08150-logny_bogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08259-08400-longwe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08259-08400-longwe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08259-08400-longwe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08259-08400-longwe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08260-08150-lonny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08260-08150-lonny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08260-08150-lonny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08260-08150-lonny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08262-08300-lucquy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08262-08300-lucquy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08262-08300-lucquy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08262-08300-lucquy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08263-08440-lumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08263-08440-lumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08263-08440-lumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08263-08440-lumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08264-08310-machault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08264-08310-machault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08264-08310-machault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08264-08310-machault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08268-08450-maisoncelle_et_villers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08268-08450-maisoncelle_et_villers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08268-08450-maisoncelle_et_villers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08268-08450-maisoncelle_et_villers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08269-08370-malandry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08269-08370-malandry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08269-08370-malandry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08269-08370-malandry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08271-08400-manre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08271-08400-manre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08271-08400-manre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08271-08400-manre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08272-08460-maranwez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08272-08460-maranwez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08272-08460-maranwez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08272-08460-maranwez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08273-08260-marby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08273-08260-marby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08273-08260-marby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08273-08260-marby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08274-08250-marcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08274-08250-marcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08274-08250-marcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08274-08250-marcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08275-08370-margny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08275-08370-margny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08275-08370-margny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08275-08370-margny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08276-08370-margut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08276-08370-margut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08276-08370-margut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08276-08370-margut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08277-08290-marlemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08277-08290-marlemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08277-08290-marlemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08277-08290-marlemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08278-08390-marquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08278-08390-marquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08278-08390-marquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08278-08390-marquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08279-08400-mars_sous_bourcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08279-08400-mars_sous_bourcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08279-08400-mars_sous_bourcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08279-08400-mars_sous_bourcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08280-08400-marvaux_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08280-08400-marvaux_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08280-08400-marvaux_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08280-08400-marvaux_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08281-08110-matton_et_clemency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08281-08110-matton_et_clemency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08281-08110-matton_et_clemency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08281-08110-matton_et_clemency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08282-08260-maubert_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08282-08260-maubert_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08282-08260-maubert_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08282-08260-maubert_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08283-08430-mazerny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08283-08430-mazerny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08283-08430-mazerny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08283-08430-mazerny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08284-08500-les_mazures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08284-08500-les_mazures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08284-08500-les_mazures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08284-08500-les_mazures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08286-08310-menil_annelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08286-08310-menil_annelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08286-08310-menil_annelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08286-08310-menil_annelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08287-08310-menil_lepinois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08287-08310-menil_lepinois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08287-08310-menil_lepinois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08287-08310-menil_lepinois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08288-08270-mesmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08288-08270-mesmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08288-08270-mesmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08288-08270-mesmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08289-08110-messincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08289-08110-messincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08289-08110-messincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08289-08110-messincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08291-08110-mogues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08291-08110-mogues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08291-08110-mogues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08291-08110-mogues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08293-08370-moiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08293-08370-moiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08293-08370-moiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08293-08370-moiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08294-08140-la_moncelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08294-08140-la_moncelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08294-08140-la_moncelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08294-08140-la_moncelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08295-08430-mondigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08295-08430-mondigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08295-08430-mondigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08295-08430-mondigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08296-08250-montcheutin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08296-08250-montcheutin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08296-08250-montcheutin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08296-08250-montcheutin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08297-08090-montcornet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08297-08090-montcornet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08297-08090-montcornet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08297-08090-montcornet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08298-08090-montcy_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08298-08090-montcy_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08298-08090-montcy_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08298-08090-montcy_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08300-08390-le_mont_dieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08300-08390-le_mont_dieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08300-08390-le_mont_dieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08300-08390-le_mont_dieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08301-08390-montgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08301-08390-montgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08301-08390-montgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08301-08390-montgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08302-08800-montherme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08302-08800-montherme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08302-08800-montherme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08302-08800-montherme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08303-08400-monthois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08303-08400-monthois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08303-08400-monthois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08303-08400-monthois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08304-08170-montigny_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08304-08170-montigny_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08304-08170-montigny_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08304-08170-montigny_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08305-08430-montigny_sur_vence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08305-08430-montigny_sur_vence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08305-08430-montigny_sur_vence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08305-08430-montigny_sur_vence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08306-08130-mont_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08306-08130-mont_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08306-08130-mont_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08306-08130-mont_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08307-08220-montmeillant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08307-08220-montmeillant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08307-08220-montmeillant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08307-08220-montmeillant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08308-08400-mont_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08308-08400-mont_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08308-08400-mont_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08308-08400-mont_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08309-08310-mont_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08309-08310-mont_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08309-08310-mont_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08309-08310-mont_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08310-08250-mouron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08310-08250-mouron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08310-08250-mouron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08310-08250-mouron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08311-08210-mouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08311-08210-mouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08311-08210-mouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08311-08210-mouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08312-08150-murtin_et_bogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08312-08150-murtin_et_bogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08312-08150-murtin_et_bogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08312-08150-murtin_et_bogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08313-08300-nanteuil_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08313-08300-nanteuil_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08313-08300-nanteuil_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08313-08300-nanteuil_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08314-08300-neuflize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08314-08300-neuflize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08314-08300-neuflize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08314-08300-neuflize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08315-08460-neufmaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08315-08460-neufmaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08315-08460-neufmaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08315-08460-neufmaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08316-08700-neufmanil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08316-08700-neufmanil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08316-08700-neufmanil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08316-08700-neufmanil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08317-08450-la_neuville_a_maire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08317-08450-la_neuville_a_maire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08317-08450-la_neuville_a_maire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08317-08450-la_neuville_a_maire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08318-08380-la_neuville_aux_joutes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08318-08380-la_neuville_aux_joutes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08318-08380-la_neuville_aux_joutes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08318-08380-la_neuville_aux_joutes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08319-08380-neuville_lez_beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08319-08380-neuville_lez_beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08319-08380-neuville_lez_beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08319-08380-neuville_lez_beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08320-08310-la_neuville_en_tourne_a_fuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08320-08310-la_neuville_en_tourne_a_fuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08320-08310-la_neuville_en_tourne_a_fuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08320-08310-la_neuville_en_tourne_a_fuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08321-08130-neuville_day/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08321-08130-neuville_day/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08321-08130-neuville_day/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08321-08130-neuville_day/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08322-08090-neuville_les_this/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08322-08090-neuville_les_this/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08322-08090-neuville_les_this/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08322-08090-neuville_les_this/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08323-08270-la_neuville_les_wasigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08323-08270-la_neuville_les_wasigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08323-08270-la_neuville_les_wasigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08323-08270-la_neuville_les_wasigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08324-08430-neuvizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08324-08430-neuvizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08324-08430-neuvizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08324-08430-neuvizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08325-08400-noirval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08325-08400-noirval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08325-08400-noirval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08325-08400-noirval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08326-08240-nouart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08326-08240-nouart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08326-08240-nouart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08326-08240-nouart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08327-08160-nouvion_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08327-08160-nouvion_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08327-08160-nouvion_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08327-08160-nouvion_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08328-08700-nouzonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08328-08700-nouzonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08328-08700-nouzonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08328-08700-nouzonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08329-08270-novion_porcien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08329-08270-novion_porcien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08329-08270-novion_porcien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08329-08270-novion_porcien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08330-08300-novy_chevrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08330-08300-novy_chevrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08330-08300-novy_chevrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08330-08300-novy_chevrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08331-08350-noyers_pont_maugis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08331-08350-noyers_pont_maugis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08331-08350-noyers_pont_maugis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08331-08350-noyers_pont_maugis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08332-08240-oches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08332-08240-oches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08332-08240-oches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08332-08240-oches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08333-08250-olizy_primat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08333-08250-olizy_primat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08333-08250-olizy_primat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08333-08250-olizy_primat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08334-08450-omicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08334-08450-omicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08334-08450-omicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08334-08450-omicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08335-08430-omont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08335-08430-omont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08335-08430-omont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08335-08430-omont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08336-08110-osnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08336-08110-osnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08336-08110-osnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08336-08110-osnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08338-08310-pauvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08338-08310-pauvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08338-08310-pauvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08338-08310-pauvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08339-08300-perthes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08339-08300-perthes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08339-08300-perthes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08339-08300-perthes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08340-08190-poilcourt_sydney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08340-08190-poilcourt_sydney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08340-08190-poilcourt_sydney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08340-08190-poilcourt_sydney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08341-08430-poix_terron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08341-08430-poix_terron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08341-08430-poix_terron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08341-08430-poix_terron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08342-08140-pouru_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08342-08140-pouru_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08342-08140-pouru_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08342-08140-pouru_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08343-08140-pouru_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08343-08140-pouru_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08343-08140-pouru_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08343-08140-pouru_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08344-08290-prez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08344-08290-prez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08344-08290-prez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08344-08290-prez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08346-08000-prix_les_mezieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08346-08000-prix_les_mezieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08346-08000-prix_les_mezieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08346-08000-prix_les_mezieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08347-08370-puilly_et_charbeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08347-08370-puilly_et_charbeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08347-08370-puilly_et_charbeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08347-08370-puilly_et_charbeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08348-08270-puiseux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08348-08270-puiseux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08348-08270-puiseux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08348-08270-puiseux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08349-08110-pure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08349-08110-pure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08349-08110-pure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08349-08110-pure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08350-08400-quatre_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08350-08400-quatre_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08350-08400-quatre_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08350-08400-quatre_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08351-08400-quilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08351-08400-quilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08351-08400-quilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08351-08400-quilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08352-08430-raillicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08352-08430-raillicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08352-08430-raillicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08352-08430-raillicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08353-08600-rancennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08353-08600-rancennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08353-08600-rancennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08353-08600-rancennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08354-08450-raucourt_et_flaba/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08354-08450-raucourt_et_flaba/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08354-08450-raucourt_et_flaba/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08354-08450-raucourt_et_flaba/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08355-08230-regniowez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08355-08230-regniowez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08355-08230-regniowez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08355-08230-regniowez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08356-08220-remaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08356-08220-remaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08356-08220-remaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08356-08220-remaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08357-08450-remilly_aillicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08357-08450-remilly_aillicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08357-08450-remilly_aillicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08357-08450-remilly_aillicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08358-08150-remilly_les_pothees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08358-08150-remilly_les_pothees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08358-08150-remilly_les_pothees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08358-08150-remilly_les_pothees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08360-08220-renneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08360-08220-renneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08360-08220-renneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08360-08220-renneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08361-08150-renwez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08361-08150-renwez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08361-08150-renwez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08361-08150-renwez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08362-08300-rethel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08362-08300-rethel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08362-08300-rethel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08362-08300-rethel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08363-08500-revin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08363-08500-revin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08363-08500-revin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08363-08500-revin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08363-08800-revin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08363-08800-revin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08363-08800-revin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08363-08800-revin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08364-08130-rilly_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08364-08130-rilly_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08364-08130-rilly_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08364-08130-rilly_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08365-08150-rimogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08365-08150-rimogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08365-08150-rimogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08365-08150-rimogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08366-08220-rocquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08366-08220-rocquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08366-08220-rocquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08366-08220-rocquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08367-08230-rocroi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08367-08230-rocroi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08367-08230-rocroi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08367-08230-rocroi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08367-08500-rocroi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08367-08500-rocroi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08367-08500-rocroi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08367-08500-rocroi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08368-08190-roizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08368-08190-roizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08368-08190-roizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08368-08190-roizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08369-08220-la_romagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08369-08220-la_romagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08369-08220-la_romagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08369-08220-la_romagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08370-08150-rouvroy_sur_audry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08370-08150-rouvroy_sur_audry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08370-08150-rouvroy_sur_audry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08370-08150-rouvroy_sur_audry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08372-08220-rubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08372-08220-rubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08372-08220-rubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08372-08220-rubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08373-08290-rumigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08373-08290-rumigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08373-08290-rumigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08373-08290-rumigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08374-08130-la_sabotterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08374-08130-la_sabotterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08374-08130-la_sabotterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08374-08130-la_sabotterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08375-08110-sachy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08375-08110-sachy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08375-08110-sachy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08375-08110-sachy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08376-08110-sailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08376-08110-sailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08376-08110-sailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08376-08110-sailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08377-08350-saint_aignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08377-08350-saint_aignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08377-08350-saint_aignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08377-08350-saint_aignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08378-08310-saint_clement_a_arnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08378-08310-saint_clement_a_arnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08378-08310-saint_clement_a_arnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08378-08310-saint_clement_a_arnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08379-08310-saint_etienne_a_arnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08379-08310-saint_etienne_a_arnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08379-08310-saint_etienne_a_arnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08379-08310-saint_etienne_a_arnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08380-08360-saint_fergeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08380-08360-saint_fergeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08380-08360-saint_fergeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08380-08360-saint_fergeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08381-08190-saint_germainmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08381-08190-saint_germainmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08381-08190-saint_germainmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08381-08190-saint_germainmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08382-08220-saint_jean_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08382-08220-saint_jean_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08382-08220-saint_jean_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08382-08220-saint_jean_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08383-08250-saint_juvin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08383-08250-saint_juvin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08383-08250-saint_juvin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08383-08250-saint_juvin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08384-08130-saint_lambert_et_mont_de_jeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08384-08130-saint_lambert_et_mont_de_jeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08384-08130-saint_lambert_et_mont_de_jeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08384-08130-saint_lambert_et_mont_de_jeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08385-08090-saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08385-08090-saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08385-08090-saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08385-08090-saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08386-08300-saint_loup_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08386-08300-saint_loup_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08386-08300-saint_loup_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08386-08300-saint_loup_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08387-08130-saint_loup_terrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08387-08130-saint_loup_terrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08387-08130-saint_loup_terrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08387-08130-saint_loup_terrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08388-08160-saint_marceau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08388-08160-saint_marceau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08388-08160-saint_marceau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08388-08160-saint_marceau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08389-08460-saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08389-08460-saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08389-08460-saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08389-08460-saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08390-08400-sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08390-08400-sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08390-08400-sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08390-08400-sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08391-08200-saint_menges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08391-08200-saint_menges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08391-08200-saint_menges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08391-08200-saint_menges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08392-08400-saint_morel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08392-08400-saint_morel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08392-08400-saint_morel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08392-08400-saint_morel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08393-08310-saint_pierre_a_arnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08393-08310-saint_pierre_a_arnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08393-08310-saint_pierre_a_arnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08393-08310-saint_pierre_a_arnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08394-08240-saint_pierremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08394-08240-saint_pierremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08394-08240-saint_pierremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08394-08240-saint_pierremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08395-08430-saint_pierre_sur_vence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08395-08430-saint_pierre_sur_vence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08395-08430-saint_pierre_sur_vence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08395-08430-saint_pierre_sur_vence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08396-08220-saint_quentin_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08396-08220-saint_quentin_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08396-08220-saint_quentin_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08396-08220-saint_quentin_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08397-08300-saint_remy_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08397-08300-saint_remy_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08397-08300-saint_remy_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08397-08300-saint_remy_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08398-08130-sainte_vaubourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08398-08130-sainte_vaubourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08398-08130-sainte_vaubourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08398-08130-sainte_vaubourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08399-08370-sapogne_sur_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08399-08370-sapogne_sur_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08399-08370-sapogne_sur_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08399-08370-sapogne_sur_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08400-08160-sapogne_et_feucheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08400-08160-sapogne_et_feucheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08400-08160-sapogne_et_feucheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08400-08160-sapogne_et_feucheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08401-08130-saulces_champenoises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08401-08130-saulces_champenoises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08401-08130-saulces_champenoises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08401-08130-saulces_champenoises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08402-08270-saulces_monclin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08402-08270-saulces_monclin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08402-08270-saulces_monclin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08402-08270-saulces_monclin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08403-08300-sault_les_rethel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08403-08300-sault_les_rethel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08403-08300-sault_les_rethel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08403-08300-sault_les_rethel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08404-08190-sault_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08404-08190-sault_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08404-08190-sault_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08404-08190-sault_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08405-08390-sauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08405-08390-sauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08405-08390-sauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08405-08390-sauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08406-08400-savigny_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08406-08400-savigny_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08406-08400-savigny_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08406-08400-savigny_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08407-08250-sechault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08407-08250-sechault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08407-08250-sechault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08407-08250-sechault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08408-08150-secheval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08408-08150-secheval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08408-08150-secheval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08408-08150-secheval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08409-08200-sedan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08409-08200-sedan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08409-08200-sedan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08409-08200-sedan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08410-08400-semide/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08410-08400-semide/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08410-08400-semide/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08410-08400-semide/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08411-08130-semuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08411-08130-semuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08411-08130-semuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08411-08130-semuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08412-08250-senuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08412-08250-senuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08412-08250-senuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08412-08250-senuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08413-08220-seraincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08413-08220-seraincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08413-08220-seraincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08413-08220-seraincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08415-08270-sery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08415-08270-sery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08415-08270-sery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08415-08270-sery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08416-08300-seuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08416-08300-seuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08416-08300-seuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08416-08300-seuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08417-08230-sevigny_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08417-08230-sevigny_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08417-08230-sevigny_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08417-08230-sevigny_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08418-08220-sevigny_waleppe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08418-08220-sevigny_waleppe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08418-08220-sevigny_waleppe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08418-08220-sevigny_waleppe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08419-08460-signy_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08419-08460-signy_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08419-08460-signy_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08419-08460-signy_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08420-08380-signy_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08420-08380-signy_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08420-08380-signy_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08420-08380-signy_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08421-08370-signy_montlibert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08421-08370-signy_montlibert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08421-08370-signy_montlibert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08421-08370-signy_montlibert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08422-08430-singly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08422-08430-singly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08422-08430-singly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08422-08430-singly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08424-08240-sommauthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08424-08240-sommauthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08424-08240-sommauthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08424-08240-sommauthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08425-08250-sommerance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08425-08250-sommerance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08425-08250-sommerance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08425-08250-sommerance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08426-08300-son/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08426-08300-son/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08426-08300-son/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08426-08300-son/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08427-08300-sorbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08427-08300-sorbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08427-08300-sorbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08427-08300-sorbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08428-08270-sorcy_bauthemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08428-08270-sorcy_bauthemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08428-08270-sorcy_bauthemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08428-08270-sorcy_bauthemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08429-08150-sormonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08429-08150-sormonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08429-08150-sormonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08429-08150-sormonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08430-08390-stonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08430-08390-stonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08430-08390-stonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08430-08390-stonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08431-08400-sugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08431-08400-sugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08431-08400-sugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08431-08400-sugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08432-08090-sury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08432-08090-sury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08432-08090-sury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08432-08090-sury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08433-08130-suzanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08433-08130-suzanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08433-08130-suzanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08433-08130-suzanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08434-08390-sy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08434-08390-sy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08434-08390-sy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08434-08390-sy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08435-08300-tagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08435-08300-tagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08435-08300-tagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08435-08300-tagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08436-08230-taillette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08436-08230-taillette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08436-08230-taillette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08436-08230-taillette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08437-08240-tailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08437-08240-tailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08437-08240-tailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08437-08240-tailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08438-08360-taizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08438-08360-taizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08438-08360-taizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08438-08360-taizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08439-08390-tannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08439-08390-tannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08439-08390-tannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08439-08390-tannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08440-08380-tarzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08440-08380-tarzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08440-08380-tarzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08440-08380-tarzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08444-08110-tetaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08444-08110-tetaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08444-08110-tetaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08444-08110-tetaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08445-08350-thelonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08445-08350-thelonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08445-08350-thelonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08445-08350-thelonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08446-08240-thenorgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08446-08240-thenorgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08446-08240-thenorgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08446-08240-thenorgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08448-08800-thilay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08448-08800-thilay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08448-08800-thilay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08448-08800-thilay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08460-thin_le_moutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08460-thin_le_moutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08460-thin_le_moutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08460-thin_le_moutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08090-thin_le_moutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08090-thin_le_moutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08090-thin_le_moutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08090-thin_le_moutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08430-thin_le_moutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08430-thin_le_moutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08430-thin_le_moutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08449-08430-thin_le_moutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08450-08090-this/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08450-08090-this/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08450-08090-this/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08450-08090-this/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08451-08190-le_thour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08451-08190-le_thour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08451-08190-le_thour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08451-08190-le_thour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08452-08300-thugny_trugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08452-08300-thugny_trugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08452-08300-thugny_trugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08452-08300-thugny_trugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08453-08400-toges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08453-08400-toges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08453-08400-toges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08453-08400-toges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08454-08430-touligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08454-08430-touligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08454-08430-touligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08454-08430-touligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08455-08400-tourcelles_chaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08455-08400-tourcelles_chaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08455-08400-tourcelles_chaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08455-08400-tourcelles_chaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08456-08800-tournavaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08456-08800-tournavaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08456-08800-tournavaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08456-08800-tournavaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08457-08090-tournes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08457-08090-tournes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08457-08090-tournes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08457-08090-tournes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08458-08130-tourteron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08458-08130-tourteron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08458-08130-tourteron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08458-08130-tourteron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08459-08110-tremblois_les_carignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08459-08110-tremblois_les_carignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08459-08110-tremblois_les_carignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08459-08110-tremblois_les_carignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08460-08150-tremblois_les_rocroi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08460-08150-tremblois_les_rocroi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08460-08150-tremblois_les_rocroi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08460-08150-tremblois_les_rocroi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08461-08400-vandy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08461-08400-vandy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08461-08400-vandy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08461-08400-vandy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08462-08130-vaux_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08462-08130-vaux_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08462-08130-vaux_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08462-08130-vaux_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08463-08240-vaux_en_dieulet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08463-08240-vaux_en_dieulet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08463-08240-vaux_en_dieulet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08463-08240-vaux_en_dieulet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08464-08250-vaux_les_mouron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08464-08250-vaux_les_mouron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08464-08250-vaux_les_mouron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08464-08250-vaux_les_mouron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08465-08220-vaux_les_rubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08465-08220-vaux_les_rubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08465-08220-vaux_les_rubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08465-08220-vaux_les_rubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08466-08210-vaux_les_mouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08466-08210-vaux_les_mouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08466-08210-vaux_les_mouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08466-08210-vaux_les_mouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08467-08270-vaux_montreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08467-08270-vaux_montreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08467-08270-vaux_montreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08467-08270-vaux_montreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08468-08150-vaux_villaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08468-08150-vaux_villaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08468-08150-vaux_villaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08468-08150-vaux_villaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08469-08160-vendresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08469-08160-vendresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08469-08160-vendresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08469-08160-vendresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08470-08240-verpel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08470-08240-verpel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08470-08240-verpel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08470-08240-verpel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08471-08390-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08471-08390-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08471-08390-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08471-08390-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08472-08270-viel_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08472-08270-viel_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08472-08270-viel_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08472-08270-viel_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08473-08190-vieux_les_asfeld/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08473-08190-vieux_les_asfeld/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08473-08190-vieux_les_asfeld/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08473-08190-vieux_les_asfeld/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08476-08190-villers_devant_le_thour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08476-08190-villers_devant_le_thour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08476-08190-villers_devant_le_thour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08476-08190-villers_devant_le_thour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08477-08210-villers_devant_mouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08477-08210-villers_devant_mouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08477-08210-villers_devant_mouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08477-08210-villers_devant_mouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08478-08430-villers_le_tilleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08478-08430-villers_le_tilleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08478-08430-villers_le_tilleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08478-08430-villers_le_tilleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08479-08430-villers_le_tourneur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08479-08430-villers_le_tourneur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08479-08430-villers_le_tourneur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08479-08430-villers_le_tourneur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08480-08000-villers_semeuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08480-08000-villers_semeuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08480-08000-villers_semeuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08480-08000-villers_semeuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08481-08350-villers_sur_bar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08481-08350-villers_sur_bar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08481-08350-villers_sur_bar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08481-08350-villers_sur_bar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08482-08430-villers_sur_le_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08482-08430-villers_sur_le_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08482-08430-villers_sur_le_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08482-08430-villers_sur_le_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08483-08440-ville_sur_lumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08483-08440-ville_sur_lumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08483-08440-ville_sur_lumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08483-08440-ville_sur_lumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08484-08310-ville_sur_retourne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08484-08310-ville_sur_retourne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08484-08310-ville_sur_retourne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08484-08310-ville_sur_retourne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08485-08370-villy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08485-08370-villy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08485-08370-villy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08485-08370-villy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08486-08320-vireux_molhain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08486-08320-vireux_molhain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08486-08320-vireux_molhain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08486-08320-vireux_molhain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08487-08320-vireux_wallerand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08487-08320-vireux_wallerand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08487-08320-vireux_wallerand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08487-08320-vireux_wallerand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08488-08440-vivier_au_court/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08488-08440-vivier_au_court/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08488-08440-vivier_au_court/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08488-08440-vivier_au_court/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08489-08400-voncq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08489-08400-voncq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08489-08400-voncq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08489-08400-voncq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08490-08400-vouziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08490-08400-vouziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08490-08400-vouziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08490-08400-vouziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08491-08330-vrigne_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08491-08330-vrigne_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08491-08330-vrigne_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08491-08330-vrigne_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08491-08350-vrigne_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08491-08350-vrigne_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08491-08350-vrigne_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08491-08350-vrigne_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08492-08350-vrigne_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08492-08350-vrigne_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08492-08350-vrigne_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08492-08350-vrigne_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08494-08200-wadelincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08494-08200-wadelincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08494-08200-wadelincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08494-08200-wadelincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08496-08270-wagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08496-08270-wagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08496-08270-wagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08496-08270-wagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08497-08000-warcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08497-08000-warcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08497-08000-warcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08497-08000-warcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08498-08090-warnecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08498-08090-warnecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08498-08090-warnecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08498-08090-warnecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08499-08270-wasigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08499-08270-wasigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08499-08270-wasigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08499-08270-wasigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08500-08270-wignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08500-08270-wignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08500-08270-wignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08500-08270-wignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08501-08110-williers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08501-08110-williers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08501-08110-williers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08501-08110-williers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08502-08210-yoncq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08502-08210-yoncq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08502-08210-yoncq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08502-08210-yoncq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08503-08430-yvernaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08503-08430-yvernaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08503-08430-yvernaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt08-ardennes/commune08503-08430-yvernaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-09.xml
+++ b/public/sitemaps/sitemap-09.xml
@@ -5,682 +5,1360 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09001-09240-aigues_juntes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09001-09240-aigues_juntes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09001-09240-aigues_juntes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09001-09240-aigues_juntes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09002-09600-aigues_vives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09002-09600-aigues_vives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09002-09600-aigues_vives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09002-09600-aigues_vives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09003-09300-l_aiguillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09003-09300-l_aiguillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09003-09300-l_aiguillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09003-09300-l_aiguillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09004-09310-albies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09004-09310-albies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09004-09310-albies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09004-09310-albies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09005-09320-aleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09005-09320-aleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09005-09320-aleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09005-09320-aleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09006-09400-alliat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09006-09400-alliat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09006-09400-alliat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09006-09400-alliat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09007-09240-allieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09007-09240-allieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09007-09240-allieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09007-09240-allieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09008-09200-alos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09008-09200-alos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09008-09200-alos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09008-09200-alos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09009-09240-alzen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09009-09240-alzen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09009-09240-alzen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09009-09240-alzen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09011-09800-antras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09011-09800-antras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09011-09800-antras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09011-09800-antras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09012-09250-appy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09012-09250-appy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09012-09250-appy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09012-09250-appy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09013-09000-arabaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09013-09000-arabaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09013-09000-arabaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09013-09000-arabaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09014-09800-argein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09014-09800-argein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09014-09800-argein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09014-09800-argein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09015-09400-arignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09015-09400-arignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09015-09400-arignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09015-09400-arignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09016-09400-arnave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09016-09400-arnave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09016-09400-arnave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09016-09400-arnave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09017-09800-arrien_en_bethmale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09017-09800-arrien_en_bethmale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09017-09800-arrien_en_bethmale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09017-09800-arrien_en_bethmale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09018-09800-arrout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09018-09800-arrout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09018-09800-arrout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09018-09800-arrout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09019-09130-artigat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09019-09130-artigat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09019-09130-artigat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09019-09130-artigat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09020-09460-artigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09020-09460-artigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09020-09460-artigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09020-09460-artigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09021-09120-artix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09021-09120-artix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09021-09120-artix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09021-09120-artix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09022-09100-arvigna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09022-09100-arvigna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09022-09100-arvigna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09022-09100-arvigna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09023-09110-ascou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09023-09110-ascou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09023-09110-ascou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09023-09110-ascou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09024-09310-aston/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09024-09310-aston/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09024-09310-aston/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09024-09310-aston/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09025-09800-aucazein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09025-09800-aucazein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09025-09800-aucazein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09025-09800-aucazein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09026-09800-audressein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09026-09800-audressein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09026-09800-audressein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09026-09800-audressein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09027-09800-augirein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09027-09800-augirein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09027-09800-augirein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09027-09800-augirein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09029-09140-aulus_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09029-09140-aulus_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09029-09140-aulus_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09029-09140-aulus_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09030-09220-auzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09030-09220-auzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09030-09220-auzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09030-09220-auzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09031-09250-axiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09031-09250-axiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09031-09250-axiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09031-09250-axiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09032-09110-ax_les_thermes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09032-09110-ax_les_thermes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09032-09110-ax_les_thermes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09032-09110-ax_les_thermes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09033-09230-bagert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09033-09230-bagert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09033-09230-bagert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09033-09230-bagert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09033-09160-bagert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09033-09160-bagert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09033-09160-bagert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09033-09160-bagert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09034-09800-balacet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09034-09800-balacet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09034-09800-balacet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09034-09800-balacet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09035-09800-balagueres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09035-09800-balagueres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09035-09800-balagueres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09035-09800-balagueres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09037-09230-barjac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09037-09230-barjac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09037-09230-barjac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09037-09230-barjac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09038-09350-la_bastide_de_besplas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09038-09350-la_bastide_de_besplas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09038-09350-la_bastide_de_besplas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09038-09350-la_bastide_de_besplas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09039-09500-la_bastide_de_bousignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09039-09500-la_bastide_de_bousignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09039-09500-la_bastide_de_bousignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09039-09500-la_bastide_de_bousignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09040-09700-la_bastide_de_lordat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09040-09700-la_bastide_de_lordat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09040-09700-la_bastide_de_lordat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09040-09700-la_bastide_de_lordat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09041-09160-la_bastide_du_salat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09041-09160-la_bastide_du_salat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09041-09160-la_bastide_du_salat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09041-09160-la_bastide_du_salat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09042-09240-la_bastide_de_serou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09042-09240-la_bastide_de_serou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09042-09240-la_bastide_de_serou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09042-09240-la_bastide_de_serou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09043-09600-la_bastide_sur_l_hers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09043-09600-la_bastide_sur_l_hers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09043-09600-la_bastide_sur_l_hers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09043-09600-la_bastide_sur_l_hers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09044-09000-baulou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09044-09000-baulou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09044-09000-baulou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09044-09000-baulou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09045-09400-bedeilhac_et_aynat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09045-09400-bedeilhac_et_aynat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09045-09400-bedeilhac_et_aynat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09045-09400-bedeilhac_et_aynat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09046-09230-bedeille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09046-09230-bedeille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09046-09230-bedeille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09046-09230-bedeille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09047-09300-belesta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09047-09300-belesta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09047-09300-belesta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09047-09300-belesta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09048-09600-belloc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09048-09600-belloc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09048-09600-belloc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09048-09600-belloc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09049-09000-benac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09049-09000-benac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09049-09000-benac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09049-09000-benac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09050-09100-benagues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09050-09100-benagues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09050-09100-benagues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09050-09100-benagues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09051-09300-benaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09051-09300-benaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09051-09300-benaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09051-09300-benaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09052-09500-besset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09052-09500-besset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09052-09500-besset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09052-09500-besset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09053-09250-bestiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09053-09250-bestiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09053-09250-bestiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09053-09250-bestiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09054-09160-betchat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09054-09160-betchat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09054-09160-betchat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09054-09160-betchat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09055-09800-bethmale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09055-09800-bethmale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09055-09800-bethmale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09055-09800-bethmale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09056-09100-bezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09056-09100-bezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09056-09100-bezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09056-09100-bezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09057-09320-biert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09057-09320-biert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09057-09320-biert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09057-09320-biert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09058-09400-bompas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09058-09400-bompas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09058-09400-bompas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09058-09400-bompas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09059-09800-bonac_irazein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09059-09800-bonac_irazein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09059-09800-bonac_irazein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09059-09800-bonac_irazein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09060-09100-bonnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09060-09100-bonnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09060-09100-bonnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09060-09100-bonnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09061-09350-les_bordes_sur_arize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09061-09350-les_bordes_sur_arize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09061-09350-les_bordes_sur_arize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09061-09350-les_bordes_sur_arize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09062-09800-bordes_uchentein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09062-09800-bordes_uchentein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09062-09800-bordes_uchentein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09062-09800-bordes_uchentein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09063-09000-le_bosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09063-09000-le_bosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09063-09000-le_bosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09063-09000-le_bosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09064-09310-bouan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09064-09310-bouan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09064-09310-bouan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09064-09310-bouan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09065-09320-boussenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09065-09320-boussenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09065-09320-boussenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09065-09320-boussenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09066-09000-brassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09066-09000-brassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09066-09000-brassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09066-09000-brassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09067-09700-brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09067-09700-brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09067-09700-brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09067-09700-brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09068-09000-burret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09068-09000-burret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09068-09000-burret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09068-09000-burret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09069-09800-buzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09069-09800-buzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09069-09800-buzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09069-09800-buzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09070-09310-les_cabannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09070-09310-les_cabannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09070-09310-les_cabannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09070-09310-les_cabannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09071-09240-cadarcet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09071-09240-cadarcet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09071-09240-cadarcet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09071-09240-cadarcet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09072-09120-calzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09072-09120-calzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09072-09120-calzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09072-09120-calzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09073-09290-camarade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09073-09290-camarade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09073-09290-camarade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09073-09290-camarade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09074-09500-camon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09074-09500-camon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09074-09500-camon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09074-09500-camon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09074-09600-camon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09074-09600-camon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09074-09600-camon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09074-09600-camon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09075-09350-campagne_sur_arize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09075-09350-campagne_sur_arize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09075-09350-campagne_sur_arize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09075-09350-campagne_sur_arize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09076-09700-cante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09076-09700-cante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09076-09700-cante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09076-09700-cante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09077-09400-capoulet_et_junac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09077-09400-capoulet_et_junac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09077-09400-capoulet_et_junac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09077-09400-capoulet_et_junac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09078-09460-carcanieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09078-09460-carcanieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09078-09460-carcanieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09078-09460-carcanieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09079-09130-carla_bayle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09079-09130-carla_bayle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09079-09130-carla_bayle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09079-09130-carla_bayle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09080-09300-carla_de_roquefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09080-09300-carla_de_roquefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09080-09300-carla_de_roquefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09080-09300-carla_de_roquefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09081-09100-le_carlaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09081-09100-le_carlaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09081-09100-le_carlaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09081-09100-le_carlaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09082-09420-castelnau_durban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09082-09420-castelnau_durban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09082-09420-castelnau_durban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09082-09420-castelnau_durban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09083-09130-casteras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09083-09130-casteras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09083-09130-casteras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09083-09130-casteras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09084-09350-castex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09084-09350-castex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09084-09350-castex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09084-09350-castex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09085-09800-castillon_en_couserans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09085-09800-castillon_en_couserans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09085-09800-castillon_en_couserans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09085-09800-castillon_en_couserans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09086-09160-caumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09086-09160-caumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09086-09160-caumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09086-09160-caumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09087-09250-caussou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09087-09250-caussou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09087-09250-caussou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09087-09250-caussou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09088-09250-caychax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09088-09250-caychax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09088-09250-caychax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09088-09250-caychax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09089-09500-cazals_des_bayles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09089-09500-cazals_des_bayles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09089-09500-cazals_des_bayles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09089-09500-cazals_des_bayles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09090-09120-cazaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09090-09120-cazaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09090-09120-cazaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09090-09120-cazaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09091-09160-cazavet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09091-09160-cazavet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09091-09160-cazavet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09091-09160-cazavet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09092-09400-cazenave_serres_et_allens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09092-09400-cazenave_serres_et_allens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09092-09400-cazenave_serres_et_allens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09092-09400-cazenave_serres_et_allens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09093-09000-celles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09093-09000-celles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09093-09000-celles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09093-09000-celles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09094-09230-cerizols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09094-09230-cerizols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09094-09230-cerizols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09094-09230-cerizols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09095-09800-cescau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09095-09800-cescau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09095-09800-cescau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09095-09800-cescau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09096-09310-chateau_verdun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09096-09310-chateau_verdun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09096-09310-chateau_verdun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09096-09310-chateau_verdun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09097-09420-clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09097-09420-clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09097-09420-clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09097-09420-clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09098-09230-contrazy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09098-09230-contrazy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09098-09230-contrazy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09098-09230-contrazy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09099-09000-cos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09099-09000-cos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09099-09000-cos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09099-09000-cos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09100-09140-couflens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09100-09140-couflens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09100-09140-couflens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09100-09140-couflens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09101-09120-coussa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09101-09120-coussa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09101-09120-coussa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09101-09120-coussa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09102-09500-coutens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09102-09500-coutens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09102-09500-coutens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09102-09500-coutens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09103-09120-crampagna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09103-09120-crampagna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09103-09120-crampagna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09103-09120-crampagna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09104-09120-dalou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09104-09120-dalou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09104-09120-dalou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09104-09120-dalou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09105-09350-daumazan_sur_arize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09105-09350-daumazan_sur_arize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09105-09350-daumazan_sur_arize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09105-09350-daumazan_sur_arize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09106-09300-dreuilhe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09106-09300-dreuilhe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09106-09300-dreuilhe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09106-09300-dreuilhe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09107-09600-dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09107-09600-dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09107-09600-dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09107-09600-dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09107-09120-dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09107-09120-dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09107-09120-dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09107-09120-dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09108-09240-durban_sur_arize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09108-09240-durban_sur_arize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09108-09240-durban_sur_arize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09108-09240-durban_sur_arize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09109-09130-durfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09109-09130-durfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09109-09130-durfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09109-09130-durfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09110-09200-encourtiech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09110-09200-encourtiech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09110-09200-encourtiech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09110-09200-encourtiech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09111-09800-engomer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09111-09800-engomer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09111-09800-engomer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09111-09800-engomer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09113-09140-erce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09113-09140-erce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09113-09140-erce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09113-09140-erce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09114-09200-erp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09114-09200-erp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09114-09200-erp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09114-09200-erp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09115-09600-esclagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09115-09600-esclagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09115-09600-esclagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09115-09600-esclagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09116-09100-escosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09116-09100-escosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09116-09100-escosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09116-09100-escosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09117-09700-esplas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09117-09700-esplas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09117-09700-esplas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09117-09700-esplas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09118-09420-esplas_de_serou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09118-09420-esplas_de_serou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09118-09420-esplas_de_serou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09118-09420-esplas_de_serou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09118-09240-esplas_de_serou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09118-09240-esplas_de_serou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09118-09240-esplas_de_serou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09118-09240-esplas_de_serou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09119-09200-eycheil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09119-09200-eycheil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09119-09200-eycheil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09119-09200-eycheil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09120-09230-fabas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09120-09230-fabas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09120-09230-fabas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09120-09230-fabas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09121-09000-ferrieres_sur_ariege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09121-09000-ferrieres_sur_ariege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09121-09000-ferrieres_sur_ariege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09121-09000-ferrieres_sur_ariege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09122-09000-foix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09122-09000-foix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09122-09000-foix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09122-09000-foix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09123-09350-fornex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09123-09350-fornex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09123-09350-fornex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09123-09350-fornex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09124-09130-le_fossat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09124-09130-le_fossat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09124-09130-le_fossat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09124-09130-le_fossat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09125-09300-fougax_et_barrineuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09125-09300-fougax_et_barrineuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09125-09300-fougax_et_barrineuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09125-09300-fougax_et_barrineuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09126-09300-freychenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09126-09300-freychenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09126-09300-freychenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09126-09300-freychenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09126-09000-freychenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09126-09000-freychenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09126-09000-freychenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09126-09000-freychenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09127-09290-gabre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09127-09290-gabre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09127-09290-gabre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09127-09290-gabre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09128-09190-gajan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09128-09190-gajan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09128-09190-gajan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09128-09190-gajan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09129-09800-galey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09129-09800-galey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09129-09800-galey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09129-09800-galey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09130-09000-ganac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09130-09000-ganac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09130-09000-ganac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09130-09000-ganac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09131-09250-garanou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09131-09250-garanou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09131-09250-garanou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09131-09250-garanou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09132-09700-gaudies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09132-09700-gaudies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09132-09700-gaudies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09132-09700-gaudies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09133-09400-genat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09133-09400-genat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09133-09400-genat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09133-09400-genat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09134-09220-gesties/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09134-09220-gesties/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09134-09220-gesties/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09134-09220-gesties/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09136-09400-gourbit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09136-09400-gourbit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09136-09400-gourbit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09136-09400-gourbit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09137-09120-gudas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09137-09120-gudas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09137-09120-gudas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09137-09120-gudas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09138-09000-l_herm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09138-09000-l_herm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09138-09000-l_herm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09138-09000-l_herm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09139-09390-l_hospitalet_pres_l_andorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09139-09390-l_hospitalet_pres_l_andorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09139-09390-l_hospitalet_pres_l_andorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09139-09390-l_hospitalet_pres_l_andorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09140-09110-ignaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09140-09110-ignaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09140-09110-ignaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09140-09110-ignaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09141-09800-illartein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09141-09800-illartein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09141-09800-illartein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09141-09800-illartein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09142-09300-ilhat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09142-09300-ilhat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09142-09300-ilhat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09142-09300-ilhat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09143-09220-illier_et_laramade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09143-09220-illier_et_laramade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09143-09220-illier_et_laramade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09143-09220-illier_et_laramade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09145-09100-les_issards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09145-09100-les_issards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09145-09100-les_issards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09145-09100-les_issards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09146-09700-justiniac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09146-09700-justiniac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09146-09700-justiniac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09146-09700-justiniac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09147-09700-labatut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09147-09700-labatut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09147-09700-labatut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09147-09700-labatut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09148-09160-lacave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09148-09160-lacave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09148-09160-lacave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09148-09160-lacave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09149-09200-lacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09149-09200-lacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09149-09200-lacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09149-09200-lacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09150-09500-lagarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09150-09500-lagarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09150-09500-lagarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09150-09500-lagarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09151-09130-lanoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09151-09130-lanoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09151-09130-lanoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09151-09130-lanoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09152-09400-lapege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09152-09400-lapege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09152-09400-lapege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09152-09400-lapege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09153-09500-lapenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09153-09500-lapenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09153-09500-lapenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09153-09500-lapenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09154-09240-larbont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09154-09240-larbont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09154-09240-larbont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09154-09240-larbont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09155-09310-larcat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09155-09310-larcat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09155-09310-larcat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09155-09310-larcat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09156-09310-larnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09156-09310-larnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09156-09310-larnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09156-09310-larnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09157-09600-laroque_d_olmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09157-09600-laroque_d_olmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09157-09600-laroque_d_olmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09157-09600-laroque_d_olmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09158-09230-lasserre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09158-09230-lasserre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09158-09230-lasserre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09158-09230-lasserre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09159-09310-lassur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09159-09310-lassur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09159-09310-lassur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09159-09310-lassur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09160-09300-lavelanet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09160-09300-lavelanet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09160-09300-lavelanet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09160-09300-lavelanet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09161-09600-leran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09161-09600-leran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09161-09600-leran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09161-09600-leran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09162-09220-lercoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09162-09220-lercoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09162-09220-lercoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09162-09220-lercoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09163-09100-lescousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09163-09100-lescousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09163-09100-lescousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09163-09100-lescousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09164-09420-lescure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09164-09420-lescure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09164-09420-lescure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09164-09420-lescure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09165-09300-lesparrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09165-09300-lesparrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09165-09300-lesparrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09165-09300-lesparrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09166-09300-leychert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09166-09300-leychert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09166-09300-leychert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09166-09300-leychert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09167-09210-lezat_sur_leze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09167-09210-lezat_sur_leze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09167-09210-lezat_sur_leze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09167-09210-lezat_sur_leze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09168-09300-lieurac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09168-09300-lieurac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09168-09300-lieurac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09168-09300-lieurac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09169-09600-limbrassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09169-09600-limbrassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09169-09600-limbrassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09169-09600-limbrassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09170-09700-lissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09170-09700-lissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09170-09700-lissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09170-09700-lissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09171-09250-lordat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09171-09250-lordat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09171-09250-lordat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09171-09250-lordat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09172-09350-loubaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09172-09350-loubaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09172-09350-loubaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09172-09350-loubaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09173-09120-loubens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09173-09120-loubens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09173-09120-loubens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09173-09120-loubens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09174-09000-loubieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09174-09000-loubieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09174-09000-loubieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09174-09000-loubieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09175-09100-ludies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09175-09100-ludies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09175-09100-ludies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09175-09100-ludies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09176-09250-luzenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09176-09250-luzenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09176-09250-luzenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09176-09250-luzenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09177-09100-madiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09177-09100-madiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09177-09100-madiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09177-09100-madiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09177-09130-madiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09177-09130-madiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09177-09130-madiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09177-09130-madiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09178-09500-malegoude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09178-09500-malegoude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09178-09500-malegoude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09178-09500-malegoude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09179-09120-malleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09179-09120-malleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09179-09120-malleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09179-09120-malleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09180-09500-manses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09180-09500-manses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09180-09500-manses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09180-09500-manses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09181-09290-le_mas_d_azil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09181-09290-le_mas_d_azil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09181-09290-le_mas_d_azil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09181-09290-le_mas_d_azil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09182-09320-massat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09182-09320-massat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09182-09320-massat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09182-09320-massat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09183-09160-mauvezin_de_prat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09183-09160-mauvezin_de_prat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09183-09160-mauvezin_de_prat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09183-09160-mauvezin_de_prat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09184-09230-mauvezin_de_sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09184-09230-mauvezin_de_sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09184-09230-mauvezin_de_sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09184-09230-mauvezin_de_sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09185-09270-mazeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09185-09270-mazeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09185-09270-mazeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09185-09270-mazeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09186-09350-meras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09186-09350-meras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09186-09350-meras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09186-09350-meras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09187-09160-mercenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09187-09160-mercenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09187-09160-mercenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09187-09160-mercenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09188-09400-mercus_garrabet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09188-09400-mercus_garrabet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09188-09400-mercus_garrabet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09188-09400-mercus_garrabet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09189-09110-merens_les_vals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09189-09110-merens_les_vals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09189-09110-merens_les_vals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09189-09110-merens_les_vals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09190-09230-merigon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09190-09230-merigon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09190-09230-merigon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09190-09230-merigon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09192-09400-miglos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09192-09400-miglos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09192-09400-miglos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09192-09400-miglos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09193-09460-mijanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09193-09460-mijanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09193-09460-mijanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09193-09460-mijanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09194-09500-mirepoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09194-09500-mirepoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09194-09500-mirepoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09194-09500-mirepoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09195-09130-monesple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09195-09130-monesple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09195-09130-monesple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09195-09130-monesple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09196-09240-montagagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09196-09240-montagagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09196-09240-montagagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09196-09240-montagagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09197-09110-montaillou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09197-09110-montaillou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09197-09110-montaillou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09197-09110-montaillou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09198-09230-montardit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09198-09230-montardit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09198-09230-montardit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09198-09230-montardit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09199-09700-montaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09199-09700-montaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09199-09700-montaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09199-09700-montaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09200-09600-montbel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09200-09600-montbel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09200-09600-montbel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09200-09600-montbel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09201-09200-montegut_en_couserans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09201-09200-montegut_en_couserans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09201-09200-montegut_en_couserans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09201-09200-montegut_en_couserans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09202-09120-montegut_plantaurel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09202-09120-montegut_plantaurel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09202-09120-montegut_plantaurel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09202-09120-montegut_plantaurel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09203-09240-montels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09203-09240-montels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09203-09240-montels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09203-09240-montels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09204-09200-montesquieu_avantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09204-09200-montesquieu_avantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09204-09200-montesquieu_avantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09204-09200-montesquieu_avantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09205-09350-montfa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09205-09350-montfa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09205-09350-montfa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09205-09350-montfa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09206-09300-montferrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09206-09300-montferrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09206-09300-montferrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09206-09300-montferrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09207-09330-montgaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09207-09330-montgaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09207-09330-montgaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09207-09330-montgaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09208-09160-montgauch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09208-09160-montgauch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09208-09160-montgauch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09208-09160-montgauch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09209-09200-montjoie_en_couserans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09209-09200-montjoie_en_couserans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09209-09200-montjoie_en_couserans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09209-09200-montjoie_en_couserans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09210-09000-montoulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09210-09000-montoulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09210-09000-montoulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09210-09000-montoulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09211-09300-montsegur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09211-09300-montsegur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09211-09300-montsegur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09211-09300-montsegur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09212-09240-montseron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09212-09240-montseron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09212-09240-montseron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09212-09240-montseron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09213-09500-moulin_neuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09213-09500-moulin_neuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09213-09500-moulin_neuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09213-09500-moulin_neuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09214-09200-moulis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09214-09200-moulis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09214-09200-moulis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09214-09200-moulis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09215-09300-nalzen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09215-09300-nalzen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09215-09300-nalzen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09215-09300-nalzen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09216-09240-nescus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09216-09240-nescus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09216-09240-nescus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09216-09240-nescus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09217-09400-niaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09217-09400-niaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09217-09400-niaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09217-09400-niaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09218-09110-orgeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09218-09110-orgeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09218-09110-orgeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09218-09110-orgeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09219-09800-orgibet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09219-09800-orgibet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09219-09800-orgibet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09219-09800-orgibet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09220-09110-orlu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09220-09110-orlu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09220-09110-orlu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09220-09110-orlu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09221-09400-ornolac_ussat_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09221-09400-ornolac_ussat_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09221-09400-ornolac_ussat_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09221-09400-ornolac_ussat_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09222-09220-orus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09222-09220-orus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09222-09220-orus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09222-09220-orus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09223-09140-oust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09223-09140-oust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09223-09140-oust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09223-09140-oust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09224-09130-pailhes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09224-09130-pailhes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09224-09130-pailhes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09224-09130-pailhes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09225-09100-pamiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09225-09100-pamiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09225-09100-pamiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09225-09100-pamiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09226-09310-pech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09226-09310-pech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09226-09310-pech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09226-09310-pech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09227-09300-pereille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09227-09300-pereille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09227-09300-pereille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09227-09300-pereille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09228-09110-perles_et_castelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09228-09110-perles_et_castelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09228-09110-perles_et_castelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09228-09110-perles_et_castelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09229-09600-le_peyrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09229-09600-le_peyrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09229-09600-le_peyrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09229-09600-le_peyrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09230-09460-le_pla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09230-09460-le_pla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09230-09460-le_pla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09230-09460-le_pla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09231-09320-le_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09231-09320-le_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09231-09320-le_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09231-09320-le_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09232-09110-prades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09232-09110-prades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09232-09110-prades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09232-09110-prades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09233-09600-pradettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09233-09600-pradettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09233-09600-pradettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09233-09600-pradettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09234-09000-pradieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09234-09000-pradieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09234-09000-pradieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09234-09000-pradieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09235-09160-prat_bonrepaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09235-09160-prat_bonrepaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09235-09160-prat_bonrepaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09235-09160-prat_bonrepaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09236-09000-prayols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09236-09000-prayols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09236-09000-prayols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09236-09000-prayols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09237-09460-le_puch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09237-09460-le_puch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09237-09460-le_puch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09237-09460-le_puch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09238-09100-les_pujols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09238-09100-les_pujols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09238-09100-les_pujols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09238-09100-les_pujols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09239-09460-querigut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09239-09460-querigut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09239-09460-querigut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09239-09460-querigut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09240-09400-quie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09240-09400-quie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09240-09400-quie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09240-09400-quie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09241-09400-rabat_les_trois_seigneurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09241-09400-rabat_les_trois_seigneurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09241-09400-rabat_les_trois_seigneurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09241-09400-rabat_les_trois_seigneurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09242-09300-raissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09242-09300-raissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09242-09300-raissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09242-09300-raissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09243-09600-regat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09243-09600-regat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09243-09600-regat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09243-09600-regat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09244-09500-rieucros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09244-09500-rieucros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09244-09500-rieucros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09244-09500-rieucros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09245-09120-rieux_de_pelleport/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09245-09120-rieux_de_pelleport/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09245-09120-rieux_de_pelleport/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09245-09120-rieux_de_pelleport/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09246-09420-rimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09246-09420-rimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09246-09420-rimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09246-09420-rimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09247-09200-riverenert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09247-09200-riverenert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09247-09200-riverenert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09247-09200-riverenert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09249-09300-roquefixade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09249-09300-roquefixade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09249-09300-roquefixade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09249-09300-roquefixade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09250-09300-roquefort_les_cascades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09250-09300-roquefort_les_cascades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09250-09300-roquefort_les_cascades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09250-09300-roquefort_les_cascades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09251-09500-roumengoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09251-09500-roumengoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09251-09500-roumengoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09251-09500-roumengoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09252-09460-rouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09252-09460-rouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09252-09460-rouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09252-09460-rouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09253-09350-sabarat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09253-09350-sabarat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09253-09350-sabarat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09253-09350-sabarat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09254-09100-saint_amadou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09254-09100-saint_amadou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09254-09100-saint_amadou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09254-09100-saint_amadou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09255-09100-saint_amans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09255-09100-saint_amans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09255-09100-saint_amans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09255-09100-saint_amans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09256-09120-saint_bauzeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09256-09120-saint_bauzeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09256-09120-saint_bauzeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09256-09120-saint_bauzeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09256-09100-saint_bauzeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09256-09100-saint_bauzeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09256-09100-saint_bauzeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09256-09100-saint_bauzeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09257-09230-sainte_croix_volvestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09257-09230-sainte_croix_volvestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09257-09230-sainte_croix_volvestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09257-09230-sainte_croix_volvestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09258-09120-saint_felix_de_rieutord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09258-09120-saint_felix_de_rieutord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09258-09120-saint_felix_de_rieutord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09258-09120-saint_felix_de_rieutord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09259-09500-saint_felix_de_tournegat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09259-09500-saint_felix_de_tournegat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09259-09500-saint_felix_de_tournegat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09259-09500-saint_felix_de_tournegat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09260-09500-sainte_foi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09260-09500-sainte_foi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09260-09500-sainte_foi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09260-09500-sainte_foi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09261-09200-saint_girons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09261-09200-saint_girons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09261-09200-saint_girons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09261-09200-saint_girons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09262-09300-saint_jean_d_aigues_vives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09262-09300-saint_jean_d_aigues_vives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09262-09300-saint_jean_d_aigues_vives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09262-09300-saint_jean_d_aigues_vives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09263-09800-saint_jean_du_castillonnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09263-09800-saint_jean_du_castillonnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09263-09800-saint_jean_du_castillonnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09263-09800-saint_jean_du_castillonnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09264-09000-saint_jean_de_verges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09264-09000-saint_jean_de_verges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09264-09000-saint_jean_de_verges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09264-09000-saint_jean_de_verges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09265-09100-saint_jean_du_falga/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09265-09100-saint_jean_du_falga/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09265-09100-saint_jean_du_falga/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09265-09100-saint_jean_du_falga/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09266-09500-saint_julien_de_gras_capou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09266-09500-saint_julien_de_gras_capou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09266-09500-saint_julien_de_gras_capou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09266-09500-saint_julien_de_gras_capou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09267-09800-saint_lary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09267-09800-saint_lary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09267-09800-saint_lary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09267-09800-saint_lary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09268-09190-saint_lizier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09268-09190-saint_lizier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09268-09190-saint_lizier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09268-09190-saint_lizier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09269-09000-saint_martin_de_caralp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09269-09000-saint_martin_de_caralp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09269-09000-saint_martin_de_caralp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09269-09000-saint_martin_de_caralp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09269-09240-saint_martin_de_caralp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09269-09240-saint_martin_de_caralp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09269-09240-saint_martin_de_caralp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09269-09240-saint_martin_de_caralp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09270-09100-saint_martin_d_oydes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09270-09100-saint_martin_d_oydes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09270-09100-saint_martin_d_oydes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09270-09100-saint_martin_d_oydes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09271-09100-saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09271-09100-saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09271-09100-saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09271-09100-saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09272-09000-saint_paul_de_jarrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09272-09000-saint_paul_de_jarrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09272-09000-saint_paul_de_jarrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09272-09000-saint_paul_de_jarrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09273-09000-saint_pierre_de_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09273-09000-saint_pierre_de_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09273-09000-saint_pierre_de_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09273-09000-saint_pierre_de_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09274-09500-saint_quentin_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09274-09500-saint_quentin_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09274-09500-saint_quentin_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09274-09500-saint_quentin_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09274-09600-saint_quentin_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09274-09600-saint_quentin_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09274-09600-saint_quentin_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09274-09600-saint_quentin_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09275-09700-saint_quirc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09275-09700-saint_quirc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09275-09700-saint_quirc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09275-09700-saint_quirc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09276-09100-saint_victor_rouzaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09276-09100-saint_victor_rouzaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09276-09100-saint_victor_rouzaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09276-09100-saint_victor_rouzaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09276-09120-saint_victor_rouzaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09276-09120-saint_victor_rouzaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09276-09120-saint_victor_rouzaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09276-09120-saint_victor_rouzaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09277-09210-saint_ybars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09277-09210-saint_ybars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09277-09210-saint_ybars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09277-09210-saint_ybars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09279-09800-salsein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09279-09800-salsein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09279-09800-salsein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09279-09800-salsein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09280-09400-saurat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09280-09400-saurat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09280-09400-saurat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09280-09400-saurat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09281-09300-sautel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09281-09300-sautel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09281-09300-sautel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09281-09300-sautel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09282-09700-saverdun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09282-09700-saverdun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09282-09700-saverdun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09282-09700-saverdun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09283-09110-savignac_les_ormeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09283-09110-savignac_les_ormeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09283-09110-savignac_les_ormeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09283-09110-savignac_les_ormeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09284-09120-segura/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09284-09120-segura/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09284-09120-segura/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09284-09120-segura/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09285-09140-seix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09285-09140-seix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09285-09140-seix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09285-09140-seix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09287-09250-senconac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09287-09250-senconac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09287-09250-senconac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09287-09250-senconac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09289-09190-lorp_sentaraille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09289-09190-lorp_sentaraille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09289-09190-lorp_sentaraille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09289-09190-lorp_sentaraille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09290-09800-sentein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09290-09800-sentein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09290-09800-sentein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09290-09800-sentein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09291-09140-sentenac_d_oust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09291-09140-sentenac_d_oust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09291-09140-sentenac_d_oust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09291-09140-sentenac_d_oust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09292-09240-sentenac_de_serou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09292-09240-sentenac_de_serou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09292-09240-sentenac_de_serou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09292-09240-sentenac_de_serou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09293-09000-serres_sur_arget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09293-09000-serres_sur_arget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09293-09000-serres_sur_arget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09293-09000-serres_sur_arget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09294-09130-sieuras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09294-09130-sieuras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09294-09130-sieuras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09294-09130-sieuras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09295-09220-siguer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09295-09220-siguer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09295-09220-siguer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09295-09220-siguer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09296-09310-aulos_sinsat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09296-09310-aulos_sinsat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09296-09310-aulos_sinsat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09296-09310-aulos_sinsat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09297-09800-sor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09297-09800-sor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09297-09800-sor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09297-09800-sor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09298-09110-sorgeat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09298-09110-sorgeat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09298-09110-sorgeat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09298-09110-sorgeat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09299-09140-soueix_rogalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09299-09140-soueix_rogalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09299-09140-soueix_rogalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09299-09140-soueix_rogalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09300-09000-soula/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09300-09000-soula/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09300-09000-soula/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09300-09000-soula/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09301-09320-soulan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09301-09320-soulan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09301-09320-soulan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09301-09320-soulan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09303-09400-surba/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09303-09400-surba/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09303-09400-surba/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09303-09400-surba/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09304-09240-suzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09304-09240-suzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09304-09240-suzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09304-09240-suzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09305-09600-tabre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09305-09600-tabre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09305-09600-tabre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09305-09600-tabre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09306-09400-tarascon_sur_ariege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09306-09400-tarascon_sur_ariege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09306-09400-tarascon_sur_ariege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09306-09400-tarascon_sur_ariege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09307-09160-taurignan_castet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09307-09160-taurignan_castet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09307-09160-taurignan_castet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09307-09160-taurignan_castet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09308-09190-taurignan_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09308-09190-taurignan_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09308-09190-taurignan_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09308-09190-taurignan_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09309-09500-teilhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09309-09500-teilhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09309-09500-teilhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09309-09500-teilhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09310-09350-thouars_sur_arize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09310-09350-thouars_sur_arize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09310-09350-thouars_sur_arize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09310-09350-thouars_sur_arize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09311-09110-tignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09311-09110-tignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09311-09110-tignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09311-09110-tignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09312-09100-la_tour_du_crieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09312-09100-la_tour_du_crieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09312-09100-la_tour_du_crieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09312-09100-la_tour_du_crieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09313-09230-tourtouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09313-09230-tourtouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09313-09230-tourtouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09313-09230-tourtouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09314-09500-tourtrol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09314-09500-tourtrol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09314-09500-tourtrol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09314-09500-tourtrol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09315-09700-tremoulet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09315-09700-tremoulet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09315-09700-tremoulet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09315-09700-tremoulet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09316-09500-troye_d_ariege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09316-09500-troye_d_ariege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09316-09500-troye_d_ariege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09316-09500-troye_d_ariege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09318-09250-unac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09318-09250-unac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09318-09250-unac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09318-09250-unac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09319-09100-unzent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09319-09100-unzent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09319-09100-unzent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09319-09100-unzent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09320-09310-urs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09320-09310-urs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09320-09310-urs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09320-09310-urs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09321-09400-ussat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09321-09400-ussat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09321-09400-ussat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09321-09400-ussat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09322-09140-ustou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09322-09140-ustou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09322-09140-ustou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09322-09140-ustou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09323-09500-vals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09323-09500-vals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09323-09500-vals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09323-09500-vals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09324-09120-varilhes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09324-09120-varilhes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09324-09120-varilhes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09324-09120-varilhes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09325-09110-vaychis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09325-09110-vaychis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09325-09110-vaychis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09325-09110-vaychis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09326-09310-vebre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09326-09310-vebre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09326-09310-vebre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09326-09310-vebre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09327-09120-ventenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09327-09120-ventenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09327-09120-ventenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09327-09120-ventenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09328-09310-verdun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09328-09310-verdun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09328-09310-verdun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09328-09310-verdun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09329-09000-vernajoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09329-09000-vernajoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09329-09000-vernajoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09329-09000-vernajoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09330-09250-vernaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09330-09250-vernaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09330-09250-vernaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09330-09250-vernaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09331-09700-le_vernet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09331-09700-le_vernet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09331-09700-le_vernet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09331-09700-le_vernet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09331-09100-le_vernet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09331-09100-le_vernet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09331-09100-le_vernet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09331-09100-le_vernet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09332-09340-verniolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09332-09340-verniolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09332-09340-verniolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09332-09340-verniolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09334-09220-val_de_sos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09334-09220-val_de_sos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09334-09220-val_de_sos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09334-09220-val_de_sos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09335-09800-villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09335-09800-villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09335-09800-villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09335-09800-villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09336-09300-villeneuve_d_olmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09336-09300-villeneuve_d_olmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09336-09300-villeneuve_d_olmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09336-09300-villeneuve_d_olmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09338-09130-villeneuve_du_latou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09338-09130-villeneuve_du_latou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09338-09130-villeneuve_du_latou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09338-09130-villeneuve_du_latou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09339-09100-villeneuve_du_pareage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09339-09100-villeneuve_du_pareage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09339-09100-villeneuve_du_pareage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09339-09100-villeneuve_du_pareage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09340-09120-vira/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09340-09120-vira/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09340-09120-vira/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09340-09120-vira/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09341-09500-vivies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09341-09500-vivies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09341-09500-vivies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09341-09500-vivies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09342-09130-sainte_suzanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09342-09130-sainte_suzanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09342-09130-sainte_suzanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt09-ariege/commune09342-09130-sainte_suzanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-10.xml
+++ b/public/sitemaps/sitemap-10.xml
@@ -5,870 +5,1736 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10002-10200-ailleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10002-10200-ailleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10002-10200-ailleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10002-10200-ailleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10003-10160-aix_villemaur_palis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10003-10160-aix_villemaur_palis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10003-10160-aix_villemaur_palis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10003-10160-aix_villemaur_palis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10003-10190-aix_villemaur_palis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10003-10190-aix_villemaur_palis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10003-10190-aix_villemaur_palis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10003-10190-aix_villemaur_palis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10004-10700-allibaudieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10004-10700-allibaudieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10004-10700-allibaudieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10004-10700-allibaudieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10005-10140-amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10005-10140-amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10005-10140-amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10005-10140-amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10006-10700-arcis_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10006-10700-arcis_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10006-10700-arcis_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10006-10700-arcis_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10007-10200-arconville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10007-10200-arconville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10007-10200-arconville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10007-10200-arconville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10008-10140-argancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10008-10140-argancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10008-10140-argancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10008-10140-argancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10009-10340-arrelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10009-10340-arrelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10009-10340-arrelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10009-10340-arrelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10010-10330-arrembecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10010-10330-arrembecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10010-10330-arrembecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10010-10330-arrembecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10011-10200-arrentieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10011-10200-arrentieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10011-10200-arrentieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10011-10200-arrentieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10012-10200-arsonval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10012-10200-arsonval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10012-10200-arsonval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10012-10200-arsonval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10013-10320-assenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10013-10320-assenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10013-10320-assenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10013-10320-assenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10014-10220-assencieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10014-10220-assencieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10014-10220-assencieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10014-10220-assencieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10015-10150-aubeterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10015-10150-aubeterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10015-10150-aubeterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10015-10150-aubeterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10017-10240-aulnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10017-10240-aulnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10017-10240-aulnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10017-10240-aulnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10018-10130-auxon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10018-10130-auxon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10018-10130-auxon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10018-10130-auxon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10019-10220-val_d_auzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10019-10220-val_d_auzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10019-10220-val_d_auzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10019-10220-val_d_auzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10020-10400-avant_les_marcilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10020-10400-avant_les_marcilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10020-10400-avant_les_marcilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10020-10400-avant_les_marcilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10021-10240-avant_les_ramerupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10021-10240-avant_les_ramerupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10021-10240-avant_les_ramerupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10021-10240-avant_les_ramerupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10022-10340-avirey_lingey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10022-10340-avirey_lingey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10022-10340-avirey_lingey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10022-10340-avirey_lingey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10023-10290-avon_la_peze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10023-10290-avon_la_peze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10023-10290-avon_la_peze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10023-10290-avon_la_peze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10024-10130-avreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10024-10130-avreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10024-10130-avreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10024-10130-avreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10025-10340-bagneux_la_fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10025-10340-bagneux_la_fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10025-10340-bagneux_la_fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10025-10340-bagneux_la_fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10026-10330-bailly_le_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10026-10330-bailly_le_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10026-10330-bailly_le_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10026-10330-bailly_le_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10027-10330-balignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10027-10330-balignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10027-10330-balignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10027-10330-balignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10028-10210-balnot_la_grange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10028-10210-balnot_la_grange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10028-10210-balnot_la_grange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10028-10210-balnot_la_grange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10029-10110-balnot_sur_laignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10029-10110-balnot_sur_laignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10029-10110-balnot_sur_laignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10029-10110-balnot_sur_laignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10030-10600-barberey_saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10030-10600-barberey_saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10030-10600-barberey_saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10030-10600-barberey_saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10031-10400-barbuise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10031-10400-barbuise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10031-10400-barbuise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10031-10400-barbuise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10032-10200-baroville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10032-10200-baroville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10032-10200-baroville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10032-10200-baroville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10033-10200-bar_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10033-10200-bar_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10033-10200-bar_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10033-10200-bar_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10034-10110-bar_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10034-10110-bar_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10034-10110-bar_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10034-10110-bar_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10035-10310-bayel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10035-10310-bayel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10035-10310-bayel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10035-10310-bayel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10037-10190-bercenay_en_othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10037-10190-bercenay_en_othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10037-10190-bercenay_en_othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10037-10190-bercenay_en_othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10038-10290-bercenay_le_hayer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10038-10290-bercenay_le_hayer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10038-10290-bercenay_le_hayer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10038-10290-bercenay_le_hayer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10039-10200-bergeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10039-10200-bergeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10039-10200-bergeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10039-10200-bergeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10040-10130-bernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10040-10130-bernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10040-10130-bernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10040-10130-bernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10041-10110-bertignolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10041-10110-bertignolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10041-10110-bertignolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10041-10110-bertignolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10042-10160-berulle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10042-10160-berulle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10042-10160-berulle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10042-10160-berulle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10043-10170-bessy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10043-10170-bessy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10043-10170-bessy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10043-10170-bessy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10044-10500-betignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10044-10500-betignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10044-10500-betignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10044-10500-betignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10045-10140-beurey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10045-10140-beurey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10045-10140-beurey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10045-10140-beurey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10046-10500-blaincourt_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10046-10500-blaincourt_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10046-10500-blaincourt_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10046-10500-blaincourt_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10047-10500-blignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10047-10500-blignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10047-10500-blignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10047-10500-blignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10048-10200-bligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10048-10200-bligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10048-10200-bligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10048-10200-bligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10049-10800-les_bordes_aumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10049-10800-les_bordes_aumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10049-10800-les_bordes_aumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10049-10800-les_bordes_aumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10050-10140-bossancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10050-10140-bossancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10050-10140-bossancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10050-10140-bossancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10051-10320-bouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10051-10320-bouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10051-10320-bouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10051-10320-bouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10052-10380-boulages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10052-10380-boulages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10052-10380-boulages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10052-10380-boulages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10053-10270-bouranton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10053-10270-bouranton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10053-10270-bouranton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10053-10270-bouranton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10054-10290-bourdenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10054-10290-bourdenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10054-10290-bourdenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10054-10290-bourdenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10055-10110-bourguignons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10055-10110-bourguignons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10055-10110-bourguignons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10055-10110-bourguignons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10056-10220-bouy_luxembourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10056-10220-bouy_luxembourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10056-10220-bouy_luxembourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10056-10220-bouy_luxembourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10057-10400-bouy_sur_orvin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10057-10400-bouy_sur_orvin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10057-10400-bouy_sur_orvin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10057-10400-bouy_sur_orvin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10058-10340-bragelogne_beauvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10058-10340-bragelogne_beauvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10058-10340-bragelogne_beauvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10058-10340-bragelogne_beauvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10059-10500-braux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10059-10500-braux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10059-10500-braux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10059-10500-braux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10060-10450-breviandes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10060-10450-breviandes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10060-10450-breviandes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10060-10450-breviandes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10061-10220-brevonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10061-10220-brevonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10061-10220-brevonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10061-10220-brevonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10062-10140-briel_sur_barse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10062-10140-briel_sur_barse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10062-10140-briel_sur_barse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10062-10140-briel_sur_barse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10063-10500-brienne_la_vieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10063-10500-brienne_la_vieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10063-10500-brienne_la_vieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10063-10500-brienne_la_vieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10064-10500-brienne_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10064-10500-brienne_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10064-10500-brienne_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10064-10500-brienne_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10065-10240-brillecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10065-10240-brillecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10065-10240-brillecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10065-10240-brillecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10066-10190-bucey_en_othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10066-10190-bucey_en_othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10066-10190-bucey_en_othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10066-10190-bucey_en_othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10067-10800-bucheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10067-10800-bucheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10067-10800-bucheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10067-10800-bucheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10068-10110-buxeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10068-10110-buxeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10068-10110-buxeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10068-10110-buxeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10069-10110-buxieres_sur_arce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10069-10110-buxieres_sur_arce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10069-10110-buxieres_sur_arce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10069-10110-buxieres_sur_arce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10070-10110-celles_sur_ource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10070-10110-celles_sur_ource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10070-10110-celles_sur_ource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10070-10110-celles_sur_ource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10071-10110-chacenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10071-10110-chacenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10071-10110-chacenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10071-10110-chacenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10072-10500-la_chaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10072-10500-la_chaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10072-10500-la_chaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10072-10500-la_chaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10073-10500-chalette_sur_voire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10073-10500-chalette_sur_voire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10073-10500-chalette_sur_voire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10073-10500-chalette_sur_voire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10074-10130-chamoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10074-10130-chamoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10074-10130-chamoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10074-10130-chamoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10075-10700-champfleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10075-10700-champfleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10075-10700-champfleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10075-10700-champfleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10076-10200-champignol_lez_mondeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10076-10200-champignol_lez_mondeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10076-10200-champignol_lez_mondeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10076-10200-champignol_lez_mondeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10077-10700-champigny_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10077-10700-champigny_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10077-10700-champigny_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10077-10700-champigny_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10078-10140-champ_sur_barse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10078-10140-champ_sur_barse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10078-10140-champ_sur_barse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10078-10140-champ_sur_barse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10079-10340-channes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10079-10340-channes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10079-10340-channes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10079-10340-channes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10080-10210-chaource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10080-10210-chaource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10080-10210-chaource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10080-10210-chaource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10081-10600-la_chapelle_saint_luc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10081-10600-la_chapelle_saint_luc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10081-10600-la_chapelle_saint_luc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10081-10600-la_chapelle_saint_luc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10082-10700-chapelle_vallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10082-10700-chapelle_vallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10082-10700-chapelle_vallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10082-10700-chapelle_vallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10083-10260-chappes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10083-10260-chappes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10083-10260-chappes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10083-10260-chappes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10084-10150-charmont_sous_barbuise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10084-10150-charmont_sous_barbuise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10084-10150-charmont_sous_barbuise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10084-10150-charmont_sous_barbuise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10085-10290-charmoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10085-10290-charmoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10085-10290-charmoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10085-10290-charmoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10086-10380-charny_le_bachot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10086-10380-charny_le_bachot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10086-10380-charny_le_bachot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10086-10380-charny_le_bachot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10087-10210-chaserey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10087-10210-chaserey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10087-10210-chaserey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10087-10210-chaserey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10089-10510-chatres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10089-10510-chatres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10089-10510-chatres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10089-10510-chatres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10090-10170-chauchigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10090-10170-chauchigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10090-10170-chauchigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10090-10170-chauchigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10091-10240-chaudrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10091-10240-chaudrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10091-10240-chaudrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10091-10240-chaudrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10092-10110-chauffour_les_bailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10092-10110-chauffour_les_bailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10092-10110-chauffour_les_bailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10092-10110-chauffour_les_bailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10093-10500-chaumesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10093-10500-chaumesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10093-10500-chaumesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10093-10500-chaumesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10094-10330-chavanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10094-10330-chavanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10094-10330-chavanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10094-10330-chavanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10095-10700-le_chene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10095-10700-le_chene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10095-10700-le_chene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10095-10700-le_chene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10096-10190-chennegy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10096-10190-chennegy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10096-10190-chennegy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10096-10190-chennegy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10097-10110-chervey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10097-10110-chervey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10097-10110-chervey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10097-10110-chervey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10098-10210-chesley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10098-10210-chesley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10098-10210-chesley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10098-10210-chesley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10099-10130-chessy_les_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10099-10130-chessy_les_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10099-10130-chessy_les_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10099-10130-chessy_les_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10100-10390-clerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10100-10390-clerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10100-10390-clerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10100-10390-clerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10101-10240-coclois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10101-10240-coclois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10101-10240-coclois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10101-10240-coclois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10102-10200-colombe_la_fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10102-10200-colombe_la_fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10102-10200-colombe_la_fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10102-10200-colombe_la_fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10103-10200-colombe_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10103-10200-colombe_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10103-10200-colombe_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10103-10200-colombe_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10104-10800-cormost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10104-10800-cormost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10104-10800-cormost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10104-10800-cormost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10105-10500-courcelles_sur_voire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10105-10500-courcelles_sur_voire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10105-10500-courcelles_sur_voire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10105-10500-courcelles_sur_voire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10106-10400-courceroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10106-10400-courceroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10106-10400-courceroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10106-10400-courceroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10107-10130-coursan_en_othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10107-10130-coursan_en_othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10107-10130-coursan_en_othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10107-10130-coursan_en_othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10108-10130-courtaoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10108-10130-courtaoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10108-10130-courtaoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10108-10130-courtaoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10109-10260-courtenot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10109-10260-courtenot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10109-10260-courtenot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10109-10260-courtenot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10110-10270-courteranges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10110-10270-courteranges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10110-10270-courteranges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10110-10270-courteranges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10111-10250-courteron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10111-10250-courteron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10111-10250-courteron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10111-10250-courteron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10112-10210-coussegrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10112-10210-coussegrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10112-10210-coussegrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10112-10210-coussegrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10113-10200-couvignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10113-10200-couvignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10113-10200-couvignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10113-10200-couvignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10114-10100-crancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10114-10100-crancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10114-10100-crancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10114-10100-crancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10115-10150-creney_pres_troyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10115-10150-creney_pres_troyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10115-10150-creney_pres_troyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10115-10150-creney_pres_troyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10116-10320-cresantignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10116-10320-cresantignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10116-10320-cresantignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10116-10320-cresantignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10117-10500-crespy_le_neuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10117-10500-crespy_le_neuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10117-10500-crespy_le_neuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10117-10500-crespy_le_neuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10118-10130-les_croutes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10118-10130-les_croutes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10118-10130-les_croutes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10118-10130-les_croutes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10119-10360-cunfin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10119-10360-cunfin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10119-10360-cunfin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10119-10360-cunfin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10120-10210-cussangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10120-10210-cussangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10120-10210-cussangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10120-10210-cussangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10121-10240-dampierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10121-10240-dampierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10121-10240-dampierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10121-10240-dampierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10122-10130-davrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10122-10130-davrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10122-10130-davrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10122-10130-davrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10123-10500-dienville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10123-10500-dienville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10123-10500-dienville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10123-10500-dienville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10124-10190-dierrey_saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10124-10190-dierrey_saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10124-10190-dierrey_saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10124-10190-dierrey_saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10125-10190-dierrey_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10125-10190-dierrey_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10125-10190-dierrey_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10125-10190-dierrey_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10126-10200-dolancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10126-10200-dolancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10126-10200-dolancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10126-10200-dolancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10127-10240-dommartin_le_coq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10127-10240-dommartin_le_coq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10127-10240-dommartin_le_coq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10127-10240-dommartin_le_coq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10128-10330-donnement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10128-10330-donnement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10128-10330-donnement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10128-10330-donnement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10129-10220-dosches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10129-10220-dosches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10129-10220-dosches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10129-10220-dosches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10130-10700-dosnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10130-10700-dosnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10130-10700-dosnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10130-10700-dosnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10131-10170-droupt_saint_basle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10131-10170-droupt_saint_basle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10131-10170-droupt_saint_basle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10131-10170-droupt_saint_basle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10132-10170-droupt_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10132-10170-droupt_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10132-10170-droupt_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10132-10170-droupt_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10133-10130-eaux_puiseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10133-10130-eaux_puiseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10133-10130-eaux_puiseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10133-10130-eaux_puiseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10134-10350-echemines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10134-10350-echemines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10134-10350-echemines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10134-10350-echemines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10135-10200-eclance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10135-10200-eclance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10135-10200-eclance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10135-10200-eclance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10136-10110-eguilly_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10136-10110-eguilly_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10136-10110-eguilly_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10136-10110-eguilly_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10137-10200-engente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10137-10200-engente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10137-10200-engente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10137-10200-engente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10138-10500-epagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10138-10500-epagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10138-10500-epagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10138-10500-epagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10139-10500-epothemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10139-10500-epothemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10139-10500-epothemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10139-10500-epothemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10140-10130-ervy_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10140-10130-ervy_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10140-10130-ervy_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10140-10130-ervy_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10141-10360-essoyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10141-10360-essoyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10141-10360-essoyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10141-10360-essoyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10142-10190-estissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10142-10190-estissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10142-10190-estissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10142-10190-estissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10143-10210-etourvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10143-10210-etourvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10143-10210-etourvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10143-10210-etourvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10144-10170-etrelles_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10144-10170-etrelles_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10144-10170-etrelles_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10144-10170-etrelles_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10145-10290-faux_villecerf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10145-10290-faux_villecerf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10145-10290-faux_villecerf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10145-10290-faux_villecerf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10146-10290-fay_les_marcilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10146-10290-fay_les_marcilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10146-10290-fay_les_marcilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10146-10290-fay_les_marcilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10147-10320-fays_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10147-10320-fays_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10147-10320-fays_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10147-10320-fays_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10148-10400-ferreux_quincey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10148-10400-ferreux_quincey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10148-10400-ferreux_quincey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10148-10400-ferreux_quincey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10149-10150-feuges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10149-10150-feuges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10149-10150-feuges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10149-10150-feuges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10150-10200-fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10150-10200-fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10150-10200-fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10150-10200-fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10151-10280-fontaine_les_gres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10151-10280-fontaine_les_gres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10151-10280-fontaine_les_gres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10151-10280-fontaine_les_gres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10153-10400-fontaine_macon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10153-10400-fontaine_macon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10153-10400-fontaine_macon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10153-10400-fontaine_macon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10154-10400-fontenay_de_bossery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10154-10400-fontenay_de_bossery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10154-10400-fontenay_de_bossery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10154-10400-fontenay_de_bossery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10155-10360-fontette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10155-10360-fontette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10155-10360-fontette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10155-10360-fontette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10156-10190-fontvannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10156-10190-fontvannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10156-10190-fontvannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10156-10190-fontvannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10157-10100-la_fosse_corduan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10157-10100-la_fosse_corduan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10157-10100-la_fosse_corduan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10157-10100-la_fosse_corduan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10158-10260-foucheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10158-10260-foucheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10158-10260-foucheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10158-10260-foucheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10159-10110-fralignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10159-10110-fralignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10159-10110-fralignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10159-10110-fralignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10160-10200-fravaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10160-10200-fravaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10160-10200-fravaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10160-10200-fravaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10161-10200-fresnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10161-10200-fresnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10161-10200-fresnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10161-10200-fresnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10162-10270-fresnoy_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10162-10270-fresnoy_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10162-10270-fresnoy_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10162-10270-fresnoy_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10163-10200-fuligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10163-10200-fuligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10163-10200-fuligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10163-10200-fuligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10164-10100-gelannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10164-10100-gelannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10164-10100-gelannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10164-10100-gelannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10165-10220-geraudot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10165-10220-geraudot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10165-10220-geraudot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10165-10220-geraudot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10166-10170-les_grandes_chapelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10166-10170-les_grandes_chapelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10166-10170-les_grandes_chapelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10166-10170-les_grandes_chapelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10167-10700-grandville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10167-10700-grandville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10167-10700-grandville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10167-10700-grandville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10168-10210-les_granges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10168-10210-les_granges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10168-10210-les_granges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10168-10210-les_granges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10169-10400-gumery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10169-10400-gumery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10169-10400-gumery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10169-10400-gumery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10170-10250-gye_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10170-10250-gye_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10170-10250-gye_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10170-10250-gye_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10171-10500-hampigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10171-10500-hampigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10171-10500-hampigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10171-10500-hampigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10172-10700-herbisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10172-10700-herbisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10172-10700-herbisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10172-10700-herbisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10173-10800-isle_aumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10173-10800-isle_aumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10173-10800-isle_aumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10173-10800-isle_aumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10174-10240-isle_aubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10174-10240-isle_aubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10174-10240-isle_aubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10174-10240-isle_aubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10175-10330-jasseines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10175-10330-jasseines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10175-10330-jasseines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10175-10330-jasseines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10176-10200-jaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10176-10200-jaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10176-10200-jaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10176-10200-jaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10177-10320-javernant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10177-10320-javernant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10177-10320-javernant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10177-10320-javernant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10178-10140-jessains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10178-10140-jessains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10178-10140-jessains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10178-10140-jessains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10179-10320-jeugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10179-10320-jeugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10179-10320-jeugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10179-10320-jeugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10180-10330-joncreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10180-10330-joncreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10180-10330-joncreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10180-10330-joncreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10181-10260-jully_sur_sarce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10181-10260-jully_sur_sarce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10181-10260-jully_sur_sarce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10181-10260-jully_sur_sarce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10182-10310-juvancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10182-10310-juvancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10182-10310-juvancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10182-10310-juvancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10183-10140-juvanze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10183-10140-juvanze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10183-10140-juvanze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10183-10140-juvanze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10184-10500-juzanvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10184-10500-juzanvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10184-10500-juzanvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10184-10500-juzanvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10185-10210-lagesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10185-10210-lagesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10185-10210-lagesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10185-10210-lagesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10186-10120-laines_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10186-10120-laines_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10186-10120-laines_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10186-10120-laines_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10187-10110-landreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10187-10110-landreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10187-10110-landreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10187-10110-landreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10188-10210-lantages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10188-10210-lantages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10188-10210-lantages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10188-10210-lantages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10189-10500-lassicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10189-10500-lassicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10189-10500-lassicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10189-10500-lassicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10190-10270-laubressel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10190-10270-laubressel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10190-10270-laubressel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10190-10270-laubressel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10191-10150-lavau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10191-10150-lavau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10191-10150-lavau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10191-10150-lavau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10192-10330-lentilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10192-10330-lentilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10192-10330-lentilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10192-10330-lentilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10193-10500-lesmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10193-10500-lesmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10193-10500-lesmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10193-10500-lesmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10194-10200-levigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10194-10200-levigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10194-10200-levigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10194-10200-levigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10195-10700-lhuitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10195-10700-lhuitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10195-10700-lhuitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10195-10700-lhuitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10196-10130-lignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10196-10130-lignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10196-10130-lignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10196-10130-lignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10197-10200-lignol_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10197-10200-lignol_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10197-10200-lignol_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10197-10200-lignol_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10198-10320-lirey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10198-10320-lirey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10198-10320-lirey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10198-10320-lirey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10199-10110-loches_sur_ource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10199-10110-loches_sur_ource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10199-10110-loches_sur_ource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10199-10110-loches_sur_ource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10200-10140-la_loge_aux_chevres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10200-10140-la_loge_aux_chevres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10200-10140-la_loge_aux_chevres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10200-10140-la_loge_aux_chevres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10201-10210-la_loge_pomblin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10201-10210-la_loge_pomblin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10201-10210-la_loge_pomblin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10201-10210-la_loge_pomblin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10202-10210-les_loges_margueron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10202-10210-les_loges_margueron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10202-10210-les_loges_margueron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10202-10210-les_loges_margueron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10203-10310-longchamp_sur_aujon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10203-10310-longchamp_sur_aujon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10203-10310-longchamp_sur_aujon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10203-10310-longchamp_sur_aujon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10204-10320-longeville_sur_mogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10204-10320-longeville_sur_mogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10204-10320-longeville_sur_mogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10204-10320-longeville_sur_mogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10205-10140-longpre_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10205-10140-longpre_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10205-10140-longpre_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10205-10140-longpre_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10206-10240-longsols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10206-10240-longsols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10206-10240-longsols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10206-10240-longsols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10207-10170-longueville_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10207-10170-longueville_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10207-10170-longueville_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10207-10170-longueville_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10208-10400-la_louptiere_thenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10208-10400-la_louptiere_thenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10208-10400-la_louptiere_thenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10208-10400-la_louptiere_thenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10209-10270-lusigny_sur_barse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10209-10270-lusigny_sur_barse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10209-10270-lusigny_sur_barse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10209-10270-lusigny_sur_barse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10210-10150-luyeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10210-10150-luyeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10210-10150-luyeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10210-10150-luyeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10211-10300-macey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10211-10300-macey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10211-10300-macey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10211-10300-macey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10212-10320-machy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10212-10320-machy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10212-10320-machy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10212-10320-machy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10213-10110-magnant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10213-10110-magnant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10213-10110-magnant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10213-10110-magnant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10214-10240-magnicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10214-10240-magnicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10214-10240-magnicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10214-10240-magnicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10215-10140-magny_fouchard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10215-10140-magny_fouchard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10215-10140-magny_fouchard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10215-10140-magny_fouchard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10216-10230-mailly_le_camp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10216-10230-mailly_le_camp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10216-10230-mailly_le_camp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10216-10230-mailly_le_camp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10217-10140-maison_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10217-10140-maison_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10217-10140-maison_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10217-10140-maison_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10218-10210-maisons_les_chaource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10218-10210-maisons_les_chaource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10218-10210-maisons_les_chaource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10218-10210-maisons_les_chaource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10219-10200-maisons_les_soulaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10219-10200-maisons_les_soulaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10219-10200-maisons_les_soulaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10219-10200-maisons_les_soulaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10220-10510-maizieres_la_grande_paroisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10220-10510-maizieres_la_grande_paroisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10220-10510-maizieres_la_grande_paroisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10220-10510-maizieres_la_grande_paroisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10221-10500-maizieres_les_brienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10221-10500-maizieres_les_brienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10221-10500-maizieres_les_brienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10221-10500-maizieres_les_brienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10222-10160-maraye_en_othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10222-10160-maraye_en_othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10222-10160-maraye_en_othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10222-10160-maraye_en_othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10223-10290-marcilly_le_hayer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10223-10290-marcilly_le_hayer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10223-10290-marcilly_le_hayer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10223-10290-marcilly_le_hayer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10224-10350-marigny_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10224-10350-marigny_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10224-10350-marigny_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10224-10350-marigny_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10225-10400-marnay_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10225-10400-marnay_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10225-10400-marnay_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10225-10400-marnay_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10226-10110-marolles_les_bailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10226-10110-marolles_les_bailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10226-10110-marolles_les_bailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10226-10110-marolles_les_bailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10227-10130-marolles_sous_lignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10227-10130-marolles_sous_lignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10227-10130-marolles_sous_lignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10227-10130-marolles_sous_lignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10228-10500-mathaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10228-10500-mathaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10228-10500-mathaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10228-10500-mathaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10229-10320-maupas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10229-10320-maupas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10229-10320-maupas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10229-10320-maupas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10230-10600-mergey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10230-10600-mergey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10230-10600-mergey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10230-10600-mergey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10231-10400-le_meriot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10231-10400-le_meriot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10231-10400-le_meriot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10231-10400-le_meriot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10232-10110-merrey_sur_arce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10232-10110-merrey_sur_arce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10232-10110-merrey_sur_arce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10232-10110-merrey_sur_arce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10233-10170-mery_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10233-10170-mery_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10233-10170-mery_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10233-10170-mery_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10234-10170-mesgrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10234-10170-mesgrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10234-10170-mesgrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10234-10170-mesgrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10235-10700-mesnil_la_comtesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10235-10700-mesnil_la_comtesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10235-10700-mesnil_la_comtesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10235-10700-mesnil_la_comtesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10236-10240-mesnil_lettre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10236-10240-mesnil_lettre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10236-10240-mesnil_lettre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10236-10240-mesnil_lettre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10237-10190-mesnil_saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10237-10190-mesnil_saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10237-10190-mesnil_saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10237-10190-mesnil_saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10238-10140-mesnil_saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10238-10140-mesnil_saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10238-10140-mesnil_saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10238-10140-mesnil_saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10239-10220-mesnil_sellieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10239-10220-mesnil_sellieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10239-10220-mesnil_sellieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10239-10220-mesnil_sellieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10240-10190-messon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10240-10190-messon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10240-10190-messon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10240-10190-messon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10241-10210-metz_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10241-10210-metz_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10241-10210-metz_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10241-10210-metz_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10242-10200-meurville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10242-10200-meurville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10242-10200-meurville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10242-10200-meurville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10243-10500-molins_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10243-10500-molins_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10243-10500-molins_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10243-10500-molins_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10245-10270-montaulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10245-10270-montaulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10245-10270-montaulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10245-10270-montaulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10246-10260-montceaux_les_vaudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10246-10260-montceaux_les_vaudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10246-10260-montceaux_les_vaudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10246-10260-montceaux_les_vaudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10247-10130-montfey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10247-10130-montfey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10247-10130-montfey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10247-10130-montfey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10248-10300-montgueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10248-10300-montgueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10248-10300-montgueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10248-10300-montgueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10249-10270-montieramey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10249-10270-montieramey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10249-10270-montieramey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10249-10270-montieramey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10250-10200-montier_en_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10250-10200-montier_en_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10250-10200-montier_en_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10250-10200-montier_en_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10251-10130-montigny_les_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10251-10130-montigny_les_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10251-10130-montigny_les_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10251-10130-montigny_les_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10252-10140-montmartin_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10252-10140-montmartin_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10252-10140-montmartin_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10252-10140-montmartin_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10253-10330-montmorency_beaufort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10253-10330-montmorency_beaufort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10253-10330-montmorency_beaufort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10253-10330-montmorency_beaufort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10254-10400-montpothier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10254-10400-montpothier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10254-10400-montpothier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10254-10400-montpothier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10255-10270-montreuil_sur_barse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10255-10270-montreuil_sur_barse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10255-10270-montreuil_sur_barse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10255-10270-montreuil_sur_barse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10256-10150-montsuzain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10256-10150-montsuzain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10256-10150-montsuzain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10256-10150-montsuzain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10257-10240-morembert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10257-10240-morembert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10257-10240-morembert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10257-10240-morembert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10258-10500-morvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10258-10500-morvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10258-10500-morvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10258-10500-morvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10259-10400-la_motte_tilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10259-10400-la_motte_tilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10259-10400-la_motte_tilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10259-10400-la_motte_tilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10260-10800-moussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10260-10800-moussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10260-10800-moussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10260-10800-moussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10261-10250-mussy_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10261-10250-mussy_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10261-10250-mussy_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10261-10250-mussy_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10262-10250-neuville_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10262-10250-neuville_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10262-10250-neuville_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10262-10250-neuville_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10263-10190-neuville_sur_vanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10263-10190-neuville_sur_vanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10263-10190-neuville_sur_vanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10263-10190-neuville_sur_vanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10264-10360-noe_les_mallets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10264-10360-noe_les_mallets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10264-10360-noe_les_mallets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10264-10360-noe_les_mallets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10265-10420-les_noes_pres_troyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10265-10420-les_noes_pres_troyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10265-10420-les_noes_pres_troyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10265-10420-les_noes_pres_troyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10266-10160-nogent_en_othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10266-10160-nogent_en_othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10266-10160-nogent_en_othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10266-10160-nogent_en_othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10267-10240-nogent_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10267-10240-nogent_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10267-10240-nogent_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10267-10240-nogent_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10268-10400-nogent_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10268-10400-nogent_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10268-10400-nogent_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10268-10400-nogent_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10269-10700-nozay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10269-10700-nozay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10269-10700-nozay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10269-10700-nozay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10270-10220-onjon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10270-10220-onjon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10270-10220-onjon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10270-10220-onjon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10271-10510-origny_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10271-10510-origny_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10271-10510-origny_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10271-10510-origny_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10272-10700-ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10272-10700-ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10272-10700-ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10272-10700-ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10273-10700-ortillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10273-10700-ortillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10273-10700-ortillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10273-10700-ortillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10274-10170-orvilliers_saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10274-10170-orvilliers_saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10274-10170-orvilliers_saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10274-10170-orvilliers_saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10275-10100-ossey_les_trois_maisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10275-10100-ossey_les_trois_maisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10275-10100-ossey_les_trois_maisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10275-10100-ossey_les_trois_maisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10276-10160-paisy_cosdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10276-10160-paisy_cosdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10276-10160-paisy_cosdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10276-10160-paisy_cosdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10278-10210-pargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10278-10210-pargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10278-10210-pargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10278-10210-pargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10279-10330-pars_les_chavanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10279-10330-pars_les_chavanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10279-10330-pars_les_chavanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10279-10330-pars_les_chavanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10280-10100-pars_les_romilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10280-10100-pars_les_romilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10280-10100-pars_les_romilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10280-10100-pars_les_romilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10281-10350-le_pavillon_sainte_julie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10281-10350-le_pavillon_sainte_julie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10281-10350-le_pavillon_sainte_julie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10281-10350-le_pavillon_sainte_julie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10282-10600-payns/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10282-10600-payns/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10282-10600-payns/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10282-10600-payns/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10283-10500-pel_et_der/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10283-10500-pel_et_der/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10283-10500-pel_et_der/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10283-10500-pel_et_der/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10284-10400-perigny_la_rose/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10284-10400-perigny_la_rose/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10284-10400-perigny_la_rose/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10284-10400-perigny_la_rose/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10285-10500-perthes_les_brienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10285-10500-perthes_les_brienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10285-10500-perthes_les_brienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10285-10500-perthes_les_brienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10286-10500-petit_mesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10286-10500-petit_mesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10286-10500-petit_mesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10286-10500-petit_mesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10287-10220-piney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10287-10220-piney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10287-10220-piney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10287-10220-piney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10288-10250-plaines_saint_lange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10288-10250-plaines_saint_lange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10288-10250-plaines_saint_lange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10288-10250-plaines_saint_lange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10289-10380-plancy_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10289-10380-plancy_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10289-10380-plancy_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10289-10380-plancy_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10290-10160-planty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10290-10160-planty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10290-10160-planty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10290-10160-planty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10291-10400-plessis_barbuise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10291-10400-plessis_barbuise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10291-10400-plessis_barbuise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10291-10400-plessis_barbuise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10293-10700-poivres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10293-10700-poivres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10293-10700-poivres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10293-10700-poivres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10294-10110-poligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10294-10110-poligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10294-10110-poligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10294-10110-poligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10295-10110-polisot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10295-10110-polisot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10295-10110-polisot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10295-10110-polisot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10296-10110-polisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10296-10110-polisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10296-10110-polisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10296-10110-polisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10297-10150-pont_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10297-10150-pont_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10297-10150-pont_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10297-10150-pont_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10298-10400-pont_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10298-10400-pont_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10298-10400-pont_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10298-10400-pont_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10299-10700-pouan_les_vallees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10299-10700-pouan_les_vallees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10299-10700-pouan_les_vallees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10299-10700-pouan_les_vallees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10300-10240-pougy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10300-10240-pougy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10300-10240-pougy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10300-10240-pougy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10301-10290-pouy_sur_vannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10301-10290-pouy_sur_vannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10301-10290-pouy_sur_vannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10301-10290-pouy_sur_vannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10302-10210-praslin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10302-10210-praslin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10302-10210-praslin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10302-10210-praslin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10303-10500-precy_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10303-10500-precy_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10303-10500-precy_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10303-10500-precy_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10304-10500-precy_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10304-10500-precy_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10304-10500-precy_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10304-10500-precy_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10305-10170-premierfait/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10305-10170-premierfait/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10305-10170-premierfait/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10305-10170-premierfait/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10306-10200-proverville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10306-10200-proverville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10306-10200-proverville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10306-10200-proverville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10307-10190-prugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10307-10190-prugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10307-10190-prugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10307-10190-prugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10308-10350-prunay_belleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10308-10350-prunay_belleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10308-10350-prunay_belleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10308-10350-prunay_belleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10309-10210-prusy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10309-10210-prusy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10309-10210-prusy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10309-10210-prusy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10310-10140-puits_et_nuisement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10310-10140-puits_et_nuisement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10310-10140-puits_et_nuisement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10310-10140-puits_et_nuisement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10312-10130-racines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10312-10130-racines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10312-10130-racines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10312-10130-racines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10313-10500-radonvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10313-10500-radonvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10313-10500-radonvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10313-10500-radonvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10314-10240-ramerupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10314-10240-ramerupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10314-10240-ramerupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10314-10240-ramerupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10315-10500-rances/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10315-10500-rances/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10315-10500-rances/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10315-10500-rances/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10316-10170-rheges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10316-10170-rheges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10316-10170-rheges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10316-10170-rheges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10317-10340-les_riceys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10317-10340-les_riceys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10317-10340-les_riceys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10317-10340-les_riceys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10318-10290-rigny_la_nonneuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10318-10290-rigny_la_nonneuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10318-10290-rigny_la_nonneuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10318-10290-rigny_la_nonneuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10319-10160-rigny_le_ferron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10319-10160-rigny_le_ferron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10319-10160-rigny_le_ferron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10319-10160-rigny_le_ferron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10320-10280-rilly_sainte_syre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10320-10280-rilly_sainte_syre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10320-10280-rilly_sainte_syre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10320-10280-rilly_sainte_syre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10321-10440-la_riviere_de_corps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10321-10440-la_riviere_de_corps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10321-10440-la_riviere_de_corps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10321-10440-la_riviere_de_corps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10323-10100-romilly_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10323-10100-romilly_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10323-10100-romilly_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10323-10100-romilly_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10324-10320-roncenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10324-10320-roncenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10324-10320-roncenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10324-10320-roncenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10325-10430-rosieres_pres_troyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10325-10430-rosieres_pres_troyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10325-10430-rosieres_pres_troyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10325-10430-rosieres_pres_troyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10326-10500-rosnay_l_hopital/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10326-10500-rosnay_l_hopital/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10326-10500-rosnay_l_hopital/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10326-10500-rosnay_l_hopital/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10327-10500-la_rothiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10327-10500-la_rothiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10327-10500-la_rothiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10327-10500-la_rothiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10328-10220-rouilly_sacey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10328-10220-rouilly_sacey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10328-10220-rouilly_sacey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10328-10220-rouilly_sacey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10329-10800-rouilly_saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10329-10800-rouilly_saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10329-10800-rouilly_saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10329-10800-rouilly_saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10330-10200-rouvres_les_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10330-10200-rouvres_les_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10330-10200-rouvres_les_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10330-10200-rouvres_les_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10331-10260-rumilly_les_vaudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10331-10260-rumilly_les_vaudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10331-10260-rumilly_les_vaudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10331-10260-rumilly_les_vaudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10332-10410-ruvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10332-10410-ruvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10332-10410-ruvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10332-10410-ruvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10333-10120-saint_andre_les_vergers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10333-10120-saint_andre_les_vergers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10333-10120-saint_andre_les_vergers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10333-10120-saint_andre_les_vergers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10334-10400-saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10334-10400-saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10334-10400-saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10334-10400-saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10335-10160-saint_benoist_sur_vanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10335-10160-saint_benoist_sur_vanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10335-10160-saint_benoist_sur_vanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10335-10160-saint_benoist_sur_vanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10336-10180-saint_benoit_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10336-10180-saint_benoit_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10336-10180-saint_benoit_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10336-10180-saint_benoit_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10337-10500-saint_christophe_dodinicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10337-10500-saint_christophe_dodinicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10337-10500-saint_christophe_dodinicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10337-10500-saint_christophe_dodinicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10338-10700-saint_etienne_sous_barbuise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10338-10700-saint_etienne_sous_barbuise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10338-10700-saint_etienne_sous_barbuise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10338-10700-saint_etienne_sous_barbuise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10339-10350-saint_flavy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10339-10350-saint_flavy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10339-10350-saint_flavy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10339-10350-saint_flavy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10340-10120-saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10340-10120-saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10340-10120-saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10340-10120-saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10341-10100-saint_hilaire_sous_romilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10341-10100-saint_hilaire_sous_romilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10341-10100-saint_hilaire_sous_romilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10341-10100-saint_hilaire_sous_romilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10342-10320-saint_jean_de_bonneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10342-10320-saint_jean_de_bonneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10342-10320-saint_jean_de_bonneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10342-10320-saint_jean_de_bonneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10343-10800-saint_julien_les_villas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10343-10800-saint_julien_les_villas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10343-10800-saint_julien_les_villas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10343-10800-saint_julien_les_villas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10344-10800-saint_leger_pres_troyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10344-10800-saint_leger_pres_troyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10344-10800-saint_leger_pres_troyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10344-10800-saint_leger_pres_troyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10345-10500-saint_leger_sous_brienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10345-10500-saint_leger_sous_brienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10345-10500-saint_leger_sous_brienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10345-10500-saint_leger_sous_brienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10346-10330-saint_leger_sous_margerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10346-10330-saint_leger_sous_margerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10346-10330-saint_leger_sous_margerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10346-10330-saint_leger_sous_margerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10347-10100-saint_loup_de_buffigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10347-10100-saint_loup_de_buffigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10347-10100-saint_loup_de_buffigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10347-10100-saint_loup_de_buffigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10348-10350-saint_lupien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10348-10350-saint_lupien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10348-10350-saint_lupien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10348-10350-saint_lupien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10349-10180-saint_lye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10349-10180-saint_lye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10349-10180-saint_lye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10349-10180-saint_lye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10350-10160-saint_mards_en_othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10350-10160-saint_mards_en_othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10350-10160-saint_mards_en_othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10350-10160-saint_mards_en_othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10351-10100-saint_martin_de_bossenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10351-10100-saint_martin_de_bossenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10351-10100-saint_martin_de_bossenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10351-10100-saint_martin_de_bossenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10352-10150-sainte_maure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10352-10150-sainte_maure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10352-10150-sainte_maure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10352-10150-sainte_maure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10353-10280-saint_mesmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10353-10280-saint_mesmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10353-10280-saint_mesmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10353-10280-saint_mesmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10354-10700-saint_nabord_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10354-10700-saint_nabord_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10354-10700-saint_nabord_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10354-10700-saint_nabord_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10355-10400-saint_nicolas_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10355-10400-saint_nicolas_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10355-10400-saint_nicolas_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10355-10400-saint_nicolas_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10356-10170-saint_oulph/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10356-10170-saint_oulph/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10356-10170-saint_oulph/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10356-10170-saint_oulph/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10357-10410-saint_parres_aux_tertres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10357-10410-saint_parres_aux_tertres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10357-10410-saint_parres_aux_tertres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10357-10410-saint_parres_aux_tertres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10358-10260-saint_parres_les_vaudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10358-10260-saint_parres_les_vaudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10358-10260-saint_parres_les_vaudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10358-10260-saint_parres_les_vaudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10359-10130-saint_phal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10359-10130-saint_phal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10359-10130-saint_phal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10359-10130-saint_phal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10360-10120-saint_pouange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10360-10120-saint_pouange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10360-10120-saint_pouange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10360-10120-saint_pouange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10361-10700-saint_remy_sous_barbuise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10361-10700-saint_remy_sous_barbuise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10361-10700-saint_remy_sous_barbuise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10361-10700-saint_remy_sous_barbuise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10362-10300-sainte_savine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10362-10300-sainte_savine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10362-10300-sainte_savine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10362-10300-sainte_savine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10363-10800-saint_thibault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10363-10800-saint_thibault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10363-10800-saint_thibault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10363-10800-saint_thibault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10364-10360-saint_usage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10364-10360-saint_usage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10364-10360-saint_usage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10364-10360-saint_usage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10365-10700-salon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10365-10700-salon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10365-10700-salon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10365-10700-salon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10366-10200-saulcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10366-10200-saulcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10366-10200-saulcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10366-10200-saulcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10367-10400-la_saulsotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10367-10400-la_saulsotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10367-10400-la_saulsotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10367-10400-la_saulsotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10368-10600-savieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10368-10600-savieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10368-10600-savieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10368-10600-savieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10369-10700-semoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10369-10700-semoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10369-10700-semoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10369-10700-semoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10370-10400-soligny_les_etangs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10370-10400-soligny_les_etangs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10370-10400-soligny_les_etangs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10370-10400-soligny_les_etangs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10371-10320-sommeval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10371-10320-sommeval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10371-10320-sommeval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10371-10320-sommeval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10372-10200-soulaines_dhuys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10372-10200-soulaines_dhuys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10372-10200-soulaines_dhuys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10372-10200-soulaines_dhuys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10373-10320-souligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10373-10320-souligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10373-10320-souligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10373-10320-souligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10374-10200-spoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10374-10200-spoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10374-10200-spoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10374-10200-spoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10375-10410-thennelieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10375-10410-thennelieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10375-10410-thennelieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10375-10410-thennelieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10376-10140-thieffrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10376-10140-thieffrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10376-10140-thieffrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10376-10140-thieffrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10377-10200-thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10377-10200-thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10377-10200-thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10377-10200-thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10378-10200-thors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10378-10200-thors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10378-10200-thors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10378-10200-thors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10379-10700-torcy_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10379-10700-torcy_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10379-10700-torcy_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10379-10700-torcy_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10380-10700-torcy_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10380-10700-torcy_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10380-10700-torcy_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10380-10700-torcy_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10381-10440-torvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10381-10440-torvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10381-10440-torvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10381-10440-torvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10382-10400-trainel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10382-10400-trainel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10382-10400-trainel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10382-10400-trainel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10383-10290-trancault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10383-10290-trancault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10383-10290-trancault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10383-10290-trancault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10384-10140-trannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10384-10140-trannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10384-10140-trannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10384-10140-trannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10386-10700-trouans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10386-10700-trouans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10386-10700-trouans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10386-10700-trouans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10387-10000-troyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10387-10000-troyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10387-10000-troyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10387-10000-troyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10388-10210-turgy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10388-10210-turgy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10388-10210-turgy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10388-10210-turgy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10389-10140-unienville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10389-10140-unienville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10389-10140-unienville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10389-10140-unienville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10390-10200-urville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10390-10200-urville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10390-10200-urville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10390-10200-urville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10391-10150-vailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10391-10150-vailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10391-10150-vailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10391-10150-vailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10392-10170-vallant_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10392-10170-vallant_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10392-10170-vallant_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10392-10170-vallant_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10393-10500-vallentigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10393-10500-vallentigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10393-10500-vallentigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10393-10500-vallentigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10394-10210-vallieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10394-10210-vallieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10394-10210-vallieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10394-10210-vallieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10395-10210-vanlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10395-10210-vanlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10395-10210-vanlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10395-10210-vanlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10396-10190-vauchassis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10396-10190-vauchassis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10396-10190-vauchassis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10396-10190-vauchassis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10397-10140-vauchonvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10397-10140-vauchonvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10397-10140-vauchonvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10397-10140-vauchonvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10398-10240-vaucogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10398-10240-vaucogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10398-10240-vaucogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10398-10240-vaucogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10399-10260-vaudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10399-10260-vaudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10399-10260-vaudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10399-10260-vaudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10400-10700-vaupoisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10400-10700-vaupoisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10400-10700-vaupoisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10400-10700-vaupoisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10401-10140-vendeuvre_sur_barse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10401-10140-vendeuvre_sur_barse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10401-10140-vendeuvre_sur_barse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10401-10140-vendeuvre_sur_barse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10402-10800-la_vendue_mignot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10402-10800-la_vendue_mignot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10402-10800-la_vendue_mignot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10402-10800-la_vendue_mignot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10403-10200-vernonvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10403-10200-vernonvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10403-10200-vernonvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10403-10200-vernonvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10404-10360-verpillieres_sur_ource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10404-10360-verpillieres_sur_ource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10404-10360-verpillieres_sur_ource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10404-10360-verpillieres_sur_ource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10405-10240-verricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10405-10240-verricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10405-10240-verricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10405-10240-verricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10406-10390-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10406-10390-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10406-10390-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10406-10390-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10408-10380-viapres_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10408-10380-viapres_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10408-10380-viapres_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10408-10380-viapres_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10409-10600-villacerf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10409-10600-villacerf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10409-10600-villacerf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10409-10600-villacerf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10410-10290-villadin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10410-10290-villadin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10410-10290-villadin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10410-10290-villadin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10411-10500-la_ville_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10411-10500-la_ville_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10411-10500-la_ville_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10411-10500-la_ville_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10412-10410-villechetif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10412-10410-villechetif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10412-10410-villechetif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10412-10410-villechetif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10414-10350-villeloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10414-10350-villeloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10414-10350-villeloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10414-10350-villeloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10416-10800-villemereuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10416-10800-villemereuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10416-10800-villemereuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10416-10800-villemereuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10417-10160-villemoiron_en_othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10417-10160-villemoiron_en_othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10417-10160-villemoiron_en_othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10417-10160-villemoiron_en_othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10418-10110-villemorien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10418-10110-villemorien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10418-10110-villemorien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10418-10110-villemorien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10419-10260-villemoyenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10419-10260-villemoyenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10419-10260-villemoyenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10419-10260-villemoyenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10420-10370-villenauxe_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10420-10370-villenauxe_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10420-10370-villenauxe_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10420-10370-villenauxe_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10421-10400-la_villeneuve_au_chatelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10421-10400-la_villeneuve_au_chatelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10421-10400-la_villeneuve_au_chatelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10421-10400-la_villeneuve_au_chatelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10422-10130-villeneuve_au_chemin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10422-10130-villeneuve_au_chemin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10422-10130-villeneuve_au_chemin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10422-10130-villeneuve_au_chemin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10423-10140-la_villeneuve_au_chene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10423-10140-la_villeneuve_au_chene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10423-10140-la_villeneuve_au_chene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10423-10140-la_villeneuve_au_chene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10424-10330-villeret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10424-10330-villeret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10424-10330-villeret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10424-10330-villeret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10425-10320-villery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10425-10320-villery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10425-10320-villery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10425-10320-villery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10426-10310-ville_sous_la_ferte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10426-10310-ville_sous_la_ferte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10426-10310-ville_sous_la_ferte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10426-10310-ville_sous_la_ferte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10427-10110-ville_sur_arce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10427-10110-ville_sur_arce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10427-10110-ville_sur_arce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10427-10110-ville_sur_arce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10428-10200-ville_sur_terre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10428-10200-ville_sur_terre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10428-10200-ville_sur_terre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10428-10200-ville_sur_terre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10429-10700-villette_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10429-10700-villette_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10429-10700-villette_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10429-10700-villette_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10430-10700-villiers_herbisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10430-10700-villiers_herbisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10430-10700-villiers_herbisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10430-10700-villiers_herbisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10431-10210-villiers_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10431-10210-villiers_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10431-10210-villiers_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10431-10210-villiers_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10432-10210-villiers_sous_praslin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10432-10210-villiers_sous_praslin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10432-10210-villiers_sous_praslin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10432-10210-villiers_sous_praslin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10433-10140-villy_en_trodes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10433-10140-villy_en_trodes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10433-10140-villy_en_trodes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10433-10140-villy_en_trodes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10434-10800-villy_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10434-10800-villy_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10434-10800-villy_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10434-10800-villy_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10435-10800-villy_le_marechal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10435-10800-villy_le_marechal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10435-10800-villy_le_marechal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10435-10800-villy_le_marechal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10436-10700-vinets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10436-10700-vinets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10436-10700-vinets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10436-10700-vinets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10437-10260-virey_sous_bar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10437-10260-virey_sous_bar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10437-10260-virey_sous_bar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10437-10260-virey_sous_bar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10438-10110-vitry_le_croise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10438-10110-vitry_le_croise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10438-10110-vitry_le_croise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10438-10110-vitry_le_croise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10439-10110-viviers_sur_artaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10439-10110-viviers_sur_artaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10439-10110-viviers_sur_artaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10439-10110-viviers_sur_artaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10440-10200-voigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10440-10200-voigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10440-10200-voigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10440-10200-voigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10441-10130-vosnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10441-10130-vosnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10441-10130-vosnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10441-10130-vosnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10442-10150-voue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10442-10150-voue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10442-10150-voue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10442-10150-voue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10443-10210-vougrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10443-10210-vougrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10443-10210-vougrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10443-10210-vougrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10444-10160-vulaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10444-10160-vulaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10444-10160-vulaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10444-10160-vulaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10445-10500-yevres_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10445-10500-yevres_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10445-10500-yevres_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt10-aube/commune10445-10500-yevres_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-11.xml
+++ b/public/sitemaps/sitemap-11.xml
@@ -5,874 +5,1744 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11001-11800-aigues_vives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11001-11800-aigues_vives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11001-11800-aigues_vives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11001-11800-aigues_vives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11002-11320-airoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11002-11320-airoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11002-11320-airoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11002-11320-airoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11003-11300-ajac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11003-11300-ajac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11003-11300-ajac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11003-11300-ajac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11004-11240-alaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11004-11240-alaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11004-11240-alaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11004-11240-alaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11005-11290-alairac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11005-11290-alairac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11005-11290-alairac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11005-11290-alairac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11006-11360-albas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11006-11360-albas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11006-11360-albas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11006-11360-albas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11007-11330-albieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11007-11330-albieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11007-11330-albieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11007-11330-albieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11008-11580-alet_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11008-11580-alet_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11008-11580-alet_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11008-11580-alet_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11009-11170-alzonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11009-11170-alzonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11009-11170-alzonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11009-11170-alzonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11010-11190-antugnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11010-11190-antugnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11010-11190-antugnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11010-11190-antugnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11011-11600-aragon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11011-11600-aragon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11011-11600-aragon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11011-11600-aragon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11012-11120-argeliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11012-11120-argeliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11012-11120-argeliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11012-11120-argeliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11013-11200-argens_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11013-11200-argens_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11013-11200-argens_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11013-11200-argens_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11014-11110-armissan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11014-11110-armissan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11014-11110-armissan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11014-11110-armissan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11015-11190-arques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11015-11190-arques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11015-11190-arques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11015-11190-arques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11016-11220-arquettes_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11016-11220-arquettes_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11016-11220-arquettes_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11016-11220-arquettes_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11017-11140-artigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11017-11140-artigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11017-11140-artigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11017-11140-artigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11018-11290-arzens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11018-11290-arzens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11018-11290-arzens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11018-11290-arzens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11019-11140-aunat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11019-11140-aunat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11019-11140-aunat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11019-11140-aunat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11020-11330-auriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11020-11330-auriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11020-11330-auriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11020-11330-auriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11021-11140-axat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11021-11140-axat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11021-11140-axat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11021-11140-axat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11022-11700-azille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11022-11700-azille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11022-11700-azille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11022-11700-azille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11023-11800-badens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11023-11800-badens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11023-11800-badens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11023-11800-badens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11024-11100-bages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11024-11100-bages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11024-11100-bages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11024-11100-bages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11025-11600-bagnoles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11025-11600-bagnoles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11025-11600-bagnoles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11025-11600-bagnoles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11026-11410-baraigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11026-11410-baraigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11026-11410-baraigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11026-11410-baraigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11027-11800-barbaira/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11027-11800-barbaira/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11027-11800-barbaira/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11027-11800-barbaira/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11028-11340-belcaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11028-11340-belcaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11028-11340-belcaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11028-11340-belcaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11029-11580-belcastel_et_buc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11029-11580-belcastel_et_buc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11029-11580-belcastel_et_buc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11029-11580-belcastel_et_buc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11030-11410-belflou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11030-11410-belflou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11030-11410-belflou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11030-11410-belflou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11031-11140-belfort_sur_rebenty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11031-11140-belfort_sur_rebenty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11031-11140-belfort_sur_rebenty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11031-11140-belfort_sur_rebenty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11032-11240-bellegarde_du_razes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11032-11240-bellegarde_du_razes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11032-11240-bellegarde_du_razes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11032-11240-bellegarde_du_razes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11033-11420-belpech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11033-11420-belpech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11033-11420-belpech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11033-11420-belpech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11034-11240-belveze_du_razes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11034-11240-belveze_du_razes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11034-11240-belveze_du_razes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11034-11240-belveze_du_razes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11035-11500-belvianes_et_cavirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11035-11500-belvianes_et_cavirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11035-11500-belvianes_et_cavirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11035-11500-belvianes_et_cavirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11036-11340-belvis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11036-11340-belvis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11036-11340-belvis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11036-11340-belvis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11037-11000-berriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11037-11000-berriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11037-11000-berriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11037-11000-berriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11038-11140-bessede_de_sault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11038-11140-bessede_de_sault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11038-11140-bessede_de_sault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11038-11140-bessede_de_sault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11039-11300-la_bezole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11039-11300-la_bezole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11039-11300-la_bezole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11039-11300-la_bezole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11040-11200-bizanet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11040-11200-bizanet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11040-11200-bizanet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11040-11200-bizanet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11041-11120-bize_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11041-11120-bize_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11041-11120-bize_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11041-11120-bize_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11042-11700-blomac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11042-11700-blomac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11042-11700-blomac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11042-11700-blomac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11043-11800-bouilhonnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11043-11800-bouilhonnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11043-11800-bouilhonnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11043-11800-bouilhonnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11044-11330-bouisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11044-11330-bouisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11044-11330-bouisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11044-11330-bouisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11045-11300-bouriege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11045-11300-bouriege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11045-11300-bouriege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11045-11300-bouriege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11046-11300-bourigeole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11046-11300-bourigeole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11046-11300-bourigeole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11046-11300-bourigeole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11047-11140-le_bousquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11047-11140-le_bousquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11047-11140-le_bousquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11047-11140-le_bousquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11048-11200-boutenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11048-11200-boutenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11048-11200-boutenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11048-11200-boutenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11049-11150-bram/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11049-11150-bram/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11049-11150-bram/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11049-11150-bram/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11051-11270-brezilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11051-11270-brezilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11051-11270-brezilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11051-11270-brezilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11052-11390-brousses_et_villaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11052-11390-brousses_et_villaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11052-11390-brousses_et_villaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11052-11390-brousses_et_villaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11053-11300-brugairolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11053-11300-brugairolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11053-11300-brugairolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11053-11300-brugairolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11054-11400-les_brunels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11054-11400-les_brunels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11054-11400-les_brunels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11054-11400-les_brunels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11055-11190-bugarach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11055-11190-bugarach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11055-11190-bugarach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11055-11190-bugarach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11056-11160-cabrespine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11056-11160-cabrespine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11056-11160-cabrespine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11056-11160-cabrespine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11057-11420-cahuzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11057-11420-cahuzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11057-11420-cahuzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11057-11420-cahuzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11058-11240-cailhau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11058-11240-cailhau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11058-11240-cailhau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11058-11240-cailhau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11059-11240-cailhavel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11059-11240-cailhavel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11059-11240-cailhavel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11059-11240-cailhavel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11060-11140-cailla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11060-11140-cailla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11060-11140-cailla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11060-11140-cailla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11061-11240-cambieure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11061-11240-cambieure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11061-11240-cambieure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11061-11240-cambieure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11062-11140-campagna_de_sault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11062-11140-campagna_de_sault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11062-11140-campagna_de_sault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11062-11140-campagna_de_sault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11063-11260-campagne_sur_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11063-11260-campagne_sur_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11063-11260-campagne_sur_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11063-11260-campagne_sur_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11064-11200-camplong_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11064-11200-camplong_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11064-11200-camplong_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11064-11200-camplong_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11065-11190-camps_sur_l_agly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11065-11190-camps_sur_l_agly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11065-11190-camps_sur_l_agly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11065-11190-camps_sur_l_agly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11066-11340-camurac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11066-11340-camurac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11066-11340-camurac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11066-11340-camurac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11067-11200-canet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11067-11200-canet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11067-11200-canet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11067-11200-canet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11068-11700-capendu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11068-11700-capendu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11068-11700-capendu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11068-11700-capendu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11069-11000-carcassonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11069-11000-carcassonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11069-11000-carcassonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11069-11000-carcassonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11070-11170-carlipa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11070-11170-carlipa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11070-11170-carlipa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11070-11170-carlipa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11071-11360-cascastel_des_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11071-11360-cascastel_des_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11071-11360-cascastel_des_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11071-11360-cascastel_des_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11072-11270-la_cassaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11072-11270-la_cassaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11072-11270-la_cassaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11072-11270-la_cassaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11073-11190-cassaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11073-11190-cassaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11073-11190-cassaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11073-11190-cassaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11074-11320-les_casses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11074-11320-les_casses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11074-11320-les_casses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11074-11320-les_casses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11075-11160-castans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11075-11160-castans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11075-11160-castans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11075-11160-castans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11076-11400-castelnaudary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11076-11400-castelnaudary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11076-11400-castelnaudary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11076-11400-castelnaudary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11077-11700-castelnau_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11077-11700-castelnau_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11077-11700-castelnau_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11077-11700-castelnau_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11078-11300-castelreng/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11078-11300-castelreng/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11078-11300-castelreng/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11078-11300-castelreng/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11079-11390-caudebronde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11079-11390-caudebronde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11079-11390-caudebronde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11079-11390-caudebronde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11080-11230-val_de_lambronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11080-11230-val_de_lambronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11080-11230-val_de_lambronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11080-11230-val_de_lambronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11081-11160-caunes_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11081-11160-caunes_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11081-11160-caunes_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11081-11160-caunes_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11082-11250-caunette_sur_lauquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11082-11250-caunette_sur_lauquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11082-11250-caunette_sur_lauquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11082-11250-caunette_sur_lauquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11083-11220-caunettes_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11083-11220-caunettes_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11083-11220-caunettes_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11083-11220-caunettes_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11084-11170-caux_et_sauzens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11084-11170-caux_et_sauzens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11084-11170-caux_et_sauzens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11084-11170-caux_et_sauzens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11085-11570-cavanac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11085-11570-cavanac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11085-11570-cavanac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11085-11570-cavanac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11086-11510-caves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11086-11510-caves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11086-11510-caves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11086-11510-caves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11087-11270-cazalrenoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11087-11270-cazalrenoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11087-11270-cazalrenoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11087-11270-cazalrenoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11088-11570-cazilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11088-11570-cazilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11088-11570-cazilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11088-11570-cazilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11089-11170-cenne_monesties/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11089-11170-cenne_monesties/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11089-11170-cenne_monesties/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11089-11170-cenne_monesties/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11090-11300-cepie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11090-11300-cepie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11090-11300-cepie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11090-11300-cepie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11091-11230-chalabre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11091-11230-chalabre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11091-11230-chalabre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11091-11230-chalabre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11092-11160-citou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11092-11160-citou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11092-11160-citou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11092-11160-citou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11093-11140-le_clat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11093-11140-le_clat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11093-11140-le_clat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11093-11140-le_clat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11094-11250-clermont_sur_lauquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11094-11250-clermont_sur_lauquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11094-11250-clermont_sur_lauquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11094-11250-clermont_sur_lauquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11095-11700-comigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11095-11700-comigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11095-11700-comigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11095-11700-comigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11096-11340-comus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11096-11340-comus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11096-11340-comus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11096-11340-comus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11098-11200-conilhac_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11098-11200-conilhac_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11098-11200-conilhac_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11098-11200-conilhac_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11099-11600-conques_sur_orbiel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11099-11600-conques_sur_orbiel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11099-11600-conques_sur_orbiel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11099-11600-conques_sur_orbiel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11100-11230-corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11100-11230-corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11100-11230-corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11100-11230-corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11101-11500-coudons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11101-11500-coudons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11101-11500-coudons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11101-11500-coudons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11102-11250-couffoulens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11102-11250-couffoulens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11102-11250-couffoulens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11102-11250-couffoulens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11103-11190-couiza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11103-11190-couiza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11103-11190-couiza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11103-11190-couiza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11104-11140-counozouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11104-11140-counozouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11104-11140-counozouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11104-11140-counozouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11105-11300-cournanel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11105-11300-cournanel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11105-11300-cournanel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11105-11300-cournanel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11106-11110-coursan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11106-11110-coursan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11106-11110-coursan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11106-11110-coursan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11107-11230-courtauly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11107-11230-courtauly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11107-11230-courtauly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11107-11230-courtauly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11108-11240-la_courtete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11108-11240-la_courtete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11108-11240-la_courtete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11108-11240-la_courtete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11109-11190-coustaussa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11109-11190-coustaussa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11109-11190-coustaussa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11109-11190-coustaussa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11110-11220-coustouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11110-11220-coustouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11110-11220-coustouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11110-11220-coustouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11111-11200-cruscades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11111-11200-cruscades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11111-11200-cruscades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11111-11200-cruscades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11112-11190-cubieres_sur_cinoble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11112-11190-cubieres_sur_cinoble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11112-11190-cubieres_sur_cinoble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11112-11190-cubieres_sur_cinoble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11113-11350-cucugnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11113-11350-cucugnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11113-11350-cucugnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11113-11350-cucugnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11114-11410-cumies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11114-11410-cumies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11114-11410-cumies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11114-11410-cumies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11115-11390-cuxac_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11115-11390-cuxac_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11115-11390-cuxac_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11115-11390-cuxac_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11116-11590-cuxac_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11116-11590-cuxac_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11116-11590-cuxac_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11116-11590-cuxac_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11117-11330-davejean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11117-11330-davejean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11117-11330-davejean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11117-11330-davejean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11118-11330-dernacueillette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11118-11330-dernacueillette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11118-11330-dernacueillette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11118-11330-dernacueillette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11119-11300-la_digne_d_amont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11119-11300-la_digne_d_amont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11119-11300-la_digne_d_amont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11119-11300-la_digne_d_amont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11120-11300-la_digne_d_aval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11120-11300-la_digne_d_aval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11120-11300-la_digne_d_aval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11120-11300-la_digne_d_aval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11121-11240-donazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11121-11240-donazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11121-11240-donazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11121-11240-donazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11122-11700-douzens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11122-11700-douzens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11122-11700-douzens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11122-11700-douzens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11123-11350-duilhac_sous_peyrepertuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11123-11350-duilhac_sous_peyrepertuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11123-11350-duilhac_sous_peyrepertuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11123-11350-duilhac_sous_peyrepertuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11124-11360-durban_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11124-11360-durban_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11124-11360-durban_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11124-11360-durban_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11125-11360-embres_et_castelmaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11125-11360-embres_et_castelmaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11125-11360-embres_et_castelmaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11125-11360-embres_et_castelmaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11126-11200-escales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11126-11200-escales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11126-11200-escales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11126-11200-escales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11127-11140-escouloubre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11127-11140-escouloubre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11127-11140-escouloubre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11127-11140-escouloubre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11128-11240-escueillens_et_saint_just_de_belengard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11128-11240-escueillens_et_saint_just_de_belengard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11128-11240-escueillens_et_saint_just_de_belengard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11128-11240-escueillens_et_saint_just_de_belengard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11129-11260-esperaza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11129-11260-esperaza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11129-11260-esperaza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11129-11260-esperaza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11130-11340-espezel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11130-11340-espezel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11130-11340-espezel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11130-11340-espezel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11131-11260-val_du_faby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11131-11260-val_du_faby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11131-11260-val_du_faby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11131-11260-val_du_faby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11132-11200-fabrezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11132-11200-fabrezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11132-11200-fabrezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11132-11200-fabrezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11133-11220-fajac_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11133-11220-fajac_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11133-11220-fajac_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11133-11220-fajac_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11134-11410-fajac_la_relenque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11134-11410-fajac_la_relenque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11134-11410-fajac_la_relenque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11134-11410-fajac_la_relenque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11135-11140-la_fajolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11135-11140-la_fajolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11135-11140-la_fajolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11135-11140-la_fajolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11136-11270-fanjeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11136-11270-fanjeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11136-11270-fanjeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11136-11270-fanjeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11137-11330-felines_termenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11137-11330-felines_termenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11137-11330-felines_termenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11137-11330-felines_termenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11138-11400-fendeille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11138-11400-fendeille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11138-11400-fendeille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11138-11400-fendeille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11139-11240-fenouillet_du_razes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11139-11240-fenouillet_du_razes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11139-11240-fenouillet_du_razes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11139-11240-fenouillet_du_razes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11140-11200-ferrals_les_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11140-11200-ferrals_les_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11140-11200-ferrals_les_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11140-11200-ferrals_les_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11141-11240-ferran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11141-11240-ferran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11141-11240-ferran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11141-11240-ferran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11142-11300-festes_et_saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11142-11300-festes_et_saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11142-11300-festes_et_saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11142-11300-festes_et_saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11143-11510-feuilla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11143-11510-feuilla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11143-11510-feuilla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11143-11510-feuilla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11144-11510-fitou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11144-11510-fitou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11144-11510-fitou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11144-11510-fitou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11145-11560-fleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11145-11560-fleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11145-11560-fleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11145-11560-fleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11146-11800-floure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11146-11800-floure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11146-11800-floure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11146-11800-floure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11147-11140-fontanes_de_sault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11147-11140-fontanes_de_sault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11147-11140-fontanes_de_sault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11147-11140-fontanes_de_sault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11148-11700-fontcouverte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11148-11700-fontcouverte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11148-11700-fontcouverte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11148-11700-fontcouverte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11149-11400-fonters_du_razes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11149-11400-fonters_du_razes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11149-11400-fonters_du_razes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11149-11400-fonters_du_razes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11150-11390-fontiers_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11150-11390-fontiers_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11150-11390-fontiers_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11150-11390-fontiers_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11151-11800-fonties_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11151-11800-fonties_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11151-11800-fonties_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11151-11800-fonties_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11152-11360-fontjoncouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11152-11360-fontjoncouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11152-11360-fontjoncouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11152-11360-fontjoncouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11153-11270-la_force/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11153-11270-la_force/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11153-11270-la_force/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11153-11270-la_force/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11154-11600-fournes_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11154-11600-fournes_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11154-11600-fournes_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11154-11600-fournes_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11155-11190-fourtou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11155-11190-fourtou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11155-11190-fourtou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11155-11190-fourtou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11156-11600-fraisse_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11156-11600-fraisse_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11156-11600-fraisse_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11156-11600-fraisse_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11157-11360-fraisse_des_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11157-11360-fraisse_des_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11157-11360-fraisse_des_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11157-11360-fraisse_des_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11158-11300-gaja_et_villedieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11158-11300-gaja_et_villedieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11158-11300-gaja_et_villedieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11158-11300-gaja_et_villedieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11159-11270-gaja_la_selve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11159-11270-gaja_la_selve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11159-11270-gaja_la_selve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11159-11270-gaja_la_selve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11160-11140-galinagues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11160-11140-galinagues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11160-11140-galinagues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11160-11140-galinagues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11161-11250-gardie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11161-11250-gardie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11161-11250-gardie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11161-11250-gardie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11162-11270-generville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11162-11270-generville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11162-11270-generville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11162-11270-generville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11163-11140-gincla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11163-11140-gincla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11163-11140-gincla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11163-11140-gincla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11164-11120-ginestas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11164-11120-ginestas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11164-11120-ginestas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11164-11120-ginestas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11165-11500-ginoles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11165-11500-ginoles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11165-11500-ginoles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11165-11500-ginoles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11166-11410-gourvieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11166-11410-gourvieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11166-11410-gourvieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11166-11410-gourvieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11167-11240-gramazie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11167-11240-gramazie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11167-11240-gramazie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11167-11240-gramazie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11168-11500-granes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11168-11500-granes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11168-11500-granes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11168-11500-granes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11169-11250-greffeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11169-11250-greffeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11169-11250-greffeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11169-11250-greffeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11170-11430-gruissan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11170-11430-gruissan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11170-11430-gruissan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11170-11430-gruissan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11172-11200-homps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11172-11200-homps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11172-11200-homps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11172-11200-homps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11173-11240-hounoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11173-11240-hounoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11173-11240-hounoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11173-11240-hounoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11174-11380-les_ilhes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11174-11380-les_ilhes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11174-11380-les_ilhes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11174-11380-les_ilhes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11175-11400-issel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11175-11400-issel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11175-11400-issel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11175-11400-issel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11176-11220-jonquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11176-11220-jonquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11176-11220-jonquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11176-11220-jonquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11177-11140-joucou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11177-11140-joucou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11177-11140-joucou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11177-11140-joucou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11178-11320-labastide_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11178-11320-labastide_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11178-11320-labastide_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11178-11320-labastide_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11179-11220-labastide_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11179-11220-labastide_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11179-11220-labastide_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11179-11220-labastide_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11180-11380-labastide_esparbairenque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11180-11380-labastide_esparbairenque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11180-11380-labastide_esparbairenque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11180-11380-labastide_esparbairenque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11181-11400-labecede_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11181-11400-labecede_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11181-11400-labecede_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11181-11400-labecede_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11182-11310-lacombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11182-11310-lacombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11182-11310-lacombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11182-11310-lacombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11183-11250-ladern_sur_lauquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11183-11250-ladern_sur_lauquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11183-11250-ladern_sur_lauquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11183-11250-ladern_sur_lauquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11184-11420-lafage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11184-11420-lafage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11184-11420-lafage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11184-11420-lafage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11185-11220-lagrasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11185-11220-lagrasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11185-11220-lagrasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11185-11220-lagrasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11186-11330-lairiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11186-11330-lairiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11186-11330-lairiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11186-11330-lairiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11187-11330-lanet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11187-11330-lanet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11187-11330-lanet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11187-11330-lanet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11188-11480-la_palme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11188-11480-la_palme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11188-11480-la_palme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11188-11480-la_palme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11189-11390-laprade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11189-11390-laprade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11189-11390-laprade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11189-11390-laprade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11190-11700-la_redorte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11190-11700-la_redorte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11190-11700-la_redorte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11190-11700-la_redorte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11191-11330-laroque_de_fa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11191-11330-laroque_de_fa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11191-11330-laroque_de_fa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11191-11330-laroque_de_fa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11192-11400-lasbordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11192-11400-lasbordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11192-11400-lasbordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11192-11400-lasbordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11193-11270-lasserre_de_prouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11193-11270-lasserre_de_prouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11193-11270-lasserre_de_prouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11193-11270-lasserre_de_prouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11194-11600-lastours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11194-11600-lastours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11194-11600-lastours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11194-11600-lastours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11195-11400-laurabuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11195-11400-laurabuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11195-11400-laurabuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11195-11400-laurabuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11196-11270-laurac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11196-11270-laurac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11196-11270-laurac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11196-11270-laurac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11197-11300-lauraguel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11197-11300-lauraguel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11197-11300-lauraguel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11197-11300-lauraguel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11198-11800-laure_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11198-11800-laure_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11198-11800-laure_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11198-11800-laure_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11199-11290-lavalette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11199-11290-lavalette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11199-11290-lavalette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11199-11290-lavalette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11200-11160-lespinassiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11200-11160-lespinassiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11200-11160-lespinassiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11200-11160-lespinassiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11201-11250-leuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11201-11250-leuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11201-11250-leuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11201-11250-leuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11202-11370-leucate/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11202-11370-leucate/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11202-11370-leucate/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11202-11370-leucate/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11203-11200-lezignan_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11203-11200-lezignan_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11203-11200-lezignan_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11203-11200-lezignan_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11204-11240-lignairolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11204-11240-lignairolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11204-11240-lignairolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11204-11240-lignairolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11205-11600-limousis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11205-11600-limousis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11205-11600-limousis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11205-11600-limousis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11206-11300-limoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11206-11300-limoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11206-11300-limoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11206-11300-limoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11207-11300-loupia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11207-11300-loupia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11207-11300-loupia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11207-11300-loupia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11208-11410-la_louviere_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11208-11410-la_louviere_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11208-11410-la_louviere_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11208-11410-la_louviere_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11209-11190-luc_sur_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11209-11190-luc_sur_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11209-11190-luc_sur_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11209-11190-luc_sur_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11210-11200-luc_sur_orbieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11210-11200-luc_sur_orbieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11210-11200-luc_sur_orbieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11210-11200-luc_sur_orbieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11211-11300-magrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11211-11300-magrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11211-11300-magrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11211-11300-magrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11212-11120-mailhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11212-11120-mailhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11212-11120-mailhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11212-11120-mailhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11213-11330-maisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11213-11330-maisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11213-11330-maisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11213-11330-maisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11214-11300-malras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11214-11300-malras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11214-11300-malras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11214-11300-malras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11215-11600-malves_en_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11215-11600-malves_en_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11215-11600-malves_en_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11215-11600-malves_en_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11216-11300-malvies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11216-11300-malvies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11216-11300-malvies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11216-11300-malvies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11217-11120-marcorignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11217-11120-marcorignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11217-11120-marcorignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11217-11120-marcorignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11218-11410-marquein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11218-11410-marquein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11218-11410-marquein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11218-11410-marquein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11219-11140-marsa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11219-11140-marsa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11219-11140-marsa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11219-11140-marsa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11220-11800-marseillette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11220-11800-marseillette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11220-11800-marseillette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11220-11800-marseillette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11221-11390-les_martys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11221-11390-les_martys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11221-11390-les_martys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11221-11390-les_martys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11222-11380-mas_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11222-11380-mas_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11222-11380-mas_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11222-11380-mas_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11223-11570-mas_des_cours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11223-11570-mas_des_cours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11223-11570-mas_des_cours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11223-11570-mas_des_cours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11224-11330-massac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11224-11330-massac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11224-11330-massac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11224-11330-massac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11225-11400-mas_saintes_puelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11225-11400-mas_saintes_puelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11225-11400-mas_saintes_puelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11225-11400-mas_saintes_puelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11226-11420-mayreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11226-11420-mayreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11226-11420-mayreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11226-11420-mayreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11227-11220-mayronnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11227-11220-mayronnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11227-11220-mayronnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11227-11220-mayronnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11228-11240-mazerolles_du_razes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11228-11240-mazerolles_du_razes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11228-11240-mazerolles_du_razes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11228-11240-mazerolles_du_razes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11229-11140-mazuby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11229-11140-mazuby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11229-11140-mazuby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11229-11140-mazuby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11230-11140-merial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11230-11140-merial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11230-11140-merial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11230-11140-merial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11231-11410-mezerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11231-11410-mezerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11231-11410-mezerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11231-11410-mezerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11232-11380-miraval_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11232-11380-miraval_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11232-11380-miraval_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11232-11380-miraval_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11233-11120-mirepeisset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11233-11120-mirepeisset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11233-11120-mirepeisset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11233-11120-mirepeisset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11234-11400-mireval_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11234-11400-mireval_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11234-11400-mireval_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11234-11400-mireval_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11235-11580-missegre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11235-11580-missegre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11235-11580-missegre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11235-11580-missegre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11236-11420-molandier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11236-11420-molandier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11236-11420-molandier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11236-11420-molandier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11238-11410-molleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11238-11410-molleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11238-11410-molleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11238-11410-molleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11239-11410-montauriol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11239-11410-montauriol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11239-11410-montauriol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11239-11410-montauriol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11240-11190-montazels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11240-11190-montazels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11240-11190-montazels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11240-11190-montazels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11241-11700-montbrun_des_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11241-11700-montbrun_des_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11241-11700-montbrun_des_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11241-11700-montbrun_des_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11242-11250-montclar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11242-11250-montclar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11242-11250-montclar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11242-11250-montclar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11243-11320-montferrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11243-11320-montferrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11243-11320-montferrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11243-11320-montferrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11244-11140-montfort_sur_boulzane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11244-11140-montfort_sur_boulzane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11244-11140-montfort_sur_boulzane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11244-11140-montfort_sur_boulzane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11245-11330-montgaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11245-11330-montgaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11245-11330-montgaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11245-11330-montgaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11246-11240-montgradail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11246-11240-montgradail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11246-11240-montgradail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11246-11240-montgradail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11247-11240-monthaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11247-11240-monthaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11247-11240-monthaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11247-11240-monthaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11248-11800-montirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11248-11800-montirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11248-11800-montirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11248-11800-montirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11249-11230-montjardin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11249-11230-montjardin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11249-11230-montjardin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11249-11230-montjardin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11250-11330-montjoi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11250-11330-montjoi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11250-11330-montjoi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11250-11330-montjoi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11251-11220-val_de_dagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11251-11220-val_de_dagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11251-11220-val_de_dagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11251-11220-val_de_dagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11252-11320-montmaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11252-11320-montmaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11252-11320-montmaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11252-11320-montmaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11253-11170-montolieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11253-11170-montolieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11253-11170-montolieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11253-11170-montolieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11254-11290-montreal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11254-11290-montreal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11254-11290-montreal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11254-11290-montreal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11255-11100-montredon_des_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11255-11100-montredon_des_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11255-11100-montredon_des_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11255-11100-montredon_des_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11256-11200-montseret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11256-11200-montseret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11256-11200-montseret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11256-11200-montseret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11257-11800-monze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11257-11800-monze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11257-11800-monze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11257-11800-monze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11258-11120-moussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11258-11120-moussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11258-11120-moussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11258-11120-moussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11259-11170-moussoulens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11259-11170-moussoulens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11259-11170-moussoulens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11259-11170-moussoulens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11260-11330-mouthoumet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11260-11330-mouthoumet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11260-11330-mouthoumet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11260-11330-mouthoumet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11261-11700-moux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11261-11700-moux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11261-11700-moux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11261-11700-moux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11262-11100-narbonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11262-11100-narbonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11262-11100-narbonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11262-11100-narbonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11263-11500-nebias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11263-11500-nebias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11263-11500-nebias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11263-11500-nebias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11264-11200-nevian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11264-11200-nevian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11264-11200-nevian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11264-11200-nevian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11265-11140-niort_de_sault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11265-11140-niort_de_sault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11265-11140-niort_de_sault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11265-11140-niort_de_sault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11266-11210-port_la_nouvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11266-11210-port_la_nouvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11266-11210-port_la_nouvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11266-11210-port_la_nouvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11267-11200-ornaisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11267-11200-ornaisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11267-11200-ornaisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11267-11200-ornaisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11268-11270-orsans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11268-11270-orsans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11268-11270-orsans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11268-11270-orsans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11269-11590-ouveillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11269-11590-ouveillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11269-11590-ouveillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11269-11590-ouveillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11270-11350-padern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11270-11350-padern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11270-11350-padern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11270-11350-padern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11271-11330-palairac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11271-11330-palairac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11271-11330-palairac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11271-11330-palairac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11272-11570-palaja/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11272-11570-palaja/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11272-11570-palaja/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11272-11570-palaja/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11273-11200-paraza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11273-11200-paraza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11273-11200-paraza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11273-11200-paraza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11274-11300-pauligne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11274-11300-pauligne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11274-11300-pauligne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11274-11300-pauligne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11275-11410-payra_sur_l_hers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11275-11410-payra_sur_l_hers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11275-11410-payra_sur_l_hers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11275-11410-payra_sur_l_hers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11276-11350-paziols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11276-11350-paziols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11276-11350-paziols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11276-11350-paziols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11277-11420-pecharic_et_le_py/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11277-11420-pecharic_et_le_py/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11277-11420-pecharic_et_le_py/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11277-11420-pecharic_et_le_py/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11278-11420-pech_luna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11278-11420-pech_luna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11278-11420-pech_luna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11278-11420-pech_luna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11279-11610-pennautier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11279-11610-pennautier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11279-11610-pennautier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11279-11610-pennautier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11280-11700-pepieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11280-11700-pepieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11280-11700-pepieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11280-11700-pepieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11281-11150-pexiora/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11281-11150-pexiora/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11281-11150-pexiora/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11281-11150-pexiora/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11282-11230-peyrefitte_du_razes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11282-11230-peyrefitte_du_razes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11282-11230-peyrefitte_du_razes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11282-11230-peyrefitte_du_razes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11283-11420-peyrefitte_sur_l_hers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11283-11420-peyrefitte_sur_l_hers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11283-11420-peyrefitte_sur_l_hers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11283-11420-peyrefitte_sur_l_hers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11284-11400-peyrens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11284-11400-peyrens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11284-11400-peyrens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11284-11400-peyrens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11285-11440-peyriac_de_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11285-11440-peyriac_de_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11285-11440-peyriac_de_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11285-11440-peyriac_de_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11286-11160-peyriac_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11286-11160-peyriac_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11286-11160-peyriac_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11286-11160-peyriac_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11287-11190-peyrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11287-11190-peyrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11287-11190-peyrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11287-11190-peyrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11288-11170-pezens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11288-11170-pezens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11288-11170-pezens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11288-11170-pezens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11289-11300-pieusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11289-11300-pieusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11289-11300-pieusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11289-11300-pieusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11290-11420-plaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11290-11420-plaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11290-11420-plaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11290-11420-plaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11291-11270-plavilla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11291-11270-plavilla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11291-11270-plavilla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11291-11270-plavilla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11292-11400-la_pomarede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11292-11400-la_pomarede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11292-11400-la_pomarede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11292-11400-la_pomarede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11293-11250-pomas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11293-11250-pomas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11293-11250-pomas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11293-11250-pomas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11294-11300-pomy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11294-11300-pomy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11294-11300-pomy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11294-11300-pomy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11295-11490-portel_des_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11295-11490-portel_des_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11295-11490-portel_des_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11295-11490-portel_des_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11296-11120-pouzols_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11296-11120-pouzols_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11296-11120-pouzols_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11296-11120-pouzols_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11297-11380-pradelles_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11297-11380-pradelles_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11297-11380-pradelles_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11297-11380-pradelles_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11299-11250-preixan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11299-11250-preixan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11299-11250-preixan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11299-11250-preixan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11300-11400-puginier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11300-11400-puginier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11300-11400-puginier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11300-11400-puginier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11301-11700-puicheric/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11301-11700-puicheric/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11301-11700-puicheric/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11301-11700-puicheric/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11302-11140-puilaurens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11302-11140-puilaurens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11302-11140-puilaurens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11302-11140-puilaurens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11303-11230-puivert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11303-11230-puivert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11303-11230-puivert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11303-11230-puivert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11304-11500-quillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11304-11500-quillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11304-11500-quillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11304-11500-quillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11305-11360-quintillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11305-11360-quintillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11305-11360-quintillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11305-11360-quintillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11306-11500-quirbajou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11306-11500-quirbajou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11306-11500-quirbajou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11306-11500-quirbajou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11307-11200-raissac_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11307-11200-raissac_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11307-11200-raissac_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11307-11200-raissac_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11308-11170-raissac_sur_lampy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11308-11170-raissac_sur_lampy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11308-11170-raissac_sur_lampy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11308-11170-raissac_sur_lampy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11309-11190-rennes_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11309-11190-rennes_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11309-11190-rennes_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11309-11190-rennes_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11310-11190-rennes_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11310-11190-rennes_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11310-11190-rennes_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11310-11190-rennes_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11311-11220-ribaute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11311-11220-ribaute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11311-11220-ribaute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11311-11220-ribaute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11312-11270-ribouisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11312-11270-ribouisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11312-11270-ribouisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11312-11270-ribouisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11313-11400-ricaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11313-11400-ricaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11313-11400-ricaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11313-11400-ricaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11314-11220-rieux_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11314-11220-rieux_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11314-11220-rieux_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11314-11220-rieux_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11315-11160-rieux_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11315-11160-rieux_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11315-11160-rieux_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11315-11160-rieux_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11316-11230-rivel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11316-11230-rivel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11316-11230-rivel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11316-11230-rivel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11317-11140-rodome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11317-11140-rodome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11317-11140-rodome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11317-11140-rodome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11318-11700-roquecourbe_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11318-11700-roquecourbe_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11318-11700-roquecourbe_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11318-11700-roquecourbe_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11319-11380-roquefere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11319-11380-roquefere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11319-11380-roquefere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11319-11380-roquefere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11320-11340-roquefeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11320-11340-roquefeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11320-11340-roquefeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11320-11340-roquefeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11321-11140-roquefort_de_sault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11321-11140-roquefort_de_sault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11321-11140-roquefort_de_sault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11321-11140-roquefort_de_sault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11322-11540-roquefort_des_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11322-11540-roquefort_des_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11322-11540-roquefort_des_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11322-11540-roquefort_des_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11323-11300-roquetaillade_et_conilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11323-11300-roquetaillade_et_conilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11323-11300-roquetaillade_et_conilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11323-11300-roquetaillade_et_conilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11323-11190-roquetaillade_et_conilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11323-11190-roquetaillade_et_conilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11323-11190-roquetaillade_et_conilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11323-11190-roquetaillade_et_conilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11324-11200-roubia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11324-11200-roubia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11324-11200-roubia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11324-11200-roubia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11325-11250-rouffiac_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11325-11250-rouffiac_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11325-11250-rouffiac_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11325-11250-rouffiac_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11326-11350-rouffiac_des_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11326-11350-rouffiac_des_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11326-11350-rouffiac_des_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11326-11350-rouffiac_des_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11327-11290-roullens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11327-11290-roullens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11327-11290-roullens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11327-11290-roullens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11328-11240-routier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11328-11240-routier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11328-11240-routier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11328-11240-routier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11330-11800-rustiques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11330-11800-rustiques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11330-11800-rustiques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11330-11800-rustiques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11331-11270-saint_amans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11331-11270-saint_amans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11331-11270-saint_amans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11331-11270-saint_amans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11332-11200-saint_andre_de_roquelongue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11332-11200-saint_andre_de_roquelongue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11332-11200-saint_andre_de_roquelongue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11332-11200-saint_andre_de_roquelongue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11333-11230-saint_benoit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11333-11230-saint_benoit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11333-11230-saint_benoit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11333-11230-saint_benoit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11334-11410-sainte_camelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11334-11410-sainte_camelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11334-11410-sainte_camelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11334-11410-sainte_camelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11335-11140-sainte_colombe_sur_guette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11335-11140-sainte_colombe_sur_guette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11335-11140-sainte_colombe_sur_guette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11335-11140-sainte_colombe_sur_guette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11336-11230-sainte_colombe_sur_l_hers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11336-11230-sainte_colombe_sur_l_hers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11336-11230-sainte_colombe_sur_l_hers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11336-11230-sainte_colombe_sur_l_hers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11337-11700-saint_couat_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11337-11700-saint_couat_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11337-11700-saint_couat_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11337-11700-saint_couat_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11338-11300-saint_couat_du_razes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11338-11300-saint_couat_du_razes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11338-11300-saint_couat_du_razes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11338-11300-saint_couat_du_razes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11339-11310-saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11339-11310-saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11339-11310-saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11339-11310-saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11340-11170-sainte_eulalie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11340-11170-sainte_eulalie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11340-11170-sainte_eulalie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11340-11170-sainte_eulalie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11341-11500-saint_ferriol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11341-11500-saint_ferriol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11341-11500-saint_ferriol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11341-11500-saint_ferriol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11342-11800-saint_frichoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11342-11800-saint_frichoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11342-11800-saint_frichoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11342-11800-saint_frichoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11343-11270-saint_gauderic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11343-11270-saint_gauderic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11343-11270-saint_gauderic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11343-11270-saint_gauderic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11344-11250-saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11344-11250-saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11344-11250-saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11344-11250-saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11345-11360-saint_jean_de_barrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11345-11360-saint_jean_de_barrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11345-11360-saint_jean_de_barrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11345-11360-saint_jean_de_barrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11346-11260-saint_jean_de_paracol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11346-11260-saint_jean_de_paracol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11346-11260-saint_jean_de_paracol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11346-11260-saint_jean_de_paracol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11347-11500-saint_julia_de_bec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11347-11500-saint_julia_de_bec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11347-11500-saint_julia_de_bec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11347-11500-saint_julia_de_bec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11348-11270-saint_julien_de_briola/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11348-11270-saint_julien_de_briola/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11348-11270-saint_julien_de_briola/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11348-11270-saint_julien_de_briola/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11350-11500-saint_just_et_le_bezu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11350-11500-saint_just_et_le_bezu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11350-11500-saint_just_et_le_bezu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11350-11500-saint_just_et_le_bezu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11351-11220-saint_laurent_de_la_cabrerisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11351-11220-saint_laurent_de_la_cabrerisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11351-11220-saint_laurent_de_la_cabrerisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11351-11220-saint_laurent_de_la_cabrerisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11352-11500-saint_louis_et_parahou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11352-11500-saint_louis_et_parahou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11352-11500-saint_louis_et_parahou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11352-11500-saint_louis_et_parahou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11353-11120-saint_marcel_sur_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11353-11120-saint_marcel_sur_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11353-11120-saint_marcel_sur_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11353-11120-saint_marcel_sur_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11354-11220-saint_martin_des_puits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11354-11220-saint_martin_des_puits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11354-11220-saint_martin_des_puits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11354-11220-saint_martin_des_puits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11355-11300-saint_martin_de_villereglan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11355-11300-saint_martin_de_villereglan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11355-11300-saint_martin_de_villereglan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11355-11300-saint_martin_de_villereglan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11356-11400-saint_martin_lalande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11356-11400-saint_martin_lalande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11356-11400-saint_martin_lalande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11356-11400-saint_martin_lalande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11357-11170-saint_martin_le_vieil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11357-11170-saint_martin_le_vieil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11357-11170-saint_martin_le_vieil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11357-11170-saint_martin_le_vieil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11358-11500-saint_martin_lys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11358-11500-saint_martin_lys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11358-11500-saint_martin_lys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11358-11500-saint_martin_lys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11359-11410-saint_michel_de_lanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11359-11410-saint_michel_de_lanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11359-11410-saint_michel_de_lanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11359-11410-saint_michel_de_lanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11360-11120-saint_nazaire_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11360-11120-saint_nazaire_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11360-11120-saint_nazaire_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11360-11120-saint_nazaire_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11361-11400-saint_papoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11361-11400-saint_papoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11361-11400-saint_papoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11361-11400-saint_papoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11362-11320-saint_paulet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11362-11320-saint_paulet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11362-11320-saint_paulet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11362-11320-saint_paulet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11363-11220-saint_pierre_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11363-11220-saint_pierre_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11363-11220-saint_pierre_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11363-11220-saint_pierre_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11364-11300-saint_polycarpe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11364-11300-saint_polycarpe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11364-11300-saint_polycarpe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11364-11300-saint_polycarpe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11365-11420-saint_sernin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11365-11420-saint_sernin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11365-11420-saint_sernin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11365-11420-saint_sernin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11366-11120-sainte_valiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11366-11120-sainte_valiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11366-11120-sainte_valiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11366-11120-sainte_valiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11367-11310-saissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11367-11310-saissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11367-11310-saissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11367-11310-saissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11368-11600-salleles_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11368-11600-salleles_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11368-11600-salleles_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11368-11600-salleles_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11369-11590-salleles_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11369-11590-salleles_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11369-11590-salleles_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11369-11590-salleles_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11370-11110-salles_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11370-11110-salles_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11370-11110-salles_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11370-11110-salles_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11371-11410-salles_sur_l_hers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11371-11410-salles_sur_l_hers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11371-11410-salles_sur_l_hers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11371-11410-salles_sur_l_hers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11372-11600-salsigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11372-11600-salsigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11372-11600-salsigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11372-11600-salsigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11373-11140-salvezines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11373-11140-salvezines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11373-11140-salvezines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11373-11140-salvezines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11374-11330-salza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11374-11330-salza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11374-11330-salza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11374-11330-salza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11375-11240-seignalens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11375-11240-seignalens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11375-11240-seignalens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11375-11240-seignalens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11376-11190-la_serpent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11376-11190-la_serpent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11376-11190-la_serpent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11376-11190-la_serpent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11377-11190-serres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11377-11190-serres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11377-11190-serres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11377-11190-serres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11378-11220-servies_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11378-11220-servies_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11378-11220-servies_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11378-11220-servies_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11379-11130-sigean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11379-11130-sigean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11379-11130-sigean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11379-11130-sigean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11380-11230-sonnac_sur_l_hers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11380-11230-sonnac_sur_l_hers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11380-11230-sonnac_sur_l_hers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11380-11230-sonnac_sur_l_hers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11381-11190-sougraigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11381-11190-sougraigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11381-11190-sougraigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11381-11190-sougraigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11382-11400-souilhanels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11382-11400-souilhanels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11382-11400-souilhanels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11382-11400-souilhanels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11383-11400-souilhe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11383-11400-souilhe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11383-11400-souilhe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11383-11400-souilhe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11384-11330-soulatge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11384-11330-soulatge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11384-11330-soulatge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11384-11330-soulatge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11385-11320-soupex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11385-11320-soupex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11385-11320-soupex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11385-11320-soupex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11386-11220-talairan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11386-11220-talairan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11386-11220-talairan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11386-11220-talairan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11387-11220-taurize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11387-11220-taurize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11387-11220-taurize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11387-11220-taurize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11388-11330-termes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11388-11330-termes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11388-11330-termes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11388-11330-termes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11389-11580-terroles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11389-11580-terroles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11389-11580-terroles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11389-11580-terroles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11390-11200-thezan_des_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11390-11200-thezan_des_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11390-11200-thezan_des_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11390-11200-thezan_des_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11391-11380-la_tourette_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11391-11380-la_tourette_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11391-11380-la_tourette_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11391-11380-la_tourette_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11392-11220-tournissan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11392-11220-tournissan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11392-11220-tournissan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11392-11220-tournissan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11393-11200-tourouzelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11393-11200-tourouzelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11393-11200-tourouzelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11393-11200-tourouzelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11394-11300-tourreilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11394-11300-tourreilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11394-11300-tourreilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11394-11300-tourreilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11395-11160-trassanel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11395-11160-trassanel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11395-11160-trassanel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11395-11160-trassanel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11396-11160-trausse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11396-11160-trausse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11396-11160-trausse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11396-11160-trausse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11397-11800-trebes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11397-11800-trebes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11397-11800-trebes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11397-11800-trebes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11398-11510-treilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11398-11510-treilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11398-11510-treilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11398-11510-treilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11399-11400-treville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11399-11400-treville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11399-11400-treville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11399-11400-treville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11400-11230-treziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11400-11230-treziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11400-11230-treziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11400-11230-treziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11401-11350-tuchan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11401-11350-tuchan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11401-11350-tuchan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11401-11350-tuchan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11402-11580-valmigere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11402-11580-valmigere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11402-11580-valmigere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11402-11580-valmigere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11404-11610-ventenac_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11404-11610-ventenac_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11404-11610-ventenac_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11404-11610-ventenac_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11405-11120-ventenac_en_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11405-11120-ventenac_en_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11405-11120-ventenac_en_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11405-11120-ventenac_en_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11406-11580-veraza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11406-11580-veraza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11406-11580-veraza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11406-11580-veraza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11407-11400-verdun_en_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11407-11400-verdun_en_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11407-11400-verdun_en_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11407-11400-verdun_en_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11408-11250-verzeille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11408-11250-verzeille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11408-11250-verzeille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11408-11250-verzeille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11409-11330-vignevieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11409-11330-vignevieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11409-11330-vignevieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11409-11330-vignevieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11410-11600-villalier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11410-11600-villalier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11410-11600-villalier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11410-11600-villalier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11411-11600-villaniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11411-11600-villaniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11411-11600-villaniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11411-11600-villaniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11412-11580-villardebelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11412-11580-villardebelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11412-11580-villardebelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11412-11580-villardebelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11413-11600-villardonnel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11413-11600-villardonnel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11413-11600-villardonnel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11413-11600-villardonnel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11414-11220-villar_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11414-11220-villar_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11414-11220-villar_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11414-11220-villar_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11415-11250-villar_saint_anselme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11415-11250-villar_saint_anselme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11415-11250-villar_saint_anselme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11415-11250-villar_saint_anselme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11416-11600-villarzel_cabardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11416-11600-villarzel_cabardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11416-11600-villarzel_cabardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11416-11600-villarzel_cabardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11417-11300-villarzel_du_razes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11417-11300-villarzel_du_razes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11417-11300-villarzel_du_razes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11417-11300-villarzel_du_razes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11418-11150-villasavary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11418-11150-villasavary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11418-11150-villasavary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11418-11150-villasavary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11419-11420-villautou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11419-11420-villautou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11419-11420-villautou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11419-11420-villautou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11420-11250-villebazy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11420-11250-villebazy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11420-11250-villebazy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11420-11250-villebazy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11421-11200-villedaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11421-11200-villedaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11421-11200-villedaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11421-11200-villedaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11422-11800-villedubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11422-11800-villedubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11422-11800-villedubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11422-11800-villedubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11423-11570-villefloure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11423-11570-villefloure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11423-11570-villefloure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11423-11570-villefloure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11424-11230-villefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11424-11230-villefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11424-11230-villefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11424-11230-villefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11425-11600-villegailhenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11425-11600-villegailhenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11425-11600-villegailhenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11425-11600-villegailhenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11426-11600-villegly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11426-11600-villegly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11426-11600-villegly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11426-11600-villegly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11427-11300-villelongue_d_aude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11427-11300-villelongue_d_aude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11427-11300-villelongue_d_aude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11427-11300-villelongue_d_aude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11428-11310-villemagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11428-11310-villemagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11428-11310-villemagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11428-11310-villemagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11429-11620-villemoustaussou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11429-11620-villemoustaussou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11429-11620-villemoustaussou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11429-11620-villemoustaussou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11430-11400-villeneuve_la_comptal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11430-11400-villeneuve_la_comptal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11430-11400-villeneuve_la_comptal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11430-11400-villeneuve_la_comptal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11431-11360-villeneuve_les_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11431-11360-villeneuve_les_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11431-11360-villeneuve_les_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11431-11360-villeneuve_les_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11432-11290-villeneuve_les_montreal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11432-11290-villeneuve_les_montreal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11432-11290-villeneuve_les_montreal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11432-11290-villeneuve_les_montreal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11433-11160-villeneuve_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11433-11160-villeneuve_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11433-11160-villeneuve_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11433-11160-villeneuve_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11434-11150-villepinte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11434-11150-villepinte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11434-11150-villepinte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11434-11150-villepinte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11435-11330-villerouge_termenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11435-11330-villerouge_termenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11435-11330-villerouge_termenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11435-11330-villerouge_termenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11436-11360-villeseque_des_corbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11436-11360-villeseque_des_corbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11436-11360-villeseque_des_corbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11436-11360-villeseque_des_corbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11437-11170-villesequelande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11437-11170-villesequelande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11437-11170-villesequelande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11437-11170-villesequelande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11438-11150-villesiscle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11438-11150-villesiscle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11438-11150-villesiscle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11438-11150-villesiscle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11439-11170-villespy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11439-11170-villespy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11439-11170-villespy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11439-11170-villespy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11440-11220-villetritouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11440-11220-villetritouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11440-11220-villetritouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11440-11220-villetritouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11441-11110-vinassan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11441-11110-vinassan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11441-11110-vinassan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt11-aude/commune11441-11110-vinassan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-12.xml
+++ b/public/sitemaps/sitemap-12.xml
@@ -5,700 +5,1396 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12001-12630-agen_d_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12001-12630-agen_d_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12001-12630-agen_d_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12001-12630-agen_d_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12002-12520-aguessac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12002-12520-aguessac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12002-12520-aguessac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12002-12520-aguessac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12003-12220-les_albres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12003-12220-les_albres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12003-12220-les_albres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12003-12220-les_albres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12004-12300-almont_les_junies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12004-12300-almont_les_junies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12004-12300-almont_les_junies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12004-12300-almont_les_junies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12006-12430-alrance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12006-12430-alrance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12006-12430-alrance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12006-12430-alrance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12007-12260-ambeyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12007-12260-ambeyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12007-12260-ambeyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12007-12260-ambeyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12008-12390-anglars_saint_felix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12008-12390-anglars_saint_felix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12008-12390-anglars_saint_felix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12008-12390-anglars_saint_felix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12009-12360-arnac_sur_dourdou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12009-12360-arnac_sur_dourdou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12009-12360-arnac_sur_dourdou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12009-12360-arnac_sur_dourdou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12010-12290-arques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12010-12290-arques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12010-12290-arques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12010-12290-arques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12011-12120-arvieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12011-12120-arvieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12011-12120-arvieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12011-12120-arvieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12011-12410-arvieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12011-12410-arvieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12011-12410-arvieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12011-12410-arvieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12012-12700-asprieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12012-12700-asprieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12012-12700-asprieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12012-12700-asprieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12013-12110-aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12013-12110-aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12013-12110-aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12013-12110-aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12013-12300-aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12013-12300-aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12013-12300-aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12013-12300-aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12015-12120-auriac_lagast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12015-12120-auriac_lagast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12015-12120-auriac_lagast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12015-12120-auriac_lagast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12016-12390-auzits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12016-12390-auzits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12016-12390-auzits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12016-12390-auzits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12016-12110-auzits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12016-12110-auzits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12016-12110-auzits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12016-12110-auzits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12017-12430-ayssenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12017-12430-ayssenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12017-12430-ayssenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12017-12430-ayssenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12018-12260-balaguier_d_olt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12018-12260-balaguier_d_olt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12018-12260-balaguier_d_olt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12018-12260-balaguier_d_olt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12019-12380-balaguier_sur_rance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12019-12380-balaguier_sur_rance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12019-12380-balaguier_sur_rance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12019-12380-balaguier_sur_rance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12021-12200-le_bas_segala/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12021-12200-le_bas_segala/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12021-12200-le_bas_segala/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12021-12200-le_bas_segala/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12021-12240-le_bas_segala/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12021-12240-le_bas_segala/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12021-12240-le_bas_segala/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12021-12240-le_bas_segala/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12022-12490-la_bastide_pradines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12022-12490-la_bastide_pradines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12022-12490-la_bastide_pradines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12022-12490-la_bastide_pradines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12023-12550-la_bastide_solages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12023-12550-la_bastide_solages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12023-12550-la_bastide_solages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12023-12550-la_bastide_solages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12024-12390-belcastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12024-12390-belcastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12024-12390-belcastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12024-12390-belcastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12025-12370-belmont_sur_rance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12025-12370-belmont_sur_rance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12025-12370-belmont_sur_rance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12025-12370-belmont_sur_rance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12026-12310-bertholene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12026-12310-bertholene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12026-12310-bertholene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12026-12310-bertholene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12500-bessuejouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12500-bessuejouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12500-bessuejouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12500-bessuejouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12340-bessuejouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12340-bessuejouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12340-bessuejouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12340-bessuejouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12190-bessuejouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12190-bessuejouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12190-bessuejouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12027-12190-bessuejouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12028-12300-boisse_penchot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12028-12300-boisse_penchot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12028-12300-boisse_penchot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12028-12300-boisse_penchot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12029-12270-bor_et_bar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12029-12270-bor_et_bar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12029-12270-bor_et_bar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12029-12270-bor_et_bar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12030-12300-bouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12030-12300-bouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12030-12300-bouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12030-12300-bouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12031-12390-bournazel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12031-12390-bournazel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12031-12390-bournazel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12031-12390-bournazel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12032-12160-boussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12032-12160-boussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12032-12160-boussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12032-12160-boussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12340-bozouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12340-bozouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12340-bozouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12340-bozouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12500-bozouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12500-bozouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12500-bozouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12500-bozouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12190-bozouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12190-bozouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12190-bozouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12033-12190-bozouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12034-12350-brandonnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12034-12350-brandonnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12034-12350-brandonnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12034-12350-brandonnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12035-12550-brasc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12035-12550-brasc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12035-12550-brasc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12035-12550-brasc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12035-12170-brasc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12035-12170-brasc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12035-12170-brasc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12035-12170-brasc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12036-12600-brommat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12036-12600-brommat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12036-12600-brommat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12036-12600-brommat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12037-12480-broquies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12037-12480-broquies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12037-12480-broquies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12037-12480-broquies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12038-12480-brousse_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12038-12480-brousse_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12038-12480-brousse_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12038-12480-brousse_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12039-12360-brusque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12039-12360-brusque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12039-12360-brusque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12039-12360-brusque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12041-12800-cabanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12041-12800-cabanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12041-12800-cabanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12041-12800-cabanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12042-12400-calmels_et_le_viala/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12042-12400-calmels_et_le_viala/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12042-12400-calmels_et_le_viala/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12042-12400-calmels_et_le_viala/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12043-12450-calmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12043-12450-calmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12043-12450-calmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12043-12450-calmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12043-12120-calmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12043-12120-calmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12043-12120-calmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12043-12120-calmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12044-12360-camares/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12044-12360-camares/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12044-12360-camares/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12044-12360-camares/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12045-12160-camboulazet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12045-12160-camboulazet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12045-12160-camboulazet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12045-12160-camboulazet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12046-12800-camjac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12046-12800-camjac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12046-12800-camjac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12046-12800-camjac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12047-12560-campagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12047-12560-campagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12047-12560-campagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12047-12560-campagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12048-12140-campouriez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12048-12140-campouriez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12048-12140-campouriez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12048-12140-campouriez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12048-12460-campouriez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12048-12460-campouriez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12048-12460-campouriez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12048-12460-campouriez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12049-12580-campuac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12049-12580-campuac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12049-12580-campuac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12049-12580-campuac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12050-12290-canet_de_salars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12050-12290-canet_de_salars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12050-12290-canet_de_salars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12050-12290-canet_de_salars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12051-12420-cantoin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12051-12420-cantoin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12051-12420-cantoin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12051-12420-cantoin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12052-12700-capdenac_gare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12052-12700-capdenac_gare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12052-12700-capdenac_gare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12052-12700-capdenac_gare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12053-12260-la_capelle_balaguier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12053-12260-la_capelle_balaguier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12053-12260-la_capelle_balaguier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12053-12260-la_capelle_balaguier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12054-12240-la_capelle_bleys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12054-12240-la_capelle_bleys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12054-12240-la_capelle_bleys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12054-12240-la_capelle_bleys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12055-12130-la_capelle_bonance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12055-12130-la_capelle_bonance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12055-12130-la_capelle_bonance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12055-12130-la_capelle_bonance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12056-12160-baraqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12056-12160-baraqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12056-12160-baraqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12056-12160-baraqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12057-12120-cassagnes_begonhes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12057-12120-cassagnes_begonhes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12057-12120-cassagnes_begonhes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12057-12120-cassagnes_begonhes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12058-12210-cassuejouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12058-12210-cassuejouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12058-12210-cassuejouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12058-12210-cassuejouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12059-12240-castanet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12059-12240-castanet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12059-12240-castanet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12059-12240-castanet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12060-12800-castelmary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12060-12800-castelmary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12060-12800-castelmary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12060-12800-castelmary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12061-12500-castelnau_de_mandailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12061-12500-castelnau_de_mandailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12061-12500-castelnau_de_mandailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12061-12500-castelnau_de_mandailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12062-12620-castelnau_pegayrols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12062-12620-castelnau_pegayrols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12062-12620-castelnau_pegayrols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12062-12620-castelnau_pegayrols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12063-12230-la_cavalerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12063-12230-la_cavalerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12063-12230-la_cavalerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12063-12230-la_cavalerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12064-12500-le_cayrol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12064-12500-le_cayrol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12064-12500-le_cayrol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12064-12500-le_cayrol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12064-12210-le_cayrol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12064-12210-le_cayrol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12064-12210-le_cayrol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12064-12210-le_cayrol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12065-12120-centres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12065-12120-centres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12065-12120-centres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12065-12120-centres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12066-12330-clairvaux_d_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12066-12330-clairvaux_d_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12066-12330-clairvaux_d_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12066-12330-clairvaux_d_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12066-12390-clairvaux_d_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12066-12390-clairvaux_d_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12066-12390-clairvaux_d_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12066-12390-clairvaux_d_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12067-12540-le_clapier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12067-12540-le_clapier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12067-12540-le_clapier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12067-12540-le_clapier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12067-34260-le_clapier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12067-34260-le_clapier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12067-34260-le_clapier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12067-34260-le_clapier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12068-12240-colombies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12068-12240-colombies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12068-12240-colombies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12068-12240-colombies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12069-12370-combret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12069-12370-combret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12069-12370-combret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12069-12370-combret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12069-12380-combret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12069-12380-combret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12069-12380-combret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12069-12380-combret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12070-12520-compeyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12070-12520-compeyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12070-12520-compeyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12070-12520-compeyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12070-12640-compeyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12070-12640-compeyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12070-12640-compeyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12070-12640-compeyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12071-12350-compolibat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12071-12350-compolibat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12071-12350-compolibat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12071-12350-compolibat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12072-12100-compregnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12072-12100-compregnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12072-12100-compregnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12072-12100-compregnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12073-12120-comps_la_grand_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12073-12120-comps_la_grand_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12073-12120-comps_la_grand_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12073-12120-comps_la_grand_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12074-12470-condom_d_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12074-12470-condom_d_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12074-12470-condom_d_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12074-12470-condom_d_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12075-12170-connac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12075-12170-connac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12075-12170-connac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12075-12170-connac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12076-12320-conques_en_rouergue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12076-12320-conques_en_rouergue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12076-12320-conques_en_rouergue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12076-12320-conques_en_rouergue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12077-12540-cornus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12077-12540-cornus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12077-12540-cornus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12077-12540-cornus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12078-12400-les_costes_gozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12078-12400-les_costes_gozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12078-12400-les_costes_gozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12078-12400-les_costes_gozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12190-coubisou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12190-coubisou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12190-coubisou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12190-coubisou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12210-coubisou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12210-coubisou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12210-coubisou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12210-coubisou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12500-coubisou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12500-coubisou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12500-coubisou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12079-12500-coubisou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12080-12550-coupiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12080-12550-coupiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12080-12550-coupiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12080-12550-coupiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12082-12230-la_couvertoirade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12082-12230-la_couvertoirade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12082-12230-la_couvertoirade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12082-12230-la_couvertoirade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12083-12110-cransac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12083-12110-cransac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12083-12110-cransac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12083-12110-cransac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12084-12100-creissels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12084-12100-creissels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12084-12100-creissels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12084-12100-creissels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12085-12800-crespin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12085-12800-crespin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12085-12800-crespin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12085-12800-crespin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12086-12640-la_cresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12086-12640-la_cresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12086-12640-la_cresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12086-12640-la_cresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12088-12210-curieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12088-12210-curieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12088-12210-curieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12088-12210-curieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12089-12300-decazeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12089-12300-decazeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12089-12300-decazeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12089-12300-decazeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12090-12510-druelle_balsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12090-12510-druelle_balsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12090-12510-druelle_balsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12090-12510-druelle_balsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12090-12000-druelle_balsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12090-12000-druelle_balsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12090-12000-druelle_balsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12090-12000-druelle_balsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12091-12350-drulhe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12091-12350-drulhe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12091-12350-drulhe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12091-12350-drulhe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12092-12170-durenque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12092-12170-durenque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12092-12170-durenque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12092-12170-durenque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12093-12140-le_fel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12093-12140-le_fel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12093-12140-le_fel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12093-12140-le_fel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12094-12140-entraygues_sur_truyere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12094-12140-entraygues_sur_truyere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12094-12140-entraygues_sur_truyere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12094-12140-entraygues_sur_truyere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12095-12390-escandolieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12095-12390-escandolieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12095-12390-escandolieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12095-12390-escandolieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12096-12500-espalion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12096-12500-espalion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12096-12500-espalion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12096-12500-espalion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12097-12140-espeyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12097-12140-espeyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12097-12140-espeyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12097-12140-espeyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12097-12320-espeyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12097-12320-espeyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12097-12320-espeyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12097-12320-espeyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12098-12190-estaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12098-12190-estaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12098-12190-estaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12098-12190-estaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12099-12360-fayet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12099-12360-fayet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12099-12360-fayet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12099-12360-fayet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12100-12300-firmi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12100-12300-firmi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12100-12300-firmi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12100-12300-firmi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12100-12110-firmi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12100-12110-firmi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12100-12110-firmi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12100-12110-firmi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12101-12300-flagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12101-12300-flagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12101-12300-flagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12101-12300-flagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12102-12450-flavin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12102-12450-flavin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12102-12450-flavin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12102-12450-flavin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12103-12140-florentin_la_capelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12103-12140-florentin_la_capelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12103-12140-florentin_la_capelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12103-12140-florentin_la_capelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12104-12260-foissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12104-12260-foissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12104-12260-foissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12104-12260-foissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12105-12270-la_fouillade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12105-12270-la_fouillade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12105-12270-la_fouillade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12105-12270-la_fouillade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12106-12340-gabriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12106-12340-gabriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12106-12340-gabriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12106-12340-gabriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12107-12310-gaillac_d_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12107-12310-gaillac_d_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12107-12310-gaillac_d_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12107-12310-gaillac_d_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12108-12220-galgan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12108-12220-galgan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12108-12220-galgan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12108-12220-galgan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12109-12360-gissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12109-12360-gissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12109-12360-gissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12109-12360-gissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12110-12140-golinhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12110-12140-golinhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12110-12140-golinhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12110-12140-golinhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12110-12580-golinhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12110-12580-golinhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12110-12580-golinhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12110-12580-golinhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12111-12390-goutrens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12111-12390-goutrens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12111-12390-goutrens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12111-12390-goutrens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12113-12160-gramond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12113-12160-gramond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12113-12160-gramond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12113-12160-gramond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12115-12230-l_hospitalet_du_larzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12115-12230-l_hospitalet_du_larzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12115-12230-l_hospitalet_du_larzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12115-12230-l_hospitalet_du_larzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12116-12460-huparlac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12116-12460-huparlac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12116-12460-huparlac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12116-12460-huparlac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12118-12600-lacroix_barrez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12118-12600-lacroix_barrez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12118-12600-lacroix_barrez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12118-12600-lacroix_barrez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12119-12210-laguiole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12119-12210-laguiole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12119-12210-laguiole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12119-12210-laguiole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12120-12310-laissac_severac_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12120-12310-laissac_severac_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12120-12310-laissac_severac_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12120-12310-laissac_severac_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12121-12350-lanuejouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12121-12350-lanuejouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12121-12350-lanuejouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12121-12350-lanuejouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12122-12230-lapanouse_de_cernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12122-12230-lapanouse_de_cernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12122-12230-lapanouse_de_cernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12122-12230-lapanouse_de_cernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12124-12500-lassouts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12124-12500-lassouts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12124-12500-lassouts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12124-12500-lassouts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12125-12380-laval_roqueceziere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12125-12380-laval_roqueceziere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12125-12380-laval_roqueceziere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12125-12380-laval_roqueceziere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12125-12370-laval_roqueceziere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12125-12370-laval_roqueceziere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12125-12370-laval_roqueceziere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12125-12370-laval_roqueceziere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12127-12170-ledergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12127-12170-ledergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12127-12170-ledergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12127-12170-ledergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12128-12440-lescure_jaoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12128-12440-lescure_jaoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12128-12440-lescure_jaoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12128-12440-lescure_jaoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12129-12430-lestrade_et_thouels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12129-12430-lestrade_et_thouels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12129-12430-lestrade_et_thouels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12129-12430-lestrade_et_thouels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12129-12480-lestrade_et_thouels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12129-12480-lestrade_et_thouels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12129-12480-lestrade_et_thouels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12129-12480-lestrade_et_thouels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12130-12300-livinhac_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12130-12300-livinhac_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12130-12300-livinhac_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12130-12300-livinhac_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12131-12740-la_loubiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12131-12740-la_loubiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12131-12740-la_loubiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12131-12740-la_loubiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12133-12450-luc_la_primaube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12133-12450-luc_la_primaube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12133-12450-luc_la_primaube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12133-12450-luc_la_primaube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12134-12220-lugan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12134-12220-lugan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12134-12220-lugan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12134-12220-lugan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12135-12270-lunac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12135-12270-lunac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12135-12270-lunac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12135-12270-lunac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12136-12350-maleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12136-12350-maleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12136-12350-maleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12136-12350-maleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12136-12260-maleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12136-12260-maleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12136-12260-maleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12136-12260-maleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12137-12160-manhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12137-12160-manhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12137-12160-manhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12137-12160-manhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12138-12330-marcillac_vallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12138-12330-marcillac_vallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12138-12330-marcillac_vallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12138-12330-marcillac_vallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12139-12540-marnhagues_et_latour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12139-12540-marnhagues_et_latour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12139-12540-marnhagues_et_latour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12139-12540-marnhagues_et_latour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12140-12200-martiel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12140-12200-martiel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12140-12200-martiel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12140-12200-martiel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12141-12550-martrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12141-12550-martrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12141-12550-martrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12141-12550-martrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12142-12390-mayran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12142-12390-mayran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12142-12390-mayran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12142-12390-mayran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12143-12360-melagues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12143-12360-melagues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12143-12360-melagues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12143-12360-melagues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12144-12120-meljac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12144-12120-meljac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12144-12120-meljac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12144-12120-meljac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12145-12100-millau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12145-12100-millau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12145-12100-millau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12145-12100-millau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12145-12720-millau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12145-12720-millau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12145-12720-millau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12145-12720-millau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12146-12000-le_monastere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12146-12000-le_monastere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12146-12000-le_monastere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12146-12000-le_monastere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12147-12360-montagnol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12147-12360-montagnol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12147-12360-montagnol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12147-12360-montagnol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12148-12220-montbazens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12148-12220-montbazens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12148-12220-montbazens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12148-12220-montbazens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12149-12550-montclar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12149-12550-montclar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12149-12550-montclar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12149-12550-montclar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12149-12480-montclar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12149-12480-montclar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12149-12480-montclar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12149-12480-montclar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12150-12200-monteils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12150-12200-monteils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12150-12200-monteils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12150-12200-monteils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12151-12460-montezic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12151-12460-montezic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12151-12460-montezic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12151-12460-montezic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12152-12380-montfranc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12152-12380-montfranc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12152-12380-montfranc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12152-12380-montfranc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12153-12490-montjaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12153-12490-montjaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12153-12490-montjaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12153-12490-montjaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12154-12400-montlaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12154-12400-montlaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12154-12400-montlaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12154-12400-montlaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12155-12540-fondamente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12155-12540-fondamente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12155-12540-fondamente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12155-12540-fondamente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12156-12210-montpeyroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12156-12210-montpeyroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12156-12210-montpeyroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12156-12210-montpeyroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12157-12630-montrozier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12157-12630-montrozier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12157-12630-montrozier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12157-12630-montrozier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12157-12740-montrozier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12157-12740-montrozier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12157-12740-montrozier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12157-12740-montrozier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12158-12260-montsales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12158-12260-montsales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12158-12260-montsales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12158-12260-montsales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12159-12200-morlhon_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12159-12200-morlhon_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12159-12200-morlhon_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12159-12200-morlhon_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12160-12720-mostuejouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12160-12720-mostuejouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12160-12720-mostuejouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12160-12720-mostuejouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12330-mouret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12330-mouret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12330-mouret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12330-mouret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12580-mouret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12580-mouret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12580-mouret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12580-mouret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12320-mouret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12320-mouret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12320-mouret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12161-12320-mouret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12162-12160-moyrazes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12162-12160-moyrazes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12162-12160-moyrazes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12162-12160-moyrazes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12163-12370-murasson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12163-12370-murasson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12163-12370-murasson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12163-12370-murasson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12164-12600-mur_de_barrez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12164-12600-mur_de_barrez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12164-12600-mur_de_barrez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12164-12600-mur_de_barrez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12165-12330-muret_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12165-12330-muret_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12165-12330-muret_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12165-12330-muret_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12165-12580-muret_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12165-12580-muret_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12165-12580-muret_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12165-12580-muret_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12166-12600-murols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12166-12600-murols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12166-12600-murols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12166-12600-murols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-12270-najac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-12270-najac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-12270-najac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-12270-najac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-82160-najac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-82160-najac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-82160-najac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-82160-najac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-82330-najac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-82330-najac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-82330-najac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12167-82330-najac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12168-12230-nant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12168-12230-nant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12168-12230-nant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12168-12230-nant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12168-30750-nant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12168-30750-nant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12168-30750-nant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12168-30750-nant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12169-12800-naucelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12169-12800-naucelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12169-12800-naucelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12169-12800-naucelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12170-12700-naussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12170-12700-naussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12170-12700-naussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12170-12700-naussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12171-12330-nauviale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12171-12330-nauviale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12171-12330-nauviale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12171-12330-nauviale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12171-12320-nauviale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12171-12320-nauviale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12171-12320-nauviale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12171-12320-nauviale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12172-12190-le_nayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12172-12190-le_nayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12172-12190-le_nayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12172-12190-le_nayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12172-12140-le_nayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12172-12140-le_nayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12172-12140-le_nayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12172-12140-le_nayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12174-12510-olemps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12174-12510-olemps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12174-12510-olemps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12174-12510-olemps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12174-12000-olemps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12174-12000-olemps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12174-12000-olemps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12174-12000-olemps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12175-12260-ols_et_rinhodes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12175-12260-ols_et_rinhodes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12175-12260-ols_et_rinhodes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12175-12260-ols_et_rinhodes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12176-12850-onet_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12176-12850-onet_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12176-12850-onet_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12176-12850-onet_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12177-12310-palmas_d_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12177-12310-palmas_d_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12177-12310-palmas_d_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12177-12310-palmas_d_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12177-12340-palmas_d_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12177-12340-palmas_d_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12177-12340-palmas_d_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12177-12340-palmas_d_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12178-12520-paulhe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12178-12520-paulhe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12178-12520-paulhe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12178-12520-paulhe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12179-12360-peux_et_couffouleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12179-12360-peux_et_couffouleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12179-12360-peux_et_couffouleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12179-12360-peux_et_couffouleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12180-12720-peyreleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12180-12720-peyreleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12180-12720-peyreleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12180-12720-peyreleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12181-12220-peyrusse_le_roc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12181-12220-peyrusse_le_roc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12181-12220-peyrusse_le_roc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12181-12220-peyrusse_le_roc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12182-12130-pierrefiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12182-12130-pierrefiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12182-12130-pierrefiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12182-12130-pierrefiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12183-12550-plaisance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12183-12550-plaisance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12183-12550-plaisance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12183-12550-plaisance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12184-12130-pomayrols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12184-12130-pomayrols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12184-12130-pomayrols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12184-12130-pomayrols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12185-12290-pont_de_salars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12185-12290-pont_de_salars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12185-12290-pont_de_salars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12185-12290-pont_de_salars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12186-12380-pousthomy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12186-12380-pousthomy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12186-12380-pousthomy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12186-12380-pousthomy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12187-12470-prades_d_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12187-12470-prades_d_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12187-12470-prades_d_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12187-12470-prades_d_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12188-12290-prades_salars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12188-12290-prades_salars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12188-12290-prades_salars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12188-12290-prades_salars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12189-12240-pradinas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12189-12240-pradinas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12189-12240-pradinas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12189-12240-pradinas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12190-12350-previnquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12190-12350-previnquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12190-12350-previnquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12190-12350-previnquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12191-12350-privezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12191-12350-privezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12191-12350-privezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12191-12350-privezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12192-12370-mounes_prohencoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12192-12370-mounes_prohencoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12192-12370-mounes_prohencoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12192-12370-mounes_prohencoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12193-12320-pruines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12193-12320-pruines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12193-12320-pruines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12193-12320-pruines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12194-12800-quins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12194-12800-quins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12194-12800-quins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12194-12800-quins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12195-12400-rebourguil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12195-12400-rebourguil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12195-12400-rebourguil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12195-12400-rebourguil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12197-12170-requista/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12197-12170-requista/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12197-12170-requista/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12197-12170-requista/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12197-12550-requista/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12197-12550-requista/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12197-12550-requista/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12197-12550-requista/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12198-12240-rieupeyroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12198-12240-rieupeyroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12198-12240-rieupeyroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12198-12240-rieupeyroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12199-12390-rignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12199-12390-rignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12199-12390-rignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12199-12390-rignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12200-12640-riviere_sur_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12200-12640-riviere_sur_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12200-12640-riviere_sur_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12200-12640-riviere_sur_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12201-12340-rodelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12201-12340-rodelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12201-12340-rodelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12201-12340-rodelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12201-12190-rodelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12201-12190-rodelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12201-12190-rodelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12201-12190-rodelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12202-12000-rodez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12202-12000-rodez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12202-12000-rodez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12202-12000-rodez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12203-12250-roquefort_sur_soulzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12203-12250-roquefort_sur_soulzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12203-12250-roquefort_sur_soulzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12203-12250-roquefort_sur_soulzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12204-12100-la_roque_sainte_marguerite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12204-12100-la_roque_sainte_marguerite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12204-12100-la_roque_sainte_marguerite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12204-12100-la_roque_sainte_marguerite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12204-12720-la_roque_sainte_marguerite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12204-12720-la_roque_sainte_marguerite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12204-12720-la_roque_sainte_marguerite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12204-12720-la_roque_sainte_marguerite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12205-12200-la_rouquette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12205-12200-la_rouquette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12205-12200-la_rouquette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12205-12200-la_rouquette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12206-12220-roussennac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12206-12220-roussennac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12206-12220-roussennac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12206-12220-roussennac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12206-12390-roussennac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12206-12390-roussennac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12206-12390-roussennac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12206-12390-roussennac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12207-12120-rullac_saint_cirq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12207-12120-rullac_saint_cirq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12207-12120-rullac_saint_cirq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12207-12120-rullac_saint_cirq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12208-12400-saint_affrique/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12208-12400-saint_affrique/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12208-12400-saint_affrique/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12208-12400-saint_affrique/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12209-12460-saint_amans_des_cots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12209-12460-saint_amans_des_cots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12209-12460-saint_amans_des_cots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12209-12460-saint_amans_des_cots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12210-12270-saint_andre_de_najac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12210-12270-saint_andre_de_najac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12210-12270-saint_andre_de_najac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12210-12270-saint_andre_de_najac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12211-12720-saint_andre_de_vezines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12211-12720-saint_andre_de_vezines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12211-12720-saint_andre_de_vezines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12211-12720-saint_andre_de_vezines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12212-12540-saint_beaulize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12212-12540-saint_beaulize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12212-12540-saint_beaulize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12212-12540-saint_beaulize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12213-12620-saint_beauzely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12213-12620-saint_beauzely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12213-12620-saint_beauzely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12213-12620-saint_beauzely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12214-12470-saint_chely_d_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12214-12470-saint_chely_d_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12214-12470-saint_chely_d_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12214-12470-saint_chely_d_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12214-12500-saint_chely_d_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12214-12500-saint_chely_d_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12214-12500-saint_chely_d_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12214-12500-saint_chely_d_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12215-12330-saint_christophe_vallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12215-12330-saint_christophe_vallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12215-12330-saint_christophe_vallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12215-12330-saint_christophe_vallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12216-12500-saint_come_d_olt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12216-12500-saint_come_d_olt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12216-12500-saint_come_d_olt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12216-12500-saint_come_d_olt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12217-12260-sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12217-12260-sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12217-12260-sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12217-12260-sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12219-12130-sainte_eulalie_d_olt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12219-12130-sainte_eulalie_d_olt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12219-12130-sainte_eulalie_d_olt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12219-12130-sainte_eulalie_d_olt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12220-12230-sainte_eulalie_de_cernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12220-12230-sainte_eulalie_de_cernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12220-12230-sainte_eulalie_de_cernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12220-12230-sainte_eulalie_de_cernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12221-12320-saint_felix_de_lunel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12221-12320-saint_felix_de_lunel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12221-12320-saint_felix_de_lunel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12221-12320-saint_felix_de_lunel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12222-12400-saint_felix_de_sorgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12222-12400-saint_felix_de_sorgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12222-12400-saint_felix_de_sorgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12222-12400-saint_felix_de_sorgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12223-12420-argences_en_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12223-12420-argences_en_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12223-12420-argences_en_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12223-12420-argences_en_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12223-12210-argences_en_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12223-12210-argences_en_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12223-12210-argences_en_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12223-12210-argences_en_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12224-12130-saint_geniez_d_olt_et_d_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12224-12130-saint_geniez_d_olt_et_d_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12224-12130-saint_geniez_d_olt_et_d_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12224-12130-saint_geniez_d_olt_et_d_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12224-12470-saint_geniez_d_olt_et_d_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12224-12470-saint_geniez_d_olt_et_d_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12224-12470-saint_geniez_d_olt_et_d_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12224-12470-saint_geniez_d_olt_et_d_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12225-12100-saint_georges_de_luzencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12225-12100-saint_georges_de_luzencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12225-12100-saint_georges_de_luzencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12225-12100-saint_georges_de_luzencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12226-12140-saint_hippolyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12226-12140-saint_hippolyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12226-12140-saint_hippolyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12226-12140-saint_hippolyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12226-12600-saint_hippolyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12226-12600-saint_hippolyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12226-12600-saint_hippolyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12226-12600-saint_hippolyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12227-12260-saint_igest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12227-12260-saint_igest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12227-12260-saint_igest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12227-12260-saint_igest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12228-12480-saint_izaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12228-12480-saint_izaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12228-12480-saint_izaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12228-12480-saint_izaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12229-12250-saint_jean_d_alcapies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12229-12250-saint_jean_d_alcapies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12229-12250-saint_jean_d_alcapies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12229-12250-saint_jean_d_alcapies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12230-12170-saint_jean_delnous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12230-12170-saint_jean_delnous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12230-12170-saint_jean_delnous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12230-12170-saint_jean_delnous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12231-12230-saint_jean_du_bruel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12231-12230-saint_jean_du_bruel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12231-12230-saint_jean_du_bruel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12231-12230-saint_jean_du_bruel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12231-30750-saint_jean_du_bruel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12231-30750-saint_jean_du_bruel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12231-30750-saint_jean_du_bruel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12231-30750-saint_jean_du_bruel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12232-12250-saint_jean_et_saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12232-12250-saint_jean_et_saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12232-12250-saint_jean_et_saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12232-12250-saint_jean_et_saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12233-12550-saint_juery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12233-12550-saint_juery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12233-12550-saint_juery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12233-12550-saint_juery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12233-12380-saint_juery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12233-12380-saint_juery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12233-12380-saint_juery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12233-12380-saint_juery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12234-12120-sainte_juliette_sur_viaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12234-12120-sainte_juliette_sur_viaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12234-12120-sainte_juliette_sur_viaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12234-12120-sainte_juliette_sur_viaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12235-12800-saint_just_sur_viaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12235-12800-saint_just_sur_viaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12235-12800-saint_just_sur_viaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12235-12800-saint_just_sur_viaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12235-12170-saint_just_sur_viaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12235-12170-saint_just_sur_viaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12235-12170-saint_just_sur_viaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12235-12170-saint_just_sur_viaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12236-12620-saint_laurent_de_levezou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12236-12620-saint_laurent_de_levezou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12236-12620-saint_laurent_de_levezou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12236-12620-saint_laurent_de_levezou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12237-12560-saint_laurent_d_olt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12237-12560-saint_laurent_d_olt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12237-12560-saint_laurent_d_olt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12237-12560-saint_laurent_d_olt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12237-48500-saint_laurent_d_olt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12237-48500-saint_laurent_d_olt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12237-48500-saint_laurent_d_olt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12237-48500-saint_laurent_d_olt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12238-12780-saint_leons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12238-12780-saint_leons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12238-12780-saint_leons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12238-12780-saint_leons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12239-12130-saint_martin_de_lenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12239-12130-saint_martin_de_lenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12239-12130-saint_martin_de_lenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12239-12130-saint_martin_de_lenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12240-12300-saint_parthem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12240-12300-saint_parthem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12240-12300-saint_parthem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12240-12300-saint_parthem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12241-12850-sainte_radegonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12241-12850-sainte_radegonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12241-12850-sainte_radegonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12241-12850-sainte_radegonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12241-12450-sainte_radegonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12241-12450-sainte_radegonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12241-12450-sainte_radegonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12241-12450-sainte_radegonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12242-12200-saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12242-12200-saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12242-12200-saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12242-12200-saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12243-12490-saint_rome_de_cernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12243-12490-saint_rome_de_cernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12243-12490-saint_rome_de_cernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12243-12490-saint_rome_de_cernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12244-12490-saint_rome_de_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12244-12490-saint_rome_de_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12244-12490-saint_rome_de_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12244-12490-saint_rome_de_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12246-12300-saint_santin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12246-12300-saint_santin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12246-12300-saint_santin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12246-12300-saint_santin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12247-12560-saint_saturnin_de_lenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12247-12560-saint_saturnin_de_lenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12247-12560-saint_saturnin_de_lenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12247-12560-saint_saturnin_de_lenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12248-12380-saint_sernin_sur_rance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12248-12380-saint_sernin_sur_rance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12248-12380-saint_sernin_sur_rance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12248-12380-saint_sernin_sur_rance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12249-12370-saint_sever_du_moustier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12249-12370-saint_sever_du_moustier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12249-12370-saint_sever_du_moustier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12249-12370-saint_sever_du_moustier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12250-12460-saint_symphorien_de_thenieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12250-12460-saint_symphorien_de_thenieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12250-12460-saint_symphorien_de_thenieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12250-12460-saint_symphorien_de_thenieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12251-12400-saint_victor_et_melvieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12251-12400-saint_victor_et_melvieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12251-12400-saint_victor_et_melvieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12251-12400-saint_victor_et_melvieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12252-12260-salles_courbaties/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12252-12260-salles_courbaties/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12252-12260-salles_courbaties/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12252-12260-salles_courbaties/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12253-12410-salles_curan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12253-12410-salles_curan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12253-12410-salles_curan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12253-12410-salles_curan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12254-12330-salles_la_source/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12254-12330-salles_la_source/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12254-12330-salles_la_source/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12254-12330-salles_la_source/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12255-12120-salmiech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12255-12120-salmiech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12255-12120-salmiech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12255-12120-salmiech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12256-12260-salvagnac_cajarc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12256-12260-salvagnac_cajarc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12256-12260-salvagnac_cajarc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12256-12260-salvagnac_cajarc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12257-12700-causse_et_diege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12257-12700-causse_et_diege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12257-12700-causse_et_diege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12257-12700-causse_et_diege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12258-12440-la_salvetat_peyrales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12258-12440-la_salvetat_peyrales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12258-12440-la_salvetat_peyrales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12258-12440-la_salvetat_peyrales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12259-12200-sanvensa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12259-12200-sanvensa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12259-12200-sanvensa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12259-12200-sanvensa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12260-12230-sauclieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12260-12230-sauclieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12260-12230-sauclieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12260-12230-sauclieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12261-12260-saujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12261-12260-saujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12261-12260-saujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12261-12260-saujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12262-12800-sauveterre_de_rouergue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12262-12800-sauveterre_de_rouergue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12262-12800-sauveterre_de_rouergue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12262-12800-sauveterre_de_rouergue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12263-12200-savignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12263-12200-savignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12263-12200-savignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12263-12200-savignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12264-12740-sebazac_concoures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12264-12740-sebazac_concoures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12264-12740-sebazac_concoures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12264-12740-sebazac_concoures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12265-12190-sebrazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12265-12190-sebrazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12265-12190-sebrazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12265-12190-sebrazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12266-12290-segur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12266-12290-segur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12266-12290-segur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12266-12290-segur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12267-12170-la_selve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12267-12170-la_selve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12267-12170-la_selve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12267-12170-la_selve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12268-12320-senergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12268-12320-senergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12268-12320-senergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12268-12320-senergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12269-12380-la_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12269-12380-la_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12269-12380-la_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12269-12380-la_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12150-severac_d_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12150-severac_d_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12150-severac_d_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12150-severac_d_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12640-severac_d_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12640-severac_d_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12640-severac_d_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12640-severac_d_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12720-severac_d_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12720-severac_d_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12720-severac_d_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12270-12720-severac_d_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12272-12700-sonnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12272-12700-sonnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12272-12700-sonnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12272-12700-sonnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12272-12220-sonnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12272-12220-sonnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12272-12220-sonnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12272-12220-sonnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12273-12210-soulages_bonneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12273-12210-soulages_bonneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12273-12210-soulages_bonneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12273-12210-soulages_bonneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12274-12360-sylvanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12274-12360-sylvanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12274-12360-sylvanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12274-12360-sylvanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12275-12360-tauriac_de_camares/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12275-12360-tauriac_de_camares/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12275-12360-tauriac_de_camares/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12275-12360-tauriac_de_camares/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12276-12800-tauriac_de_naucelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12276-12800-tauriac_de_naucelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12276-12800-tauriac_de_naucelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12276-12800-tauriac_de_naucelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12277-12600-taussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12277-12600-taussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12277-12600-taussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12277-12600-taussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12278-12440-tayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12278-12440-tayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12278-12440-tayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12278-12440-tayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12280-12600-therondels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12280-12600-therondels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12280-12600-therondels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12280-12600-therondels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12280-15230-therondels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12280-15230-therondels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12280-15230-therondels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12280-15230-therondels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12281-12200-toulonjac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12281-12200-toulonjac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12281-12200-toulonjac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12281-12200-toulonjac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12282-12250-tournemire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12282-12250-tournemire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12282-12250-tournemire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12282-12250-tournemire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12283-12290-tremouilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12283-12290-tremouilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12283-12290-tremouilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12283-12290-tremouilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12284-12430-le_truel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12284-12430-le_truel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12284-12430-le_truel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12284-12430-le_truel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12286-12400-vabres_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12286-12400-vabres_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12286-12400-vabres_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12286-12400-vabres_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12287-12200-vailhourles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12287-12200-vailhourles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12287-12200-vailhourles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12287-12200-vailhourles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12288-12330-valady/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12288-12330-valady/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12288-12330-valady/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12288-12330-valady/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12289-12220-valzergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12289-12220-valzergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12289-12220-valzergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12289-12220-valzergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12290-12220-vaureilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12290-12220-vaureilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12290-12220-vaureilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12290-12220-vaureilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12520-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12520-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12520-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12520-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12780-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12780-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12780-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12780-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12640-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12640-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12640-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12640-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12150-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12150-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12150-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12291-12150-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12292-12400-versols_et_lapeyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12292-12400-versols_et_lapeyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12292-12400-versols_et_lapeyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12292-12400-versols_et_lapeyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12293-12720-veyreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12293-12720-veyreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12293-12720-veyreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12293-12720-veyreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12294-12780-vezins_de_levezou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12294-12780-vezins_de_levezou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12294-12780-vezins_de_levezou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12294-12780-vezins_de_levezou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12295-12250-viala_du_pas_de_jaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12295-12250-viala_du_pas_de_jaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12295-12250-viala_du_pas_de_jaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12295-12250-viala_du_pas_de_jaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12296-12490-viala_du_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12296-12490-viala_du_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12296-12490-viala_du_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12296-12490-viala_du_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12297-12290-le_vibal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12297-12290-le_vibal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12297-12290-le_vibal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12297-12290-le_vibal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12580-villecomtal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12580-villecomtal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12580-villecomtal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12580-villecomtal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12330-villecomtal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12330-villecomtal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12330-villecomtal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12330-villecomtal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12340-villecomtal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12340-villecomtal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12340-villecomtal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12298-12340-villecomtal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12299-12430-villefranche_de_panat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12299-12430-villefranche_de_panat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12299-12430-villefranche_de_panat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12299-12430-villefranche_de_panat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12299-12480-villefranche_de_panat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12299-12480-villefranche_de_panat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12299-12480-villefranche_de_panat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12299-12480-villefranche_de_panat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12300-12200-villefranche_de_rouergue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12300-12200-villefranche_de_rouergue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12300-12200-villefranche_de_rouergue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12300-12200-villefranche_de_rouergue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12301-12260-villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12301-12260-villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12301-12260-villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12301-12260-villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12303-12310-vimenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12303-12310-vimenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12303-12310-vimenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12303-12310-vimenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12305-12110-viviez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12305-12110-viviez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12305-12110-viviez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12305-12110-viviez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12307-12410-curan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12307-12410-curan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12307-12410-curan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12307-12410-curan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12307-12620-curan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12307-12620-curan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12307-12620-curan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt12-aveyron/commune12307-12620-curan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-13.xml
+++ b/public/sitemaps/sitemap-13.xml
@@ -5,306 +5,608 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13090-aix_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13090-aix_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13090-aix_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13090-aix_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13100-aix_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13100-aix_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13100-aix_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13100-aix_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13290-aix_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13290-aix_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13290-aix_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13290-aix_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13080-aix_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13080-aix_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13080-aix_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13080-aix_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13540-aix_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13540-aix_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13540-aix_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13540-aix_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13122-aix_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13122-aix_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13122-aix_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13001-13122-aix_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13002-13190-allauch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13002-13190-allauch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13002-13190-allauch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13002-13190-allauch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13003-13980-alleins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13003-13980-alleins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13003-13980-alleins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13003-13980-alleins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13104-arles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13104-arles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13104-arles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13104-arles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13129-arles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13129-arles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13129-arles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13129-arles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13200-arles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13200-arles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13200-arles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13200-arles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13280-arles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13280-arles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13280-arles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13280-arles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13123-arles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13123-arles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13123-arles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13123-arles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13270-arles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13270-arles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13270-arles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13004-13270-arles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13005-13400-aubagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13005-13400-aubagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13005-13400-aubagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13005-13400-aubagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13005-13470-aubagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13005-13470-aubagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13005-13470-aubagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13005-13470-aubagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13006-13930-aureille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13006-13930-aureille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13006-13930-aureille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13006-13930-aureille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13007-13390-auriol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13007-13390-auriol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13007-13390-auriol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13007-13390-auriol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13007-13112-auriol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13007-13112-auriol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13007-13112-auriol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13007-13112-auriol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13008-13121-aurons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13008-13121-aurons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13008-13121-aurons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13008-13121-aurons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13009-13330-la_barben/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13009-13330-la_barben/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13009-13330-la_barben/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13009-13330-la_barben/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13010-13570-barbentane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13010-13570-barbentane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13010-13570-barbentane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13010-13570-barbentane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13011-13520-les_baux_de_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13011-13520-les_baux_de_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13011-13520-les_baux_de_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13011-13520-les_baux_de_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13012-13100-beaurecueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13012-13100-beaurecueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13012-13100-beaurecueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13012-13100-beaurecueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13013-13720-belcodene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13013-13720-belcodene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13013-13720-belcodene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13013-13720-belcodene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13014-13130-berre_l_etang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13014-13130-berre_l_etang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13014-13130-berre_l_etang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13014-13130-berre_l_etang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13015-13320-bouc_bel_air/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13015-13320-bouc_bel_air/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13015-13320-bouc_bel_air/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13015-13320-bouc_bel_air/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13016-13720-la_bouilladisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13016-13720-la_bouilladisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13016-13720-la_bouilladisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13016-13720-la_bouilladisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13017-13150-boulbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13017-13150-boulbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13017-13150-boulbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13017-13150-boulbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13018-13440-cabannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13018-13440-cabannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13018-13440-cabannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13018-13440-cabannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13019-13480-cabries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13019-13480-cabries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13019-13480-cabries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13019-13480-cabries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13020-13950-cadolive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13020-13950-cadolive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13020-13950-cadolive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13020-13950-cadolive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13021-13620-carry_le_rouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13021-13620-carry_le_rouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13021-13620-carry_le_rouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13021-13620-carry_le_rouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13022-13260-cassis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13022-13260-cassis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13022-13260-cassis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13022-13260-cassis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13023-13600-ceyreste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13023-13600-ceyreste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13023-13600-ceyreste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13023-13600-ceyreste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13024-13350-charleval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13024-13350-charleval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13024-13350-charleval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13024-13350-charleval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13025-13790-chateauneuf_le_rouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13025-13790-chateauneuf_le_rouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13025-13790-chateauneuf_le_rouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13025-13790-chateauneuf_le_rouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13026-13220-chateauneuf_les_martigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13026-13220-chateauneuf_les_martigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13026-13220-chateauneuf_les_martigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13026-13220-chateauneuf_les_martigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13027-13160-chateaurenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13027-13160-chateaurenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13027-13160-chateaurenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13027-13160-chateaurenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13028-13600-la_ciotat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13028-13600-la_ciotat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13028-13600-la_ciotat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13028-13600-la_ciotat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13029-13250-cornillon_confoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13029-13250-cornillon_confoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13029-13250-cornillon_confoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13029-13250-cornillon_confoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13030-13780-cuges_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13030-13780-cuges_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13030-13780-cuges_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13030-13780-cuges_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13031-13112-la_destrousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13031-13112-la_destrousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13031-13112-la_destrousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13031-13112-la_destrousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13032-13510-eguilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13032-13510-eguilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13032-13510-eguilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13032-13510-eguilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13033-13820-ensues_la_redonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13033-13820-ensues_la_redonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13033-13820-ensues_la_redonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13033-13820-ensues_la_redonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13034-13810-eygalieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13034-13810-eygalieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13034-13810-eygalieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13034-13810-eygalieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13035-13430-eyguieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13035-13430-eyguieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13035-13430-eyguieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13035-13430-eyguieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13036-13630-eyragues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13036-13630-eyragues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13036-13630-eyragues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13036-13630-eyragues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13037-13580-la_fare_les_oliviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13037-13580-la_fare_les_oliviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13037-13580-la_fare_les_oliviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13037-13580-la_fare_les_oliviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13038-13990-fontvieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13038-13990-fontvieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13038-13990-fontvieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13038-13990-fontvieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13039-13270-fos_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13039-13270-fos_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13039-13270-fos_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13039-13270-fos_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13040-13710-fuveau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13040-13710-fuveau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13040-13710-fuveau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13040-13710-fuveau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13041-13120-gardanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13041-13120-gardanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13041-13120-gardanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13041-13120-gardanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13042-13420-gemenos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13042-13420-gemenos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13042-13420-gemenos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13042-13420-gemenos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13043-13180-gignac_la_nerthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13043-13180-gignac_la_nerthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13043-13180-gignac_la_nerthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13043-13180-gignac_la_nerthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13044-13450-grans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13044-13450-grans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13044-13450-grans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13044-13450-grans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13045-13690-graveson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13045-13690-graveson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13045-13690-graveson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13045-13690-graveson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13046-13850-greasque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13046-13850-greasque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13046-13850-greasque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13046-13850-greasque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13800-istres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13800-istres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13800-istres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13800-istres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13118-istres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13118-istres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13118-istres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13118-istres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13140-istres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13140-istres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13140-istres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13140-istres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13128-istres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13128-istres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13128-istres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13047-13128-istres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13048-13490-jouques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13048-13490-jouques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13048-13490-jouques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13048-13490-jouques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13049-13113-lamanon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13049-13113-lamanon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13049-13113-lamanon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13049-13113-lamanon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13050-13410-lambesc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13050-13410-lambesc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13050-13410-lambesc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13050-13410-lambesc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13051-13680-lancon_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13051-13680-lancon_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13051-13680-lancon_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13051-13680-lancon_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13052-13910-maillane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13052-13910-maillane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13052-13910-maillane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13052-13910-maillane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13053-13370-mallemort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13053-13370-mallemort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13053-13370-mallemort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13053-13370-mallemort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13054-13700-marignane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13054-13700-marignane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13054-13700-marignane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13054-13700-marignane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13001-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13001-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13001-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13001-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13002-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13002-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13002-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13002-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13003-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13003-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13003-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13003-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13004-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13004-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13004-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13004-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13005-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13005-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13005-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13005-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13006-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13006-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13006-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13006-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13007-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13007-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13007-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13007-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13008-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13008-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13008-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13008-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13009-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13009-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13009-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13009-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13010-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13010-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13010-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13010-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13011-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13011-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13011-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13011-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13012-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13012-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13012-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13012-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13013-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13013-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13013-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13013-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13014-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13014-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13014-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13014-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13015-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13015-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13015-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13015-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13016-marseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13016-marseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13016-marseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13055-13016-marseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13056-13500-martigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13056-13500-martigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13056-13500-martigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13056-13500-martigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13056-13117-martigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13056-13117-martigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13056-13117-martigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13056-13117-martigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13057-13103-mas_blanc_des_alpilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13057-13103-mas_blanc_des_alpilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13057-13103-mas_blanc_des_alpilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13057-13103-mas_blanc_des_alpilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13058-13520-maussane_les_alpilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13058-13520-maussane_les_alpilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13058-13520-maussane_les_alpilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13058-13520-maussane_les_alpilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13059-13650-meyrargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13059-13650-meyrargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13059-13650-meyrargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13059-13650-meyrargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13060-13590-meyreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13060-13590-meyreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13060-13590-meyreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13060-13590-meyreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13061-13150-saint_pierre_de_mezoargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13061-13150-saint_pierre_de_mezoargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13061-13150-saint_pierre_de_mezoargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13061-13150-saint_pierre_de_mezoargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13062-13105-mimet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13062-13105-mimet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13062-13105-mimet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13062-13105-mimet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13063-13140-miramas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13063-13140-miramas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13063-13140-miramas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13063-13140-miramas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13064-13940-molleges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13064-13940-molleges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13064-13940-molleges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13064-13940-molleges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13065-13890-mouries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13065-13890-mouries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13065-13890-mouries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13065-13890-mouries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13066-13550-noves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13066-13550-noves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13066-13550-noves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13066-13550-noves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13067-13660-orgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13067-13660-orgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13067-13660-orgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13067-13660-orgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13068-13520-paradou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13068-13520-paradou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13068-13520-paradou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13068-13520-paradou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13069-13330-pelissanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13069-13330-pelissanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13069-13330-pelissanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13069-13330-pelissanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13070-13821-la_penne_sur_huveaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13070-13821-la_penne_sur_huveaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13070-13821-la_penne_sur_huveaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13070-13821-la_penne_sur_huveaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13071-13170-les_pennes_mirabeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13071-13170-les_pennes_mirabeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13071-13170-les_pennes_mirabeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13071-13170-les_pennes_mirabeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13072-13790-peynier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13072-13790-peynier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13072-13790-peynier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13072-13790-peynier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13073-13124-peypin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13073-13124-peypin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13073-13124-peypin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13073-13124-peypin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13074-13860-peyrolles_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13074-13860-peyrolles_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13074-13860-peyrolles_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13074-13860-peyrolles_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13075-13380-plan_de_cuques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13075-13380-plan_de_cuques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13075-13380-plan_de_cuques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13075-13380-plan_de_cuques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13076-13750-plan_d_orgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13076-13750-plan_d_orgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13076-13750-plan_d_orgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13076-13750-plan_d_orgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13077-13110-port_de_bouc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13077-13110-port_de_bouc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13077-13110-port_de_bouc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13077-13110-port_de_bouc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13078-13230-port_saint_louis_du_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13078-13230-port_saint_louis_du_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13078-13230-port_saint_louis_du_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13078-13230-port_saint_louis_du_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13079-13114-puyloubier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13079-13114-puyloubier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13079-13114-puyloubier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13079-13114-puyloubier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13080-13610-le_puy_sainte_reparade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13080-13610-le_puy_sainte_reparade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13080-13610-le_puy_sainte_reparade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13080-13610-le_puy_sainte_reparade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13081-13340-rognac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13081-13340-rognac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13081-13340-rognac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13081-13340-rognac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13082-13840-rognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13082-13840-rognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13082-13840-rognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13082-13840-rognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13083-13870-rognonas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13083-13870-rognonas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13083-13870-rognonas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13083-13870-rognonas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13084-13640-la_roque_d_antheron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13084-13640-la_roque_d_antheron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13084-13640-la_roque_d_antheron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13084-13640-la_roque_d_antheron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13085-13830-roquefort_la_bedoule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13085-13830-roquefort_la_bedoule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13085-13830-roquefort_la_bedoule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13085-13830-roquefort_la_bedoule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13086-13360-roquevaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13086-13360-roquevaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13086-13360-roquevaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13086-13360-roquevaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13087-13790-rousset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13087-13790-rousset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13087-13790-rousset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13087-13790-rousset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13088-13740-le_rove/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13088-13740-le_rove/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13088-13740-le_rove/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13088-13740-le_rove/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13089-13670-saint_andiol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13089-13670-saint_andiol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13089-13670-saint_andiol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13089-13670-saint_andiol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13090-13100-saint_antonin_sur_bayon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13090-13100-saint_antonin_sur_bayon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13090-13100-saint_antonin_sur_bayon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13090-13100-saint_antonin_sur_bayon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13091-13760-saint_cannat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13091-13760-saint_cannat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13091-13760-saint_cannat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13091-13760-saint_cannat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13092-13250-saint_chamas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13092-13250-saint_chamas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13092-13250-saint_chamas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13092-13250-saint_chamas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13093-13610-saint_esteve_janson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13093-13610-saint_esteve_janson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13093-13610-saint_esteve_janson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13093-13610-saint_esteve_janson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13094-13103-saint_etienne_du_gres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13094-13103-saint_etienne_du_gres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13094-13103-saint_etienne_du_gres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13094-13103-saint_etienne_du_gres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13095-13100-saint_marc_jaumegarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13095-13100-saint_marc_jaumegarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13095-13100-saint_marc_jaumegarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13095-13100-saint_marc_jaumegarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13096-13460-saintes_maries_de_la_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13096-13460-saintes_maries_de_la_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13096-13460-saintes_maries_de_la_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13096-13460-saintes_maries_de_la_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13097-13310-saint_martin_de_crau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13097-13310-saint_martin_de_crau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13097-13310-saint_martin_de_crau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13097-13310-saint_martin_de_crau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13098-13920-saint_mitre_les_remparts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13098-13920-saint_mitre_les_remparts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13098-13920-saint_mitre_les_remparts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13098-13920-saint_mitre_les_remparts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13099-13115-saint_paul_les_durance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13099-13115-saint_paul_les_durance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13099-13115-saint_paul_les_durance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13099-13115-saint_paul_les_durance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13100-13210-saint_remy_de_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13100-13210-saint_remy_de_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13100-13210-saint_remy_de_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13100-13210-saint_remy_de_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13101-13119-saint_savournin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13101-13119-saint_savournin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13101-13119-saint_savournin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13101-13119-saint_savournin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13102-13730-saint_victoret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13102-13730-saint_victoret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13102-13730-saint_victoret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13102-13730-saint_victoret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13103-13300-salon_de_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13103-13300-salon_de_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13103-13300-salon_de_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13103-13300-salon_de_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13104-13960-sausset_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13104-13960-sausset_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13104-13960-sausset_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13104-13960-sausset_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13105-13560-senas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13105-13560-senas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13105-13560-senas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13105-13560-senas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13106-13240-septemes_les_vallons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13106-13240-septemes_les_vallons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13106-13240-septemes_les_vallons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13106-13240-septemes_les_vallons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13107-13109-simiane_collongue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13107-13109-simiane_collongue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13107-13109-simiane_collongue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13107-13109-simiane_collongue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13108-13150-tarascon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13108-13150-tarascon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13108-13150-tarascon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13108-13150-tarascon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13109-13100-le_tholonet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13109-13100-le_tholonet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13109-13100-le_tholonet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13109-13100-le_tholonet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13110-13530-trets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13110-13530-trets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13110-13530-trets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13110-13530-trets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13111-13126-vauvenargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13111-13126-vauvenargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13111-13126-vauvenargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13111-13126-vauvenargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13112-13880-velaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13112-13880-velaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13112-13880-velaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13112-13880-velaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13113-13770-venelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13113-13770-venelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13113-13770-venelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13113-13770-venelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13114-13122-ventabren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13114-13122-ventabren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13114-13122-ventabren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13114-13122-ventabren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13115-13116-vernegues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13115-13116-vernegues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13115-13116-vernegues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13115-13116-vernegues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13116-13670-verquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13116-13670-verquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13116-13670-verquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13116-13670-verquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13117-13127-vitrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13117-13127-vitrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13117-13127-vitrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13117-13127-vitrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13118-13111-coudoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13118-13111-coudoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13118-13111-coudoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13118-13111-coudoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13119-13470-carnoux_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13119-13470-carnoux_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13119-13470-carnoux_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt13-bouches_du_rhone/commune13119-13470-carnoux_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-14.xml
+++ b/public/sitemaps/sitemap-14.xml
@@ -5,1104 +5,2204 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14001-14600-ablon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14001-14600-ablon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14001-14600-ablon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14001-14600-ablon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14003-14400-agy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14003-14400-agy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14003-14400-agy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14003-14400-agy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14370-valambray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14370-valambray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14370-valambray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14370-valambray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14540-valambray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14540-valambray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14540-valambray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14540-valambray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14190-valambray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14190-valambray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14190-valambray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14005-14190-valambray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14006-14210-amaye_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14006-14210-amaye_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14006-14210-amaye_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14006-14210-amaye_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14007-14310-amaye_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14007-14310-amaye_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14007-14310-amaye_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14007-14310-amaye_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14009-14860-amfreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14009-14860-amfreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14009-14860-amfreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14009-14860-amfreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14011-14240-aurseulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14011-14240-aurseulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14011-14240-aurseulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14011-14240-aurseulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14011-14250-aurseulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14011-14250-aurseulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14011-14250-aurseulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14011-14250-aurseulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14012-14430-angerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14012-14430-angerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14012-14430-angerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14012-14430-angerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14014-14610-colomby_anguerny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14014-14610-colomby_anguerny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14014-14610-colomby_anguerny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14014-14610-colomby_anguerny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14015-14610-anisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14015-14610-anisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14015-14610-anisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14015-14610-anisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14016-14430-annebault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14016-14430-annebault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14016-14430-annebault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14016-14430-annebault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14019-14400-arganchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14019-14400-arganchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14019-14400-arganchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14019-14400-arganchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14020-14370-argences/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14020-14370-argences/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14020-14370-argences/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14020-14370-argences/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14021-14117-arromanches_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14021-14117-arromanches_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14021-14117-arromanches_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14021-14117-arromanches_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14022-14960-asnelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14022-14960-asnelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14022-14960-asnelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14022-14960-asnelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14023-14710-asnieres_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14023-14710-asnieres_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14023-14710-asnieres_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14023-14710-asnieres_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14024-14640-auberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14024-14640-auberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14024-14640-auberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14024-14640-auberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14025-14700-aubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14025-14700-aubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14025-14700-aubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14025-14700-aubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14026-14250-audrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14026-14250-audrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14026-14250-audrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14026-14250-audrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14027-14260-les_monts_d_aunay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14027-14260-les_monts_d_aunay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14027-14260-les_monts_d_aunay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14027-14260-les_monts_d_aunay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14027-14770-les_monts_d_aunay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14027-14770-les_monts_d_aunay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14027-14770-les_monts_d_aunay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14027-14770-les_monts_d_aunay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14030-14280-authie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14030-14280-authie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14030-14280-authie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14030-14280-authie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14032-14130-les_authieux_sur_calonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14032-14130-les_authieux_sur_calonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14032-14130-les_authieux_sur_calonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14032-14130-les_authieux_sur_calonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14033-14340-auvillars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14033-14340-auvillars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14033-14340-auvillars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14033-14340-auvillars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14034-14210-avenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14034-14210-avenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14034-14210-avenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14034-14210-avenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14035-14490-balleroy_sur_drome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14035-14490-balleroy_sur_drome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14035-14490-balleroy_sur_drome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14035-14490-balleroy_sur_drome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14036-14940-banneville_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14036-14940-banneville_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14036-14940-banneville_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14036-14940-banneville_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14037-14260-malherbe_sur_ajon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14037-14260-malherbe_sur_ajon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14037-14260-malherbe_sur_ajon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14037-14260-malherbe_sur_ajon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14038-14480-banville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14038-14480-banville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14038-14480-banville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14038-14480-banville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14039-14220-barbery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14039-14220-barbery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14039-14220-barbery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14039-14220-barbery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14040-14400-barbeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14040-14400-barbeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14040-14400-barbeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14040-14400-barbeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14041-14600-barneville_la_bertran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14041-14600-barneville_la_bertran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14041-14600-barneville_la_bertran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14041-14600-barneville_la_bertran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14042-14210-baron_sur_odon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14042-14210-baron_sur_odon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14042-14210-baron_sur_odon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14042-14210-baron_sur_odon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14043-14620-barou_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14043-14620-barou_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14043-14620-barou_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14043-14620-barou_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14044-14610-basly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14044-14610-basly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14044-14610-basly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14044-14610-basly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14045-14670-basseneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14045-14670-basseneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14045-14670-basseneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14045-14670-basseneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14046-14860-bavent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14046-14860-bavent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14046-14860-bavent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14046-14860-bavent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14047-14400-bayeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14047-14400-bayeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14047-14400-bayeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14047-14400-bayeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14049-14480-bazenville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14049-14480-bazenville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14049-14480-bazenville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14049-14480-bazenville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14050-14490-la_bazoque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14050-14490-la_bazoque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14050-14490-la_bazoque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14050-14490-la_bazoque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14053-14620-beaumais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14053-14620-beaumais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14053-14620-beaumais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14053-14620-beaumais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14054-14380-beaumesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14054-14380-beaumesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14054-14380-beaumesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14054-14380-beaumesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14055-14950-beaumont_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14055-14950-beaumont_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14055-14950-beaumont_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14055-14950-beaumont_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14057-14370-bellengreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14057-14370-bellengreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14057-14370-bellengreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14057-14370-bellengreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14059-14910-benerville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14059-14910-benerville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14059-14910-benerville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14059-14910-benerville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14060-14970-benouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14060-14970-benouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14060-14970-benouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14060-14970-benouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14061-14350-souleuvre_en_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14061-14350-souleuvre_en_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14061-14350-souleuvre_en_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14061-14350-souleuvre_en_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14061-14260-souleuvre_en_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14061-14260-souleuvre_en_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14061-14260-souleuvre_en_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14061-14260-souleuvre_en_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14062-14440-beny_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14062-14440-beny_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14062-14440-beny_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14062-14440-beny_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14063-14710-bernesq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14063-14710-bernesq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14063-14710-bernesq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14063-14710-bernesq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14064-14170-bernieres_d_ailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14064-14170-bernieres_d_ailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14064-14170-bernieres_d_ailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14064-14170-bernieres_d_ailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14066-14990-bernieres_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14066-14990-bernieres_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14066-14990-bernieres_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14066-14990-bernieres_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14068-14112-bieville_beuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14068-14112-bieville_beuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14068-14112-bieville_beuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14068-14112-bieville_beuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14069-14100-beuvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14069-14100-beuvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14069-14100-beuvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14069-14100-beuvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14070-14430-beuvron_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14070-14430-beuvron_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14070-14430-beuvron_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14070-14430-beuvron_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14076-14550-blainville_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14076-14550-blainville_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14076-14550-blainville_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14076-14550-blainville_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14077-14130-blangy_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14077-14130-blangy_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14077-14130-blangy_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14077-14130-blangy_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14078-14400-blay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14078-14400-blay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14078-14400-blay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14078-14400-blay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14079-14910-blonville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14079-14910-blonville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14079-14910-blonville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14079-14910-blonville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14080-14690-le_bo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14080-14690-le_bo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14080-14690-le_bo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14080-14690-le_bo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14082-14340-la_boissiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14082-14340-la_boissiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14082-14340-la_boissiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14082-14340-la_boissiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14083-14340-bonnebosq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14083-14340-bonnebosq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14083-14340-bonnebosq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14083-14340-bonnebosq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14084-14260-bonnemaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14084-14260-bonnemaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14084-14260-bonnemaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14084-14260-bonnemaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14085-14130-bonneville_la_louvet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14085-14130-bonneville_la_louvet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14085-14130-bonneville_la_louvet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14085-14130-bonneville_la_louvet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14086-14800-bonneville_sur_touques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14086-14800-bonneville_sur_touques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14086-14800-bonneville_sur_touques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14086-14800-bonneville_sur_touques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14087-14700-bonnoeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14087-14700-bonnoeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14087-14700-bonnoeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14087-14700-bonnoeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14088-14420-bons_tassilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14088-14420-bons_tassilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14088-14420-bons_tassilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14088-14420-bons_tassilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14089-14210-bougy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14089-14210-bougy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14089-14210-bougy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14089-14210-bougy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14090-14220-boulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14090-14220-boulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14090-14220-boulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14090-14220-boulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14091-14430-bourgeauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14091-14430-bourgeauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14091-14430-bourgeauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14091-14430-bourgeauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14092-14540-bourguebus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14092-14540-bourguebus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14092-14540-bourguebus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14092-14540-bourguebus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14093-14430-branville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14093-14430-branville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14093-14430-branville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14093-14430-branville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14096-14260-bremoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14096-14260-bremoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14096-14260-bremoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14096-14260-bremoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14097-14190-bretteville_le_rabet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14097-14190-bretteville_le_rabet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14097-14190-bretteville_le_rabet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14097-14190-bretteville_le_rabet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14210-thue_et_mue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14210-thue_et_mue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14210-thue_et_mue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14210-thue_et_mue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14740-thue_et_mue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14740-thue_et_mue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14740-thue_et_mue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14740-thue_et_mue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14250-thue_et_mue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14250-thue_et_mue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14250-thue_et_mue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14098-14250-thue_et_mue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14100-14680-bretteville_sur_laize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14100-14680-bretteville_sur_laize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14100-14680-bretteville_sur_laize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14100-14680-bretteville_sur_laize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14101-14760-bretteville_sur_odon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14101-14760-bretteville_sur_odon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14101-14760-bretteville_sur_odon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14101-14760-bretteville_sur_odon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14102-14130-le_breuil_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14102-14130-le_breuil_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14102-14130-le_breuil_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14102-14130-le_breuil_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14103-14330-le_breuil_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14103-14330-le_breuil_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14103-14330-le_breuil_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14103-14330-le_breuil_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14104-14130-le_brevedent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14104-14130-le_brevedent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14104-14130-le_brevedent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14104-14130-le_brevedent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14106-14860-breville_les_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14106-14860-breville_les_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14106-14860-breville_les_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14106-14860-breville_les_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14107-14710-bricqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14107-14710-bricqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14107-14710-bricqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14107-14710-bricqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14110-14160-brucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14110-14160-brucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14110-14160-brucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14110-14160-brucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14111-14250-buceels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14111-14250-buceels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14111-14250-buceels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14111-14250-buceels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14116-14190-le_bu_sur_rouvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14116-14190-le_bu_sur_rouvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14116-14190-le_bu_sur_rouvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14116-14190-le_bu_sur_rouvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14117-14390-cabourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14117-14390-cabourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14117-14390-cabourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14117-14390-cabourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14118-14000-caen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14118-14000-caen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14118-14000-caen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14118-14000-caen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14119-14630-cagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14119-14630-cagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14119-14630-cagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14119-14630-cagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14120-14240-cahagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14120-14240-cahagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14120-14240-cahagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14120-14240-cahagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14121-14490-cahagnolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14121-14490-cahagnolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14121-14490-cahagnolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14121-14490-cahagnolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14122-14210-la_caine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14122-14210-la_caine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14122-14210-la_caine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14122-14210-la_caine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14123-14610-cairon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14123-14610-cairon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14123-14610-cairon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14123-14610-cairon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14124-14230-la_cambe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14124-14230-la_cambe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14124-14230-la_cambe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14124-14230-la_cambe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14125-14610-cambes_en_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14125-14610-cambes_en_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14125-14610-cambes_en_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14125-14610-cambes_en_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14126-14340-cambremer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14126-14340-cambremer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14126-14340-cambremer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14126-14340-cambremer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14127-14500-campagnolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14127-14500-campagnolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14127-14500-campagnolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14127-14500-campagnolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14130-14490-campigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14130-14490-campigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14130-14490-campigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14130-14490-campigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14131-14800-canapville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14131-14800-canapville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14131-14800-canapville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14131-14800-canapville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14132-14230-canchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14132-14230-canchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14132-14230-canchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14132-14230-canchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14134-14370-canteloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14134-14370-canteloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14134-14370-canteloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14134-14370-canteloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14135-14740-carcagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14135-14740-carcagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14135-14740-carcagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14135-14740-carcagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14136-14230-cardonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14136-14230-cardonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14136-14230-cardonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14136-14230-cardonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14137-14650-carpiquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14137-14650-carpiquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14137-14650-carpiquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14137-14650-carpiquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14138-14330-cartigny_l_epinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14138-14330-cartigny_l_epinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14138-14330-cartigny_l_epinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14138-14330-cartigny_l_epinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14140-14490-castillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14140-14490-castillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14140-14490-castillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14140-14490-castillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14141-14140-castillon_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14141-14140-castillon_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14141-14140-castillon_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14141-14140-castillon_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14143-14240-caumont_sur_aure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14143-14240-caumont_sur_aure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14143-14240-caumont_sur_aure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14143-14240-caumont_sur_aure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14145-14190-cauvicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14145-14190-cauvicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14145-14190-cauvicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14145-14190-cauvicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14146-14770-cauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14146-14770-cauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14146-14770-cauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14146-14770-cauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14147-14290-cernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14147-14290-cernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14147-14290-cernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14147-14290-cernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14149-14270-cesny_aux_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14149-14270-cesny_aux_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14149-14270-cesny_aux_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14149-14270-cesny_aux_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14150-14220-cesny_les_sources/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14150-14220-cesny_les_sources/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14150-14220-cesny_les_sources/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14150-14220-cesny_les_sources/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14159-14250-chouain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14159-14250-chouain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14159-14250-chouain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14159-14250-chouain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14160-14680-cintheaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14160-14680-cintheaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14160-14680-cintheaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14160-14680-cintheaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14161-14130-clarbec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14161-14130-clarbec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14161-14130-clarbec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14161-14130-clarbec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14162-14570-clecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14162-14570-clecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14162-14570-clecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14162-14570-clecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14163-14370-cleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14163-14370-cleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14163-14370-cleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14163-14370-cleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14165-14710-colleville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14165-14710-colleville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14165-14710-colleville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14165-14710-colleville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14166-14880-colleville_montgomery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14166-14880-colleville_montgomery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14166-14880-colleville_montgomery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14166-14880-colleville_montgomery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14167-14460-colombelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14167-14460-colombelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14167-14460-colombelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14167-14460-colombelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14168-14710-colombieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14168-14710-colombieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14168-14710-colombieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14168-14710-colombieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14169-14480-colombiers_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14169-14480-colombiers_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14169-14480-colombiers_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14169-14480-colombiers_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14171-14220-combray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14171-14220-combray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14171-14220-combray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14171-14220-combray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14172-14520-commes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14172-14520-commes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14172-14520-commes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14172-14520-commes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14173-14270-conde_sur_ifs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14173-14270-conde_sur_ifs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14173-14270-conde_sur_ifs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14173-14270-conde_sur_ifs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14174-14110-conde_en_normandie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14174-14110-conde_en_normandie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14174-14110-conde_en_normandie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14174-14110-conde_en_normandie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14174-14770-conde_en_normandie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14174-14770-conde_en_normandie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14174-14770-conde_en_normandie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14174-14770-conde_en_normandie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14175-14400-conde_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14175-14400-conde_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14175-14400-conde_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14175-14400-conde_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14177-14130-coquainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14177-14130-coquainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14177-14130-coquainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14177-14130-coquainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14179-14100-cordebugle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14179-14100-cordebugle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14179-14100-cordebugle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14179-14100-cordebugle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14180-14700-cordey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14180-14700-cordey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14180-14700-cordey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14180-14700-cordey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14181-14123-cormelles_le_royal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14181-14123-cormelles_le_royal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14181-14123-cormelles_le_royal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14181-14123-cormelles_le_royal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14182-14240-cormolain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14182-14240-cormolain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14182-14240-cormolain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14182-14240-cormolain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14183-14690-cossesseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14183-14690-cossesseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14183-14690-cossesseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14183-14690-cossesseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14184-14400-cottun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14184-14400-cottun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14184-14400-cottun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14184-14400-cottun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14190-14170-courcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14190-14170-courcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14190-14170-courcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14190-14170-courcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14191-14470-courseulles_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14191-14470-courseulles_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14191-14470-courseulles_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14191-14470-courseulles_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14193-14100-courtonne_la_meurdrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14193-14100-courtonne_la_meurdrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14193-14100-courtonne_la_meurdrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14193-14100-courtonne_la_meurdrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14194-14290-courtonne_les_deux_eglises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14194-14290-courtonne_les_deux_eglises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14194-14290-courtonne_les_deux_eglises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14194-14290-courtonne_les_deux_eglises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14195-14260-courvaudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14195-14260-courvaudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14195-14260-courvaudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14195-14260-courvaudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14196-14480-crepon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14196-14480-crepon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14196-14480-crepon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14196-14480-crepon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14197-14440-cresserons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14197-14440-cresserons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14197-14440-cresserons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14197-14440-cresserons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14198-14430-cresseveuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14198-14430-cresseveuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14198-14430-cresseveuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14198-14430-cresseveuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14200-14480-creully_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14200-14480-creully_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14200-14480-creully_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14200-14480-creully_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14202-14113-cricqueboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14202-14113-cricqueboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14202-14113-cricqueboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14202-14113-cricqueboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14203-14430-cricqueville_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14203-14430-cricqueville_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14203-14430-cricqueville_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14203-14430-cricqueville_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14204-14450-cricqueville_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14204-14450-cricqueville_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14204-14450-cricqueville_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14204-14450-cricqueville_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14205-14250-cristot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14205-14250-cristot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14205-14250-cristot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14205-14250-cristot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14206-14620-crocy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14206-14620-crocy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14206-14620-crocy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14206-14620-crocy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14207-14220-croisilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14207-14220-croisilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14207-14220-croisilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14207-14220-croisilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14209-14400-crouay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14209-14400-crouay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14209-14400-crouay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14209-14400-crouay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14211-14220-culey_le_patry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14211-14220-culey_le_patry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14211-14220-culey_le_patry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14211-14220-culey_le_patry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14214-14400-cussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14214-14400-cussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14214-14400-cussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14214-14400-cussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14215-14840-cuverville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14215-14840-cuverville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14215-14840-cuverville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14215-14840-cuverville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14216-14620-damblainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14216-14620-damblainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14216-14620-damblainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14216-14620-damblainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14218-14430-danestal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14218-14430-danestal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14218-14430-danestal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14218-14430-danestal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14220-14800-deauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14220-14800-deauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14220-14800-deauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14220-14800-deauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14221-14840-demouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14221-14840-demouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14221-14840-demouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14221-14840-demouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14223-14690-le_detroit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14223-14690-le_detroit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14223-14690-le_detroit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14223-14690-le_detroit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14224-14230-deux_jumeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14224-14230-deux_jumeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14224-14230-deux_jumeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14224-14230-deux_jumeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14225-14160-dives_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14225-14160-dives_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14225-14160-dives_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14225-14160-dives_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14226-14220-donnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14226-14220-donnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14226-14220-donnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14226-14220-donnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14227-14430-douville_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14227-14430-douville_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14227-14430-douville_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14227-14430-douville_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14228-14440-douvres_la_delivrande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14228-14440-douvres_la_delivrande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14228-14440-douvres_la_delivrande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14228-14440-douvres_la_delivrande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14229-14430-dozule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14229-14430-dozule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14229-14430-dozule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14229-14430-dozule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14230-14130-drubec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14230-14130-drubec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14230-14130-drubec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14230-14130-drubec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14231-14340-beaufour_druval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14231-14340-beaufour_druval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14231-14340-beaufour_druval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14231-14340-beaufour_druval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14232-14250-ducy_sainte_marguerite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14232-14250-ducy_sainte_marguerite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14232-14250-ducy_sainte_marguerite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14232-14250-ducy_sainte_marguerite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14236-14250-ellon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14236-14250-ellon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14236-14250-ellon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14236-14250-ellon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14237-14630-emieville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14237-14630-emieville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14237-14630-emieville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14237-14630-emieville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14238-14800-englesqueville_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14238-14800-englesqueville_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14238-14800-englesqueville_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14238-14800-englesqueville_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14239-14710-englesqueville_la_percee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14239-14710-englesqueville_la_percee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14239-14710-englesqueville_la_percee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14239-14710-englesqueville_la_percee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14240-14170-epaney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14240-14170-epaney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14240-14170-epaney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14240-14170-epaney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14241-14310-epinay_sur_odon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14241-14310-epinay_sur_odon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14241-14310-epinay_sur_odon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14241-14310-epinay_sur_odon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14242-14610-epron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14242-14610-epron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14242-14610-epron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14242-14610-epron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14243-14600-equemauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14243-14600-equemauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14243-14600-equemauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14243-14600-equemauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14244-14700-eraines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14244-14700-eraines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14244-14700-eraines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14244-14700-eraines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14245-14270-ernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14245-14270-ernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14245-14270-ernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14245-14270-ernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14246-14850-escoville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14246-14850-escoville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14246-14850-escoville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14246-14850-escoville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14248-14220-espins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14248-14220-espins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14248-14220-espins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14248-14220-espins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14249-14210-esquay_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14249-14210-esquay_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14249-14210-esquay_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14249-14210-esquay_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14250-14400-esquay_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14250-14400-esquay_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14250-14400-esquay_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14250-14400-esquay_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14251-14220-esson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14251-14220-esson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14251-14220-esson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14251-14220-esson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14252-14190-estrees_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14252-14190-estrees_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14252-14190-estrees_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14252-14190-estrees_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14254-14930-eterville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14254-14930-eterville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14254-14930-eterville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14254-14930-eterville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14256-14400-etreham/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14256-14400-etreham/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14256-14400-etreham/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14256-14400-etreham/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14257-14210-evrecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14257-14210-evrecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14257-14210-evrecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14257-14210-evrecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14258-14700-falaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14258-14700-falaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14258-14700-falaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14258-14700-falaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14260-14100-fauguernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14260-14100-fauguernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14260-14100-fauguernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14260-14100-fauguernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14261-14130-le_faulq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14261-14130-le_faulq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14261-14130-le_faulq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14261-14130-le_faulq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14266-14320-feuguerolles_bully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14266-14320-feuguerolles_bully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14266-14320-feuguerolles_bully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14266-14320-feuguerolles_bully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14269-14130-fierville_les_parcs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14269-14130-fierville_les_parcs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14269-14130-fierville_les_parcs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14269-14130-fierville_les_parcs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14270-14100-firfol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14270-14100-firfol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14270-14100-firfol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14270-14100-firfol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14271-14123-fleury_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14271-14123-fleury_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14271-14123-fleury_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14271-14123-fleury_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14272-14710-la_folie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14272-14710-la_folie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14272-14710-la_folie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14272-14710-la_folie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14273-14290-la_folletiere_abenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14273-14290-la_folletiere_abenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14273-14290-la_folletiere_abenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14273-14290-la_folletiere_abenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14274-14790-fontaine_etoupefour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14274-14790-fontaine_etoupefour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14274-14790-fontaine_etoupefour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14274-14790-fontaine_etoupefour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14275-14610-fontaine_henry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14275-14610-fontaine_henry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14275-14610-fontaine_henry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14275-14610-fontaine_henry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14276-14190-fontaine_le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14276-14190-fontaine_le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14276-14190-fontaine_le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14276-14190-fontaine_le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14277-14320-fontenay_le_marmion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14277-14320-fontenay_le_marmion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14277-14320-fontenay_le_marmion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14277-14320-fontenay_le_marmion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14278-14250-fontenay_le_pesnel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14278-14250-fontenay_le_pesnel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14278-14250-fontenay_le_pesnel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14278-14250-fontenay_le_pesnel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14280-14340-formentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14280-14340-formentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14280-14340-formentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14280-14340-formentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14281-14710-formigny_la_bataille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14281-14710-formigny_la_bataille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14281-14710-formigny_la_bataille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14281-14710-formigny_la_bataille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14282-14240-foulognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14282-14240-foulognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14282-14240-foulognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14282-14240-foulognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14283-14620-fourches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14283-14620-fourches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14283-14620-fourches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14283-14620-fourches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14284-14700-fourneaux_le_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14284-14700-fourneaux_le_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14284-14700-fourneaux_le_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14284-14700-fourneaux_le_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14285-14340-le_fournet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14285-14340-le_fournet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14285-14340-le_fournet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14285-14340-le_fournet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14286-14600-fourneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14286-14600-fourneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14286-14600-fourneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14286-14600-fourneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14287-14630-frenouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14287-14630-frenouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14287-14630-frenouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14287-14630-frenouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14288-14480-le_fresne_camilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14288-14480-le_fresne_camilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14288-14480-le_fresne_camilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14288-14480-le_fresne_camilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14289-14700-fresne_la_mere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14289-14700-fresne_la_mere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14289-14700-fresne_la_mere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14289-14700-fresne_la_mere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14290-14680-fresney_le_puceux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14290-14680-fresney_le_puceux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14290-14680-fresney_le_puceux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14290-14680-fresney_le_puceux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14291-14220-fresney_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14291-14220-fresney_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14291-14220-fresney_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14291-14220-fresney_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14293-14590-fumichon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14293-14590-fumichon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14293-14590-fumichon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14293-14590-fumichon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14297-14210-gavrus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14297-14210-gavrus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14297-14210-gavrus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14297-14210-gavrus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14298-14230-gefosse_fontenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14298-14230-gefosse_fontenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14298-14230-gefosse_fontenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14298-14230-gefosse_fontenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14299-14600-genneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14299-14600-genneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14299-14600-genneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14299-14600-genneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14300-14430-gerrots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14300-14430-gerrots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14300-14430-gerrots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14300-14430-gerrots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14301-14730-giberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14301-14730-giberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14301-14730-giberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14301-14730-giberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14302-14950-glanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14302-14950-glanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14302-14950-glanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14302-14950-glanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14303-14100-glos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14303-14100-glos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14303-14100-glos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14303-14100-glos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14304-14600-gonneville_sur_honfleur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14304-14600-gonneville_sur_honfleur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14304-14600-gonneville_sur_honfleur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14304-14600-gonneville_sur_honfleur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14305-14510-gonneville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14305-14510-gonneville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14305-14510-gonneville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14305-14510-gonneville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14306-14810-gonneville_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14306-14810-gonneville_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14306-14810-gonneville_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14306-14810-gonneville_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14308-14430-goustranville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14308-14430-goustranville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14308-14430-goustranville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14308-14430-goustranville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14309-14680-gouvix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14309-14680-gouvix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14309-14680-gouvix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14309-14680-gouvix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14310-14190-grainville_langannerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14310-14190-grainville_langannerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14310-14190-grainville_langannerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14310-14190-grainville_langannerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14311-14210-grainville_sur_odon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14311-14210-grainville_sur_odon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14311-14210-grainville_sur_odon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14311-14210-grainville_sur_odon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14312-14450-grandcamp_maisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14312-14450-grandcamp_maisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14312-14450-grandcamp_maisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14312-14450-grandcamp_maisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14316-14160-grangues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14316-14160-grangues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14316-14160-grangues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14316-14160-grangues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14318-14470-graye_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14318-14470-graye_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14318-14470-graye_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14318-14470-graye_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14319-14540-grentheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14319-14540-grentheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14319-14540-grentheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14319-14540-grentheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14320-14220-grimbosq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14320-14220-grimbosq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14320-14220-grimbosq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14320-14220-grimbosq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14322-14400-gueron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14322-14400-gueron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14322-14400-gueron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14322-14400-gueron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14325-14880-hermanville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14325-14880-hermanville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14325-14880-hermanville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14325-14880-hermanville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14326-14100-hermival_les_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14326-14100-hermival_les_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14326-14100-hermival_les_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14326-14100-hermival_les_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14327-14200-herouville_saint_clair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14327-14200-herouville_saint_clair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14327-14200-herouville_saint_clair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14327-14200-herouville_saint_clair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14328-14850-herouvillette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14328-14850-herouvillette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14328-14850-herouvillette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14328-14850-herouvillette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14329-14430-heuland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14329-14430-heuland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14329-14430-heuland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14329-14430-heuland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14332-14700-la_hoguette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14332-14700-la_hoguette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14332-14700-la_hoguette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14332-14700-la_hoguette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14333-14600-honfleur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14333-14600-honfleur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14333-14600-honfleur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14333-14600-honfleur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14334-14100-l_hotellerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14334-14100-l_hotellerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14334-14100-l_hotellerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14334-14100-l_hotellerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14335-14430-hotot_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14335-14430-hotot_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14335-14430-hotot_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14335-14430-hotot_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14336-14250-hottot_les_bagues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14336-14250-hottot_les_bagues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14336-14250-hottot_les_bagues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14336-14250-hottot_les_bagues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14337-14340-la_houblonniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14337-14340-la_houblonniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14337-14340-la_houblonniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14337-14340-la_houblonniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14338-14510-houlgate/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14338-14510-houlgate/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14338-14510-houlgate/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14338-14510-houlgate/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14341-14123-ifs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14341-14123-ifs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14341-14123-ifs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14341-14123-ifs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14342-14230-isigny_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14342-14230-isigny_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14342-14230-isigny_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14342-14230-isigny_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14342-14330-isigny_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14342-14330-isigny_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14342-14330-isigny_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14342-14330-isigny_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14343-14690-les_isles_bardel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14343-14690-les_isles_bardel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14343-14690-les_isles_bardel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14343-14690-les_isles_bardel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14344-14670-janville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14344-14670-janville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14344-14670-janville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14344-14670-janville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14345-14170-jort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14345-14170-jort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14345-14170-jort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14345-14170-jort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14346-14250-juaye_mondaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14346-14250-juaye_mondaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14346-14250-juaye_mondaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14346-14250-juaye_mondaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14347-14260-dialan_sur_chaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14347-14260-dialan_sur_chaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14347-14260-dialan_sur_chaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14347-14260-dialan_sur_chaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14348-14250-juvigny_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14348-14250-juvigny_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14348-14250-juvigny_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14348-14250-juvigny_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14349-14320-laize_clinchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14349-14320-laize_clinchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14349-14320-laize_clinchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14349-14320-laize_clinchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14352-14380-landelles_et_coupigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14352-14380-landelles_et_coupigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14352-14380-landelles_et_coupigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14352-14380-landelles_et_coupigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14353-14310-landes_sur_ajon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14353-14310-landes_sur_ajon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14353-14310-landes_sur_ajon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14353-14310-landes_sur_ajon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14354-14830-langrune_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14354-14830-langrune_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14354-14830-langrune_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14354-14830-langrune_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14355-14480-ponts_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14355-14480-ponts_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14355-14480-ponts_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14355-14480-ponts_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14357-14770-terres_de_druance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14357-14770-terres_de_druance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14357-14770-terres_de_druance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14357-14770-terres_de_druance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14358-14340-leaupartie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14358-14340-leaupartie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14358-14340-leaupartie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14358-14340-leaupartie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14360-14700-leffard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14360-14700-leffard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14360-14700-leffard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14360-14700-leffard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14362-14140-lessard_et_le_chene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14362-14140-lessard_et_le_chene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14362-14140-lessard_et_le_chene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14362-14140-lessard_et_le_chene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14364-14250-lingevres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14364-14250-lingevres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14364-14250-lingevres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14364-14250-lingevres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14365-14780-lion_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14365-14780-lion_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14365-14780-lion_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14365-14780-lion_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14366-14100-lisieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14366-14100-lisieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14366-14100-lisieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14366-14100-lisieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14367-14330-lison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14367-14330-lison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14367-14330-lison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14367-14330-lison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14368-14140-lisores/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14368-14140-lisores/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14368-14140-lisores/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14368-14140-lisores/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14369-14490-litteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14369-14490-litteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14369-14490-litteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14369-14490-litteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14370-14330-le_molay_littry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14370-14330-le_molay_littry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14370-14330-le_molay_littry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14370-14330-le_molay_littry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14371-14140-livarot_pays_d_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14371-14140-livarot_pays_d_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14371-14140-livarot_pays_d_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14371-14140-livarot_pays_d_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14371-14290-livarot_pays_d_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14371-14290-livarot_pays_d_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14371-14290-livarot_pays_d_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14371-14290-livarot_pays_d_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14374-14240-les_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14374-14240-les_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14374-14240-les_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14374-14240-les_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14375-14700-les_loges_saulces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14375-14700-les_loges_saulces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14375-14700-les_loges_saulces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14375-14700-les_loges_saulces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14377-14400-longues_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14377-14400-longues_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14377-14400-longues_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14377-14400-longues_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14378-14230-longueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14378-14230-longueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14378-14230-longueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14378-14230-longueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14379-14310-longvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14379-14310-longvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14379-14310-longvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14379-14310-longvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14380-14250-loucelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14380-14250-loucelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14380-14250-loucelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14380-14250-loucelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14381-14170-louvagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14381-14170-louvagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14381-14170-louvagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14381-14170-louvagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14383-14111-louvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14383-14111-louvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14383-14111-louvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14383-14111-louvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14384-14530-luc_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14384-14530-luc_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14384-14530-luc_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14384-14530-luc_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14385-14400-magny_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14385-14400-magny_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14385-14400-magny_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14385-14400-magny_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14389-14310-maisoncelles_pelvey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14389-14310-maisoncelles_pelvey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14389-14310-maisoncelles_pelvey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14389-14310-maisoncelles_pelvey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14390-14210-maisoncelles_sur_ajon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14390-14210-maisoncelles_sur_ajon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14390-14210-maisoncelles_sur_ajon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14390-14210-maisoncelles_sur_ajon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14391-14400-maisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14391-14400-maisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14391-14400-maisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14391-14400-maisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14393-14210-maizet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14393-14210-maizet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14393-14210-maizet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14393-14210-maizet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14394-14190-maizieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14394-14190-maizieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14394-14190-maizieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14394-14190-maizieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14396-14930-maltot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14396-14930-maltot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14396-14930-maltot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14396-14930-maltot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14397-14710-mandeville_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14397-14710-mandeville_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14397-14710-mandeville_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14397-14710-mandeville_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14398-14340-manerbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14398-14340-manerbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14398-14340-manerbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14398-14340-manerbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14399-14130-manneville_la_pipard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14399-14130-manneville_la_pipard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14399-14130-manneville_la_pipard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14399-14130-manneville_la_pipard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14400-14400-le_manoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14400-14400-le_manoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14400-14400-le_manoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14400-14400-le_manoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14401-14117-manvieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14401-14117-manvieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14401-14117-manvieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14401-14117-manvieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14402-14620-le_marais_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14402-14620-le_marais_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14402-14620-le_marais_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14402-14620-le_marais_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14403-14100-marolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14403-14100-marolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14403-14100-marolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14403-14100-marolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14404-14220-martainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14404-14220-martainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14404-14220-martainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14404-14220-martainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14405-14700-martigny_sur_l_ante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14405-14700-martigny_sur_l_ante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14405-14700-martigny_sur_l_ante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14405-14700-martigny_sur_l_ante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14406-14740-moulins_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14406-14740-moulins_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14406-14740-moulins_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14406-14740-moulins_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14406-14480-moulins_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14406-14480-moulins_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14406-14480-moulins_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14406-14480-moulins_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14407-14920-mathieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14407-14920-mathieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14407-14920-mathieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14407-14920-mathieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14408-14320-may_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14408-14320-may_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14408-14320-may_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14408-14320-may_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14409-14810-merville_franceville_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14409-14810-merville_franceville_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14409-14810-merville_franceville_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14409-14810-merville_franceville_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14410-14370-mery_bissieres_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14410-14370-mery_bissieres_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14410-14370-mery_bissieres_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14410-14370-mery_bissieres_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14411-14220-meslay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14411-14220-meslay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14411-14220-meslay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14411-14220-meslay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14412-14260-le_mesnil_au_grain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14412-14260-le_mesnil_au_grain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14412-14260-le_mesnil_au_grain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14412-14260-le_mesnil_au_grain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14419-14100-le_mesnil_eudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14419-14100-le_mesnil_eudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14419-14100-le_mesnil_eudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14419-14100-le_mesnil_eudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14421-14100-le_mesnil_guillaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14421-14100-le_mesnil_guillaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14421-14100-le_mesnil_guillaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14421-14100-le_mesnil_guillaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14424-14380-le_mesnil_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14424-14380-le_mesnil_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14424-14380-le_mesnil_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14424-14380-le_mesnil_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14425-14140-le_mesnil_simon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14425-14140-le_mesnil_simon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14425-14140-le_mesnil_simon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14425-14140-le_mesnil_simon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14426-14130-le_mesnil_sur_blangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14426-14130-le_mesnil_sur_blangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14426-14130-le_mesnil_sur_blangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14426-14130-le_mesnil_sur_blangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14427-14690-le_mesnil_villement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14427-14690-le_mesnil_villement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14427-14690-le_mesnil_villement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14427-14690-le_mesnil_villement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14430-14960-meuvaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14430-14960-meuvaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14430-14960-meuvaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14430-14960-meuvaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14270-mezidon_vallee_d_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14270-mezidon_vallee_d_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14270-mezidon_vallee_d_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14270-mezidon_vallee_d_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14140-mezidon_vallee_d_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14140-mezidon_vallee_d_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14140-mezidon_vallee_d_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14140-mezidon_vallee_d_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14340-mezidon_vallee_d_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14340-mezidon_vallee_d_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14340-mezidon_vallee_d_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14340-mezidon_vallee_d_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14370-mezidon_vallee_d_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14370-mezidon_vallee_d_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14370-mezidon_vallee_d_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14431-14370-mezidon_vallee_d_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14435-14100-les_monceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14435-14100-les_monceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14435-14100-les_monceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14435-14100-les_monceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14436-14400-monceaux_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14436-14400-monceaux_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14436-14400-monceaux_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14436-14400-monceaux_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14437-14120-mondeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14437-14120-mondeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14437-14120-mondeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14437-14120-mondeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14438-14210-mondrainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14438-14210-mondrainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14438-14210-mondrainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14438-14210-mondrainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14439-14230-monfreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14439-14230-monfreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14439-14230-monfreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14439-14230-monfreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14445-14490-montfiquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14445-14490-montfiquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14445-14490-montfiquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14445-14490-montfiquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14446-14210-montigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14446-14210-montigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14446-14210-montigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14446-14210-montigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14448-14340-montreuil_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14448-14340-montreuil_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14448-14340-montreuil_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14448-14340-montreuil_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14449-14310-monts_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14449-14310-monts_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14449-14310-monts_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14449-14310-monts_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14452-14620-morteaux_couliboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14452-14620-morteaux_couliboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14452-14620-morteaux_couliboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14452-14620-morteaux_couliboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14453-14400-mosles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14453-14400-mosles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14453-14400-mosles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14453-14400-mosles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14454-14790-mouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14454-14790-mouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14454-14790-mouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14454-14790-mouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14455-14220-moulines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14455-14220-moulines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14455-14220-moulines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14455-14220-moulines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14456-14370-moult_chicheboville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14456-14370-moult_chicheboville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14456-14370-moult_chicheboville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14456-14370-moult_chicheboville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14457-14620-les_moutiers_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14457-14620-les_moutiers_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14457-14620-les_moutiers_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14457-14620-les_moutiers_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14458-14220-les_moutiers_en_cinglais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14458-14220-les_moutiers_en_cinglais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14458-14220-les_moutiers_en_cinglais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14458-14220-les_moutiers_en_cinglais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14460-14590-moyaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14460-14590-moyaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14460-14590-moyaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14460-14590-moyaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14461-14220-mutrecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14461-14220-mutrecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14461-14220-mutrecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14461-14220-mutrecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14465-14400-nonant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14465-14400-nonant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14465-14400-nonant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14465-14400-nonant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14466-14100-norolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14466-14100-norolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14466-14100-norolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14466-14100-norolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14467-14700-noron_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14467-14700-noron_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14467-14700-noron_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14467-14700-noron_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14468-14490-noron_la_poterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14468-14490-noron_la_poterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14468-14490-noron_la_poterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14468-14490-noron_la_poterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14469-14620-norrey_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14469-14620-norrey_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14469-14620-norrey_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14469-14620-norrey_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14473-14340-notre_dame_de_livaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14473-14340-notre_dame_de_livaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14473-14340-notre_dame_de_livaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14473-14340-notre_dame_de_livaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14474-14340-notre_dame_d_estrees_corbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14474-14340-notre_dame_d_estrees_corbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14474-14340-notre_dame_d_estrees_corbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14474-14340-notre_dame_d_estrees_corbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14475-14210-val_d_arry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14475-14210-val_d_arry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14475-14210-val_d_arry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14475-14210-val_d_arry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14475-14310-val_d_arry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14475-14310-val_d_arry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14475-14310-val_d_arry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14475-14310-val_d_arry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14476-14170-olendon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14476-14170-olendon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14476-14170-olendon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14476-14170-olendon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14478-14290-orbec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14478-14290-orbec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14478-14290-orbec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14478-14290-orbec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14480-14230-osmanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14480-14230-osmanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14480-14230-osmanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14480-14230-osmanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14482-14270-ouezy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14482-14270-ouezy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14482-14270-ouezy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14482-14270-ouezy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14483-14220-ouffieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14483-14220-ouffieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14483-14220-ouffieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14483-14220-ouffieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14484-14590-ouilly_du_houley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14484-14590-ouilly_du_houley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14484-14590-ouilly_du_houley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14484-14590-ouilly_du_houley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14486-14190-ouilly_le_tesson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14486-14190-ouilly_le_tesson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14486-14190-ouilly_le_tesson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14486-14190-ouilly_le_tesson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14487-14100-ouilly_le_vicomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14487-14100-ouilly_le_vicomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14487-14100-ouilly_le_vicomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14487-14100-ouilly_le_vicomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14488-14150-ouistreham/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14488-14150-ouistreham/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14488-14150-ouistreham/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14488-14150-ouistreham/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14491-14310-parfouru_sur_odon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14491-14310-parfouru_sur_odon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14491-14310-parfouru_sur_odon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14491-14310-parfouru_sur_odon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14492-14600-pennedepie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14492-14600-pennedepie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14492-14600-pennedepie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14492-14600-pennedepie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14494-14160-periers_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14494-14160-periers_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14494-14160-periers_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14494-14160-periers_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14495-14112-periers_sur_le_dan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14495-14112-periers_sur_le_dan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14495-14112-periers_sur_le_dan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14495-14112-periers_sur_le_dan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14496-14770-perigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14496-14770-perigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14496-14770-perigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14496-14770-perigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14497-14170-perrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14497-14170-perrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14497-14170-perrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14497-14170-perrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14498-14700-pertheville_ners/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14498-14700-pertheville_ners/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14498-14700-pertheville_ners/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14498-14700-pertheville_ners/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14499-14390-petiville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14499-14390-petiville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14499-14390-petiville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14499-14390-petiville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14500-14130-pierrefitte_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14500-14130-pierrefitte_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14500-14130-pierrefitte_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14500-14130-pierrefitte_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14501-14690-pierrefitte_en_cinglais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14501-14690-pierrefitte_en_cinglais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14501-14690-pierrefitte_en_cinglais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14501-14690-pierrefitte_en_cinglais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14502-14690-pierrepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14502-14690-pierrepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14502-14690-pierrepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14502-14690-pierrepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14504-14590-le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14504-14590-le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14504-14590-le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14504-14590-le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14506-14490-planquery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14506-14490-planquery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14506-14490-planquery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14506-14490-planquery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14509-14440-plumetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14509-14440-plumetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14509-14440-plumetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14509-14440-plumetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14510-14690-la_pommeraye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14510-14690-la_pommeraye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14510-14690-la_pommeraye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14510-14690-la_pommeraye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14511-14380-pont_bellanger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14511-14380-pont_bellanger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14511-14380-pont_bellanger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14511-14380-pont_bellanger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14512-14110-pontecoulant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14512-14110-pontecoulant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14512-14110-pontecoulant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14512-14110-pontecoulant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14514-14130-pont_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14514-14130-pont_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14514-14130-pont_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14514-14130-pont_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14515-14520-port_en_bessin_huppain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14515-14520-port_en_bessin_huppain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14515-14520-port_en_bessin_huppain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14515-14520-port_en_bessin_huppain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14516-14420-potigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14516-14420-potigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14516-14420-potigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14516-14420-potigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14519-14210-preaux_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14519-14210-preaux_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14519-14210-preaux_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14519-14210-preaux_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14520-14340-le_pre_d_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14520-14340-le_pre_d_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14520-14340-le_pre_d_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14520-14340-le_pre_d_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14522-14140-pretreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14522-14140-pretreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14522-14140-pretreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14522-14140-pretreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14524-14430-putot_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14524-14430-putot_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14524-14430-putot_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14524-14430-putot_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14527-14270-belle_vie_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14527-14270-belle_vie_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14527-14270-belle_vie_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14527-14270-belle_vie_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14527-14340-belle_vie_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14527-14340-belle_vie_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14527-14340-belle_vie_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14527-14340-belle_vie_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14528-14130-quetteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14528-14130-quetteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14528-14130-quetteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14528-14130-quetteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14529-14400-ranchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14529-14400-ranchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14529-14400-ranchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14529-14400-ranchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14530-14860-ranville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14530-14860-ranville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14530-14860-ranville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14530-14860-ranville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14531-14690-rapilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14531-14690-rapilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14531-14690-rapilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14531-14690-rapilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14533-14340-repentigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14533-14340-repentigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14533-14340-repentigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14533-14340-repentigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14534-14130-reux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14534-14130-reux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14534-14130-reux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14534-14130-reux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14535-14470-reviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14535-14470-reviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14535-14470-reviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14535-14470-reviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14536-14600-la_riviere_saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14536-14600-la_riviere_saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14536-14600-la_riviere_saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14536-14600-la_riviere_saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14538-14540-castine_en_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14538-14540-castine_en_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14538-14540-castine_en_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14538-14540-castine_en_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14540-14100-rocques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14540-14100-rocques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14540-14100-rocques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14540-14100-rocques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14541-14340-la_roque_baignard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14541-14340-la_roque_baignard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14541-14340-la_roque_baignard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14541-14340-la_roque_baignard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14542-14740-rosel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14542-14740-rosel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14542-14740-rosel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14542-14740-rosel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14543-14980-rots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14543-14980-rots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14543-14980-rots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14543-14980-rots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14543-14740-rots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14543-14740-rots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14543-14740-rots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14543-14740-rots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14546-14190-rouvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14546-14190-rouvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14546-14190-rouvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14546-14190-rouvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14547-14710-rubercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14547-14710-rubercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14547-14710-rubercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14547-14710-rubercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14550-14340-rumesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14550-14340-rumesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14550-14340-rumesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14550-14340-rumesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14552-14400-ryes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14552-14400-ryes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14552-14400-ryes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14552-14400-ryes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14554-14540-le_castelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14554-14540-le_castelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14554-14540-le_castelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14554-14540-le_castelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14555-14130-saint_andre_d_hebertot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14555-14130-saint_andre_d_hebertot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14555-14130-saint_andre_d_hebertot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14555-14130-saint_andre_d_hebertot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14556-14320-saint_andre_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14556-14320-saint_andre_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14556-14320-saint_andre_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14556-14320-saint_andre_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14557-14800-saint_arnoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14557-14800-saint_arnoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14557-14800-saint_arnoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14557-14800-saint_arnoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14558-14970-saint_aubin_d_arquenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14558-14970-saint_aubin_d_arquenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14558-14970-saint_aubin_d_arquenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14558-14970-saint_aubin_d_arquenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14559-14380-saint_aubin_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14559-14380-saint_aubin_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14559-14380-saint_aubin_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14559-14380-saint_aubin_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14562-14750-saint_aubin_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14562-14750-saint_aubin_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14562-14750-saint_aubin_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14562-14750-saint_aubin_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14563-14130-saint_benoit_d_hebertot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14563-14130-saint_benoit_d_hebertot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14563-14130-saint_benoit_d_hebertot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14563-14130-saint_benoit_d_hebertot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14565-14960-saint_come_de_fresne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14565-14960-saint_come_de_fresne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14565-14960-saint_come_de_fresne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14565-14960-saint_come_de_fresne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14566-14280-saint_contest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14566-14280-saint_contest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14566-14280-saint_contest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14566-14280-saint_contest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14569-14480-sainte_croix_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14569-14480-sainte_croix_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14569-14480-sainte_croix_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14569-14480-sainte_croix_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14570-14290-valorbiquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14570-14290-valorbiquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14570-14290-valorbiquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14570-14290-valorbiquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14571-14100-saint_denis_de_mailloc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14571-14100-saint_denis_de_mailloc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14571-14100-saint_denis_de_mailloc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14571-14100-saint_denis_de_mailloc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14572-14110-saint_denis_de_mere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14572-14110-saint_denis_de_mere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14572-14110-saint_denis_de_mere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14572-14110-saint_denis_de_mere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14574-14100-saint_desir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14574-14100-saint_desir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14574-14100-saint_desir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14574-14100-saint_desir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14575-14950-saint_etienne_la_thillaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14575-14950-saint_etienne_la_thillaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14575-14950-saint_etienne_la_thillaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14575-14950-saint_etienne_la_thillaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14576-14140-val_de_vie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14576-14140-val_de_vie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14576-14140-val_de_vie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14576-14140-val_de_vie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14578-14130-saint_gatien_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14578-14130-saint_gatien_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14578-14130-saint_gatien_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14578-14130-saint_gatien_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14579-14260-seulline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14579-14260-seulline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14579-14260-seulline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14579-14260-seulline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14579-14310-seulline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14579-14310-seulline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14579-14310-seulline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14579-14310-seulline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14582-14100-saint_germain_de_livet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14582-14100-saint_germain_de_livet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14582-14100-saint_germain_de_livet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14582-14100-saint_germain_de_livet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14586-14230-saint_germain_du_pert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14586-14230-saint_germain_du_pert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14586-14230-saint_germain_du_pert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14586-14230-saint_germain_du_pert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14587-14280-saint_germain_la_blanche_herbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14587-14280-saint_germain_la_blanche_herbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14587-14280-saint_germain_la_blanche_herbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14587-14280-saint_germain_la_blanche_herbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14588-14700-saint_germain_langot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14588-14700-saint_germain_langot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14588-14700-saint_germain_langot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14588-14700-saint_germain_langot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14589-14190-saint_germain_le_vasson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14589-14190-saint_germain_le_vasson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14589-14190-saint_germain_le_vasson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14589-14190-saint_germain_le_vasson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14590-14240-sainte_honorine_de_ducy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14590-14240-sainte_honorine_de_ducy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14590-14240-sainte_honorine_de_ducy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14590-14240-sainte_honorine_de_ducy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14591-14520-aure_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14591-14520-aure_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14591-14520-aure_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14591-14520-aure_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14592-14210-sainte_honorine_du_fay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14592-14210-sainte_honorine_du_fay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14592-14210-sainte_honorine_du_fay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14592-14210-sainte_honorine_du_fay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14593-14130-saint_hymer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14593-14130-saint_hymer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14593-14130-saint_hymer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14593-14130-saint_hymer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14595-14100-saint_jean_de_livet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14595-14100-saint_jean_de_livet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14595-14100-saint_jean_de_livet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14595-14100-saint_jean_de_livet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14598-14430-saint_jouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14598-14430-saint_jouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14598-14430-saint_jouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14598-14430-saint_jouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14601-14130-saint_julien_sur_calonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14601-14130-saint_julien_sur_calonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14601-14130-saint_julien_sur_calonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14601-14130-saint_julien_sur_calonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14602-14570-saint_lambert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14602-14570-saint_lambert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14602-14570-saint_lambert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14602-14570-saint_lambert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14603-14220-saint_laurent_de_condel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14603-14220-saint_laurent_de_condel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14603-14220-saint_laurent_de_condel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14603-14220-saint_laurent_de_condel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14605-14710-saint_laurent_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14605-14710-saint_laurent_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14605-14710-saint_laurent_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14605-14710-saint_laurent_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14606-14430-saint_leger_dubosq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14606-14430-saint_leger_dubosq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14606-14430-saint_leger_dubosq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14606-14430-saint_leger_dubosq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14607-14310-saint_louet_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14607-14310-saint_louet_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14607-14310-saint_louet_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14607-14310-saint_louet_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14609-14400-saint_loup_hors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14609-14400-saint_loup_hors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14609-14400-saint_loup_hors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14609-14400-saint_loup_hors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14610-14740-saint_manvieu_norrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14610-14740-saint_manvieu_norrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14610-14740-saint_manvieu_norrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14610-14740-saint_manvieu_norrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14613-14330-saint_marcouf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14613-14330-saint_marcouf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14613-14330-saint_marcouf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14613-14330-saint_marcouf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14614-14330-sainte_marguerite_d_elle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14614-14330-sainte_marguerite_d_elle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14614-14330-sainte_marguerite_d_elle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14614-14330-sainte_marguerite_d_elle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14619-14380-sainte_marie_outre_l_eau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14619-14380-sainte_marie_outre_l_eau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14619-14380-sainte_marie_outre_l_eau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14619-14380-sainte_marie_outre_l_eau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14620-14130-saint_martin_aux_chartrains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14620-14130-saint_martin_aux_chartrains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14620-14130-saint_martin_aux_chartrains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14620-14130-saint_martin_aux_chartrains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14621-14290-saint_martin_de_bienfaite_la_cressonniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14621-14290-saint_martin_de_bienfaite_la_cressonniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14621-14290-saint_martin_de_bienfaite_la_cressonniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14621-14290-saint_martin_de_bienfaite_la_cressonniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14622-14710-saint_martin_de_blagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14622-14710-saint_martin_de_blagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14622-14710-saint_martin_de_blagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14622-14710-saint_martin_de_blagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14623-14320-saint_martin_de_fontenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14623-14320-saint_martin_de_fontenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14623-14320-saint_martin_de_fontenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14623-14320-saint_martin_de_fontenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14625-14100-saint_martin_de_la_lieue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14625-14100-saint_martin_de_la_lieue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14625-14100-saint_martin_de_la_lieue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14625-14100-saint_martin_de_la_lieue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14626-14100-saint_martin_de_mailloc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14626-14100-saint_martin_de_mailloc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14626-14100-saint_martin_de_mailloc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14626-14100-saint_martin_de_mailloc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14627-14700-saint_martin_de_mieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14627-14700-saint_martin_de_mieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14627-14700-saint_martin_de_mieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14627-14700-saint_martin_de_mieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14630-14400-saint_martin_des_entrees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14630-14400-saint_martin_des_entrees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14630-14400-saint_martin_des_entrees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14630-14400-saint_martin_des_entrees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14635-14220-saint_omer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14635-14220-saint_omer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14635-14220-saint_omer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14635-14220-saint_omer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14637-14670-saint_ouen_du_mesnil_oger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14637-14670-saint_ouen_du_mesnil_oger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14637-14670-saint_ouen_du_mesnil_oger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14637-14670-saint_ouen_du_mesnil_oger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14639-14340-saint_ouen_le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14639-14340-saint_ouen_le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14639-14340-saint_ouen_le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14639-14340-saint_ouen_le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14640-14670-saint_pair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14640-14670-saint_pair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14640-14670-saint_pair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14640-14670-saint_pair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14643-14490-saint_paul_du_vernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14643-14490-saint_paul_du_vernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14643-14490-saint_paul_du_vernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14643-14490-saint_paul_du_vernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14644-14130-saint_philbert_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14644-14130-saint_philbert_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14644-14130-saint_philbert_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14644-14130-saint_philbert_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14645-14950-saint_pierre_azif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14645-14950-saint_pierre_azif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14645-14950-saint_pierre_azif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14645-14950-saint_pierre_azif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14646-14700-saint_pierre_canivet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14646-14700-saint_pierre_canivet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14646-14700-saint_pierre_canivet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14646-14700-saint_pierre_canivet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14648-14100-saint_pierre_des_ifs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14648-14100-saint_pierre_des_ifs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14648-14100-saint_pierre_des_ifs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14648-14100-saint_pierre_des_ifs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14649-14700-saint_pierre_du_bu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14649-14700-saint_pierre_du_bu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14649-14700-saint_pierre_du_bu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14649-14700-saint_pierre_du_bu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14650-14260-saint_pierre_du_fresne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14650-14260-saint_pierre_du_fresne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14650-14260-saint_pierre_du_fresne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14650-14260-saint_pierre_du_fresne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14651-14670-saint_pierre_du_jonquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14651-14670-saint_pierre_du_jonquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14651-14670-saint_pierre_du_jonquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14651-14670-saint_pierre_du_jonquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14652-14450-saint_pierre_du_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14652-14450-saint_pierre_du_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14652-14450-saint_pierre_du_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14652-14450-saint_pierre_du_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14654-14170-saint_pierre_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14654-14170-saint_pierre_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14654-14170-saint_pierre_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14654-14170-saint_pierre_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14654-14140-saint_pierre_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14654-14140-saint_pierre_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14654-14140-saint_pierre_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14654-14140-saint_pierre_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14656-14570-saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14656-14570-saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14656-14570-saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14656-14570-saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14657-14670-saint_samson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14657-14670-saint_samson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14657-14670-saint_samson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14657-14670-saint_samson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14658-14380-noues_de_sienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14658-14380-noues_de_sienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14658-14380-noues_de_sienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14658-14380-noues_de_sienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14659-14190-saint_sylvain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14659-14190-saint_sylvain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14659-14190-saint_sylvain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14659-14190-saint_sylvain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14660-14640-saint_vaast_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14660-14640-saint_vaast_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14660-14640-saint_vaast_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14660-14640-saint_vaast_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14661-14250-saint_vaast_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14661-14250-saint_vaast_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14661-14250-saint_vaast_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14661-14250-saint_vaast_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14663-14400-saint_vigor_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14663-14400-saint_vigor_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14663-14400-saint_vigor_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14663-14400-saint_vigor_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14664-14240-sallen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14664-14240-sallen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14664-14240-sallen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14664-14240-sallen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14665-14121-sallenelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14665-14121-sallenelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14665-14121-sallenelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14665-14121-sallenelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14667-14330-saon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14667-14330-saon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14667-14330-saon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14667-14330-saon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14668-14330-saonnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14668-14330-saonnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14668-14330-saonnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14668-14330-saonnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14669-14170-sassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14669-14170-sassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14669-14170-sassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14669-14170-sassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14672-14240-val_de_drome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14672-14240-val_de_drome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14672-14240-val_de_drome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14672-14240-val_de_drome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14672-14350-val_de_drome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14672-14350-val_de_drome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14672-14350-val_de_drome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14672-14350-val_de_drome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14674-14190-soignolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14674-14190-soignolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14674-14190-soignolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14674-14190-soignolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14675-14540-soliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14675-14540-soliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14675-14540-soliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14675-14540-soliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14676-14400-sommervieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14676-14400-sommervieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14676-14400-sommervieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14676-14400-sommervieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14677-14700-soulangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14677-14700-soulangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14677-14700-soulangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14677-14700-soulangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14678-14420-soumont_saint_quentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14678-14420-soumont_saint_quentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14678-14420-soumont_saint_quentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14678-14420-soumont_saint_quentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14679-14400-subles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14679-14400-subles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14679-14400-subles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14679-14400-subles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14680-14400-sully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14680-14400-sully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14680-14400-sully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14680-14400-sully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14681-14710-surrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14681-14710-surrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14681-14710-surrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14681-14710-surrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14682-14130-surville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14682-14130-surville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14682-14130-surville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14682-14130-surville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14684-14250-tessel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14684-14250-tessel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14684-14250-tessel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14684-14250-tessel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14685-14610-thaon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14685-14610-thaon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14685-14610-thaon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14685-14610-thaon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14687-14130-le_theil_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14687-14130-le_theil_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14687-14130-le_theil_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14687-14130-le_theil_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14689-14220-le_hom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14689-14220-le_hom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14689-14220-le_hom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14689-14220-le_hom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14692-14250-tilly_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14692-14250-tilly_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14692-14250-tilly_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14692-14250-tilly_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14694-14130-le_torquesne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14694-14130-le_torquesne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14694-14130-le_torquesne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14694-14130-le_torquesne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14698-14940-touffreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14698-14940-touffreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14698-14940-touffreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14698-14940-touffreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14699-14800-touques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14699-14800-touques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14699-14800-touques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14699-14800-touques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14700-14400-tour_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14700-14400-tour_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14700-14400-tour_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14700-14400-tour_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14701-14800-tourgeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14701-14800-tourgeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14701-14800-tourgeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14701-14800-tourgeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14705-14330-tournieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14705-14330-tournieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14705-14330-tournieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14705-14330-tournieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14706-14130-tourville_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14706-14130-tourville_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14706-14130-tourville_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14706-14130-tourville_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14707-14210-tourville_sur_odon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14707-14210-tourville_sur_odon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14707-14210-tourville_sur_odon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14707-14210-tourville_sur_odon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14708-14310-tracy_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14708-14310-tracy_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14708-14310-tracy_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14708-14310-tracy_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14709-14117-tracy_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14709-14117-tracy_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14709-14117-tracy_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14709-14117-tracy_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14710-14690-treprel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14710-14690-treprel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14710-14690-treprel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14710-14690-treprel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14711-14710-trevieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14711-14710-trevieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14711-14710-trevieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14711-14710-trevieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14712-14670-saline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14712-14670-saline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14712-14670-saline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14712-14670-saline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14712-14940-saline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14712-14940-saline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14712-14940-saline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14712-14940-saline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14713-14210-montillieres_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14713-14210-montillieres_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14713-14210-montillieres_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14713-14210-montillieres_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14714-14490-le_tronquay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14714-14490-le_tronquay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14714-14490-le_tronquay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14714-14490-le_tronquay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14715-14360-trouville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14715-14360-trouville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14715-14360-trouville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14715-14360-trouville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14716-14490-trungy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14716-14490-trungy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14716-14490-trungy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14716-14490-trungy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14719-14190-urville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14719-14190-urville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14719-14190-urville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14719-14190-urville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14720-14420-ussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14720-14420-ussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14720-14420-ussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14720-14420-ussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14721-14210-vacognes_neuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14721-14210-vacognes_neuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14721-14210-vacognes_neuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14721-14210-vacognes_neuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14723-14340-valseme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14723-14340-valseme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14723-14340-valseme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14723-14340-valseme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14724-14390-varaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14724-14390-varaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14724-14390-varaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14724-14390-varaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14726-14350-valdalliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14726-14350-valdalliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14726-14350-valdalliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14726-14350-valdalliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14726-14410-valdalliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14726-14410-valdalliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14726-14410-valdalliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14726-14410-valdalliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14728-14400-vaucelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14728-14400-vaucelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14728-14400-vaucelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14728-14400-vaucelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14731-14800-vauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14731-14800-vauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14731-14800-vauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14731-14800-vauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14732-14400-vaux_sur_aure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14732-14400-vaux_sur_aure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14732-14400-vaux_sur_aure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14732-14400-vaux_sur_aure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14733-14400-vaux_sur_seulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14733-14400-vaux_sur_seulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14733-14400-vaux_sur_seulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14733-14400-vaux_sur_seulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14734-14250-vendes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14734-14250-vendes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14734-14250-vendes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14734-14250-vendes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14735-14170-vendeuvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14735-14170-vendeuvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14735-14170-vendeuvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14735-14170-vendeuvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14737-14700-versainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14737-14700-versainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14737-14700-versainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14737-14700-versainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14738-14790-verson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14738-14790-verson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14738-14790-verson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14738-14790-verson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14739-14114-ver_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14739-14114-ver_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14739-14114-ver_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14739-14114-ver_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14740-14290-la_vespiere_friardel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14740-14290-la_vespiere_friardel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14740-14290-la_vespiere_friardel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14740-14290-la_vespiere_friardel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14741-14570-le_vey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14741-14570-le_vey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14741-14570-le_vey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14741-14570-le_vey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14742-14170-vicques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14742-14170-vicques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14742-14170-vicques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14742-14170-vicques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14743-14430-victot_pontfol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14743-14430-victot_pontfol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14743-14430-victot_pontfol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14743-14430-victot_pontfol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14744-14400-vienne_en_bessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14744-14400-vienne_en_bessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14744-14400-vienne_en_bessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14744-14400-vienne_en_bessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14745-14710-vierville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14745-14710-vierville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14745-14710-vierville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14745-14710-vierville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14747-14930-vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14747-14930-vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14747-14930-vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14747-14930-vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14748-14130-vieux_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14748-14130-vieux_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14748-14130-vieux_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14748-14130-vieux_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14751-14700-vignats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14751-14700-vignats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14751-14700-vignats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14751-14700-vignats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14752-14310-villers_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14752-14310-villers_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14752-14310-villers_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14752-14310-villers_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14753-14420-villers_canivet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14753-14420-villers_canivet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14753-14420-villers_canivet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14753-14420-villers_canivet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14754-14640-villers_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14754-14640-villers_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14754-14640-villers_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14754-14640-villers_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14755-14113-villerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14755-14113-villerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14755-14113-villerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14755-14113-villerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14756-14570-la_villette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14756-14570-la_villette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14756-14570-la_villette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14756-14570-la_villette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14758-14610-villons_les_buissons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14758-14610-villons_les_buissons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14758-14610-villons_les_buissons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14758-14610-villons_les_buissons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14759-14700-villy_lez_falaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14759-14700-villy_lez_falaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14759-14700-villy_lez_falaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14759-14700-villy_lez_falaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14760-14310-villy_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14760-14310-villy_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14760-14310-villy_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14760-14310-villy_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14761-14370-vimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14761-14370-vimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14761-14370-vimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14761-14370-vimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14762-14500-vire_normandie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14762-14500-vire_normandie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14762-14500-vire_normandie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14762-14500-vire_normandie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14764-14690-pont_d_ouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14764-14690-pont_d_ouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14764-14690-pont_d_ouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt14-calvados/commune14764-14690-pont_d_ouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-15.xml
+++ b/public/sitemaps/sitemap-15.xml
@@ -5,524 +5,1044 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15001-15160-allanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15001-15160-allanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15001-15160-allanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15001-15160-allanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15002-15100-alleuze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15002-15100-alleuze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15002-15100-alleuze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15002-15100-alleuze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15002-15260-alleuze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15002-15260-alleuze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15002-15260-alleuze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15002-15260-alleuze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15003-15700-ally/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15003-15700-ally/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15003-15700-ally/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15003-15700-ally/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15004-15100-andelat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15004-15100-andelat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15004-15100-andelat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15004-15100-andelat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15005-15100-anglards_de_saint_flour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15005-15100-anglards_de_saint_flour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15005-15100-anglards_de_saint_flour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15005-15100-anglards_de_saint_flour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15005-15320-anglards_de_saint_flour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15005-15320-anglards_de_saint_flour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15005-15320-anglards_de_saint_flour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15005-15320-anglards_de_saint_flour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15006-15380-anglards_de_salers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15006-15380-anglards_de_salers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15006-15380-anglards_de_salers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15006-15380-anglards_de_salers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15007-15110-anterrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15007-15110-anterrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15007-15110-anterrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15007-15110-anterrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15008-15240-antignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15008-15240-antignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15008-15240-antignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15008-15240-antignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15009-15400-apchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15009-15400-apchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15009-15400-apchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15009-15400-apchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15010-15200-arches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15010-15200-arches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15010-15200-arches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15010-15200-arches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15011-15150-arnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15011-15150-arnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15011-15150-arnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15011-15150-arnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15012-15130-arpajon_sur_cere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15012-15130-arpajon_sur_cere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15012-15130-arpajon_sur_cere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15012-15130-arpajon_sur_cere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15012-15000-arpajon_sur_cere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15012-15000-arpajon_sur_cere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15012-15000-arpajon_sur_cere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15012-15000-arpajon_sur_cere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15013-15500-auriac_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15013-15500-auriac_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15013-15500-auriac_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15013-15500-auriac_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15014-15000-aurillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15014-15000-aurillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15014-15000-aurillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15014-15000-aurillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15015-15240-auzers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15015-15240-auzers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15015-15240-auzers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15015-15240-auzers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15016-15250-ayrens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15016-15250-ayrens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15016-15250-ayrens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15016-15250-ayrens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15017-15800-badailhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15017-15800-badailhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15017-15800-badailhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15017-15800-badailhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15018-15700-barriac_les_bosquets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15018-15700-barriac_les_bosquets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15018-15700-barriac_les_bosquets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15018-15700-barriac_les_bosquets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15019-15240-bassignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15019-15240-bassignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15019-15240-bassignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15019-15240-bassignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15020-15270-beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15020-15270-beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15020-15270-beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15020-15270-beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15021-15600-boisset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15021-15600-boisset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15021-15600-boisset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15021-15600-boisset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15022-15500-bonnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15022-15500-bonnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15022-15500-bonnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15022-15500-bonnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15024-15700-brageac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15024-15700-brageac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15024-15700-brageac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15024-15700-brageac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15025-15300-albepierre_bredons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15025-15300-albepierre_bredons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15025-15300-albepierre_bredons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15025-15300-albepierre_bredons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15026-15230-brezons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15026-15230-brezons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15026-15230-brezons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15026-15230-brezons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15027-15340-puycapel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15027-15340-puycapel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15027-15340-puycapel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15027-15340-puycapel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15028-15130-carlat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15028-15130-carlat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15028-15130-carlat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15028-15130-carlat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15029-15340-cassaniouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15029-15340-cassaniouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15029-15340-cassaniouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15029-15340-cassaniouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15030-15290-cayrols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15030-15290-cayrols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15030-15290-cayrols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15030-15290-cayrols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15032-15500-celoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15032-15500-celoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15032-15500-celoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15032-15500-celoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15033-15230-cezens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15033-15230-cezens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15033-15230-cezens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15033-15230-cezens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15034-15320-chaliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15034-15320-chaliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15034-15320-chaliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15034-15320-chaliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15036-15200-chalvignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15036-15200-chalvignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15036-15200-chalvignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15036-15200-chalvignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15037-15350-champagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15037-15350-champagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15037-15350-champagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15037-15350-champagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15038-15270-champs_sur_tarentaine_marchal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15038-15270-champs_sur_tarentaine_marchal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15038-15270-champs_sur_tarentaine_marchal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15038-15270-champs_sur_tarentaine_marchal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15040-15190-chanterelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15040-15190-chanterelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15040-15190-chanterelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15040-15190-chanterelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15041-15300-la_chapelle_d_alagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15041-15300-la_chapelle_d_alagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15041-15300-la_chapelle_d_alagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15041-15300-la_chapelle_d_alagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15042-15500-la_chapelle_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15042-15500-la_chapelle_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15042-15500-la_chapelle_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15042-15500-la_chapelle_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15043-15500-charmensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15043-15500-charmensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15043-15500-charmensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15043-15500-charmensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15043-15170-charmensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15043-15170-charmensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15043-15170-charmensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15043-15170-charmensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15045-15110-chaudes_aigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15045-15110-chaudes_aigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15045-15110-chaudes_aigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15045-15110-chaudes_aigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15046-15700-chaussenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15046-15700-chaussenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15046-15700-chaussenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15046-15700-chaussenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15048-15500-chazelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15048-15500-chazelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15048-15500-chazelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15048-15500-chazelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15049-15400-cheylade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15049-15400-cheylade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15049-15400-cheylade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15049-15400-cheylade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15050-15400-le_claux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15050-15400-le_claux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15050-15400-le_claux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15050-15400-le_claux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15051-15320-clavieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15051-15320-clavieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15051-15320-clavieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15051-15320-clavieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15051-43300-clavieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15051-43300-clavieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15051-43300-clavieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15051-43300-clavieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15052-15400-collandres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15052-15400-collandres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15052-15400-collandres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15052-15400-collandres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15053-15170-coltines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15053-15170-coltines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15053-15170-coltines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15053-15170-coltines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15054-15190-condat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15054-15190-condat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15054-15190-condat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15054-15190-condat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15055-15100-coren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15055-15100-coren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15055-15100-coren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15055-15100-coren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15056-15250-crandelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15056-15250-crandelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15056-15250-crandelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15056-15250-crandelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15057-15150-cros_de_montvert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15057-15150-cros_de_montvert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15057-15150-cros_de_montvert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15057-15150-cros_de_montvert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15058-15130-cros_de_ronesque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15058-15130-cros_de_ronesque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15058-15130-cros_de_ronesque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15058-15130-cros_de_ronesque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15059-15430-cussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15059-15430-cussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15059-15430-cussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15059-15430-cussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15060-15110-deux_verges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15060-15110-deux_verges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15060-15110-deux_verges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15060-15110-deux_verges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15061-15300-dienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15061-15300-dienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15061-15300-dienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15061-15300-dienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15063-15140-drugeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15063-15140-drugeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15063-15140-drugeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15063-15140-drugeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15064-15700-escorailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15064-15700-escorailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15064-15700-escorailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15064-15700-escorailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15065-15110-espinasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15065-15110-espinasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15065-15110-espinasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15065-15110-espinasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15066-15380-le_falgoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15066-15380-le_falgoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15066-15380-le_falgoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15066-15380-le_falgoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15067-15140-le_fau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15067-15140-le_fau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15067-15140-le_fau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15067-15140-le_fau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15069-15170-ferrieres_saint_mary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15069-15170-ferrieres_saint_mary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15069-15170-ferrieres_saint_mary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15069-15170-ferrieres_saint_mary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15070-15140-fontanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15070-15140-fontanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15070-15140-fontanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15070-15140-fontanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15072-15310-freix_anglards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15072-15310-freix_anglards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15072-15310-freix_anglards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15072-15310-freix_anglards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15073-15110-fridefont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15073-15110-fridefont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15073-15110-fridefont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15073-15110-fridefont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15074-15130-giou_de_mamou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15074-15130-giou_de_mamou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15074-15130-giou_de_mamou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15074-15130-giou_de_mamou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15075-15310-girgols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15075-15310-girgols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15075-15310-girgols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15075-15310-girgols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15076-15150-glenat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15076-15150-glenat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15076-15150-glenat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15076-15150-glenat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15077-15230-gourdieges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15077-15230-gourdieges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15077-15230-gourdieges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15077-15230-gourdieges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15078-15110-jabrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15078-15110-jabrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15078-15110-jabrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15078-15110-jabrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15079-15200-jaleyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15079-15200-jaleyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15079-15200-jaleyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15079-15200-jaleyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15080-15170-joursac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15080-15170-joursac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15080-15170-joursac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15080-15170-joursac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15081-15800-jou_sous_monjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15081-15800-jou_sous_monjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15081-15800-jou_sous_monjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15081-15800-jou_sous_monjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15082-15120-junhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15082-15120-junhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15082-15120-junhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15082-15120-junhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15083-15250-jussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15083-15250-jussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15083-15250-jussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15083-15250-jussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15084-15120-labesserette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15084-15120-labesserette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15084-15120-labesserette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15084-15120-labesserette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15085-15130-labrousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15085-15130-labrousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15085-15130-labrousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15085-15130-labrousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15086-15230-lacapelle_barres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15086-15230-lacapelle_barres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15086-15230-lacapelle_barres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15086-15230-lacapelle_barres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15087-15120-lacapelle_del_fraisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15087-15120-lacapelle_del_fraisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15087-15120-lacapelle_del_fraisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15087-15120-lacapelle_del_fraisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15088-15150-lacapelle_viescamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15088-15150-lacapelle_viescamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15088-15150-lacapelle_viescamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15088-15150-lacapelle_viescamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15089-15120-ladinhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15089-15120-ladinhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15089-15120-ladinhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15089-15120-ladinhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15090-15130-lafeuillade_en_vezie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15090-15130-lafeuillade_en_vezie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15090-15130-lafeuillade_en_vezie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15090-15130-lafeuillade_en_vezie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15091-15160-landeyrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15091-15160-landeyrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15091-15160-landeyrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15091-15160-landeyrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15092-15270-lanobre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15092-15270-lanobre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15092-15270-lanobre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15092-15270-lanobre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15093-15120-lapeyrugue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15093-15120-lapeyrugue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15093-15120-lapeyrugue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15093-15120-lapeyrugue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15094-15150-laroquebrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15094-15150-laroquebrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15094-15150-laroquebrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15094-15150-laroquebrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15095-15250-laroquevieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15095-15250-laroquevieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15095-15250-laroquevieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15095-15250-laroquevieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15096-15590-lascelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15096-15590-lascelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15096-15590-lascelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15096-15590-lascelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15097-15500-lastic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15097-15500-lastic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15097-15500-lastic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15097-15500-lastic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15098-15500-laurie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15098-15500-laurie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15098-15500-laurie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15098-15500-laurie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15100-15300-laveissenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15100-15300-laveissenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15100-15300-laveissenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15100-15300-laveissenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15101-15300-laveissiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15101-15300-laveissiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15101-15300-laveissiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15101-15300-laveissiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15102-15300-lavigerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15102-15300-lavigerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15102-15300-lavigerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15102-15300-lavigerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15103-15120-leucamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15103-15120-leucamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15103-15120-leucamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15103-15120-leucamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15103-15130-leucamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15103-15130-leucamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15103-15130-leucamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15103-15130-leucamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15104-15600-leynhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15104-15600-leynhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15104-15600-leynhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15104-15600-leynhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15105-43450-leyvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15105-43450-leyvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15105-43450-leyvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15105-43450-leyvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15106-15110-lieutades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15106-15110-lieutades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15106-15110-lieutades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15106-15110-lieutades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15107-15320-lorcieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15107-15320-lorcieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15107-15320-lorcieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15107-15320-lorcieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15108-15320-val_d_arcomie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15108-15320-val_d_arcomie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15108-15320-val_d_arcomie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15108-15320-val_d_arcomie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15110-15190-lugarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15110-15190-lugarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15110-15190-lugarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15110-15190-lugarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15111-15210-madic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15111-15210-madic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15111-15210-madic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15111-15210-madic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15112-15230-malbo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15112-15230-malbo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15112-15230-malbo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15112-15230-malbo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15113-15590-mandailles_saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15113-15590-mandailles_saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15113-15590-mandailles_saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15113-15590-mandailles_saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15114-15190-marcenat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15114-15190-marcenat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15114-15190-marcenat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15114-15190-marcenat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15116-15400-marchastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15116-15400-marchastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15116-15400-marchastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15116-15400-marchastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15117-15220-marcoles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15117-15220-marcoles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15117-15220-marcoles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15117-15220-marcoles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15118-15250-marmanhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15118-15250-marmanhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15118-15250-marmanhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15118-15250-marmanhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15119-15500-massiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15119-15500-massiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15119-15500-massiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15119-15500-massiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15120-15200-mauriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15120-15200-mauriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15120-15200-mauriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15120-15200-mauriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15121-15110-maurines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15121-15110-maurines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15121-15110-maurines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15121-15110-maurines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15122-15600-maurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15122-15600-maurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15122-15600-maurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15122-15600-maurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15123-15200-meallet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15123-15200-meallet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15123-15200-meallet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15123-15200-meallet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15124-15400-menet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15124-15400-menet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15124-15400-menet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15124-15400-menet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15125-15100-mentieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15125-15100-mentieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15125-15100-mentieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15125-15100-mentieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15126-15500-moledes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15126-15500-moledes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15126-15500-moledes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15126-15500-moledes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15127-15500-molompize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15127-15500-molompize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15127-15500-molompize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15127-15500-molompize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15128-15240-la_monselie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15128-15240-la_monselie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15128-15240-la_monselie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15128-15240-la_monselie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15129-15190-montboudif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15129-15190-montboudif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15129-15190-montboudif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15129-15190-montboudif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15130-15100-montchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15130-15100-montchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15130-15100-montchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15130-15100-montchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15131-15240-le_monteil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15131-15240-le_monteil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15131-15240-le_monteil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15131-15240-le_monteil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15132-15190-montgreleix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15132-15190-montgreleix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15132-15190-montgreleix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15132-15190-montgreleix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15133-15600-montmurat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15133-15600-montmurat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15133-15600-montmurat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15133-15600-montmurat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15134-15120-montsalvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15134-15120-montsalvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15134-15120-montsalvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15134-15120-montsalvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15135-15150-montvert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15135-15150-montvert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15135-15150-montvert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15135-15150-montvert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15137-15380-moussages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15137-15380-moussages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15137-15380-moussages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15137-15380-moussages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15138-15300-murat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15138-15300-murat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15138-15300-murat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15138-15300-murat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15139-15230-narnhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15139-15230-narnhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15139-15230-narnhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15139-15230-narnhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15140-15250-naucelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15140-15250-naucelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15140-15250-naucelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15140-15250-naucelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15141-15170-neussargues_en_pinatelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15141-15170-neussargues_en_pinatelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15141-15170-neussargues_en_pinatelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15141-15170-neussargues_en_pinatelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15141-15300-neussargues_en_pinatelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15141-15300-neussargues_en_pinatelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15141-15300-neussargues_en_pinatelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15141-15300-neussargues_en_pinatelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15142-15260-neuveglise_sur_truyere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15142-15260-neuveglise_sur_truyere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15142-15260-neuveglise_sur_truyere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15142-15260-neuveglise_sur_truyere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15142-15100-neuveglise_sur_truyere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15142-15100-neuveglise_sur_truyere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15142-15100-neuveglise_sur_truyere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15142-15100-neuveglise_sur_truyere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15143-15150-nieudan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15143-15150-nieudan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15143-15150-nieudan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15143-15150-nieudan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15144-15290-omps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15144-15290-omps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15144-15290-omps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15144-15290-omps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15146-15800-pailherols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15146-15800-pailherols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15146-15800-pailherols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15146-15800-pailherols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15147-15290-parlan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15147-15290-parlan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15147-15290-parlan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15147-15290-parlan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15148-15430-paulhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15148-15430-paulhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15148-15430-paulhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15148-15430-paulhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15149-15230-paulhenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15149-15230-paulhenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15149-15230-paulhenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15149-15230-paulhenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15151-15170-peyrusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15151-15170-peyrusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15151-15170-peyrusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15151-15170-peyrusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15152-15230-pierrefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15152-15230-pierrefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15152-15230-pierrefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15152-15230-pierrefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15153-15700-pleaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15153-15700-pleaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15153-15700-pleaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15153-15700-pleaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15154-15800-polminhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15154-15800-polminhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15154-15800-polminhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15154-15800-polminhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15155-15160-pradiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15155-15160-pradiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15155-15160-pradiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15155-15160-pradiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15156-15130-prunet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15156-15130-prunet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15156-15130-prunet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15156-15130-prunet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15157-15600-quezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15157-15600-quezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15157-15600-quezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15157-15600-quezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15158-15500-rageade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15158-15500-rageade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15158-15500-rageade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15158-15500-rageade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15159-15800-raulhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15159-15800-raulhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15159-15800-raulhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15159-15800-raulhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15160-15250-reilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15160-15250-reilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15160-15250-reilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15160-15250-reilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15161-15170-rezentieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15161-15170-rezentieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15161-15170-rezentieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15161-15170-rezentieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15162-15400-riom_es_montagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15162-15400-riom_es_montagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15162-15400-riom_es_montagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15162-15400-riom_es_montagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15163-15220-roannes_saint_mary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15163-15220-roannes_saint_mary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15163-15220-roannes_saint_mary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15163-15220-roannes_saint_mary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15164-15100-roffiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15164-15100-roffiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15164-15100-roffiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15164-15100-roffiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15165-15150-rouffiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15165-15150-rouffiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15165-15150-rouffiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15165-15150-rouffiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15166-15290-roumegoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15166-15290-roumegoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15166-15290-roumegoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15166-15290-roumegoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15167-15600-rouziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15167-15600-rouziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15167-15600-rouziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15167-15600-rouziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15168-15320-ruynes_en_margeride/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15168-15320-ruynes_en_margeride/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15168-15320-ruynes_en_margeride/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15168-15320-ruynes_en_margeride/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15169-15240-saignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15169-15240-saignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15169-15240-saignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15169-15240-saignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15170-15190-saint_amandin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15170-15190-saint_amandin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15170-15190-saint_amandin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15170-15190-saint_amandin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15172-15220-saint_antoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15172-15220-saint_antoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15172-15220-saint_antoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15172-15220-saint_antoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15173-15190-saint_bonnet_de_condat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15173-15190-saint_bonnet_de_condat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15173-15190-saint_bonnet_de_condat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15173-15190-saint_bonnet_de_condat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15174-15140-saint_bonnet_de_salers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15174-15140-saint_bonnet_de_salers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15174-15140-saint_bonnet_de_salers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15174-15140-saint_bonnet_de_salers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15175-15310-saint_cernin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15175-15310-saint_cernin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15175-15310-saint_cernin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15175-15310-saint_cernin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15176-15140-saint_chamant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15176-15140-saint_chamant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15176-15140-saint_chamant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15176-15140-saint_chamant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15178-15590-saint_cirgues_de_jordanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15178-15590-saint_cirgues_de_jordanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15178-15590-saint_cirgues_de_jordanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15178-15590-saint_cirgues_de_jordanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15179-15140-saint_cirgues_de_malbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15179-15140-saint_cirgues_de_malbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15179-15140-saint_cirgues_de_malbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15179-15140-saint_cirgues_de_malbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15180-15800-saint_clement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15180-15800-saint_clement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15180-15800-saint_clement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15180-15800-saint_clement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15181-15600-saint_constant_fournoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15181-15600-saint_constant_fournoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15181-15600-saint_constant_fournoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15181-15600-saint_constant_fournoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15182-15150-saint_etienne_cantales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15182-15150-saint_etienne_cantales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15182-15150-saint_etienne_cantales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15182-15150-saint_etienne_cantales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15183-15130-saint_etienne_de_carlat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15183-15130-saint_etienne_de_carlat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15183-15130-saint_etienne_de_carlat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15183-15130-saint_etienne_de_carlat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15184-15600-saint_etienne_de_maurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15184-15600-saint_etienne_de_maurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15184-15600-saint_etienne_de_maurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15184-15600-saint_etienne_de_maurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15185-15400-saint_etienne_de_chomeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15185-15400-saint_etienne_de_chomeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15185-15400-saint_etienne_de_chomeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15185-15400-saint_etienne_de_chomeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15185-15270-saint_etienne_de_chomeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15185-15270-saint_etienne_de_chomeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15185-15270-saint_etienne_de_chomeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15185-15270-saint_etienne_de_chomeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15186-15140-sainte_eulalie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15186-15140-sainte_eulalie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15186-15140-sainte_eulalie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15186-15140-sainte_eulalie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15187-15100-saint_flour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15187-15100-saint_flour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15187-15100-saint_flour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15187-15100-saint_flour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15188-15100-saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15188-15100-saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15188-15100-saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15188-15100-saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15189-15150-saint_gerons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15189-15150-saint_gerons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15189-15150-saint_gerons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15189-15150-saint_gerons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15190-15400-saint_hippolyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15190-15400-saint_hippolyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15190-15400-saint_hippolyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15190-15400-saint_hippolyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15191-15310-saint_illide/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15191-15310-saint_illide/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15191-15310-saint_illide/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15191-15310-saint_illide/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15192-15800-saint_jacques_des_blats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15192-15800-saint_jacques_des_blats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15192-15800-saint_jacques_des_blats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15192-15800-saint_jacques_des_blats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15194-15600-saint_julien_de_toursac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15194-15600-saint_julien_de_toursac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15194-15600-saint_julien_de_toursac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15194-15600-saint_julien_de_toursac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15196-15220-saint_mamet_la_salvetat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15196-15220-saint_mamet_la_salvetat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15196-15220-saint_mamet_la_salvetat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15196-15220-saint_mamet_la_salvetat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15198-15230-sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15198-15230-sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15198-15230-sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15198-15230-sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15199-15110-saint_martial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15199-15110-saint_martial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15199-15110-saint_martial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15199-15110-saint_martial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15200-15140-saint_martin_cantales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15200-15140-saint_martin_cantales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15200-15140-saint_martin_cantales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15200-15140-saint_martin_cantales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15201-15230-saint_martin_sous_vigouroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15201-15230-saint_martin_sous_vigouroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15201-15230-saint_martin_sous_vigouroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15201-15230-saint_martin_sous_vigouroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15202-15140-saint_martin_valmeroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15202-15140-saint_martin_valmeroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15202-15140-saint_martin_valmeroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15202-15140-saint_martin_valmeroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15203-15500-saint_mary_le_plain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15203-15500-saint_mary_le_plain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15203-15500-saint_mary_le_plain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15203-15500-saint_mary_le_plain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15204-15250-saint_paul_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15204-15250-saint_paul_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15204-15250-saint_paul_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15204-15250-saint_paul_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15205-15140-saint_paul_de_salers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15205-15140-saint_paul_de_salers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15205-15140-saint_paul_de_salers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15205-15140-saint_paul_de_salers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15206-15350-saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15206-15350-saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15206-15350-saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15206-15350-saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15207-15500-saint_poncy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15207-15500-saint_poncy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15207-15500-saint_poncy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15207-15500-saint_poncy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15208-15140-saint_projet_de_salers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15208-15140-saint_projet_de_salers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15208-15140-saint_projet_de_salers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15208-15140-saint_projet_de_salers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15209-15110-saint_remy_de_chaudes_aigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15209-15110-saint_remy_de_chaudes_aigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15209-15110-saint_remy_de_chaudes_aigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15209-15110-saint_remy_de_chaudes_aigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15211-15150-saint_santin_cantales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15211-15150-saint_santin_cantales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15211-15150-saint_santin_cantales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15211-15150-saint_santin_cantales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15212-15600-saint_santin_de_maurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15212-15600-saint_santin_de_maurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15212-15600-saint_santin_de_maurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15212-15600-saint_santin_de_maurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15213-15190-saint_saturnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15213-15190-saint_saturnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15213-15190-saint_saturnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15213-15190-saint_saturnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15214-15290-saint_saury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15214-15290-saint_saury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15214-15290-saint_saury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15214-15290-saint_saury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15215-15130-saint_simon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15215-15130-saint_simon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15215-15130-saint_simon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15215-15130-saint_simon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15215-15000-saint_simon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15215-15000-saint_simon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15215-15000-saint_simon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15215-15000-saint_simon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15216-15110-saint_urcize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15216-15110-saint_urcize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15216-15110-saint_urcize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15216-15110-saint_urcize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15217-15150-saint_victor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15217-15150-saint_victor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15217-15150-saint_victor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15217-15150-saint_victor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15218-15380-saint_vincent_de_salers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15218-15380-saint_vincent_de_salers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15218-15380-saint_vincent_de_salers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15218-15380-saint_vincent_de_salers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15219-15140-salers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15219-15140-salers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15219-15140-salers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15219-15140-salers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15220-15200-salins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15220-15200-salins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15220-15200-salins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15220-15200-salins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15221-15130-sansac_de_marmiesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15221-15130-sansac_de_marmiesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15221-15130-sansac_de_marmiesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15221-15130-sansac_de_marmiesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15222-15120-sansac_veinazes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15222-15120-sansac_veinazes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15222-15120-sansac_veinazes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15222-15120-sansac_veinazes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15223-15240-sauvat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15223-15240-sauvat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15223-15240-sauvat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15223-15240-sauvat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15224-15290-la_segalassiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15224-15290-la_segalassiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15224-15290-la_segalassiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15224-15290-la_segalassiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15225-15300-segur_les_villas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15225-15300-segur_les_villas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15225-15300-segur_les_villas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15225-15300-segur_les_villas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15226-15340-senezergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15226-15340-senezergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15226-15340-senezergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15226-15340-senezergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15228-15150-siran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15228-15150-siran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15228-15150-siran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15228-15150-siran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15229-15100-soulages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15229-15100-soulages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15229-15100-soulages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15229-15100-soulages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15230-15200-sourniac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15230-15200-sourniac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15230-15200-sourniac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15230-15200-sourniac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15231-15170-talizat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15231-15170-talizat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15231-15170-talizat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15231-15170-talizat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15232-15100-tanavelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15232-15100-tanavelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15232-15100-tanavelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15232-15100-tanavelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15233-15250-teissieres_de_cornet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15233-15250-teissieres_de_cornet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15233-15250-teissieres_de_cornet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15233-15250-teissieres_de_cornet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15234-15130-teissieres_les_boulies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15234-15130-teissieres_les_boulies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15234-15130-teissieres_les_boulies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15234-15130-teissieres_les_boulies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15235-15100-les_ternes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15235-15100-les_ternes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15235-15100-les_ternes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15235-15100-les_ternes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15236-15800-thiezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15236-15800-thiezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15236-15800-thiezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15236-15800-thiezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15237-15100-tiviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15237-15100-tiviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15237-15100-tiviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15237-15100-tiviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15238-15310-tournemire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15238-15310-tournemire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15238-15310-tournemire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15238-15310-tournemire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15240-15270-tremouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15240-15270-tremouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15240-15270-tremouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15240-15270-tremouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15241-15110-la_trinitat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15241-15110-la_trinitat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15241-15110-la_trinitat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15241-15110-la_trinitat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15241-12210-la_trinitat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15241-12210-la_trinitat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15241-12210-la_trinitat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15241-12210-la_trinitat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15242-15600-le_trioulou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15242-15600-le_trioulou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15242-15600-le_trioulou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15242-15600-le_trioulou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15243-15400-trizac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15243-15400-trizac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15243-15400-trizac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15243-15400-trizac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15244-15300-ussel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15244-15300-ussel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15244-15300-ussel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15244-15300-ussel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15245-15100-vabres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15245-15100-vabres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15245-15100-vabres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15245-15100-vabres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15246-15400-valette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15246-15400-valette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15246-15400-valette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15246-15400-valette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15247-15170-valjouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15247-15170-valjouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15247-15170-valjouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15247-15170-valjouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15248-15300-valuejols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15248-15300-valuejols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15248-15300-valuejols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15248-15300-valuejols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15249-15380-le_vaulmier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15249-15380-le_vaulmier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15249-15380-le_vaulmier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15249-15380-le_vaulmier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15250-15240-vebret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15250-15240-vebret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15250-15240-vebret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15250-15240-vebret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15251-15100-vedrines_saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15251-15100-vedrines_saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15251-15100-vedrines_saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15251-15100-vedrines_saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15252-15590-velzic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15252-15590-velzic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15252-15590-velzic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15252-15590-velzic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15253-15160-vernols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15253-15160-vernols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15253-15160-vernols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15253-15160-vernols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15254-15350-veyrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15254-15350-veyrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15254-15350-veyrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15254-15350-veyrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15255-15130-vezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15255-15130-vezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15255-15130-vezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15255-15130-vezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15256-15160-veze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15256-15160-veze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15256-15160-veze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15256-15160-veze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15257-15130-vezels_roussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15257-15130-vezels_roussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15257-15130-vezels_roussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15257-15130-vezels_roussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15258-15800-vic_sur_cere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15258-15800-vic_sur_cere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15258-15800-vic_sur_cere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15258-15800-vic_sur_cere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15259-15500-vieillespesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15259-15500-vieillespesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15259-15500-vieillespesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15259-15500-vieillespesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15260-15120-vieillevie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15260-15120-vieillevie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15260-15120-vieillevie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15260-15120-vieillevie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15261-15200-le_vigean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15261-15200-le_vigean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15261-15200-le_vigean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15261-15200-le_vigean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15262-15100-villedieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15262-15100-villedieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15262-15100-villedieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15262-15100-villedieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15263-15300-virargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15263-15300-virargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15263-15300-virargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15263-15300-virargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15264-15220-vitrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15264-15220-vitrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15264-15220-vitrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15264-15220-vitrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15265-15210-ydes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15265-15210-ydes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15265-15210-ydes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15265-15210-ydes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15266-15130-yolet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15266-15130-yolet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15266-15130-yolet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15266-15130-yolet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15000-ytrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15000-ytrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15000-ytrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15000-ytrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15130-ytrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15130-ytrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15130-ytrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15130-ytrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15250-ytrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15250-ytrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15250-ytrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15267-15250-ytrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15268-15290-le_rouget_pers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15268-15290-le_rouget_pers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15268-15290-le_rouget_pers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15268-15290-le_rouget_pers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15269-15140-besse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15269-15140-besse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15269-15140-besse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt15-cantal/commune15269-15140-besse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-16.xml
+++ b/public/sitemaps/sitemap-16.xml
@@ -5,742 +5,1480 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16001-16500-abzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16001-16500-abzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16001-16500-abzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16001-16500-abzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16002-16700-les_adjots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16002-16700-les_adjots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16002-16700-les_adjots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16002-16700-les_adjots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16003-16110-agris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16003-16110-agris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16003-16110-agris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16003-16110-agris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16005-16140-aigre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16005-16140-aigre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16005-16140-aigre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16005-16140-aigre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16007-16490-alloue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16007-16490-alloue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16007-16490-alloue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16007-16490-alloue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16008-16140-amberac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16008-16140-amberac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16008-16140-amberac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16008-16140-amberac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16009-16490-ambernac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16009-16490-ambernac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16009-16490-ambernac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16009-16490-ambernac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16010-16300-ambleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16010-16300-ambleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16010-16300-ambleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16010-16300-ambleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16011-16560-anais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16011-16560-anais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16011-16560-anais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16011-16560-anais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16012-16130-angeac_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16012-16130-angeac_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16012-16130-angeac_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16012-16130-angeac_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16013-16120-angeac_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16013-16120-angeac_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16013-16120-angeac_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16013-16120-angeac_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16014-16300-angeduc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16014-16300-angeduc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16014-16300-angeduc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16014-16300-angeduc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16015-16000-angouleme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16015-16000-angouleme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16015-16000-angouleme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16015-16000-angouleme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16016-16500-ansac_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16016-16500-ansac_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16016-16500-ansac_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16016-16500-ansac_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16018-16130-ars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16018-16130-ars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16018-16130-ars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16018-16130-ars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16019-16290-asnieres_sur_nouere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16019-16290-asnieres_sur_nouere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16019-16290-asnieres_sur_nouere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16019-16290-asnieres_sur_nouere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16020-16390-aubeterre_sur_dronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16020-16390-aubeterre_sur_dronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16020-16390-aubeterre_sur_dronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16020-16390-aubeterre_sur_dronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16023-16460-aunac_sur_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16023-16460-aunac_sur_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16023-16460-aunac_sur_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16023-16460-aunac_sur_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16024-16560-aussac_vadalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16024-16560-aussac_vadalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16024-16560-aussac_vadalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16024-16560-aussac_vadalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16025-16360-baignes_sainte_radegonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16025-16360-baignes_sainte_radegonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16025-16360-baignes_sainte_radegonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16025-16360-baignes_sainte_radegonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16026-16430-balzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16026-16430-balzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16026-16430-balzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16026-16430-balzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16027-16140-barbezieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16027-16140-barbezieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16027-16140-barbezieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16027-16140-barbezieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16028-16300-barbezieux_saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16028-16300-barbezieux_saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16028-16300-barbezieux_saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16028-16300-barbezieux_saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16029-16210-bardenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16029-16210-bardenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16029-16210-bardenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16029-16210-bardenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16030-16300-barret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16030-16300-barret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16030-16300-barret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16030-16300-barret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16031-16700-barro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16031-16700-barro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16031-16700-barro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16031-16700-barro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16032-16120-bassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16032-16120-bassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16032-16120-bassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16032-16120-bassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16034-16210-bazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16034-16210-bazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16034-16210-bazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16034-16210-bazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16035-16450-beaulieu_sur_sonnette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16035-16450-beaulieu_sur_sonnette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16035-16450-beaulieu_sur_sonnette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16035-16450-beaulieu_sur_sonnette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16036-16250-becheresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16036-16250-becheresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16036-16250-becheresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16036-16250-becheresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16037-16210-bellon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16037-16210-bellon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16037-16210-bellon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16037-16210-bellon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16038-16350-benest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16038-16350-benest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16038-16350-benest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16038-16350-benest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16039-16700-bernac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16039-16700-bernac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16039-16700-bernac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16039-16700-bernac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16040-16480-berneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16040-16480-berneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16040-16480-berneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16040-16480-berneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16041-16250-bessac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16041-16250-bessac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16041-16250-bessac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16041-16250-bessac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16042-16140-besse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16042-16140-besse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16042-16140-besse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16042-16140-besse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16044-16700-bioussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16044-16700-bioussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16044-16700-bioussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16044-16700-bioussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16045-16120-birac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16045-16120-birac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16045-16120-birac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16045-16120-birac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16046-16250-coteaux_du_blanzacais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16046-16250-coteaux_du_blanzacais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16046-16250-coteaux_du_blanzacais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16046-16250-coteaux_du_blanzacais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16047-16320-blanzaguet_saint_cybard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16047-16320-blanzaguet_saint_cybard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16047-16320-blanzaguet_saint_cybard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16047-16320-blanzaguet_saint_cybard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16048-16480-boisbreteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16048-16480-boisbreteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16048-16480-boisbreteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16048-16480-boisbreteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16049-16390-bonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16049-16390-bonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16049-16390-bonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16049-16390-bonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16050-16120-bonneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16050-16120-bonneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16050-16120-bonneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16050-16120-bonneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16052-16190-bors_(canton_de_tude_et_lavalette)/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16052-16190-bors_(canton_de_tude_et_lavalette)/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16052-16190-bors_(canton_de_tude_et_lavalette)/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16052-16190-bors_(canton_de_tude_et_lavalette)/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16053-16360-bors_(canton_de_charente_sud)/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16053-16360-bors_(canton_de_charente_sud)/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16053-16360-bors_(canton_de_charente_sud)/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16053-16360-bors_(canton_de_charente_sud)/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16054-16350-le_bouchage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16054-16350-le_bouchage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16054-16350-le_bouchage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16054-16350-le_bouchage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16055-16410-bouex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16055-16410-bouex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16055-16410-bouex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16055-16410-bouex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16056-16200-bourg_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16056-16200-bourg_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16056-16200-bourg_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16056-16200-bourg_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16057-16120-bouteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16057-16120-bouteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16057-16120-bouteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16057-16120-bouteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16058-16100-boutiers_saint_trojan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16058-16100-boutiers_saint_trojan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16058-16100-boutiers_saint_trojan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16058-16100-boutiers_saint_trojan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16059-16240-brettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16059-16240-brettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16059-16240-brettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16059-16240-brettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16060-16370-breville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16060-16370-breville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16060-16370-breville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16060-16370-breville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16061-16590-brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16061-16590-brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16061-16590-brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16061-16590-brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16062-16300-brie_sous_barbezieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16062-16300-brie_sous_barbezieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16062-16300-brie_sous_barbezieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16062-16300-brie_sous_barbezieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16063-16210-brie_sous_chalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16063-16210-brie_sous_chalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16063-16210-brie_sous_chalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16063-16210-brie_sous_chalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16064-16420-brigueuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16064-16420-brigueuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16064-16420-brigueuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16064-16420-brigueuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16065-16500-brillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16065-16500-brillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16065-16500-brillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16065-16500-brillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16066-16480-brossac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16066-16480-brossac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16066-16480-brossac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16066-16480-brossac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16067-16110-bunzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16067-16110-bunzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16067-16110-bunzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16067-16110-bunzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16068-16260-cellefrouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16068-16260-cellefrouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16068-16260-cellefrouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16068-16260-cellefrouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16069-16230-cellettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16069-16230-cellettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16069-16230-cellettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16069-16230-cellettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16070-16150-chabanais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16070-16150-chabanais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16070-16150-chabanais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16070-16150-chabanais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16071-16150-chabrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16071-16150-chabrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16071-16150-chabrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16071-16150-chabrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16072-16250-chadurie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16072-16250-chadurie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16072-16250-chadurie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16072-16250-chadurie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16073-16210-chalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16073-16210-chalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16073-16210-chalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16073-16210-chalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16074-16300-challignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16074-16300-challignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16074-16300-challignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16074-16300-challignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16075-16250-champagne_vigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16075-16250-champagne_vigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16075-16250-champagne_vigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16075-16250-champagne_vigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16076-16350-champagne_mouton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16076-16350-champagne_mouton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16076-16350-champagne_mouton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16076-16350-champagne_mouton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16077-16290-champmillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16077-16290-champmillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16077-16290-champmillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16077-16290-champmillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16078-16430-champniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16078-16430-champniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16078-16430-champniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16078-16430-champniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16079-16360-chantillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16079-16360-chantillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16079-16360-chantillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16079-16360-chantillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16081-16140-la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16081-16140-la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16081-16140-la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16081-16140-la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16082-16320-boisne_la_tude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16082-16320-boisne_la_tude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16082-16320-boisne_la_tude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16082-16320-boisne_la_tude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16083-16140-charme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16083-16140-charme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16083-16140-charme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16083-16140-charme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16084-16380-charras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16084-16380-charras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16084-16380-charras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16084-16380-charras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16085-16260-chasseneuil_sur_bonnieure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16085-16260-chasseneuil_sur_bonnieure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16085-16260-chasseneuil_sur_bonnieure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16085-16260-chasseneuil_sur_bonnieure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16086-16150-chassenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16086-16150-chassenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16086-16150-chassenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16086-16150-chassenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16087-16350-chassiecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16087-16350-chassiecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16087-16350-chassiecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16087-16350-chassiecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16088-16200-chassors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16088-16200-chassors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16088-16200-chassors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16088-16200-chassors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16089-16100-chateaubernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16089-16100-chateaubernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16089-16100-chateaubernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16089-16100-chateaubernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16090-16120-chateauneuf_sur_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16090-16120-chateauneuf_sur_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16090-16120-chateauneuf_sur_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16090-16120-chateauneuf_sur_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16091-16480-chatignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16091-16480-chatignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16091-16480-chatignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16091-16480-chatignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16093-16380-chazelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16093-16380-chazelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16093-16380-chazelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16093-16380-chazelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16095-16460-chenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16095-16460-chenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16095-16460-chenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16095-16460-chenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16096-16310-cherves_chatelars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16096-16310-cherves_chatelars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16096-16310-cherves_chatelars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16096-16310-cherves_chatelars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16097-16370-cherves_richemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16097-16370-cherves_richemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16097-16370-cherves_richemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16097-16370-cherves_richemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16098-16240-la_chevrerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16098-16240-la_chevrerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16098-16240-la_chevrerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16098-16240-la_chevrerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16099-16480-chillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16099-16480-chillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16099-16480-chillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16099-16480-chillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16100-16150-chirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16100-16150-chirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16100-16150-chirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16100-16150-chirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16101-16440-claix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16101-16440-claix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16101-16440-claix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16101-16440-claix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16102-16100-cognac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16102-16100-cognac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16102-16100-cognac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16102-16100-cognac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16103-16320-combiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16103-16320-combiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16103-16320-combiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16103-16320-combiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16104-16700-condac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16104-16700-condac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16104-16700-condac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16104-16700-condac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16105-16360-condeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16105-16360-condeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16105-16360-condeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16105-16360-condeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16106-16500-confolens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16106-16500-confolens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16106-16500-confolens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16106-16500-confolens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16107-16560-coulgens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16107-16560-coulgens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16107-16560-coulgens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16107-16560-coulgens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16108-16330-coulonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16108-16330-coulonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16108-16330-coulonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16108-16330-coulonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16109-16200-courbillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16109-16200-courbillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16109-16200-courbillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16109-16200-courbillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16110-16240-courcome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16110-16240-courcome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16110-16240-courcome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16110-16240-courcome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16110-16700-courcome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16110-16700-courcome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16110-16700-courcome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16110-16700-courcome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16111-16190-courgeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16111-16190-courgeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16111-16190-courgeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16111-16190-courgeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16112-16210-courlac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16112-16210-courlac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16112-16210-courlac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16112-16210-courlac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16113-16400-la_couronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16113-16400-la_couronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16113-16400-la_couronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16113-16400-la_couronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16114-16460-couture/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16114-16460-couture/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16114-16460-couture/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16114-16460-couture/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16116-16300-criteuil_la_magdeleine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16116-16300-criteuil_la_magdeleine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16116-16300-criteuil_la_magdeleine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16116-16300-criteuil_la_magdeleine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16117-16210-curac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16117-16210-curac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16117-16210-curac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16117-16210-curac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16118-16190-deviat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16118-16190-deviat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16118-16190-deviat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16118-16190-deviat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16119-16410-dignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16119-16410-dignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16119-16410-dignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16119-16410-dignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16120-16410-dirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16120-16410-dirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16120-16410-dirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16120-16410-dirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16121-16290-douzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16121-16290-douzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16121-16290-douzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16121-16290-douzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16122-16140-ebreon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16122-16140-ebreon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16122-16140-ebreon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16122-16140-ebreon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16123-16170-echallat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16123-16170-echallat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16123-16170-echallat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16123-16170-echallat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16124-16220-ecuras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16124-16220-ecuras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16124-16220-ecuras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16124-16220-ecuras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16125-16320-edon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16125-16320-edon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16125-16320-edon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16125-16320-edon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16127-16240-empure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16127-16240-empure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16127-16240-empure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16127-16240-empure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16128-16490-epenede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16128-16490-epenede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16128-16490-epenede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16128-16490-epenede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16130-16210-les_essards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16130-16210-les_essards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16130-16210-les_essards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16130-16210-les_essards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16131-16500-esse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16131-16500-esse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16131-16500-esse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16131-16500-esse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16132-16150-etagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16132-16150-etagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16132-16150-etagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16132-16150-etagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16133-16250-etriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16133-16250-etriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16133-16250-etriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16133-16250-etriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16134-16150-exideuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16134-16150-exideuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16134-16150-exideuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16134-16150-exideuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16135-16220-eymouthiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16135-16220-eymouthiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16135-16220-eymouthiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16135-16220-eymouthiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16136-16700-la_faye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16136-16700-la_faye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16136-16700-la_faye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16136-16700-la_faye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16137-16380-feuillade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16137-16380-feuillade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16137-16380-feuillade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16137-16380-feuillade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16138-16730-fleac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16138-16730-fleac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16138-16730-fleac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16138-16730-fleac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16139-16200-fleurac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16139-16200-fleurac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16139-16200-fleurac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16139-16200-fleurac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16140-16230-fontclaireau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16140-16230-fontclaireau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16140-16230-fontclaireau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16140-16230-fontclaireau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16141-16230-fontenille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16141-16230-fontenille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16141-16230-fontenille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16141-16230-fontenille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16142-16240-la_foret_de_tesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16142-16240-la_foret_de_tesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16142-16240-la_foret_de_tesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16142-16240-la_foret_de_tesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16143-16410-fouquebrune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16143-16410-fouquebrune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16143-16410-fouquebrune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16143-16410-fouquebrune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16144-16140-fouqueure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16144-16140-fouqueure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16144-16140-fouqueure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16144-16140-fouqueure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16145-16200-foussignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16145-16200-foussignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16145-16200-foussignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16145-16200-foussignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16146-16410-garat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16146-16410-garat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16146-16410-garat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16146-16410-garat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16147-16320-gardes_le_pontaroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16147-16320-gardes_le_pontaroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16147-16320-gardes_le_pontaroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16147-16320-gardes_le_pontaroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16148-16170-genac_bignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16148-16170-genac_bignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16148-16170-genac_bignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16148-16170-genac_bignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16150-16130-gensac_la_pallue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16150-16130-gensac_la_pallue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16150-16130-gensac_la_pallue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16150-16130-gensac_la_pallue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16151-16130-gente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16151-16130-gente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16151-16130-gente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16151-16130-gente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16152-16130-gimeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16152-16130-gimeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16152-16130-gimeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16152-16130-gimeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16153-16200-mainxe_gondeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16153-16200-mainxe_gondeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16153-16200-mainxe_gondeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16153-16200-mainxe_gondeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16154-16160-gond_pontouvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16154-16160-gond_pontouvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16154-16160-gond_pontouvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16154-16160-gond_pontouvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16155-16140-les_gours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16155-16140-les_gours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16155-16140-les_gours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16155-16140-les_gours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16157-16450-le_grand_madieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16157-16450-le_grand_madieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16157-16450-le_grand_madieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16157-16450-le_grand_madieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16158-16380-grassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16158-16380-grassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16158-16380-grassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16158-16380-grassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16160-16300-guimps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16160-16300-guimps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16160-16300-guimps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16160-16300-guimps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16161-16480-guizengeard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16161-16480-guizengeard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16161-16480-guizengeard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16161-16480-guizengeard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16162-16320-gurat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16162-16320-gurat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16162-16320-gurat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16162-16320-gurat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16163-16290-hiersac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16163-16290-hiersac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16163-16290-hiersac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16163-16290-hiersac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16164-16490-hiesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16164-16490-hiesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16164-16490-hiesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16164-16490-hiesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16165-16200-houlette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16165-16200-houlette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16165-16200-houlette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16165-16200-houlette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16166-16340-l_isle_d_espagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16166-16340-l_isle_d_espagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16166-16340-l_isle_d_espagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16166-16340-l_isle_d_espagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16167-16200-jarnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16167-16200-jarnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16167-16200-jarnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16167-16200-jarnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16168-16560-jauldes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16168-16560-jauldes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16168-16560-jauldes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16168-16560-jauldes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16169-16100-javrezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16169-16100-javrezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16169-16100-javrezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16169-16100-javrezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16170-16190-juignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16170-16190-juignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16170-16190-juignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16170-16190-juignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16171-16130-juillac_le_coq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16171-16130-juillac_le_coq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16171-16130-juillac_le_coq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16171-16130-juillac_le_coq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16173-16230-juille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16173-16230-juille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16173-16230-juille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16173-16230-juille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16174-16200-julienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16174-16200-julienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16174-16200-julienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16174-16200-julienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16175-16250-val_des_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16175-16250-val_des_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16175-16250-val_des_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16175-16250-val_des_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16176-16300-lachaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16176-16300-lachaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16176-16300-lachaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16176-16300-lachaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16177-16120-ladiville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16177-16120-ladiville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16177-16120-ladiville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16177-16120-ladiville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16178-16300-lagarde_sur_le_ne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16178-16300-lagarde_sur_le_ne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16178-16300-lagarde_sur_le_ne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16178-16300-lagarde_sur_le_ne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16180-16390-laprade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16180-16390-laprade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16180-16390-laprade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16180-16390-laprade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16181-16500-lessac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16181-16500-lessac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16181-16500-lessac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16181-16500-lessac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16182-16420-lesterps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16182-16420-lesterps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16182-16420-lesterps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16182-16420-lesterps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16183-16310-lesignac_durand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16183-16310-lesignac_durand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16183-16310-lesignac_durand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16183-16310-lesignac_durand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16184-16460-licheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16184-16460-licheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16184-16460-licheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16184-16460-licheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16185-16140-ligne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16185-16140-ligne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16185-16140-ligne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16185-16140-ligne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16186-16130-lignieres_sonneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16186-16130-lignieres_sonneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16186-16130-lignieres_sonneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16186-16130-lignieres_sonneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16187-16730-linars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16187-16730-linars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16187-16730-linars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16187-16730-linars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16188-16310-le_lindois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16188-16310-le_lindois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16188-16310-le_lindois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16188-16310-le_lindois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16189-16700-londigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16189-16700-londigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16189-16700-londigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16189-16700-londigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16190-16240-longre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16190-16240-longre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16190-16240-longre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16190-16240-longre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16191-16230-lonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16191-16230-lonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16191-16230-lonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16191-16230-lonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16192-16270-terres_de_haute_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16192-16270-terres_de_haute_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16192-16270-terres_de_haute_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16192-16270-terres_de_haute_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16193-16100-louzac_saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16193-16100-louzac_saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16193-16100-louzac_saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16193-16100-louzac_saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16194-16140-lupsault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16194-16140-lupsault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16194-16140-lupsault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16194-16140-lupsault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16195-16450-lussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16195-16450-lussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16195-16450-lussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16195-16450-lussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16196-16230-luxe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16196-16230-luxe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16196-16230-luxe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16196-16230-luxe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16197-16240-la_magdeleine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16197-16240-la_magdeleine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16197-16240-la_magdeleine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16197-16240-la_magdeleine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16198-16320-magnac_lavalette_villars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16198-16320-magnac_lavalette_villars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16198-16320-magnac_lavalette_villars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16198-16320-magnac_lavalette_villars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16199-16600-magnac_sur_touvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16199-16600-magnac_sur_touvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16199-16600-magnac_sur_touvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16199-16600-magnac_sur_touvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16200-16230-maine_de_boixe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16200-16230-maine_de_boixe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16200-16230-maine_de_boixe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16200-16230-maine_de_boixe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16203-16380-mainzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16203-16380-mainzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16203-16380-mainzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16203-16380-mainzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16204-16120-bellevigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16204-16120-bellevigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16204-16120-bellevigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16204-16120-bellevigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16205-16500-manot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16205-16500-manot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16205-16500-manot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16205-16500-manot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16206-16230-mansle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16206-16230-mansle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16206-16230-mansle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16206-16230-mansle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16207-16140-marcillac_lanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16207-16140-marcillac_lanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16207-16140-marcillac_lanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16207-16140-marcillac_lanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16208-16170-mareuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16208-16170-mareuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16208-16170-mareuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16208-16170-mareuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16209-16110-marillac_le_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16209-16110-marillac_le_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16209-16110-marillac_le_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16209-16110-marillac_le_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16210-16570-marsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16210-16570-marsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16210-16570-marsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16210-16570-marsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16211-16380-marthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16211-16380-marthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16211-16380-marthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16211-16380-marthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16212-16310-massignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16212-16310-massignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16212-16310-massignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16212-16310-massignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16213-16310-mazerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16213-16310-mazerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16213-16310-mazerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16213-16310-mazerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16215-16210-medillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16215-16210-medillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16215-16210-medillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16215-16210-medillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16216-16200-merignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16216-16200-merignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16216-16200-merignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16216-16200-merignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16217-16100-merpins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16217-16100-merpins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16217-16100-merpins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16217-16100-merpins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16218-16370-mesnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16218-16370-mesnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16218-16370-mesnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16218-16370-mesnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16220-16200-les_metairies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16220-16200-les_metairies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16220-16200-les_metairies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16220-16200-les_metairies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16221-16140-mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16221-16140-mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16221-16140-mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16221-16140-mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16222-16620-montboyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16222-16620-montboyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16222-16620-montboyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16222-16620-montboyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16223-16220-montbron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16223-16220-montbron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16223-16220-montbron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16223-16220-montbron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16224-16300-montmerac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16224-16300-montmerac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16224-16300-montmerac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16224-16300-montmerac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16225-16310-montemboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16225-16310-montemboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16225-16310-montemboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16225-16310-montemboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16226-16330-montignac_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16226-16330-montignac_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16226-16330-montignac_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16226-16330-montignac_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16227-16390-montignac_le_coq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16227-16390-montignac_le_coq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16227-16390-montignac_le_coq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16227-16390-montignac_le_coq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16229-16240-montjean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16229-16240-montjean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16229-16240-montjean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16229-16240-montjean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16230-16190-montmoreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16230-16190-montmoreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16230-16190-montmoreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16230-16190-montmoreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16231-16420-montrollet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16231-16420-montrollet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16231-16420-montrollet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16231-16420-montrollet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16232-16600-mornac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16232-16600-mornac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16232-16600-mornac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16232-16600-mornac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16233-16120-mosnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16233-16120-mosnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16233-16120-mosnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16233-16120-mosnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16234-16290-moulidars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16234-16290-moulidars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16234-16290-moulidars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16234-16290-moulidars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16236-16440-mouthiers_sur_boeme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16236-16440-mouthiers_sur_boeme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16236-16440-mouthiers_sur_boeme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16236-16440-mouthiers_sur_boeme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16237-16460-mouton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16237-16460-mouton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16237-16460-mouton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16237-16460-mouton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16238-16460-moutonneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16238-16460-moutonneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16238-16460-moutonneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16238-16460-moutonneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16239-16310-mouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16239-16310-mouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16239-16310-mouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16239-16310-mouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16240-16390-nabinaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16240-16390-nabinaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16240-16390-nabinaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16240-16390-nabinaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16241-16230-nanclars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16241-16230-nanclars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16241-16230-nanclars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16241-16230-nanclars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16242-16700-nanteuil_en_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16242-16700-nanteuil_en_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16242-16700-nanteuil_en_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16242-16700-nanteuil_en_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16243-16200-nercillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16243-16200-nercillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16243-16200-nercillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16243-16200-nercillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16244-16440-nersac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16244-16440-nersac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16244-16440-nersac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16244-16440-nersac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16245-16270-nieuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16245-16270-nieuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16245-16270-nieuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16245-16270-nieuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16246-16190-nonac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16246-16190-nonac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16246-16190-nonac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16246-16190-nonac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16248-16140-oradour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16248-16140-oradour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16248-16140-oradour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16248-16140-oradour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16249-16500-oradour_fanais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16249-16500-oradour_fanais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16249-16500-oradour_fanais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16249-16500-oradour_fanais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16250-16220-orgedeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16250-16220-orgedeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16250-16220-orgedeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16250-16220-orgedeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16251-16480-oriolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16251-16480-oriolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16251-16480-oriolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16251-16480-oriolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16252-16210-orival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16252-16210-orival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16252-16210-orival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16252-16210-orival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16253-16240-paizay_naudouin_embourie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16253-16240-paizay_naudouin_embourie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16253-16240-paizay_naudouin_embourie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16253-16240-paizay_naudouin_embourie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16254-16390-palluaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16254-16390-palluaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16254-16390-palluaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16254-16390-palluaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16255-16450-parzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16255-16450-parzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16255-16450-parzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16255-16450-parzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16256-16480-passirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16256-16480-passirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16256-16480-passirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16256-16480-passirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16258-16250-perignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16258-16250-perignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16258-16250-perignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16258-16250-perignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16260-16390-pillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16260-16390-pillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16260-16390-pillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16260-16390-pillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16261-16260-les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16261-16260-les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16261-16260-les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16261-16260-les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16263-16250-plassac_rouffiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16263-16250-plassac_rouffiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16263-16250-plassac_rouffiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16263-16250-plassac_rouffiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16264-16490-pleuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16264-16490-pleuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16264-16490-pleuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16264-16490-pleuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16267-16190-poullignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16267-16190-poullignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16267-16190-poullignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16267-16190-poullignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16268-16700-poursac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16268-16700-poursac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16268-16700-poursac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16268-16700-poursac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16269-16110-pranzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16269-16110-pranzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16269-16110-pranzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16269-16110-pranzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16270-16150-pressignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16270-16150-pressignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16270-16150-pressignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16270-16150-pressignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16271-16400-puymoyen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16271-16400-puymoyen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16271-16400-puymoyen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16271-16400-puymoyen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16272-16230-puyreaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16272-16230-puyreaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16272-16230-puyreaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16272-16230-puyreaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16273-16240-raix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16273-16240-raix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16273-16240-raix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16273-16240-raix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16275-16140-ranville_breuillaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16275-16140-ranville_breuillaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16275-16140-ranville_breuillaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16275-16140-ranville_breuillaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16276-16360-reignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16276-16360-reignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16276-16360-reignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16276-16360-reignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16277-16200-reparsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16277-16200-reparsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16277-16200-reparsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16277-16200-reparsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16279-16210-rioux_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16279-16210-rioux_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16279-16210-rioux_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16279-16210-rioux_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16280-16110-rivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16280-16110-rivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16280-16110-rivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16280-16110-rivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16281-16110-la_rochefoucauld_en_angoumois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16281-16110-la_rochefoucauld_en_angoumois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16281-16110-la_rochefoucauld_en_angoumois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16281-16110-la_rochefoucauld_en_angoumois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16282-16110-la_rochette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16282-16110-la_rochette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16282-16110-la_rochette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16282-16110-la_rochette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16283-16320-ronsenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16283-16320-ronsenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16283-16320-ronsenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16283-16320-ronsenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16284-16210-rouffiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16284-16210-rouffiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16284-16210-rouffiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16284-16210-rouffiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16285-16320-rougnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16285-16320-rougnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16285-16320-rougnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16285-16320-rougnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16286-16170-rouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16286-16170-rouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16286-16170-rouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16286-16170-rouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16287-16440-roullet_saint_estephe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16287-16440-roullet_saint_estephe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16287-16440-roullet_saint_estephe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16287-16440-roullet_saint_estephe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16289-16310-roussines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16289-16310-roussines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16289-16310-roussines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16289-16310-roussines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16290-16220-rouzede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16290-16220-rouzede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16290-16220-rouzede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16290-16220-rouzede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16291-16600-ruelle_sur_touvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16291-16600-ruelle_sur_touvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16291-16600-ruelle_sur_touvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16291-16600-ruelle_sur_touvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16292-16700-ruffec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16292-16700-ruffec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16292-16700-ruffec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16292-16700-ruffec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16293-16310-saint_adjutory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16293-16310-saint_adjutory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16293-16310-saint_adjutory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16293-16310-saint_adjutory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16295-16330-saint_amant_de_boixe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16295-16330-saint_amant_de_boixe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16295-16330-saint_amant_de_boixe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16295-16330-saint_amant_de_boixe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16297-16120-graves_saint_amant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16297-16120-graves_saint_amant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16297-16120-graves_saint_amant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16297-16120-graves_saint_amant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16298-16170-saint_amant_de_nouere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16298-16170-saint_amant_de_nouere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16298-16170-saint_amant_de_nouere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16298-16170-saint_amant_de_nouere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16300-16230-val_de_bonnieure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16300-16230-val_de_bonnieure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16300-16230-val_de_bonnieure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16300-16230-val_de_bonnieure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16301-16300-saint_aulais_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16301-16300-saint_aulais_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16301-16300-saint_aulais_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16301-16300-saint_aulais_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16302-16210-saint_avit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16302-16210-saint_avit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16302-16210-saint_avit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16302-16210-saint_avit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16303-16300-saint_bonnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16303-16300-saint_bonnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16303-16300-saint_bonnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16303-16300-saint_bonnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16304-16100-saint_brice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16304-16100-saint_brice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16304-16100-saint_brice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16304-16100-saint_brice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16306-16420-saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16306-16420-saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16306-16420-saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16306-16420-saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16307-16230-saint_ciers_sur_bonnieure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16307-16230-saint_ciers_sur_bonnieure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16307-16230-saint_ciers_sur_bonnieure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16307-16230-saint_ciers_sur_bonnieure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16308-16450-saint_claud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16308-16450-saint_claud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16308-16450-saint_claud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16308-16450-saint_claud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16310-16350-saint_coutant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16310-16350-saint_coutant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16310-16350-saint_coutant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16310-16350-saint_coutant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16312-16170-saint_cybardeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16312-16170-saint_cybardeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16312-16170-saint_cybardeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16312-16170-saint_cybardeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16315-16480-saint_felix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16315-16480-saint_felix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16315-16480-saint_felix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16315-16480-saint_felix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16316-16130-saint_fort_sur_le_ne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16316-16130-saint_fort_sur_le_ne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16316-16130-saint_fort_sur_le_ne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16316-16130-saint_fort_sur_le_ne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16317-16140-saint_fraigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16317-16140-saint_fraigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16317-16140-saint_fraigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16317-16140-saint_fraigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16318-16460-saint_front/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16318-16460-saint_front/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16318-16460-saint_front/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16318-16460-saint_front/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16320-16570-saint_genis_d_hiersac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16320-16570-saint_genis_d_hiersac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16320-16570-saint_genis_d_hiersac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16320-16570-saint_genis_d_hiersac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16321-16700-saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16321-16700-saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16321-16700-saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16321-16700-saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16323-16380-saint_germain_de_montbron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16323-16380-saint_germain_de_montbron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16323-16380-saint_germain_de_montbron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16323-16380-saint_germain_de_montbron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16325-16700-saint_gourson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16325-16700-saint_gourson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16325-16700-saint_gourson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16325-16700-saint_gourson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16326-16230-saint_groux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16326-16230-saint_groux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16326-16230-saint_groux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16326-16230-saint_groux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16329-16450-saint_laurent_de_ceris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16329-16450-saint_laurent_de_ceris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16329-16450-saint_laurent_de_ceris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16329-16450-saint_laurent_de_ceris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16330-16100-saint_laurent_de_cognac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16330-16100-saint_laurent_de_cognac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16330-16100-saint_laurent_de_cognac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16330-16100-saint_laurent_de_cognac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16331-16480-saint_laurent_des_combes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16331-16480-saint_laurent_des_combes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16331-16480-saint_laurent_des_combes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16331-16480-saint_laurent_des_combes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16334-16190-saint_martial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16334-16190-saint_martial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16334-16190-saint_martial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16334-16190-saint_martial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16335-16700-saint_martin_du_clocher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16335-16700-saint_martin_du_clocher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16335-16700-saint_martin_du_clocher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16335-16700-saint_martin_du_clocher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16336-16260-saint_mary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16336-16260-saint_mary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16336-16260-saint_mary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16336-16260-saint_mary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16337-16500-saint_maurice_des_lions/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16337-16500-saint_maurice_des_lions/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16337-16500-saint_maurice_des_lions/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16337-16500-saint_maurice_des_lions/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16338-16300-saint_medard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16338-16300-saint_medard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16338-16300-saint_medard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16338-16300-saint_medard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16339-16170-val_d_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16339-16170-val_d_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16339-16170-val_d_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16339-16170-val_d_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16340-16720-saint_meme_les_carrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16340-16720-saint_meme_les_carrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16340-16720-saint_meme_les_carrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16340-16720-saint_meme_les_carrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16341-16470-saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16341-16470-saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16341-16470-saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16341-16470-saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16342-16300-saint_palais_du_ne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16342-16300-saint_palais_du_ne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16342-16300-saint_palais_du_ne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16342-16300-saint_palais_du_ne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16343-16130-saint_preuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16343-16130-saint_preuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16343-16130-saint_preuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16343-16130-saint_preuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16345-16150-saint_quentin_sur_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16345-16150-saint_quentin_sur_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16345-16150-saint_quentin_sur_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16345-16150-saint_quentin_sur_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16346-16210-saint_quentin_de_chalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16346-16210-saint_quentin_de_chalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16346-16210-saint_quentin_de_chalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16346-16210-saint_quentin_de_chalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16347-16210-saint_romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16347-16210-saint_romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16347-16210-saint_romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16347-16210-saint_romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16348-16290-saint_saturnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16348-16290-saint_saturnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16348-16290-saint_saturnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16348-16290-saint_saturnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16349-16200-sainte_severe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16349-16200-sainte_severe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16349-16200-sainte_severe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16349-16200-sainte_severe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16350-16390-saint_severin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16350-16390-saint_severin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16350-16390-saint_severin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16350-16390-saint_severin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16351-16120-saint_simeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16351-16120-saint_simeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16351-16120-saint_simeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16351-16120-saint_simeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16352-16120-saint_simon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16352-16120-saint_simon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16352-16120-saint_simon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16352-16120-saint_simon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16353-16220-saint_sornin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16353-16220-saint_sornin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16353-16220-saint_sornin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16353-16220-saint_sornin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16354-16480-sainte_souline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16354-16480-sainte_souline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16354-16480-sainte_souline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16354-16480-sainte_souline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16355-16370-saint_sulpice_de_cognac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16355-16370-saint_sulpice_de_cognac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16355-16370-saint_sulpice_de_cognac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16355-16370-saint_sulpice_de_cognac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16356-16460-saint_sulpice_de_ruffec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16356-16460-saint_sulpice_de_ruffec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16356-16460-saint_sulpice_de_ruffec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16356-16460-saint_sulpice_de_ruffec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16357-16480-saint_vallier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16357-16480-saint_vallier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16357-16480-saint_vallier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16357-16480-saint_vallier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16358-16710-saint_yrieix_sur_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16358-16710-saint_yrieix_sur_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16358-16710-saint_yrieix_sur_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16358-16710-saint_yrieix_sur_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16359-16130-salles_d_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16359-16130-salles_d_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16359-16130-salles_d_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16359-16130-salles_d_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16360-16300-salles_de_barbezieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16360-16300-salles_de_barbezieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16360-16300-salles_de_barbezieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16360-16300-salles_de_barbezieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16361-16700-salles_de_villefagnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16361-16700-salles_de_villefagnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16361-16700-salles_de_villefagnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16361-16700-salles_de_villefagnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16362-16190-salles_lavalette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16362-16190-salles_lavalette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16362-16190-salles_lavalette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16362-16190-salles_lavalette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16363-16420-saulgond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16363-16420-saulgond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16363-16420-saulgond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16363-16420-saulgond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16364-16310-sauvagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16364-16310-sauvagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16364-16310-sauvagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16364-16310-sauvagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16365-16480-sauvignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16365-16480-sauvignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16365-16480-sauvignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16365-16480-sauvignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16366-16130-segonzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16366-16130-segonzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16366-16130-segonzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16366-16130-segonzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16368-16410-sers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16368-16410-sers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16368-16410-sers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16368-16410-sers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16369-16200-sigogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16369-16200-sigogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16369-16200-sigogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16369-16200-sigogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16370-16440-sireuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16370-16440-sireuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16370-16440-sireuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16370-16440-sireuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16372-16380-souffrignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16372-16380-souffrignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16372-16380-souffrignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16372-16380-souffrignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16373-16240-souvigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16373-16240-souvigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16373-16240-souvigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16373-16240-souvigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16374-16800-soyaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16374-16800-soyaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16374-16800-soyaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16374-16800-soyaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16375-16260-suaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16375-16260-suaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16375-16260-suaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16375-16260-suaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16377-16260-la_tache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16377-16260-la_tache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16377-16260-la_tache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16377-16260-la_tache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16378-16700-taize_aizie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16378-16700-taize_aizie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16378-16700-taize_aizie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16378-16700-taize_aizie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16379-16110-taponnat_fleurignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16379-16110-taponnat_fleurignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16379-16110-taponnat_fleurignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16379-16110-taponnat_fleurignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16380-16360-le_tatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16380-16360-le_tatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16380-16360-le_tatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16380-16360-le_tatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16381-16240-theil_rabier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16381-16240-theil_rabier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16381-16240-theil_rabier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16381-16240-theil_rabier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16382-16410-torsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16382-16410-torsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16382-16410-torsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16382-16410-torsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16383-16560-tourriers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16383-16560-tourriers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16383-16560-tourriers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16383-16560-tourriers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16384-16360-touverac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16384-16360-touverac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16384-16360-touverac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16384-16360-touverac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16385-16600-touvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16385-16600-touvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16385-16600-touvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16385-16600-touvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16387-16200-triac_lautrait/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16387-16200-triac_lautrait/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16387-16200-triac_lautrait/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16387-16200-triac_lautrait/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16388-16730-trois_palis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16388-16730-trois_palis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16388-16730-trois_palis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16388-16730-trois_palis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16389-16350-turgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16389-16350-turgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16389-16350-turgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16389-16350-turgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16390-16140-tusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16390-16140-tusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16390-16140-tusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16390-16140-tusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16392-16460-valence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16392-16460-valence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16392-16460-valence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16392-16460-valence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16393-16330-vars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16393-16330-vars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16393-16330-vars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16393-16330-vars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16394-16320-vaux_lavalette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16394-16320-vaux_lavalette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16394-16320-vaux_lavalette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16394-16320-vaux_lavalette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16395-16170-vaux_rouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16395-16170-vaux_rouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16395-16170-vaux_rouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16395-16170-vaux_rouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16396-16460-ventouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16396-16460-ventouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16396-16460-ventouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16396-16460-ventouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16397-16140-verdille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16397-16140-verdille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16397-16140-verdille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16397-16140-verdille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16398-16310-verneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16398-16310-verneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16398-16310-verneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16398-16310-verneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16399-16130-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16399-16130-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16399-16130-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16399-16130-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16400-16510-verteuil_sur_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16400-16510-verteuil_sur_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16400-16510-verteuil_sur_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16400-16510-verteuil_sur_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16401-16330-vervant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16401-16330-vervant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16401-16330-vervant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16401-16330-vervant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16402-16120-vibrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16402-16120-vibrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16402-16120-vibrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16402-16120-vibrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16403-16350-le_vieux_cerier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16403-16350-le_vieux_cerier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16403-16350-le_vieux_cerier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16403-16350-le_vieux_cerier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16404-16350-vieux_ruffec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16404-16350-vieux_ruffec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16404-16350-vieux_ruffec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16404-16350-vieux_ruffec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16405-16300-vignolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16405-16300-vignolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16405-16300-vignolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16405-16300-vignolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16406-16220-moulins_sur_tardoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16406-16220-moulins_sur_tardoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16406-16220-moulins_sur_tardoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16406-16220-moulins_sur_tardoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16406-16110-moulins_sur_tardoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16406-16110-moulins_sur_tardoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16406-16110-moulins_sur_tardoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16406-16110-moulins_sur_tardoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16408-16320-villebois_lavalette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16408-16320-villebois_lavalette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16408-16320-villebois_lavalette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16408-16320-villebois_lavalette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16409-16240-villefagnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16409-16240-villefagnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16409-16240-villefagnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16409-16240-villefagnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16412-16560-villejoubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16412-16560-villejoubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16412-16560-villejoubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16412-16560-villejoubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16413-16240-villiers_le_roux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16413-16240-villiers_le_roux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16413-16240-villiers_le_roux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16413-16240-villiers_le_roux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16414-16230-villognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16414-16230-villognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16414-16230-villognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16414-16230-villognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16415-16430-vindelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16415-16430-vindelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16415-16430-vindelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16415-16430-vindelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16416-16310-vitrac_saint_vincent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16416-16310-vitrac_saint_vincent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16416-16310-vitrac_saint_vincent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16416-16310-vitrac_saint_vincent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16418-16400-voeuil_et_giget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16418-16400-voeuil_et_giget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16418-16400-voeuil_et_giget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16418-16400-voeuil_et_giget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16419-16330-vouharte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16419-16330-vouharte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16419-16330-vouharte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16419-16330-vouharte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16420-16250-voulgezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16420-16250-voulgezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16420-16250-voulgezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16420-16250-voulgezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16421-16220-vouthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16421-16220-vouthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16421-16220-vouthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16421-16220-vouthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16422-16410-vouzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16422-16410-vouzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16422-16410-vouzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16422-16410-vouzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16423-16330-xambes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16423-16330-xambes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16423-16330-xambes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16423-16330-xambes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16424-16210-yviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16424-16210-yviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16424-16210-yviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16424-16210-yviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16425-16110-yvrac_et_malleyrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16425-16110-yvrac_et_malleyrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16425-16110-yvrac_et_malleyrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt16-charente/commune16425-16110-yvrac_et_malleyrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-17.xml
+++ b/public/sitemaps/sitemap-17.xml
@@ -5,948 +5,1892 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17002-17500-agudelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17002-17500-agudelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17002-17500-agudelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17002-17500-agudelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17003-17290-aigrefeuille_d_aunis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17003-17290-aigrefeuille_d_aunis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17003-17290-aigrefeuille_d_aunis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17003-17290-aigrefeuille_d_aunis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17004-17123-ile_d_aix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17004-17123-ile_d_aix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17004-17123-ile_d_aix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17004-17123-ile_d_aix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17005-17150-allas_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17005-17150-allas_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17005-17150-allas_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17005-17150-allas_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17006-17500-allas_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17006-17500-allas_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17006-17500-allas_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17006-17500-allas_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17007-17540-anais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17007-17540-anais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17007-17540-anais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17007-17540-anais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17008-17230-andilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17008-17230-andilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17008-17230-andilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17008-17230-andilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17009-17540-angliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17009-17540-angliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17009-17540-angliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17009-17540-angliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17010-17690-angoulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17010-17690-angoulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17010-17690-angoulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17010-17690-angoulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17011-17350-annepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17011-17350-annepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17011-17350-annepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17011-17350-annepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17012-17380-annezay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17012-17380-annezay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17012-17380-annezay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17012-17380-annezay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17013-17400-antezant_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17013-17400-antezant_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17013-17400-antezant_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17013-17400-antezant_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17015-17120-arces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17015-17120-arces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17015-17120-arces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17015-17120-arces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17016-17520-archiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17016-17520-archiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17016-17520-archiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17016-17520-archiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17017-17380-archingeay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17017-17380-archingeay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17017-17380-archingeay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17017-17380-archingeay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17018-17290-ardillieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17018-17290-ardillieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17018-17290-ardillieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17018-17290-ardillieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17019-17590-ars_en_re/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17019-17590-ars_en_re/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17019-17590-ars_en_re/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17019-17590-ars_en_re/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17020-17520-arthenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17020-17520-arthenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17020-17520-arthenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17020-17520-arthenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17021-17530-arvert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17021-17530-arvert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17021-17530-arvert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17021-17530-arvert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17022-17400-asnieres_la_giraud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17022-17400-asnieres_la_giraud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17022-17400-asnieres_la_giraud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17022-17400-asnieres_la_giraud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17023-17770-aujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17023-17770-aujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17023-17770-aujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17023-17770-aujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17024-17470-aulnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17024-17470-aulnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17024-17470-aulnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17024-17470-aulnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17025-17770-aumagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17025-17770-aumagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17025-17770-aumagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17025-17770-aumagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17026-17770-authon_ebeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17026-17770-authon_ebeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17026-17770-authon_ebeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17026-17770-authon_ebeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17027-17800-avy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17027-17800-avy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17027-17800-avy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17027-17800-avy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17028-17440-aytre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17028-17440-aytre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17028-17440-aytre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17028-17440-aytre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17029-17160-bagnizeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17029-17160-bagnizeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17029-17160-bagnizeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17029-17160-bagnizeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17030-17600-balanzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17030-17600-balanzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17030-17600-balanzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17030-17600-balanzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17031-17160-ballans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17031-17160-ballans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17031-17160-ballans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17031-17160-ballans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17032-17290-ballon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17032-17290-ballon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17032-17290-ballon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17032-17290-ballon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17033-17360-la_barde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17033-17360-la_barde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17033-17360-la_barde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17033-17360-la_barde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17034-17120-barzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17034-17120-barzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17034-17120-barzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17034-17120-barzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17035-17490-bazauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17035-17490-bazauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17035-17490-bazauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17035-17490-bazauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17036-17620-beaugeay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17036-17620-beaugeay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17036-17620-beaugeay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17036-17620-beaugeay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17037-17490-beauvais_sur_matha/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17037-17490-beauvais_sur_matha/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17037-17490-beauvais_sur_matha/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17037-17490-beauvais_sur_matha/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17038-17210-bedenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17038-17210-bedenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17038-17210-bedenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17038-17210-bedenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17039-17800-belluire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17039-17800-belluire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17039-17800-belluire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17039-17800-belluire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17041-17170-benon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17041-17170-benon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17041-17170-benon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17041-17170-benon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17042-17770-bercloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17042-17770-bercloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17042-17770-bercloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17042-17770-bercloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17043-17330-bernay_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17043-17330-bernay_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17043-17330-bernay_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17043-17330-bernay_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17044-17460-berneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17044-17460-berneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17044-17460-berneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17044-17460-berneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17045-17250-beurlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17045-17250-beurlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17045-17250-beurlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17045-17250-beurlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17046-17400-bignay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17046-17400-bignay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17046-17400-bignay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17046-17400-bignay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17047-17800-biron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17047-17800-biron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17047-17800-biron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17047-17800-biron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17048-17160-blanzac_les_matha/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17048-17160-blanzac_les_matha/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17048-17160-blanzac_les_matha/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17048-17160-blanzac_les_matha/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17049-17470-blanzay_sur_boutonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17049-17470-blanzay_sur_boutonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17049-17470-blanzay_sur_boutonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17049-17470-blanzay_sur_boutonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17050-17240-bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17050-17240-bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17050-17240-bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17050-17240-bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17051-17580-le_bois_plage_en_re/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17051-17580-le_bois_plage_en_re/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17051-17580-le_bois_plage_en_re/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17051-17580-le_bois_plage_en_re/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17052-17150-boisredon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17052-17150-boisredon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17052-17150-boisredon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17052-17150-boisredon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17052-17130-boisredon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17052-17130-boisredon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17052-17130-boisredon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17052-17130-boisredon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17053-17430-bords/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17053-17430-bords/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17053-17430-bords/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17053-17430-bords/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17054-17270-boresse_et_martron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17054-17270-boresse_et_martron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17054-17270-boresse_et_martron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17054-17270-boresse_et_martron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17055-17360-boscamnant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17055-17360-boscamnant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17055-17360-boscamnant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17055-17360-boscamnant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17056-17800-bougneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17056-17800-bougneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17056-17800-bougneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17056-17800-bougneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17057-17540-bouhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17057-17540-bouhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17057-17540-bouhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17057-17540-bouhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17058-17560-bourcefranc_le_chapus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17058-17560-bourcefranc_le_chapus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17058-17560-bourcefranc_le_chapus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17058-17560-bourcefranc_le_chapus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17059-17220-bourgneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17059-17220-bourgneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17059-17220-bourgneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17059-17220-bourgneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17060-17120-boutenac_touvent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17060-17120-boutenac_touvent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17060-17120-boutenac_touvent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17060-17120-boutenac_touvent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17061-17210-bran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17061-17210-bran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17061-17210-bran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17061-17210-bran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17062-17490-bresdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17062-17490-bresdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17062-17490-bresdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17062-17490-bresdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17063-17700-breuil_la_reorte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17063-17700-breuil_la_reorte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17063-17700-breuil_la_reorte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17063-17700-breuil_la_reorte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17064-17920-breuillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17064-17920-breuillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17064-17920-breuillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17064-17920-breuillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17065-17870-breuil_magne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17065-17870-breuil_magne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17065-17870-breuil_magne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17065-17870-breuil_magne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17066-17520-brie_sous_archiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17066-17520-brie_sous_archiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17066-17520-brie_sous_archiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17066-17520-brie_sous_archiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17067-17160-brie_sous_matha/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17067-17160-brie_sous_matha/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17067-17160-brie_sous_matha/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17067-17160-brie_sous_matha/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17068-17120-brie_sous_mortagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17068-17120-brie_sous_mortagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17068-17120-brie_sous_mortagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17068-17120-brie_sous_mortagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17069-17800-brives_sur_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17069-17800-brives_sur_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17069-17800-brives_sur_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17069-17800-brives_sur_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17070-17770-brizambourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17070-17770-brizambourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17070-17770-brizambourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17070-17770-brizambourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17071-17160-la_brousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17071-17160-la_brousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17071-17160-la_brousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17071-17160-la_brousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17072-17770-burie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17072-17770-burie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17072-17770-burie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17072-17770-burie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17073-17100-bussac_sur_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17073-17100-bussac_sur_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17073-17100-bussac_sur_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17073-17100-bussac_sur_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17074-17210-bussac_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17074-17210-bussac_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17074-17210-bussac_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17074-17210-bussac_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17075-17430-cabariot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17075-17430-cabariot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17075-17430-cabariot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17075-17430-cabariot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17076-17520-celles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17076-17520-celles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17076-17520-celles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17076-17520-celles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17077-17270-cercoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17077-17270-cercoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17077-17270-cercoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17077-17270-cercoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17078-17800-chadenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17078-17800-chadenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17078-17800-chadenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17078-17800-chadenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17079-17890-chaillevette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17079-17890-chaillevette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17079-17890-chaillevette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17079-17890-chaillevette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17080-17290-chambon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17080-17290-chambon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17080-17290-chambon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17080-17290-chambon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17081-17130-chamouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17081-17130-chamouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17081-17130-chamouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17081-17130-chamouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17082-17500-champagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17082-17500-champagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17082-17500-champagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17082-17500-champagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17083-17620-champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17083-17620-champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17083-17620-champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17083-17620-champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17084-17240-champagnolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17084-17240-champagnolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17084-17240-champagnolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17084-17240-champagnolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17085-17430-champdolent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17085-17430-champdolent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17085-17430-champdolent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17085-17430-champdolent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17086-17610-chaniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17086-17610-chaniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17086-17610-chaniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17086-17610-chaniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17087-17380-chantemerle_sur_la_soie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17087-17380-chantemerle_sur_la_soie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17087-17380-chantemerle_sur_la_soie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17087-17380-chantemerle_sur_la_soie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17089-17100-la_chapelle_des_pots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17089-17100-la_chapelle_des_pots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17089-17100-la_chapelle_des_pots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17089-17100-la_chapelle_des_pots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17091-17230-charron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17091-17230-charron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17091-17230-charron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17091-17230-charron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17092-17130-chartuzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17092-17130-chartuzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17092-17130-chartuzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17092-17130-chartuzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17093-17480-le_chateau_d_oleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17093-17480-le_chateau_d_oleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17093-17480-le_chateau_d_oleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17093-17480-le_chateau_d_oleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17094-17340-chatelaillon_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17094-17340-chatelaillon_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17094-17340-chatelaillon_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17094-17340-chatelaillon_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17095-17210-chatenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17095-17210-chatenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17095-17210-chatenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17095-17210-chatenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17096-17130-chaunac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17096-17130-chaunac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17096-17130-chaunac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17096-17130-chaunac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17097-17600-le_chay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17097-17600-le_chay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17097-17600-le_chay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17097-17600-le_chay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17098-17120-chenac_saint_seurin_d_uzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17098-17120-chenac_saint_seurin_d_uzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17098-17120-chenac_saint_seurin_d_uzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17098-17120-chenac_saint_seurin_d_uzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17099-17210-chepniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17099-17210-chepniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17099-17210-chepniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17099-17210-chepniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17100-17610-cherac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17100-17610-cherac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17100-17610-cherac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17100-17610-cherac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17101-17470-cherbonnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17101-17470-cherbonnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17101-17470-cherbonnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17101-17470-cherbonnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17102-17460-chermignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17102-17460-chermignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17102-17460-chermignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17102-17460-chermignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17104-17210-chevanceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17104-17210-chevanceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17104-17210-chevanceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17104-17210-chevanceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17105-17510-chives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17105-17510-chives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17105-17510-chives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17105-17510-chives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17106-17520-cierzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17106-17520-cierzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17106-17520-cierzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17106-17520-cierzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17107-17290-cire_d_aunis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17107-17290-cire_d_aunis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17107-17290-cire_d_aunis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17107-17290-cire_d_aunis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17108-17500-clam/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17108-17500-clam/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17108-17500-clam/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17108-17500-clam/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17109-17220-clavette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17109-17220-clavette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17109-17220-clavette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17109-17220-clavette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17110-17270-clerac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17110-17270-clerac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17110-17270-clerac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17110-17270-clerac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17111-17240-clion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17111-17240-clion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17111-17240-clion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17111-17240-clion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17112-17600-la_clisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17112-17600-la_clisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17112-17600-la_clisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17112-17600-la_clisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17113-17360-la_clotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17113-17360-la_clotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17113-17360-la_clotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17113-17360-la_clotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17114-17330-coivert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17114-17330-coivert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17114-17330-coivert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17114-17330-coivert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17115-17460-colombiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17115-17460-colombiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17115-17460-colombiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17115-17460-colombiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17116-17150-consac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17116-17150-consac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17116-17150-consac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17116-17150-consac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17117-17470-contre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17117-17470-contre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17117-17470-contre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17117-17470-contre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17118-17130-corignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17118-17130-corignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17118-17130-corignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17118-17130-corignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17119-17600-corme_ecluse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17119-17600-corme_ecluse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17119-17600-corme_ecluse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17119-17600-corme_ecluse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17120-17600-corme_royal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17120-17600-corme_royal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17120-17600-corme_royal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17120-17600-corme_royal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17121-17670-la_couarde_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17121-17670-la_couarde_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17121-17670-la_couarde_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17121-17670-la_couarde_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17122-17800-coulonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17122-17800-coulonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17122-17800-coulonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17122-17800-coulonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17124-17330-courant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17124-17330-courant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17124-17330-courant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17124-17330-courant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17125-17400-courcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17125-17400-courcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17125-17400-courcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17125-17400-courcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17126-17160-courcerac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17126-17160-courcerac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17126-17160-courcerac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17126-17160-courcerac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17127-17170-courcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17127-17170-courcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17127-17170-courcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17127-17170-courcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17128-17100-courcoury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17128-17100-courcoury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17128-17100-courcoury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17128-17100-courcoury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17129-17130-courpignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17129-17130-courpignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17129-17130-courpignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17129-17130-courpignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17130-17130-coux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17130-17130-coux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17130-17130-coux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17130-17130-coux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17131-17120-cozes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17131-17120-cozes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17131-17120-cozes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17131-17120-cozes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17132-17170-cramchaban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17132-17170-cramchaban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17132-17170-cramchaban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17132-17170-cramchaban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17133-17260-cravans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17133-17260-cravans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17133-17260-cravans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17133-17260-cravans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17134-17350-crazannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17134-17350-crazannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17134-17350-crazannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17134-17350-crazannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17135-17160-cresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17135-17160-cresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17135-17160-cresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17135-17160-cresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17136-17220-croix_chapeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17136-17220-croix_chapeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17136-17220-croix_chapeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17136-17220-croix_chapeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17137-17330-la_croix_comtesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17137-17330-la_croix_comtesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17137-17330-la_croix_comtesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17137-17330-la_croix_comtesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17138-17470-dampierre_sur_boutonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17138-17470-dampierre_sur_boutonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17138-17470-dampierre_sur_boutonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17138-17470-dampierre_sur_boutonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17139-17330-doeuil_sur_le_mignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17139-17330-doeuil_sur_le_mignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17139-17330-doeuil_sur_le_mignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17139-17330-doeuil_sur_le_mignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17140-17550-dolus_d_oleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17140-17550-dolus_d_oleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17140-17550-dolus_d_oleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17140-17550-dolus_d_oleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17141-17610-dompierre_sur_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17141-17610-dompierre_sur_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17141-17610-dompierre_sur_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17141-17610-dompierre_sur_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17142-17139-dompierre_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17142-17139-dompierre_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17142-17139-dompierre_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17142-17139-dompierre_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17143-17100-le_douhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17143-17100-le_douhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17143-17100-le_douhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17143-17100-le_douhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17145-17800-echebrune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17145-17800-echebrune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17145-17800-echebrune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17145-17800-echebrune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17146-17620-echillais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17146-17620-echillais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17146-17620-echillais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17146-17620-echillais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17147-17770-ecoyeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17147-17770-ecoyeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17147-17770-ecoyeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17147-17770-ecoyeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17148-17810-ecurat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17148-17810-ecurat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17148-17810-ecurat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17148-17810-ecurat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17149-17510-les_eduts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17149-17510-les_eduts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17149-17510-les_eduts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17149-17510-les_eduts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17150-17400-les_eglises_d_argenteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17150-17400-les_eglises_d_argenteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17150-17400-les_eglises_d_argenteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17150-17400-les_eglises_d_argenteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17151-17600-l_eguille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17151-17600-l_eguille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17151-17600-l_eguille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17151-17600-l_eguille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17152-17120-epargnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17152-17120-epargnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17152-17120-epargnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17152-17120-epargnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17153-17137-esnandes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17153-17137-esnandes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17153-17137-esnandes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17153-17137-esnandes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17154-17250-les_essards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17154-17250-les_essards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17154-17250-les_essards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17154-17250-les_essards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17155-17750-etaules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17155-17750-etaules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17155-17750-etaules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17155-17750-etaules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17156-17130-expiremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17156-17130-expiremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17156-17130-expiremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17156-17130-expiremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17157-17350-fenioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17157-17350-fenioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17157-17350-fenioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17157-17350-fenioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17158-17170-ferrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17158-17170-ferrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17158-17170-ferrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17158-17170-ferrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17159-17800-fleac_sur_seugne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17159-17800-fleac_sur_seugne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17159-17800-fleac_sur_seugne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17159-17800-fleac_sur_seugne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17160-17120-floirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17160-17120-floirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17160-17120-floirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17160-17120-floirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17161-17630-la_flotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17161-17630-la_flotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17161-17630-la_flotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17161-17630-la_flotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17162-17510-fontaine_chalendray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17162-17510-fontaine_chalendray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17162-17510-fontaine_chalendray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17162-17510-fontaine_chalendray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17163-17500-fontaines_d_ozillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17163-17500-fontaines_d_ozillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17163-17500-fontaines_d_ozillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17163-17500-fontaines_d_ozillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17164-17100-fontcouverte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17164-17100-fontcouverte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17164-17100-fontcouverte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17164-17100-fontcouverte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17165-17400-fontenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17165-17400-fontenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17165-17400-fontenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17165-17400-fontenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17166-17290-forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17166-17290-forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17166-17290-forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17166-17290-forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17167-17270-le_fouilloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17167-17270-le_fouilloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17167-17270-le_fouilloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17167-17270-le_fouilloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17168-17450-fouras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17168-17450-fouras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17168-17450-fouras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17168-17450-fouras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17171-17250-geay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17171-17250-geay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17171-17250-geay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17171-17250-geay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17172-17260-gemozac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17172-17260-gemozac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17172-17260-gemozac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17172-17260-gemozac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17173-17360-la_genetouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17173-17360-la_genetouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17173-17360-la_genetouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17173-17360-la_genetouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17174-17430-genouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17174-17430-genouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17174-17430-genouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17174-17430-genouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17175-17520-germignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17175-17520-germignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17175-17520-germignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17175-17520-germignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17176-17160-gibourne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17176-17160-gibourne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17176-17160-gibourne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17176-17160-gibourne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17177-17160-le_gicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17177-17160-le_gicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17177-17160-le_gicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17177-17160-le_gicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17178-17260-givrezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17178-17260-givrezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17178-17260-givrezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17178-17260-givrezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17100-les_gonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17100-les_gonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17100-les_gonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17100-les_gonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17136-les_gonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17136-les_gonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17136-les_gonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17136-les_gonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17460-les_gonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17460-les_gonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17460-les_gonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17179-17460-les_gonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17180-17490-gourvillette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17180-17490-gourvillette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17180-17490-gourvillette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17180-17490-gourvillette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17181-17350-grandjean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17181-17350-grandjean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17181-17350-grandjean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17181-17350-grandjean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17182-17170-la_greve_sur_mignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17182-17170-la_greve_sur_mignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17182-17170-la_greve_sur_mignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17182-17170-la_greve_sur_mignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17183-17120-grezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17183-17120-grezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17183-17120-grezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17183-17120-grezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17184-17620-la_gripperie_saint_symphorien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17184-17620-la_gripperie_saint_symphorien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17184-17620-la_gripperie_saint_symphorien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17184-17620-la_gripperie_saint_symphorien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17185-17600-le_gua/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17185-17600-le_gua/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17185-17600-le_gua/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17185-17600-le_gua/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17186-17540-le_gue_d_allere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17186-17540-le_gue_d_allere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17186-17540-le_gue_d_allere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17186-17540-le_gue_d_allere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17187-17500-guitinieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17187-17500-guitinieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17187-17500-guitinieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17187-17500-guitinieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17188-17160-haimps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17188-17160-haimps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17188-17160-haimps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17188-17160-haimps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17190-17137-l_houmeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17190-17137-l_houmeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17190-17137-l_houmeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17190-17137-l_houmeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17191-17460-la_jard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17191-17460-la_jard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17191-17460-la_jard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17191-17460-la_jard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17192-17520-jarnac_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17192-17520-jarnac_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17192-17520-jarnac_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17192-17520-jarnac_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17193-17220-la_jarne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17193-17220-la_jarne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17193-17220-la_jarne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17193-17220-la_jarne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17194-17220-la_jarrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17194-17220-la_jarrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17194-17220-la_jarrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17194-17220-la_jarrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17195-17330-la_jarrie_audouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17195-17330-la_jarrie_audouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17195-17330-la_jarrie_audouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17195-17330-la_jarrie_audouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17196-17260-jazennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17196-17260-jazennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17196-17260-jazennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17196-17260-jazennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17197-17500-jonzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17197-17500-jonzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17197-17500-jonzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17197-17500-jonzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17198-17770-juicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17198-17770-juicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17198-17770-juicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17198-17770-juicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17199-17130-jussas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17199-17130-jussas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17199-17130-jussas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17199-17130-jussas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17200-17140-lagord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17200-17140-lagord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17200-17140-lagord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17200-17140-lagord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17201-17170-la_laigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17201-17170-la_laigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17201-17170-la_laigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17201-17170-la_laigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17202-17380-landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17202-17380-landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17202-17380-landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17202-17380-landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17203-17290-landrais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17203-17290-landrais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17203-17290-landrais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17203-17290-landrais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17204-17500-leoville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17204-17500-leoville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17204-17500-leoville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17204-17500-leoville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17205-17870-loire_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17205-17870-loire_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17205-17870-loire_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17205-17870-loire_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17206-17470-loire_sur_nie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17206-17470-loire_sur_nie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17206-17470-loire_sur_nie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17206-17470-loire_sur_nie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17207-17111-loix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17207-17111-loix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17207-17111-loix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17207-17111-loix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17208-17230-longeves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17208-17230-longeves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17208-17230-longeves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17208-17230-longeves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17209-17520-lonzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17209-17520-lonzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17209-17520-lonzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17209-17520-lonzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17210-17240-lorignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17210-17240-lorignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17210-17240-lorignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17210-17240-lorignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17211-17330-loulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17211-17330-loulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17211-17330-loulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17211-17330-loulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17212-17160-louzignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17212-17160-louzignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17212-17160-louzignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17212-17160-louzignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17213-17330-lozay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17213-17330-lozay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17213-17330-lozay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17213-17330-lozay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17214-17600-luchat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17214-17600-luchat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17214-17600-luchat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17214-17600-luchat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17215-17500-lussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17215-17500-lussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17215-17500-lussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17215-17500-lussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17216-17430-lussant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17216-17430-lussant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17216-17430-lussant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17216-17430-lussant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17217-17490-macqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17217-17490-macqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17217-17490-macqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17217-17490-macqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17218-17230-marans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17218-17230-marans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17218-17230-marans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17218-17230-marans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17219-17320-marennes_hiers_brouage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17219-17320-marennes_hiers_brouage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17219-17320-marennes_hiers_brouage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17219-17320-marennes_hiers_brouage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17220-17800-marignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17220-17800-marignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17220-17800-marignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17220-17800-marignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17221-17700-marsais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17221-17700-marsais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17221-17700-marsais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17221-17700-marsais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17222-17137-marsilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17222-17137-marsilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17222-17137-marsilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17222-17137-marsilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17223-17490-massac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17223-17490-massac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17223-17490-massac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17223-17490-massac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17224-17160-matha/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17224-17160-matha/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17224-17160-matha/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17224-17160-matha/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17225-17570-les_mathes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17225-17570-les_mathes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17225-17570-les_mathes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17225-17570-les_mathes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17226-17400-mazeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17226-17400-mazeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17226-17400-mazeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17226-17400-mazeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17227-17800-mazerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17227-17800-mazerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17227-17800-mazerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17227-17800-mazerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17228-17600-medis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17228-17600-medis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17228-17600-medis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17228-17600-medis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17229-17210-merignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17229-17210-merignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17229-17210-merignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17229-17210-merignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17230-17132-meschers_sur_gironde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17230-17132-meschers_sur_gironde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17230-17132-meschers_sur_gironde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17230-17132-meschers_sur_gironde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17231-17130-messac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17231-17130-messac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17231-17130-messac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17231-17130-messac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17232-17120-meursac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17232-17120-meursac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17232-17120-meursac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17232-17120-meursac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17233-17500-meux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17233-17500-meux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17233-17500-meux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17233-17500-meux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17234-17330-migre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17234-17330-migre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17234-17330-migre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17234-17330-migre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17235-17770-migron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17235-17770-migron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17235-17770-migron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17235-17770-migron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17236-17150-mirambeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17236-17150-mirambeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17236-17150-mirambeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17236-17150-mirambeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17237-17780-moeze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17237-17780-moeze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17237-17780-moeze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17237-17780-moeze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17239-17160-mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17239-17160-mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17239-17160-mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17239-17160-mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17240-17130-montendre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17240-17130-montendre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17240-17130-montendre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17240-17130-montendre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17241-17270-montguyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17241-17270-montguyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17241-17270-montguyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17241-17270-montguyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17242-17800-montils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17242-17800-montils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17242-17800-montils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17242-17800-montils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17243-17210-montlieu_la_garde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17243-17210-montlieu_la_garde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17243-17210-montlieu_la_garde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17243-17210-montlieu_la_garde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17244-17260-montpellier_de_medillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17244-17260-montpellier_de_medillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17244-17260-montpellier_de_medillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17244-17260-montpellier_de_medillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17245-17220-montroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17245-17220-montroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17245-17220-montroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17245-17220-montroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17246-17430-moragne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17246-17430-moragne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17246-17430-moragne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17246-17430-moragne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17247-17113-mornac_sur_seudre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17247-17113-mornac_sur_seudre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17247-17113-mornac_sur_seudre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17247-17113-mornac_sur_seudre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17248-17120-mortagne_sur_gironde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17248-17120-mortagne_sur_gironde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17248-17120-mortagne_sur_gironde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17248-17120-mortagne_sur_gironde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17249-17500-mortiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17249-17500-mortiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17249-17500-mortiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17249-17500-mortiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17250-17240-mosnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17250-17240-mosnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17250-17240-mosnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17250-17240-mosnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17252-17350-le_mung/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17252-17350-le_mung/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17252-17350-le_mung/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17252-17350-le_mung/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17253-17430-muron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17253-17430-muron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17253-17430-muron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17253-17430-muron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17254-17380-nachamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17254-17380-nachamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17254-17380-nachamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17254-17380-nachamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17255-17600-nancras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17255-17600-nancras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17255-17600-nancras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17255-17600-nancras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17256-17770-nantille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17256-17770-nantille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17256-17770-nantille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17256-17770-nantille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17257-17510-nere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17257-17510-nere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17257-17510-nere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17257-17510-nere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17258-17520-neuillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17258-17520-neuillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17258-17520-neuillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17258-17520-neuillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17259-17500-neulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17259-17500-neulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17259-17500-neulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17259-17500-neulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17260-17270-neuvicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17260-17270-neuvicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17260-17270-neuvicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17260-17270-neuvicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17261-17490-neuvicq_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17261-17490-neuvicq_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17261-17490-neuvicq_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17261-17490-neuvicq_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17262-17810-nieul_les_saintes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17262-17810-nieul_les_saintes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17262-17810-nieul_les_saintes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17262-17810-nieul_les_saintes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17263-17150-nieul_le_virouil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17263-17150-nieul_le_virouil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17263-17150-nieul_le_virouil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17263-17150-nieul_le_virouil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17264-17137-nieul_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17264-17137-nieul_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17264-17137-nieul_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17264-17137-nieul_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17265-17600-nieulle_sur_seudre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17265-17600-nieulle_sur_seudre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17265-17600-nieulle_sur_seudre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17265-17600-nieulle_sur_seudre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17266-17380-les_nouillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17266-17380-les_nouillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17266-17380-les_nouillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17266-17380-les_nouillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17267-17540-nuaille_d_aunis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17267-17540-nuaille_d_aunis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17267-17540-nuaille_d_aunis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17267-17540-nuaille_d_aunis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17268-17470-nuaille_sur_boutonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17268-17470-nuaille_sur_boutonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17268-17470-nuaille_sur_boutonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17268-17470-nuaille_sur_boutonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17269-17210-orignolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17269-17210-orignolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17269-17210-orignolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17269-17210-orignolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17270-17500-ozillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17270-17500-ozillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17270-17500-ozillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17270-17500-ozillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17271-17470-paille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17271-17470-paille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17271-17470-paille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17271-17470-paille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17273-17800-perignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17273-17800-perignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17273-17800-perignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17273-17800-perignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17274-17180-perigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17274-17180-perigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17274-17180-perigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17274-17180-perigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17275-17810-pessines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17275-17810-pessines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17275-17810-pessines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17275-17810-pessines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17276-17210-le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17276-17210-le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17276-17210-le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17276-17210-le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17277-17400-essouvert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17277-17400-essouvert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17277-17400-essouvert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17277-17400-essouvert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17278-17600-pisany/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17278-17600-pisany/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17278-17600-pisany/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17278-17600-pisany/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17279-17240-plassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17279-17240-plassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17279-17240-plassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17279-17240-plassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17280-17250-plassay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17280-17250-plassay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17280-17250-plassay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17280-17250-plassay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17281-17210-polignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17281-17210-polignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17281-17210-polignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17281-17210-polignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17282-17130-pommiers_moulons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17282-17130-pommiers_moulons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17282-17130-pommiers_moulons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17282-17130-pommiers_moulons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17283-17800-pons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17283-17800-pons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17283-17800-pons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17283-17800-pons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17284-17250-pont_l_abbe_d_arnoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17284-17250-pont_l_abbe_d_arnoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17284-17250-pont_l_abbe_d_arnoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17284-17250-pont_l_abbe_d_arnoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17285-17350-port_d_envaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17285-17350-port_d_envaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17285-17350-port_d_envaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17285-17350-port_d_envaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17286-17880-les_portes_en_re/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17286-17880-les_portes_en_re/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17286-17880-les_portes_en_re/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17286-17880-les_portes_en_re/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17287-17210-pouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17287-17210-pouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17287-17210-pouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17287-17210-pouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17288-17400-poursay_garnaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17288-17400-poursay_garnaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17288-17400-poursay_garnaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17288-17400-poursay_garnaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17289-17460-preguillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17289-17460-preguillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17289-17460-preguillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17289-17460-preguillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17290-17160-prignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17290-17160-prignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17290-17160-prignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17290-17160-prignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17291-17138-puilboreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17291-17138-puilboreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17291-17138-puilboreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17291-17138-puilboreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17292-17380-puy_du_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17292-17380-puy_du_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17292-17380-puy_du_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17292-17380-puy_du_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17293-17700-puyravault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17293-17700-puyravault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17293-17700-puyravault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17293-17700-puyravault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17294-17380-puyrolland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17294-17380-puyrolland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17294-17380-puyrolland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17294-17380-puyrolland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17295-17500-reaux_sur_trefle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17295-17500-reaux_sur_trefle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17295-17500-reaux_sur_trefle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17295-17500-reaux_sur_trefle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17296-17460-retaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17296-17460-retaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17296-17460-retaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17296-17460-retaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17297-17940-rivedoux_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17297-17940-rivedoux_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17297-17940-rivedoux_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17297-17940-rivedoux_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17298-17460-rioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17298-17460-rioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17298-17460-rioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17298-17460-rioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17300-rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17300-rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17300-rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17300-rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17134-rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17134-rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17134-rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17134-rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17135-rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17135-rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17135-rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17135-rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17133-rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17133-rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17133-rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17299-17133-rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17300-17000-la_rochelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17300-17000-la_rochelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17300-17000-la_rochelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17300-17000-la_rochelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17301-17510-romazieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17301-17510-romazieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17301-17510-romazieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17301-17510-romazieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17302-17250-romegoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17302-17250-romegoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17302-17250-romegoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17302-17250-romegoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17303-17170-la_ronde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17303-17170-la_ronde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17303-17170-la_ronde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17303-17170-la_ronde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17304-17800-rouffiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17304-17800-rouffiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17304-17800-rouffiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17304-17800-rouffiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17305-17130-rouffignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17305-17130-rouffignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17305-17130-rouffignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17305-17130-rouffignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17306-17200-royan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17306-17200-royan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17306-17200-royan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17306-17200-royan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17307-17600-sablonceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17307-17600-sablonceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17307-17600-sablonceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17307-17600-sablonceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17308-17133-saint_agnant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17308-17133-saint_agnant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17308-17133-saint_agnant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17308-17133-saint_agnant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17308-17620-saint_agnant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17308-17620-saint_agnant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17308-17620-saint_agnant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17308-17620-saint_agnant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17309-17360-saint_aigulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17309-17360-saint_aigulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17309-17360-saint_aigulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17309-17360-saint_aigulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17310-17260-saint_andre_de_lidon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17310-17260-saint_andre_de_lidon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17310-17260-saint_andre_de_lidon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17310-17260-saint_andre_de_lidon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17311-17570-saint_augustin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17311-17570-saint_augustin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17311-17570-saint_augustin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17311-17570-saint_augustin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17312-17150-saint_bonnet_sur_gironde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17312-17150-saint_bonnet_sur_gironde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17312-17150-saint_bonnet_sur_gironde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17312-17150-saint_bonnet_sur_gironde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17313-17770-saint_bris_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17313-17770-saint_bris_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17313-17770-saint_bris_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17313-17770-saint_bris_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17314-17770-saint_cesaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17314-17770-saint_cesaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17314-17770-saint_cesaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17314-17770-saint_cesaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17315-17220-saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17315-17220-saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17315-17220-saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17315-17220-saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17316-17520-saint_ciers_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17316-17520-saint_ciers_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17316-17520-saint_ciers_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17316-17520-saint_ciers_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17317-17240-saint_ciers_du_taillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17317-17240-saint_ciers_du_taillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17317-17240-saint_ciers_du_taillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17317-17240-saint_ciers_du_taillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17318-17590-saint_clement_des_baleines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17318-17590-saint_clement_des_baleines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17318-17590-saint_clement_des_baleines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17318-17590-saint_clement_des_baleines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17319-17210-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17319-17210-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17319-17210-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17319-17210-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17320-17430-saint_coutant_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17320-17430-saint_coutant_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17320-17430-saint_coutant_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17320-17430-saint_coutant_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17321-17380-saint_crepin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17321-17380-saint_crepin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17321-17380-saint_crepin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17321-17380-saint_crepin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17322-17170-saint_cyr_du_doret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17322-17170-saint_cyr_du_doret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17322-17170-saint_cyr_du_doret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17322-17170-saint_cyr_du_doret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17323-17650-saint_denis_d_oleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17323-17650-saint_denis_d_oleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17323-17650-saint_denis_d_oleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17323-17650-saint_denis_d_oleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17324-17150-saint_dizant_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17324-17150-saint_dizant_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17324-17150-saint_dizant_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17324-17150-saint_dizant_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17325-17240-saint_dizant_du_gua/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17325-17240-saint_dizant_du_gua/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17325-17240-saint_dizant_du_gua/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17325-17240-saint_dizant_du_gua/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17326-17520-saint_eugene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17326-17520-saint_eugene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17326-17520-saint_eugene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17326-17520-saint_eugene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17327-17330-saint_felix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17327-17330-saint_felix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17327-17330-saint_felix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17327-17330-saint_felix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17328-17240-saint_fort_sur_gironde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17328-17240-saint_fort_sur_gironde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17328-17240-saint_fort_sur_gironde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17328-17240-saint_fort_sur_gironde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17329-17780-saint_froult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17329-17780-saint_froult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17329-17780-saint_froult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17329-17780-saint_froult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17330-17250-sainte_gemme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17330-17250-sainte_gemme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17330-17250-sainte_gemme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17330-17250-sainte_gemme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17331-17240-saint_genis_de_saintonge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17331-17240-saint_genis_de_saintonge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17331-17240-saint_genis_de_saintonge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17331-17240-saint_genis_de_saintonge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17332-17240-saint_georges_antignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17332-17240-saint_georges_antignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17332-17240-saint_georges_antignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17332-17240-saint_georges_antignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17333-17110-saint_georges_de_didonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17333-17110-saint_georges_de_didonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17333-17110-saint_georges_de_didonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17333-17110-saint_georges_de_didonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17334-17470-saint_georges_de_longuepierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17334-17470-saint_georges_de_longuepierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17334-17470-saint_georges_de_longuepierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17334-17470-saint_georges_de_longuepierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17335-17150-saint_georges_des_agouts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17335-17150-saint_georges_des_agouts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17335-17150-saint_georges_des_agouts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17335-17150-saint_georges_des_agouts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17336-17810-saint_georges_des_coteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17336-17810-saint_georges_des_coteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17336-17810-saint_georges_des_coteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17336-17810-saint_georges_des_coteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17337-17190-saint_georges_d_oleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17337-17190-saint_georges_d_oleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17337-17190-saint_georges_d_oleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17337-17190-saint_georges_d_oleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17338-17700-saint_georges_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17338-17700-saint_georges_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17338-17700-saint_georges_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17338-17700-saint_georges_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17339-17500-saint_germain_de_lusignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17339-17500-saint_germain_de_lusignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17339-17500-saint_germain_de_lusignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17339-17500-saint_germain_de_lusignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17340-17700-saint_pierre_la_noue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17340-17700-saint_pierre_la_noue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17340-17700-saint_pierre_la_noue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17340-17700-saint_pierre_la_noue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17341-17500-saint_germain_de_vibrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17341-17500-saint_germain_de_vibrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17341-17500-saint_germain_de_vibrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17341-17500-saint_germain_de_vibrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17342-17240-saint_germain_du_seudre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17342-17240-saint_germain_du_seudre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17342-17240-saint_germain_du_seudre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17342-17240-saint_germain_du_seudre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17343-17240-saint_gregoire_d_ardennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17343-17240-saint_gregoire_d_ardennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17343-17240-saint_gregoire_d_ardennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17343-17240-saint_gregoire_d_ardennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17344-17770-saint_hilaire_de_villefranche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17344-17770-saint_hilaire_de_villefranche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17344-17770-saint_hilaire_de_villefranche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17344-17770-saint_hilaire_de_villefranche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17345-17500-saint_hilaire_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17345-17500-saint_hilaire_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17345-17500-saint_hilaire_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17345-17500-saint_hilaire_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17346-17430-saint_hippolyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17346-17430-saint_hippolyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17346-17430-saint_hippolyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17346-17430-saint_hippolyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17347-17400-saint_jean_d_angely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17347-17400-saint_jean_d_angely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17347-17400-saint_jean_d_angely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17347-17400-saint_jean_d_angely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17348-17620-saint_jean_d_angle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17348-17620-saint_jean_d_angle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17348-17620-saint_jean_d_angle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17348-17620-saint_jean_d_angle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17349-17170-saint_jean_de_liversay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17349-17170-saint_jean_de_liversay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17349-17170-saint_jean_de_liversay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17349-17170-saint_jean_de_liversay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17350-17400-saint_julien_de_l_escap/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17350-17400-saint_julien_de_l_escap/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17350-17400-saint_julien_de_l_escap/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17350-17400-saint_julien_de_l_escap/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17351-17320-saint_just_luzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17351-17320-saint_just_luzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17351-17320-saint_just_luzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17351-17320-saint_just_luzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17353-17450-saint_laurent_de_la_pree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17353-17450-saint_laurent_de_la_pree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17353-17450-saint_laurent_de_la_pree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17353-17450-saint_laurent_de_la_pree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17354-17800-saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17354-17800-saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17354-17800-saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17354-17800-saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17355-17520-sainte_lheurine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17355-17520-sainte_lheurine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17355-17520-sainte_lheurine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17355-17520-sainte_lheurine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17356-17380-saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17356-17380-saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17356-17380-saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17356-17380-saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17357-17520-saint_maigrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17357-17520-saint_maigrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17357-17520-saint_maigrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17357-17520-saint_maigrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17358-17470-saint_mande_sur_bredoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17358-17470-saint_mande_sur_bredoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17358-17470-saint_mande_sur_bredoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17358-17470-saint_mande_sur_bredoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17359-17700-saint_mard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17359-17700-saint_mard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17359-17700-saint_mard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17359-17700-saint_mard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17360-17740-sainte_marie_de_re/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17360-17740-sainte_marie_de_re/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17360-17740-sainte_marie_de_re/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17360-17740-sainte_marie_de_re/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17361-17330-saint_martial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17361-17330-saint_martial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17361-17330-saint_martial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17361-17330-saint_martial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17362-17150-saint_martial_de_mirambeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17362-17150-saint_martial_de_mirambeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17362-17150-saint_martial_de_mirambeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17362-17150-saint_martial_de_mirambeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17363-17500-saint_martial_de_vitaterne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17363-17500-saint_martial_de_vitaterne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17363-17500-saint_martial_de_vitaterne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17363-17500-saint_martial_de_vitaterne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17364-17520-saint_martial_sur_ne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17364-17520-saint_martial_sur_ne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17364-17520-saint_martial_sur_ne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17364-17520-saint_martial_sur_ne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17365-17270-saint_martin_d_ary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17365-17270-saint_martin_d_ary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17365-17270-saint_martin_d_ary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17365-17270-saint_martin_d_ary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17366-17360-saint_martin_de_coux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17366-17360-saint_martin_de_coux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17366-17360-saint_martin_de_coux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17366-17360-saint_martin_de_coux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17367-17400-saint_martin_de_juillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17367-17400-saint_martin_de_juillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17367-17400-saint_martin_de_juillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17367-17400-saint_martin_de_juillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17369-17410-saint_martin_de_re/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17369-17410-saint_martin_de_re/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17369-17410-saint_martin_de_re/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17369-17410-saint_martin_de_re/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17372-17500-saint_medard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17372-17500-saint_medard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17372-17500-saint_medard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17372-17500-saint_medard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17373-17220-saint_medard_d_aunis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17373-17220-saint_medard_d_aunis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17373-17220-saint_medard_d_aunis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17373-17220-saint_medard_d_aunis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17374-17770-sainte_meme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17374-17770-sainte_meme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17374-17770-sainte_meme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17374-17770-sainte_meme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17375-17780-saint_nazaire_sur_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17375-17780-saint_nazaire_sur_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17375-17780-saint_nazaire_sur_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17375-17780-saint_nazaire_sur_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17376-17230-saint_ouen_d_aunis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17376-17230-saint_ouen_d_aunis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17376-17230-saint_ouen_d_aunis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17376-17230-saint_ouen_d_aunis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17377-17490-saint_ouen_la_thene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17377-17490-saint_ouen_la_thene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17377-17490-saint_ouen_la_thene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17377-17490-saint_ouen_la_thene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17378-17210-saint_palais_de_negrignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17378-17210-saint_palais_de_negrignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17378-17210-saint_palais_de_negrignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17378-17210-saint_palais_de_negrignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17379-17800-saint_palais_de_phiolin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17379-17800-saint_palais_de_phiolin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17379-17800-saint_palais_de_phiolin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17379-17800-saint_palais_de_phiolin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17380-17420-saint_palais_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17380-17420-saint_palais_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17380-17420-saint_palais_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17380-17420-saint_palais_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17381-17400-saint_pardoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17381-17400-saint_pardoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17381-17400-saint_pardoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17381-17400-saint_pardoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17382-17700-saint_pierre_d_amilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17382-17700-saint_pierre_d_amilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17382-17700-saint_pierre_d_amilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17382-17700-saint_pierre_d_amilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17383-17400-saint_pierre_de_juillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17383-17400-saint_pierre_de_juillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17383-17400-saint_pierre_de_juillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17383-17400-saint_pierre_de_juillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17384-17330-saint_pierre_de_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17384-17330-saint_pierre_de_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17384-17330-saint_pierre_de_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17384-17330-saint_pierre_de_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17385-17310-saint_pierre_d_oleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17385-17310-saint_pierre_d_oleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17385-17310-saint_pierre_d_oleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17385-17310-saint_pierre_d_oleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17386-17270-saint_pierre_du_palais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17386-17270-saint_pierre_du_palais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17386-17270-saint_pierre_du_palais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17386-17270-saint_pierre_du_palais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17387-17250-saint_porchaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17387-17250-saint_porchaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17387-17250-saint_porchaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17387-17250-saint_porchaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17388-17800-saint_quantin_de_rancanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17388-17800-saint_quantin_de_rancanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17388-17800-saint_quantin_de_rancanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17388-17800-saint_quantin_de_rancanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17389-17250-sainte_radegonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17389-17250-sainte_radegonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17389-17250-sainte_radegonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17389-17250-sainte_radegonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17390-17240-sainte_ramee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17390-17240-sainte_ramee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17390-17240-sainte_ramee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17390-17240-sainte_ramee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17391-17220-saint_rogatien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17391-17220-saint_rogatien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17391-17220-saint_rogatien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17391-17220-saint_rogatien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17393-17600-saint_romain_de_benet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17393-17600-saint_romain_de_benet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17393-17600-saint_romain_de_benet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17393-17600-saint_romain_de_benet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17394-17700-saint_saturnin_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17394-17700-saint_saturnin_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17394-17700-saint_saturnin_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17394-17700-saint_saturnin_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17395-17610-saint_sauvant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17395-17610-saint_sauvant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17395-17610-saint_sauvant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17395-17610-saint_sauvant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17396-17540-saint_sauveur_d_aunis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17396-17540-saint_sauveur_d_aunis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17396-17540-saint_sauveur_d_aunis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17396-17540-saint_sauveur_d_aunis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17397-17350-saint_savinien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17397-17350-saint_savinien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17397-17350-saint_savinien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17397-17350-saint_savinien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17398-17800-saint_seurin_de_palenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17398-17800-saint_seurin_de_palenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17398-17800-saint_seurin_de_palenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17398-17800-saint_seurin_de_palenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17400-17800-saint_sever_de_saintonge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17400-17800-saint_sever_de_saintonge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17400-17800-saint_sever_de_saintonge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17400-17800-saint_sever_de_saintonge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17401-17330-saint_severin_sur_boutonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17401-17330-saint_severin_sur_boutonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17401-17330-saint_severin_sur_boutonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17401-17330-saint_severin_sur_boutonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17402-17240-saint_sigismond_de_clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17402-17240-saint_sigismond_de_clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17402-17240-saint_sigismond_de_clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17402-17240-saint_sigismond_de_clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17403-17500-saint_simon_de_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17403-17500-saint_simon_de_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17403-17500-saint_simon_de_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17403-17500-saint_simon_de_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17404-17260-saint_simon_de_pellouaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17404-17260-saint_simon_de_pellouaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17404-17260-saint_simon_de_pellouaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17404-17260-saint_simon_de_pellouaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17405-17150-saint_sorlin_de_conac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17405-17150-saint_sorlin_de_conac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17405-17150-saint_sorlin_de_conac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17405-17150-saint_sorlin_de_conac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17406-17600-saint_sornin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17406-17600-saint_sornin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17406-17600-saint_sornin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17406-17600-saint_sornin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17407-17220-sainte_soulle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17407-17220-sainte_soulle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17407-17220-sainte_soulle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17407-17220-sainte_soulle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17408-17250-saint_sulpice_d_arnoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17408-17250-saint_sulpice_d_arnoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17408-17250-saint_sulpice_d_arnoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17408-17250-saint_sulpice_d_arnoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17409-17200-saint_sulpice_de_royan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17409-17200-saint_sulpice_de_royan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17409-17200-saint_sulpice_de_royan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17409-17200-saint_sulpice_de_royan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17410-17150-saint_thomas_de_conac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17410-17150-saint_thomas_de_conac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17410-17150-saint_thomas_de_conac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17410-17150-saint_thomas_de_conac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17411-17370-saint_trojan_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17411-17370-saint_trojan_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17411-17370-saint_trojan_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17411-17370-saint_trojan_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17412-17100-saint_vaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17412-17100-saint_vaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17412-17100-saint_vaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17412-17100-saint_vaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17413-17220-saint_vivien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17413-17220-saint_vivien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17413-17220-saint_vivien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17413-17220-saint_vivien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17414-17138-saint_xandre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17414-17138-saint_xandre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17414-17138-saint_xandre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17414-17138-saint_xandre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17415-17100-saintes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17415-17100-saintes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17415-17100-saintes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17415-17100-saintes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17416-17510-saleignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17416-17510-saleignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17416-17510-saleignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17416-17510-saleignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17417-17130-salignac_de_mirambeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17417-17130-salignac_de_mirambeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17417-17130-salignac_de_mirambeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17417-17130-salignac_de_mirambeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17418-17800-salignac_sur_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17418-17800-salignac_sur_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17418-17800-salignac_sur_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17418-17800-salignac_sur_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17420-17220-salles_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17420-17220-salles_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17420-17220-salles_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17420-17220-salles_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17421-17600-saujon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17421-17600-saujon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17421-17600-saujon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17421-17600-saujon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17422-17510-seigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17422-17510-seigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17422-17510-seigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17422-17510-seigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17423-17150-semillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17423-17150-semillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17423-17150-semillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17423-17150-semillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17424-17150-semoussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17424-17150-semoussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17424-17150-semoussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17424-17150-semoussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17425-17120-semussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17425-17120-semussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17425-17120-semussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17425-17120-semussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17426-17770-le_seure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17426-17770-le_seure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17426-17770-le_seure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17426-17770-le_seure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17427-17490-siecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17427-17490-siecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17427-17490-siecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17427-17490-siecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17428-17160-sonnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17428-17160-sonnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17428-17160-sonnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17428-17160-sonnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17429-17780-soubise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17429-17780-soubise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17429-17780-soubise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17429-17780-soubise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17430-17150-soubran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17430-17150-soubran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17430-17150-soubran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17430-17150-soubran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17431-17250-soulignonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17431-17250-soulignonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17431-17250-soulignonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17431-17250-soulignonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17432-17130-soumeras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17432-17130-soumeras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17432-17130-soumeras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17432-17130-soumeras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17433-17130-sousmoulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17433-17130-sousmoulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17433-17130-sousmoulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17433-17130-sousmoulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17434-17700-surgeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17434-17700-surgeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17434-17700-surgeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17434-17700-surgeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17435-17350-taillant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17435-17350-taillant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17435-17350-taillant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17435-17350-taillant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17436-17350-taillebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17436-17350-taillebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17436-17350-taillebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17436-17350-taillebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17437-17120-talmont_sur_gironde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17437-17120-talmont_sur_gironde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17437-17120-talmont_sur_gironde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17437-17120-talmont_sur_gironde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17438-17260-tanzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17438-17260-tanzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17438-17260-tanzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17438-17260-tanzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17439-17170-taugon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17439-17170-taugon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17439-17170-taugon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17439-17170-taugon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17440-17400-ternant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17440-17400-ternant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17440-17400-ternant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17440-17400-ternant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17441-17460-tesson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17441-17460-tesson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17441-17460-tesson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17441-17460-tesson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17442-17120-thaims/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17442-17120-thaims/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17442-17120-thaims/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17442-17120-thaims/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17443-17290-thaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17443-17290-thaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17443-17290-thaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17443-17290-thaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17444-17460-thenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17444-17460-thenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17444-17460-thenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17444-17460-thenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17445-17600-thezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17445-17600-thezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17445-17600-thezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17445-17600-thezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17446-17160-thors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17446-17160-thors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17446-17160-thors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17446-17160-thors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17447-17290-le_thou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17447-17290-le_thou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17447-17290-le_thou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17447-17290-le_thou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17448-17380-tonnay_boutonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17448-17380-tonnay_boutonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17448-17380-tonnay_boutonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17448-17380-tonnay_boutonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17449-17430-tonnay_charente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17449-17430-tonnay_charente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17449-17430-tonnay_charente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17449-17430-tonnay_charente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17450-17380-torxe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17450-17380-torxe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17450-17380-torxe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17450-17380-torxe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17451-17160-les_touches_de_perigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17451-17160-les_touches_de_perigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17451-17160-les_touches_de_perigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17451-17160-les_touches_de_perigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17452-17390-la_tremblade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17452-17390-la_tremblade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17452-17390-la_tremblade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17452-17390-la_tremblade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17453-17250-trizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17453-17250-trizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17453-17250-trizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17453-17250-trizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17454-17130-tugeras_saint_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17454-17130-tugeras_saint_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17454-17130-tugeras_saint_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17454-17130-tugeras_saint_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17455-17250-la_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17455-17250-la_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17455-17250-la_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17455-17250-la_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17457-17700-la_devise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17457-17700-la_devise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17457-17700-la_devise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17457-17700-la_devise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17457-17380-la_devise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17457-17380-la_devise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17457-17380-la_devise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17457-17380-la_devise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17458-17500-vanzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17458-17500-vanzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17458-17500-vanzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17458-17500-vanzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17459-17400-varaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17459-17400-varaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17459-17400-varaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17459-17400-varaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17460-17460-varzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17460-17460-varzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17460-17460-varzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17460-17460-varzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17461-17640-vaux_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17461-17640-vaux_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17461-17640-vaux_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17461-17640-vaux_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17462-17100-venerand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17462-17100-venerand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17462-17100-venerand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17462-17100-venerand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17463-17300-vergeroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17463-17300-vergeroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17463-17300-vergeroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17463-17300-vergeroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17464-17330-vergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17464-17330-vergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17464-17330-vergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17464-17330-vergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17465-17400-la_vergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17465-17400-la_vergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17465-17400-la_vergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17465-17400-la_vergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17466-17540-verines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17466-17540-verines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17466-17540-verines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17466-17540-verines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17467-17400-vervant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17467-17400-vervant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17467-17400-vervant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17467-17400-vervant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17468-17130-vibrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17468-17130-vibrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17468-17130-vibrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17468-17130-vibrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17469-17260-villars_en_pons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17469-17260-villars_en_pons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17469-17260-villars_en_pons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17469-17260-villars_en_pons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17470-17770-villars_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17470-17770-villars_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17470-17770-villars_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17470-17770-villars_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17471-17470-la_villedieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17471-17470-la_villedieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17471-17470-la_villedieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17471-17470-la_villedieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17472-17230-villedoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17472-17230-villedoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17472-17230-villedoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17472-17230-villedoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17473-17470-villemorin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17473-17470-villemorin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17473-17470-villemorin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17473-17470-villemorin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17474-17330-villeneuve_la_comtesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17474-17330-villeneuve_la_comtesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17474-17330-villeneuve_la_comtesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17474-17330-villeneuve_la_comtesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17476-17500-villexavier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17476-17500-villexavier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17476-17500-villexavier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17476-17500-villexavier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17477-17510-villiers_couture/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17477-17510-villiers_couture/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17477-17510-villiers_couture/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17477-17510-villiers_couture/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17478-17510-vinax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17478-17510-vinax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17478-17510-vinax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17478-17510-vinax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17479-17260-virollet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17479-17260-virollet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17479-17260-virollet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17479-17260-virollet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17480-17290-virson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17480-17290-virson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17480-17290-virson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17480-17290-virson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17481-17400-voissay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17481-17400-voissay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17481-17400-voissay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17481-17400-voissay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17482-17700-vouhe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17482-17700-vouhe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17482-17700-vouhe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17482-17700-vouhe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17483-17340-yves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17483-17340-yves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17483-17340-yves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17483-17340-yves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17484-17730-port_des_barques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17484-17730-port_des_barques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17484-17730-port_des_barques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17484-17730-port_des_barques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17485-17370-le_grand_village_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17485-17370-le_grand_village_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17485-17370-le_grand_village_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17485-17370-le_grand_village_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17486-17840-la_bree_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17486-17840-la_bree_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17486-17840-la_bree_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt17-charente_maritime/commune17486-17840-la_bree_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-18.xml
+++ b/public/sitemaps/sitemap-18.xml
@@ -5,588 +5,1172 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18001-18250-acheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18001-18250-acheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18001-18250-acheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18001-18250-acheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18002-18200-ainay_le_vieil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18002-18200-ainay_le_vieil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18002-18200-ainay_le_vieil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18002-18200-ainay_le_vieil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18003-18220-les_aix_d_angillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18003-18220-les_aix_d_angillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18003-18220-les_aix_d_angillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18003-18220-les_aix_d_angillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18004-18110-allogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18004-18110-allogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18004-18110-allogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18004-18110-allogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18005-18500-allouis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18005-18500-allouis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18005-18500-allouis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18005-18500-allouis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18006-18340-annoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18006-18340-annoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18006-18340-annoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18006-18340-annoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18007-18150-apremont_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18007-18150-apremont_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18007-18150-apremont_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18007-18150-apremont_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18008-18340-arcay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18008-18340-arcay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18008-18340-arcay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18008-18340-arcay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18009-18200-arcomps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18009-18200-arcomps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18009-18200-arcomps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18009-18200-arcomps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18010-18170-ardenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18010-18170-ardenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18010-18170-ardenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18010-18170-ardenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18011-18410-argent_sur_sauldre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18011-18410-argent_sur_sauldre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18011-18410-argent_sur_sauldre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18011-18410-argent_sur_sauldre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18012-18140-argenvieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18012-18140-argenvieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18012-18140-argenvieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18012-18140-argenvieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18013-18200-arpheuilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18013-18200-arpheuilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18013-18200-arpheuilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18013-18200-arpheuilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18014-18260-assigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18014-18260-assigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18014-18260-assigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18014-18260-assigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18015-18700-aubigny_sur_nere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18015-18700-aubigny_sur_nere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18015-18700-aubigny_sur_nere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18015-18700-aubigny_sur_nere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18016-18220-aubinges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18016-18220-aubinges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18016-18220-aubinges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18016-18220-aubinges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18017-18600-augy_sur_aubois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18017-18600-augy_sur_aubois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18017-18600-augy_sur_aubois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18017-18600-augy_sur_aubois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18018-18520-avord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18018-18520-avord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18018-18520-avord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18018-18520-avord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18018-18490-avord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18018-18490-avord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18018-18490-avord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18018-18490-avord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18019-18220-azy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18019-18220-azy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18019-18220-azy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18019-18220-azy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18020-18300-bannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18020-18300-bannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18020-18300-bannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18020-18300-bannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18021-18210-bannegon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18021-18210-bannegon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18021-18210-bannegon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18021-18210-bannegon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18022-18260-barlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18022-18260-barlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18022-18260-barlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18022-18260-barlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18023-18800-baugy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18023-18800-baugy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18023-18800-baugy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18023-18800-baugy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18024-18370-beddes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18024-18370-beddes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18024-18370-beddes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18024-18370-beddes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18025-18320-beffes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18025-18320-beffes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18025-18320-beffes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18025-18320-beffes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18026-18240-belleville_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18026-18240-belleville_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18026-18240-belleville_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18026-18240-belleville_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18027-18520-bengy_sur_craon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18027-18520-bengy_sur_craon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18027-18520-bengy_sur_craon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18027-18520-bengy_sur_craon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18028-18500-berry_bouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18028-18500-berry_bouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18028-18500-berry_bouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18028-18500-berry_bouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18029-18210-bessais_le_fromental/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18029-18210-bessais_le_fromental/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18029-18210-bessais_le_fromental/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18029-18210-bessais_le_fromental/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18030-18410-blancafort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18030-18410-blancafort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18030-18410-blancafort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18030-18410-blancafort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18031-18350-blet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18031-18350-blet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18031-18350-blet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18031-18350-blet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18032-18240-boulleret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18032-18240-boulleret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18032-18240-boulleret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18032-18240-boulleret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18033-18000-bourges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18033-18000-bourges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18033-18000-bourges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18033-18000-bourges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18034-18200-bouzais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18034-18200-bouzais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18034-18200-bouzais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18034-18200-bouzais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18035-18220-brecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18035-18220-brecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18035-18220-brecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18035-18220-brecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18036-18120-brinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18036-18120-brinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18036-18120-brinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18036-18120-brinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18037-18410-brinon_sur_sauldre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18037-18410-brinon_sur_sauldre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18037-18410-brinon_sur_sauldre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18037-18410-brinon_sur_sauldre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18038-18200-bruere_allichamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18038-18200-bruere_allichamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18038-18200-bruere_allichamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18038-18200-bruere_allichamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18039-18300-bue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18039-18300-bue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18039-18300-bue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18039-18300-bue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18040-18130-bussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18040-18130-bussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18040-18130-bussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18040-18130-bussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18041-18360-la_celette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18041-18360-la_celette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18041-18360-la_celette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18041-18360-la_celette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18042-18200-la_celle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18042-18200-la_celle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18042-18200-la_celle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18042-18200-la_celle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18043-18160-la_celle_conde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18043-18160-la_celle_conde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18043-18160-la_celle_conde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18043-18160-la_celle_conde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18044-18120-cerbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18044-18120-cerbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18044-18120-cerbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18044-18120-cerbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18045-18130-chalivoy_milon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18045-18130-chalivoy_milon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18045-18130-chalivoy_milon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18045-18130-chalivoy_milon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18046-18190-chambon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18046-18190-chambon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18046-18190-chambon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18046-18190-chambon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18047-18380-la_chapelle_d_angillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18047-18380-la_chapelle_d_angillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18047-18380-la_chapelle_d_angillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18047-18380-la_chapelle_d_angillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18048-18150-la_chapelle_hugon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18048-18150-la_chapelle_hugon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18048-18150-la_chapelle_hugon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18048-18150-la_chapelle_hugon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18049-18140-la_chapelle_montlinard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18049-18140-la_chapelle_montlinard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18049-18140-la_chapelle_montlinard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18049-18140-la_chapelle_montlinard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18050-18570-la_chapelle_saint_ursin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18050-18570-la_chapelle_saint_ursin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18050-18570-la_chapelle_saint_ursin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18050-18570-la_chapelle_saint_ursin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18051-18250-la_chapelotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18051-18250-la_chapelotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18051-18250-la_chapelotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18051-18250-la_chapelotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18052-18210-charenton_du_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18052-18210-charenton_du_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18052-18210-charenton_du_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18052-18210-charenton_du_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18053-18140-charentonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18053-18140-charentonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18053-18140-charentonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18053-18140-charentonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18054-18350-charly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18054-18350-charly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18054-18350-charly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18054-18350-charly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18055-18290-charost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18055-18290-charost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18055-18290-charost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18055-18290-charost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18056-18800-chassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18056-18800-chassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18056-18800-chassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18056-18800-chassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18057-18370-chateaumeillant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18057-18370-chateaumeillant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18057-18370-chateaumeillant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18057-18370-chateaumeillant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18058-18190-chateauneuf_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18058-18190-chateauneuf_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18058-18190-chateauneuf_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18058-18190-chateauneuf_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18059-18170-le_chatelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18059-18170-le_chatelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18059-18170-le_chatelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18059-18170-le_chatelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18060-18350-chaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18060-18350-chaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18060-18350-chaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18060-18350-chaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18061-18140-chaumoux_marcilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18061-18140-chaumoux_marcilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18061-18140-chaumoux_marcilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18061-18140-chaumoux_marcilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18062-18150-le_chautay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18062-18150-le_chautay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18062-18150-le_chautay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18062-18150-le_chautay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18063-18190-chavannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18063-18190-chavannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18063-18190-chavannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18063-18190-chavannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18064-18120-chery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18064-18120-chery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18064-18120-chery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18064-18120-chery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18065-18160-chezal_benoit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18065-18160-chezal_benoit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18065-18160-chezal_benoit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18065-18160-chezal_benoit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18066-18290-civray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18066-18290-civray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18066-18290-civray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18066-18290-civray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18067-18410-clemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18067-18410-clemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18067-18410-clemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18067-18410-clemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18068-18130-cogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18068-18130-cogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18068-18130-cogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18068-18130-cogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18069-18200-colombiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18069-18200-colombiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18069-18200-colombiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18069-18200-colombiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18070-18260-concressault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18070-18260-concressault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18070-18260-concressault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18070-18260-concressault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18071-18130-contres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18071-18130-contres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18071-18130-contres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18071-18130-contres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18072-18350-cornusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18072-18350-cornusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18072-18350-cornusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18072-18350-cornusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18073-18190-corquoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18073-18190-corquoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18073-18190-corquoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18073-18190-corquoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18073-18340-corquoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18073-18340-corquoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18073-18340-corquoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18073-18340-corquoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18074-18300-couargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18074-18300-couargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18074-18300-couargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18074-18300-couargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18075-18320-cours_les_barres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18075-18320-cours_les_barres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18075-18320-cours_les_barres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18075-18320-cours_les_barres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18076-18210-coust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18076-18210-coust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18076-18210-coust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18076-18210-coust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18077-18140-couy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18077-18140-couy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18077-18140-couy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18077-18140-couy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18078-18190-crezancay_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18078-18190-crezancay_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18078-18190-crezancay_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18078-18190-crezancay_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18079-18300-crezancy_en_sancerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18079-18300-crezancy_en_sancerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18079-18300-crezancy_en_sancerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18079-18300-crezancy_en_sancerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18080-18350-croisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18080-18350-croisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18080-18350-croisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18080-18350-croisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18081-18340-crosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18081-18340-crosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18081-18340-crosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18081-18340-crosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18082-18150-cuffy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18082-18150-cuffy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18082-18150-cuffy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18082-18150-cuffy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18083-18270-culan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18083-18270-culan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18083-18270-culan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18083-18270-culan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18084-18260-dampierre_en_crot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18084-18260-dampierre_en_crot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18084-18260-dampierre_en_crot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18084-18260-dampierre_en_crot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18085-18310-dampierre_en_gracay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18085-18310-dampierre_en_gracay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18085-18310-dampierre_en_gracay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18085-18310-dampierre_en_gracay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18086-18200-drevant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18086-18200-drevant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18086-18200-drevant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18086-18200-drevant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18087-18130-dun_sur_auron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18087-18130-dun_sur_auron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18087-18130-dun_sur_auron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18087-18130-dun_sur_auron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18088-18380-ennordres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18088-18380-ennordres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18088-18380-ennordres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18088-18380-ennordres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18089-18360-epineuil_le_fleuriel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18089-18360-epineuil_le_fleuriel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18089-18360-epineuil_le_fleuriel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18089-18360-epineuil_le_fleuriel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18090-18800-etrechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18090-18800-etrechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18090-18800-etrechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18090-18800-etrechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18091-18200-farges_allichamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18091-18200-farges_allichamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18091-18200-farges_allichamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18091-18200-farges_allichamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18092-18800-farges_en_septaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18092-18800-farges_en_septaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18092-18800-farges_en_septaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18092-18800-farges_en_septaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18093-18360-faverdines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18093-18360-faverdines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18093-18360-faverdines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18093-18360-faverdines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18094-18300-feux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18094-18300-feux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18094-18300-feux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18094-18300-feux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18095-18350-flavigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18095-18350-flavigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18095-18350-flavigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18095-18350-flavigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18096-18500-foecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18096-18500-foecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18096-18500-foecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18096-18500-foecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18097-18110-fussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18097-18110-fussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18097-18110-fussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18097-18110-fussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18098-18300-gardefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18098-18300-gardefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18098-18300-gardefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18098-18300-gardefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18099-18140-garigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18099-18140-garigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18099-18140-garigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18099-18140-garigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18100-18310-genouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18100-18310-genouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18100-18310-genouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18100-18310-genouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18101-18150-germigny_l_exempt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18101-18150-germigny_l_exempt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18101-18150-germigny_l_exempt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18101-18150-germigny_l_exempt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18102-18600-givardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18102-18600-givardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18102-18600-givardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18102-18600-givardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18103-18310-gracay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18103-18310-gracay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18103-18310-gracay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18103-18310-gracay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18104-18140-groises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18104-18140-groises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18104-18140-groises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18104-18140-groises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18105-18800-gron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18105-18800-gron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18105-18800-gron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18105-18800-gron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18106-18600-grossouvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18106-18600-grossouvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18106-18600-grossouvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18106-18600-grossouvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18107-18200-la_groutte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18107-18200-la_groutte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18107-18200-la_groutte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18107-18200-la_groutte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18108-18150-la_guerche_sur_l_aubois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18108-18150-la_guerche_sur_l_aubois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18108-18150-la_guerche_sur_l_aubois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18108-18150-la_guerche_sur_l_aubois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18109-18250-henrichemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18109-18250-henrichemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18109-18250-henrichemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18109-18250-henrichemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18110-18140-herry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18110-18140-herry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18110-18140-herry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18110-18140-herry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18111-18250-humbligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18111-18250-humbligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18111-18250-humbligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18111-18250-humbligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18112-18170-ids_saint_roch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18112-18170-ids_saint_roch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18112-18170-ids_saint_roch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18112-18170-ids_saint_roch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18113-18350-ignol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18113-18350-ignol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18113-18350-ignol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18113-18350-ignol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18114-18160-ineuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18114-18160-ineuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18114-18160-ineuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18114-18160-ineuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18115-18380-ivoy_le_pre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18115-18380-ivoy_le_pre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18115-18380-ivoy_le_pre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18115-18380-ivoy_le_pre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18116-18300-jalognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18116-18300-jalognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18116-18300-jalognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18116-18300-jalognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18117-18260-jars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18117-18260-jars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18117-18260-jars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18117-18260-jars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18118-18320-jouet_sur_l_aubois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18118-18320-jouet_sur_l_aubois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18118-18320-jouet_sur_l_aubois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18118-18320-jouet_sur_l_aubois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18119-18130-jussy_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18119-18130-jussy_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18119-18130-jussy_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18119-18130-jussy_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18120-18140-jussy_le_chaudrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18120-18140-jussy_le_chaudrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18120-18140-jussy_le_chaudrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18120-18140-jussy_le_chaudrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18121-18130-lantan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18121-18130-lantan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18121-18130-lantan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18121-18130-lantan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18122-18340-lapan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18122-18340-lapan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18122-18340-lapan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18122-18340-lapan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18124-18120-lazenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18124-18120-lazenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18124-18120-lazenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18124-18120-lazenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18125-18240-lere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18125-18240-lere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18125-18240-lere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18125-18240-lere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18126-18340-levet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18126-18340-levet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18126-18340-levet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18126-18340-levet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18127-18160-lignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18127-18160-lignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18127-18160-lignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18127-18160-lignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18128-18120-limeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18128-18120-limeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18128-18120-limeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18128-18120-limeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18129-18340-lissay_lochy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18129-18340-lissay_lochy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18129-18340-lissay_lochy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18129-18340-lissay_lochy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18130-18170-loye_sur_arnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18130-18170-loye_sur_arnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18130-18170-loye_sur_arnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18130-18170-loye_sur_arnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18131-18350-lugny_bourbonnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18131-18350-lugny_bourbonnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18131-18350-lugny_bourbonnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18131-18350-lugny_bourbonnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18132-18140-lugny_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18132-18140-lugny_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18132-18140-lugny_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18132-18140-lugny_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18133-18400-lunery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18133-18400-lunery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18133-18400-lunery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18133-18400-lunery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18134-18120-lury_sur_arnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18134-18120-lury_sur_arnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18134-18120-lury_sur_arnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18134-18120-lury_sur_arnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18135-18170-maisonnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18135-18170-maisonnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18135-18170-maisonnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18135-18170-maisonnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18136-18170-marcais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18136-18170-marcais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18136-18170-marcais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18136-18170-marcais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18137-18290-mareuil_sur_arnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18137-18290-mareuil_sur_arnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18137-18290-mareuil_sur_arnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18137-18290-mareuil_sur_arnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18138-18500-marmagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18138-18500-marmagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18138-18500-marmagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18138-18500-marmagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18139-18320-marseilles_les_aubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18139-18320-marseilles_les_aubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18139-18320-marseilles_les_aubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18139-18320-marseilles_les_aubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18140-18120-massay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18140-18120-massay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18140-18120-massay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18140-18120-massay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18141-18500-mehun_sur_yevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18141-18500-mehun_sur_yevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18141-18500-mehun_sur_yevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18141-18500-mehun_sur_yevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18142-18200-meillant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18142-18200-meillant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18142-18200-meillant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18142-18200-meillant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18143-18320-menetou_couture/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18143-18320-menetou_couture/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18143-18320-menetou_couture/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18143-18320-menetou_couture/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18144-18300-menetou_ratel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18144-18300-menetou_ratel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18144-18300-menetou_ratel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18144-18300-menetou_ratel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18145-18510-menetou_salon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18145-18510-menetou_salon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18145-18510-menetou_salon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18145-18510-menetou_salon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18146-18300-menetreol_sous_sancerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18146-18300-menetreol_sous_sancerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18146-18300-menetreol_sous_sancerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18146-18300-menetreol_sous_sancerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18147-18700-menetreol_sur_sauldre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18147-18700-menetreol_sur_sauldre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18147-18700-menetreol_sur_sauldre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18147-18700-menetreol_sur_sauldre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18148-18120-mereau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18148-18120-mereau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18148-18120-mereau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18148-18120-mereau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18149-18380-mery_es_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18149-18380-mery_es_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18149-18380-mery_es_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18149-18380-mery_es_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18150-18100-mery_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18150-18100-mery_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18150-18100-mery_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18150-18100-mery_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18151-18250-montigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18151-18250-montigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18151-18250-montigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18151-18250-montigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18152-18160-montlouis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18152-18160-montlouis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18152-18160-montlouis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18152-18160-montlouis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18153-18170-morlac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18153-18170-morlac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18153-18170-morlac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18153-18170-morlac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18154-18350-mornay_berry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18154-18350-mornay_berry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18154-18350-mornay_berry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18154-18350-mornay_berry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18155-18600-mornay_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18155-18600-mornay_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18155-18600-mornay_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18155-18600-mornay_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18156-18220-morogues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18156-18220-morogues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18156-18220-morogues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18156-18220-morogues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18157-18570-morthomiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18157-18570-morthomiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18157-18570-morthomiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18157-18570-morthomiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18158-18390-moulins_sur_yevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18158-18390-moulins_sur_yevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18158-18390-moulins_sur_yevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18158-18390-moulins_sur_yevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18159-18330-nancay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18159-18330-nancay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18159-18330-nancay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18159-18330-nancay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18160-18350-nerondes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18160-18350-nerondes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18160-18350-nerondes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18160-18350-nerondes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18160-18800-nerondes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18160-18800-nerondes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18160-18800-nerondes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18160-18800-nerondes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18161-18600-neuilly_en_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18161-18600-neuilly_en_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18161-18600-neuilly_en_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18161-18600-neuilly_en_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18162-18250-neuilly_en_sancerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18162-18250-neuilly_en_sancerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18162-18250-neuilly_en_sancerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18162-18250-neuilly_en_sancerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18163-18250-neuvy_deux_clochers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18163-18250-neuvy_deux_clochers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18163-18250-neuvy_deux_clochers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18163-18250-neuvy_deux_clochers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18164-18600-neuvy_le_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18164-18600-neuvy_le_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18164-18600-neuvy_le_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18164-18600-neuvy_le_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18165-18330-neuvy_sur_barangeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18165-18330-neuvy_sur_barangeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18165-18330-neuvy_sur_barangeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18165-18330-neuvy_sur_barangeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18166-18390-nohant_en_gout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18166-18390-nohant_en_gout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18166-18390-nohant_en_gout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18166-18390-nohant_en_gout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18167-18310-nohant_en_gracay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18167-18310-nohant_en_gracay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18167-18310-nohant_en_gracay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18167-18310-nohant_en_gracay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18168-18260-le_noyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18168-18260-le_noyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18168-18260-le_noyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18168-18260-le_noyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18169-18200-nozieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18169-18200-nozieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18169-18200-nozieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18169-18200-nozieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18170-18700-oizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18170-18700-oizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18170-18700-oizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18170-18700-oizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18171-18200-orcenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18171-18200-orcenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18171-18200-orcenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18171-18200-orcenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18172-18200-orval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18172-18200-orval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18172-18200-orval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18172-18200-orval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18173-18130-osmery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18173-18130-osmery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18173-18130-osmery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18173-18130-osmery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18174-18390-osmoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18174-18390-osmoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18174-18390-osmoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18174-18390-osmoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18175-18350-ourouer_les_bourdelins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18175-18350-ourouer_les_bourdelins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18175-18350-ourouer_les_bourdelins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18175-18350-ourouer_les_bourdelins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18176-18220-parassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18176-18220-parassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18176-18220-parassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18176-18220-parassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18177-18130-parnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18177-18130-parnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18177-18130-parnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18177-18130-parnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18178-18200-la_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18178-18200-la_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18178-18200-la_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18178-18200-la_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18179-18110-pigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18179-18110-pigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18179-18110-pigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18179-18110-pigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18180-18340-plaimpied_givaudins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18180-18340-plaimpied_givaudins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18180-18340-plaimpied_givaudins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18180-18340-plaimpied_givaudins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18181-18290-plou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18181-18290-plou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18181-18290-plou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18181-18290-plou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18182-18290-poisieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18182-18290-poisieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18182-18290-poisieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18182-18290-poisieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18183-18210-le_pondy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18183-18210-le_pondy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18183-18210-le_pondy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18183-18210-le_pondy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18184-18140-precy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18184-18140-precy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18184-18140-precy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18184-18140-precy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18185-18380-presly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18185-18380-presly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18185-18380-presly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18185-18380-presly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18186-18120-preuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18186-18120-preuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18186-18120-preuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18186-18120-preuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18187-18370-preveranges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18187-18370-preveranges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18187-18370-preveranges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18187-18370-preveranges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18188-18400-primelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18188-18400-primelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18188-18400-primelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18188-18400-primelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18189-18110-quantilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18189-18110-quantilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18189-18110-quantilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18189-18110-quantilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18190-18120-quincy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18190-18120-quincy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18190-18120-quincy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18190-18120-quincy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18191-18130-raymond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18191-18130-raymond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18191-18130-raymond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18191-18130-raymond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18192-18270-reigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18192-18270-reigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18192-18270-reigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18192-18270-reigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18193-18170-rezay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18193-18170-rezay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18193-18170-rezay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18193-18170-rezay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18194-18220-rians/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18194-18220-rians/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18194-18220-rians/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18194-18220-rians/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18195-18600-sagonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18195-18600-sagonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18195-18600-sagonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18195-18600-sagonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18196-18600-saint_aignan_des_noyers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18196-18600-saint_aignan_des_noyers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18196-18600-saint_aignan_des_noyers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18196-18600-saint_aignan_des_noyers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18197-18200-saint_amand_montrond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18197-18200-saint_amand_montrond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18197-18200-saint_amand_montrond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18197-18200-saint_amand_montrond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18198-18290-saint_ambroix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18198-18290-saint_ambroix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18198-18290-saint_ambroix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18198-18290-saint_ambroix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18199-18160-saint_baudel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18199-18160-saint_baudel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18199-18160-saint_baudel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18199-18160-saint_baudel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18200-18300-saint_bouize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18200-18300-saint_bouize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18200-18300-saint_bouize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18200-18300-saint_bouize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18201-18400-saint_caprais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18201-18400-saint_caprais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18201-18400-saint_caprais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18201-18400-saint_caprais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18202-18220-saint_ceols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18202-18220-saint_ceols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18202-18220-saint_ceols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18202-18220-saint_ceols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18203-18270-saint_christophe_le_chaudry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18203-18270-saint_christophe_le_chaudry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18203-18270-saint_christophe_le_chaudry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18203-18270-saint_christophe_le_chaudry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18204-18130-saint_denis_de_palin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18204-18130-saint_denis_de_palin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18204-18130-saint_denis_de_palin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18204-18130-saint_denis_de_palin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18205-18230-saint_doulchard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18205-18230-saint_doulchard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18205-18230-saint_doulchard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18205-18230-saint_doulchard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18206-18110-saint_eloy_de_gy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18206-18110-saint_eloy_de_gy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18206-18110-saint_eloy_de_gy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18206-18110-saint_eloy_de_gy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18207-18400-saint_florent_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18207-18400-saint_florent_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18207-18400-saint_florent_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18207-18400-saint_florent_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18208-18240-sainte_gemme_en_sancerrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18208-18240-sainte_gemme_en_sancerrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18208-18240-sainte_gemme_en_sancerrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18208-18240-sainte_gemme_en_sancerrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18209-18200-saint_georges_de_poisieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18209-18200-saint_georges_de_poisieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18209-18200-saint_georges_de_poisieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18209-18200-saint_georges_de_poisieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18210-18100-saint_georges_sur_la_pree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18210-18100-saint_georges_sur_la_pree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18210-18100-saint_georges_sur_la_pree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18210-18100-saint_georges_sur_la_pree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18211-18110-saint_georges_sur_moulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18211-18110-saint_georges_sur_moulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18211-18110-saint_georges_sur_moulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18211-18110-saint_georges_sur_moulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18212-18340-saint_germain_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18212-18340-saint_germain_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18212-18340-saint_germain_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18212-18340-saint_germain_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18213-18390-saint_germain_du_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18213-18390-saint_germain_du_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18213-18390-saint_germain_du_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18213-18390-saint_germain_du_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18213-18000-saint_germain_du_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18213-18000-saint_germain_du_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18213-18000-saint_germain_du_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18213-18000-saint_germain_du_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18214-18100-saint_hilaire_de_court/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18214-18100-saint_hilaire_de_court/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18214-18100-saint_hilaire_de_court/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18214-18100-saint_hilaire_de_court/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18215-18320-saint_hilaire_de_gondilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18215-18320-saint_hilaire_de_gondilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18215-18320-saint_hilaire_de_gondilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18215-18320-saint_hilaire_de_gondilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18216-18160-saint_hilaire_en_lignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18216-18160-saint_hilaire_en_lignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18216-18160-saint_hilaire_en_lignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18216-18160-saint_hilaire_en_lignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18217-18370-saint_jeanvrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18217-18370-saint_jeanvrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18217-18370-saint_jeanvrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18217-18370-saint_jeanvrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18218-18340-saint_just/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18218-18340-saint_just/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18218-18340-saint_just/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18218-18340-saint_just/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18219-18330-saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18219-18330-saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18219-18330-saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18219-18330-saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18220-18140-saint_leger_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18220-18140-saint_leger_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18220-18140-saint_leger_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18220-18140-saint_leger_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18221-18190-saint_loup_des_chaumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18221-18190-saint_loup_des_chaumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18221-18190-saint_loup_des_chaumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18221-18190-saint_loup_des_chaumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18223-18110-saint_martin_d_auxigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18223-18110-saint_martin_d_auxigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18223-18110-saint_martin_d_auxigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18223-18110-saint_martin_d_auxigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18224-18140-saint_martin_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18224-18140-saint_martin_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18224-18140-saint_martin_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18224-18140-saint_martin_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18225-18270-saint_maur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18225-18270-saint_maur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18225-18270-saint_maur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18225-18270-saint_maur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18226-18390-saint_michel_de_volangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18226-18390-saint_michel_de_volangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18226-18390-saint_michel_de_volangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18226-18390-saint_michel_de_volangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18227-18700-sainte_montaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18227-18700-sainte_montaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18227-18700-sainte_montaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18227-18700-sainte_montaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18228-18310-saint_outrille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18228-18310-saint_outrille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18228-18310-saint_outrille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18228-18310-saint_outrille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18229-18110-saint_palais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18229-18110-saint_palais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18229-18110-saint_palais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18229-18110-saint_palais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18230-18170-saint_pierre_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18230-18170-saint_pierre_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18230-18170-saint_pierre_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18230-18170-saint_pierre_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18231-18210-saint_pierre_les_etieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18231-18210-saint_pierre_les_etieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18231-18210-saint_pierre_les_etieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18231-18210-saint_pierre_les_etieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18232-18370-saint_priest_la_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18232-18370-saint_priest_la_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18232-18370-saint_priest_la_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18232-18370-saint_priest_la_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18233-18300-saint_satur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18233-18300-saint_satur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18233-18300-saint_satur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18233-18300-saint_satur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18234-18370-saint_saturnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18234-18370-saint_saturnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18234-18370-saint_saturnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18234-18370-saint_saturnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18235-18220-sainte_solange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18235-18220-sainte_solange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18235-18220-sainte_solange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18235-18220-sainte_solange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18236-18190-saint_symphorien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18236-18190-saint_symphorien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18236-18190-saint_symphorien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18236-18190-saint_symphorien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18237-18500-sainte_thorette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18237-18500-sainte_thorette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18237-18500-sainte_thorette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18237-18500-sainte_thorette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18238-18360-saint_vitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18238-18360-saint_vitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18238-18360-saint_vitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18238-18360-saint_vitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18240-18140-sancergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18240-18140-sancergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18240-18140-sancergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18240-18140-sancergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18241-18300-sancerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18241-18300-sancerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18241-18300-sancerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18241-18300-sancerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18242-18600-sancoins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18242-18600-sancoins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18242-18600-sancoins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18242-18600-sancoins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18243-18240-santranges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18243-18240-santranges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18243-18240-santranges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18243-18240-santranges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18244-18290-saugy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18244-18290-saugy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18244-18290-saugy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18244-18290-saugy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18245-18360-saulzais_le_potier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18245-18360-saulzais_le_potier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18245-18360-saulzais_le_potier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18245-18360-saulzais_le_potier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18246-18240-savigny_en_sancerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18246-18240-savigny_en_sancerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18246-18240-savigny_en_sancerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18246-18240-savigny_en_sancerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18247-18390-savigny_en_septaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18247-18390-savigny_en_septaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18247-18390-savigny_en_septaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18247-18390-savigny_en_septaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18248-18340-sennecay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18248-18340-sennecay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18248-18340-sennecay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18248-18340-sennecay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18249-18300-sens_beaujeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18249-18300-sens_beaujeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18249-18300-sens_beaujeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18249-18300-sens_beaujeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18250-18190-serruelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18250-18190-serruelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18250-18190-serruelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18250-18190-serruelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18251-18140-sevry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18251-18140-sevry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18251-18140-sevry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18251-18140-sevry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18252-18270-sidiailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18252-18270-sidiailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18252-18270-sidiailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18252-18270-sidiailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18253-18220-soulangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18253-18220-soulangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18253-18220-soulangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18253-18220-soulangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18254-18340-soye_en_septaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18254-18340-soye_en_septaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18254-18340-soye_en_septaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18254-18340-soye_en_septaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18255-18570-le_subdray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18255-18570-le_subdray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18255-18570-le_subdray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18255-18570-le_subdray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18256-18260-subligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18256-18260-subligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18256-18260-subligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18256-18260-subligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18257-18240-sury_pres_lere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18257-18240-sury_pres_lere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18257-18240-sury_pres_lere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18257-18240-sury_pres_lere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18258-18300-sury_en_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18258-18300-sury_en_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18258-18300-sury_en_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18258-18300-sury_en_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18259-18260-sury_es_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18259-18260-sury_es_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18259-18260-sury_es_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18259-18260-sury_es_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18260-18350-tendron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18260-18350-tendron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18260-18350-tendron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18260-18350-tendron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18261-18210-thaumiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18261-18210-thaumiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18261-18210-thaumiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18261-18210-thaumiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18262-18300-thauvenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18262-18300-thauvenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18262-18300-thauvenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18262-18300-thauvenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18263-18100-thenioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18263-18100-thenioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18263-18100-thenioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18263-18100-thenioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18264-18260-thou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18264-18260-thou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18264-18260-thou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18264-18260-thou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18265-18320-torteron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18265-18320-torteron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18265-18320-torteron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18265-18320-torteron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18266-18160-touchay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18266-18160-touchay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18266-18160-touchay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18266-18160-touchay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18267-18570-trouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18267-18570-trouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18267-18570-trouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18267-18570-trouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18268-18190-uzay_le_venon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18268-18190-uzay_le_venon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18268-18190-uzay_le_venon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18268-18190-uzay_le_venon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18269-18260-vailly_sur_sauldre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18269-18260-vailly_sur_sauldre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18269-18260-vailly_sur_sauldre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18269-18260-vailly_sur_sauldre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18270-18190-vallenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18270-18190-vallenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18270-18190-vallenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18270-18190-vallenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18271-18110-vasselay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18271-18110-vasselay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18271-18110-vasselay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18271-18110-vasselay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18272-18300-veaugues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18272-18300-veaugues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18272-18300-veaugues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18272-18300-veaugues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18273-18190-venesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18273-18190-venesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18273-18190-venesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18273-18190-venesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18274-18300-verdigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18274-18300-verdigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18274-18300-verdigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18274-18300-verdigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18275-18600-vereaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18275-18600-vereaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18275-18600-vereaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18275-18600-vereaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18276-18210-vernais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18276-18210-vernais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18276-18210-vernais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18276-18210-vernais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18277-18210-verneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18277-18210-verneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18277-18210-verneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18277-18210-verneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18278-18360-vesdun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18278-18360-vesdun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18278-18360-vesdun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18278-18360-vesdun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18279-18100-vierzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18279-18100-vierzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18279-18100-vierzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18279-18100-vierzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18280-18110-vignoux_sous_les_aix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18280-18110-vignoux_sous_les_aix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18280-18110-vignoux_sous_les_aix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18280-18110-vignoux_sous_les_aix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18281-18500-vignoux_sur_barangeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18281-18500-vignoux_sur_barangeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18281-18500-vignoux_sur_barangeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18281-18500-vignoux_sur_barangeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18282-18800-villabon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18282-18800-villabon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18282-18800-villabon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18282-18800-villabon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18283-18160-villecelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18283-18160-villecelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18283-18160-villecelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18283-18160-villecelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18284-18260-villegenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18284-18260-villegenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18284-18260-villegenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18284-18260-villegenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18285-18400-villeneuve_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18285-18400-villeneuve_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18285-18400-villeneuve_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18285-18400-villeneuve_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18286-18800-villequiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18286-18800-villequiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18286-18800-villequiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18286-18800-villequiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18287-18300-vinon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18287-18300-vinon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18287-18300-vinon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18287-18300-vinon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18288-18340-vorly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18288-18340-vorly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18288-18340-vorly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18288-18340-vorly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18289-18130-vornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18289-18130-vornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18289-18130-vornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18289-18130-vornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18290-18330-vouzeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18290-18330-vouzeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18290-18330-vouzeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt18-cher/commune18290-18330-vouzeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-19.xml
+++ b/public/sitemaps/sitemap-19.xml
@@ -5,568 +5,1132 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19001-19260-affieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19001-19260-affieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19001-19260-affieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19001-19260-affieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19002-19200-aix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19002-19200-aix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19002-19200-aix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19002-19200-aix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19003-19190-albignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19003-19190-albignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19003-19190-albignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19003-19190-albignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19004-19380-albussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19004-19380-albussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19004-19380-albussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19004-19380-albussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19005-19240-allassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19005-19240-allassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19005-19240-allassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19005-19240-allassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19006-19200-alleyrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19006-19200-alleyrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19006-19200-alleyrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19006-19200-alleyrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19007-19120-altillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19007-19120-altillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19007-19120-altillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19007-19120-altillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19008-19250-ambrugeat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19008-19250-ambrugeat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19008-19250-ambrugeat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19008-19250-ambrugeat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19009-19000-les_angles_sur_correze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19009-19000-les_angles_sur_correze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19009-19000-les_angles_sur_correze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19009-19000-les_angles_sur_correze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19010-19400-argentat_sur_dordogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19010-19400-argentat_sur_dordogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19010-19400-argentat_sur_dordogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19010-19400-argentat_sur_dordogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19010-19320-argentat_sur_dordogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19010-19320-argentat_sur_dordogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19010-19320-argentat_sur_dordogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19010-19320-argentat_sur_dordogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19011-19230-arnac_pompadour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19011-19230-arnac_pompadour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19011-19230-arnac_pompadour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19011-19230-arnac_pompadour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19012-19120-astaillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19012-19120-astaillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19012-19120-astaillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19012-19120-astaillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19013-19190-aubazines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19013-19190-aubazines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19013-19190-aubazines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19013-19190-aubazines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19014-19220-auriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19014-19220-auriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19014-19220-auriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19014-19220-auriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19015-19310-ayen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19015-19310-ayen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19015-19310-ayen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19015-19310-ayen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19016-19800-bar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19016-19800-bar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19016-19800-bar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19016-19800-bar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19017-19430-bassignac_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19017-19430-bassignac_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19017-19430-bassignac_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19017-19430-bassignac_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19018-19220-bassignac_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19018-19220-bassignac_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19018-19220-bassignac_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19018-19220-bassignac_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19019-19120-beaulieu_sur_dordogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19019-19120-beaulieu_sur_dordogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19019-19120-beaulieu_sur_dordogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19019-19120-beaulieu_sur_dordogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19020-19390-beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19020-19390-beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19020-19390-beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19020-19390-beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19021-19290-bellechassagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19021-19290-bellechassagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19021-19290-bellechassagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19021-19290-bellechassagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19022-19510-benayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19022-19510-benayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19022-19510-benayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19022-19510-benayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19023-19190-beynat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19023-19190-beynat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19023-19190-beynat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19023-19190-beynat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19024-19230-beyssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19024-19230-beyssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19024-19230-beyssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19024-19230-beyssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19025-19230-beyssenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19025-19230-beyssenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19025-19230-beyssenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19025-19230-beyssenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19026-19120-bilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19026-19120-bilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19026-19120-bilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19026-19120-bilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19027-19170-bonnefond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19027-19170-bonnefond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19027-19170-bonnefond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19027-19170-bonnefond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19028-19110-bort_les_orgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19028-19110-bort_les_orgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19028-19110-bort_les_orgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19028-19110-bort_les_orgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19029-19500-branceilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19029-19500-branceilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19029-19500-branceilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19029-19500-branceilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19030-19310-brignac_la_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19030-19310-brignac_la_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19030-19310-brignac_la_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19030-19310-brignac_la_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19031-19100-brive_la_gaillarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19031-19100-brive_la_gaillarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19031-19100-brive_la_gaillarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19031-19100-brive_la_gaillarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19033-19170-bugeat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19033-19170-bugeat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19033-19170-bugeat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19033-19170-bugeat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19034-19430-camps_saint_mathurin_leobazel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19034-19430-camps_saint_mathurin_leobazel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19034-19430-camps_saint_mathurin_leobazel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19034-19430-camps_saint_mathurin_leobazel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19035-19350-chabrignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19035-19350-chabrignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19035-19350-chabrignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19035-19350-chabrignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19036-19370-chamberet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19036-19370-chamberet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19036-19370-chamberet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19036-19370-chamberet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19037-19450-chamboulive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19037-19450-chamboulive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19037-19450-chamboulive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19037-19450-chamboulive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19038-19330-chameyrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19038-19330-chameyrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19038-19330-chameyrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19038-19330-chameyrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19039-19320-champagnac_la_noaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19039-19320-champagnac_la_noaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19039-19320-champagnac_la_noaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19039-19320-champagnac_la_noaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19040-19320-champagnac_la_prune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19040-19320-champagnac_la_prune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19040-19320-champagnac_la_prune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19040-19320-champagnac_la_prune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19041-19150-chanac_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19041-19150-chanac_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19041-19150-chanac_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19041-19150-chanac_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19042-19330-chanteix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19042-19330-chanteix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19042-19330-chanteix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19042-19330-chanteix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19043-19360-la_chapelle_aux_brocs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19043-19360-la_chapelle_aux_brocs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19043-19360-la_chapelle_aux_brocs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19043-19360-la_chapelle_aux_brocs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19044-19120-la_chapelle_aux_saints/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19044-19120-la_chapelle_aux_saints/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19044-19120-la_chapelle_aux_saints/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19044-19120-la_chapelle_aux_saints/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19045-19430-la_chapelle_saint_geraud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19045-19430-la_chapelle_saint_geraud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19045-19430-la_chapelle_saint_geraud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19045-19430-la_chapelle_saint_geraud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19046-19300-chapelle_spinasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19046-19300-chapelle_spinasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19046-19300-chapelle_spinasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19046-19300-chapelle_spinasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19047-19600-chartrier_ferriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19047-19600-chartrier_ferriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19047-19600-chartrier_ferriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19047-19600-chartrier_ferriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19048-19190-le_chastang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19048-19190-le_chastang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19048-19190-le_chastang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19048-19190-le_chastang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19049-19600-chasteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19049-19600-chasteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19049-19600-chasteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19049-19600-chasteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19050-19500-chauffour_sur_vell/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19050-19500-chauffour_sur_vell/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19050-19500-chauffour_sur_vell/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19050-19500-chauffour_sur_vell/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19051-19390-chaumeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19051-19390-chaumeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19051-19390-chaumeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19051-19390-chaumeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19052-19290-chavanac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19052-19290-chavanac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19052-19290-chavanac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19052-19290-chavanac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19053-19200-chaveroche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19053-19200-chaveroche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19053-19200-chaveroche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19053-19200-chaveroche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19054-19120-chenailler_mascheix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19054-19120-chenailler_mascheix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19054-19120-chenailler_mascheix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19054-19120-chenailler_mascheix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19055-19160-chirac_bellevue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19055-19160-chirac_bellevue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19055-19160-chirac_bellevue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19055-19160-chirac_bellevue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19056-19320-clergoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19056-19320-clergoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19056-19320-clergoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19056-19320-clergoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19057-19500-collonges_la_rouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19057-19500-collonges_la_rouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19057-19500-collonges_la_rouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19057-19500-collonges_la_rouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19058-19250-combressol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19058-19250-combressol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19058-19250-combressol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19058-19250-combressol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19059-19350-conceze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19059-19350-conceze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19059-19350-conceze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19059-19350-conceze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19060-19140-condat_sur_ganaveix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19060-19140-condat_sur_ganaveix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19060-19140-condat_sur_ganaveix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19060-19140-condat_sur_ganaveix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19061-19150-cornil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19061-19150-cornil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19061-19150-cornil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19061-19150-cornil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19062-19800-correze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19062-19800-correze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19062-19800-correze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19062-19800-correze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19063-19360-cosnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19063-19360-cosnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19063-19360-cosnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19063-19360-cosnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19064-19340-couffy_sur_sarsonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19064-19340-couffy_sur_sarsonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19064-19340-couffy_sur_sarsonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19064-19340-couffy_sur_sarsonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19065-19340-courteix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19065-19340-courteix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19065-19340-courteix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19065-19340-courteix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19066-19520-cublac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19066-19520-cublac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19066-19520-cublac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19066-19520-cublac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19067-19500-curemonte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19067-19500-curemonte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19067-19500-curemonte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19067-19500-curemonte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19068-19360-dampniat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19068-19360-dampniat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19068-19360-dampniat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19068-19360-dampniat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19069-19220-darazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19069-19220-darazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19069-19220-darazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19069-19220-darazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19070-19300-darnets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19070-19300-darnets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19070-19300-darnets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19070-19300-darnets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19071-19250-davignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19071-19250-davignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19071-19250-davignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19071-19250-davignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19072-19270-donzenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19072-19270-donzenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19072-19270-donzenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19072-19270-donzenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19073-19300-egletons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19073-19300-egletons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19073-19300-egletons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19073-19300-egletons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19074-19170-l_eglise_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19074-19170-l_eglise_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19074-19170-l_eglise_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19074-19170-l_eglise_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19075-19150-espagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19075-19150-espagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19075-19150-espagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19075-19150-espagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19076-19140-espartignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19076-19140-espartignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19076-19140-espartignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19076-19140-espartignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19077-19600-estivals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19077-19600-estivals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19077-19600-estivals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19077-19600-estivals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19078-19410-estivaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19078-19410-estivaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19078-19410-estivaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19078-19410-estivaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19079-19140-eyburie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19079-19140-eyburie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19079-19140-eyburie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19079-19140-eyburie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19080-19340-eygurande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19080-19340-eygurande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19080-19340-eygurande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19080-19340-eygurande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19081-19800-eyrein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19081-19800-eyrein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19081-19800-eyrein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19081-19800-eyrein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19082-19330-favars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19082-19330-favars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19082-19330-favars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19082-19330-favars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19083-19340-feyt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19083-19340-feyt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19083-19340-feyt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19083-19340-feyt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19084-19380-forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19084-19380-forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19084-19380-forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19084-19380-forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19085-19800-gimel_les_cascades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19085-19800-gimel_les_cascades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19085-19800-gimel_les_cascades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19085-19800-gimel_les_cascades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19086-19430-goulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19086-19430-goulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19086-19430-goulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19086-19430-goulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19087-19170-gourdon_murat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19087-19170-gourdon_murat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19087-19170-gourdon_murat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19087-19170-gourdon_murat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19088-19300-grandsaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19088-19300-grandsaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19088-19300-grandsaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19088-19300-grandsaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19089-19320-gros_chastang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19089-19320-gros_chastang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19089-19320-gros_chastang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19089-19320-gros_chastang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19090-19320-gumond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19090-19320-gumond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19090-19320-gumond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19090-19320-gumond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19091-19400-hautefage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19091-19400-hautefage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19091-19400-hautefage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19091-19400-hautefage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19092-19300-le_jardin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19092-19300-le_jardin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19092-19300-le_jardin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19092-19300-le_jardin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19093-19500-jugeals_nazareth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19093-19500-jugeals_nazareth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19093-19500-jugeals_nazareth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19093-19500-jugeals_nazareth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19094-19350-juillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19094-19350-juillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19094-19350-juillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19094-19350-juillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19095-19170-lacelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19095-19170-lacelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19095-19170-lacelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19095-19170-lacelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19096-19150-ladignac_sur_rondelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19096-19150-ladignac_sur_rondelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19096-19150-ladignac_sur_rondelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19096-19150-ladignac_sur_rondelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19097-19320-lafage_sur_sombre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19097-19320-lafage_sur_sombre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19097-19320-lafage_sur_sombre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19097-19320-lafage_sur_sombre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19098-19150-lagarde_marc_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19098-19150-lagarde_marc_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19098-19150-lagarde_marc_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19098-19150-lagarde_marc_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19099-19500-lagleygeolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19099-19500-lagleygeolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19099-19500-lagleygeolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19099-19500-lagleygeolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19100-19700-lagrauliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19100-19700-lagrauliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19100-19700-lagrauliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19100-19700-lagrauliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19101-19150-laguenne_sur_avalouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19101-19150-laguenne_sur_avalouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19101-19150-laguenne_sur_avalouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19101-19150-laguenne_sur_avalouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19102-19160-lamaziere_basse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19102-19160-lamaziere_basse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19102-19160-lamaziere_basse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19102-19160-lamaziere_basse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19103-19340-lamaziere_haute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19103-19340-lamaziere_haute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19103-19340-lamaziere_haute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19103-19340-lamaziere_haute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19104-19510-lamongerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19104-19510-lamongerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19104-19510-lamongerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19104-19510-lamongerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19105-19190-lanteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19105-19190-lanteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19105-19190-lanteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19105-19190-lanteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19106-19550-lapleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19106-19550-lapleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19106-19550-lapleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19106-19550-lapleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19107-19600-larche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19107-19600-larche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19107-19600-larche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19107-19600-larche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19108-19340-laroche_pres_feyt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19108-19340-laroche_pres_feyt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19108-19340-laroche_pres_feyt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19108-19340-laroche_pres_feyt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19109-19130-lascaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19109-19130-lascaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19109-19130-lascaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19109-19130-lascaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19110-19160-latronche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19110-19160-latronche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19110-19160-latronche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19110-19160-latronche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19111-19550-laval_sur_luzege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19111-19550-laval_sur_luzege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19111-19550-laval_sur_luzege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19111-19550-laval_sur_luzege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19112-19170-lestards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19112-19170-lestards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19112-19170-lestards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19112-19170-lestards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19113-19160-liginiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19113-19160-liginiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19113-19160-liginiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19113-19160-liginiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19114-19200-lignareix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19114-19200-lignareix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19114-19200-lignareix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19114-19200-lignareix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19115-19500-ligneyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19115-19500-ligneyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19115-19500-ligneyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19115-19500-ligneyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19116-19120-liourdres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19116-19120-liourdres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19116-19120-liourdres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19116-19120-liourdres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19117-19600-lissac_sur_couze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19117-19600-lissac_sur_couze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19117-19600-lissac_sur_couze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19117-19600-lissac_sur_couze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19118-19470-le_lonzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19118-19470-le_lonzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19118-19470-le_lonzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19118-19470-le_lonzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19119-19500-lostanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19119-19500-lostanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19119-19500-lostanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19119-19500-lostanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19120-19310-louignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19120-19310-louignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19120-19310-louignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19120-19310-louignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19121-19210-lubersac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19121-19210-lubersac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19121-19210-lubersac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19121-19210-lubersac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19122-19470-madranges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19122-19470-madranges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19122-19470-madranges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19122-19470-madranges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19123-19360-malemort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19123-19360-malemort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19123-19360-malemort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19123-19360-malemort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19124-19520-mansac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19124-19520-mansac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19124-19520-mansac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19124-19520-mansac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19125-19320-marcillac_la_croisille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19125-19320-marcillac_la_croisille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19125-19320-marcillac_la_croisille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19125-19320-marcillac_la_croisille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19126-19500-marcillac_la_croze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19126-19500-marcillac_la_croze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19126-19500-marcillac_la_croze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19126-19500-marcillac_la_croze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19128-19200-margerides/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19128-19200-margerides/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19128-19200-margerides/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19128-19200-margerides/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19129-19510-masseret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19129-19510-masseret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19129-19510-masseret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19129-19510-masseret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19130-19250-maussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19130-19250-maussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19130-19250-maussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19130-19250-maussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19131-19510-meilhards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19131-19510-meilhards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19131-19510-meilhards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19131-19510-meilhards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19132-19190-menoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19132-19190-menoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19132-19190-menoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19132-19190-menoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19133-19430-mercoeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19133-19430-mercoeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19133-19430-mercoeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19133-19430-mercoeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19134-19340-merlines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19134-19340-merlines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19134-19340-merlines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19134-19340-merlines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19135-19200-mestes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19135-19200-mestes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19135-19200-mestes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19135-19200-mestes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19136-19250-meymac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19136-19250-meymac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19136-19250-meymac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19136-19250-meymac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19137-19800-meyrignac_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19137-19800-meyrignac_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19137-19800-meyrignac_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19137-19800-meyrignac_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19138-19500-meyssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19138-19500-meyssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19138-19500-meyssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19138-19500-meyssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19139-19290-millevaches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19139-19290-millevaches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19139-19290-millevaches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19139-19290-millevaches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19140-19400-monceaux_sur_dordogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19140-19400-monceaux_sur_dordogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19140-19400-monceaux_sur_dordogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19140-19400-monceaux_sur_dordogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19141-19340-monestier_merlines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19141-19340-monestier_merlines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19141-19340-monestier_merlines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19141-19340-monestier_merlines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19142-19110-monestier_port_dieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19142-19110-monestier_port_dieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19142-19110-monestier_port_dieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19142-19110-monestier_port_dieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19143-19300-montaignac_saint_hippolyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19143-19300-montaignac_saint_hippolyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19143-19300-montaignac_saint_hippolyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19143-19300-montaignac_saint_hippolyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19144-19210-montgibaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19144-19210-montgibaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19144-19210-montgibaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19144-19210-montgibaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19145-19300-moustier_ventadour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19145-19300-moustier_ventadour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19145-19300-moustier_ventadour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19145-19300-moustier_ventadour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19146-19460-naves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19146-19460-naves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19146-19460-naves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19146-19460-naves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19147-19600-nespouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19147-19600-nespouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19147-19600-nespouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19147-19600-nespouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19148-19160-neuvic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19148-19160-neuvic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19148-19160-neuvic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19148-19160-neuvic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19149-19380-neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19149-19380-neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19149-19380-neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19149-19380-neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19150-19500-noailhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19150-19500-noailhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19150-19500-noailhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19150-19500-noailhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19151-19600-noailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19151-19600-noailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19151-19600-noailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19151-19600-noailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19152-19120-nonards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19152-19120-nonards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19152-19120-nonards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19152-19120-nonards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19153-19130-objat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19153-19130-objat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19153-19130-objat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19153-19130-objat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19154-19410-orgnac_sur_vezere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19154-19410-orgnac_sur_vezere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19154-19410-orgnac_sur_vezere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19154-19410-orgnac_sur_vezere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19155-19390-orliac_de_bar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19155-19390-orliac_de_bar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19155-19390-orliac_de_bar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19155-19390-orliac_de_bar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19156-19190-palazinges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19156-19190-palazinges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19156-19190-palazinges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19156-19190-palazinges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19157-19160-palisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19157-19160-palisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19157-19160-palisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19157-19160-palisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19158-19150-pandrignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19158-19150-pandrignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19158-19150-pandrignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19158-19150-pandrignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19159-19300-peret_bel_air/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19159-19300-peret_bel_air/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19159-19300-peret_bel_air/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19159-19300-peret_bel_air/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19160-19170-perols_sur_vezere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19160-19170-perols_sur_vezere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19160-19170-perols_sur_vezere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19160-19170-perols_sur_vezere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19161-19310-perpezac_le_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19161-19310-perpezac_le_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19161-19310-perpezac_le_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19161-19310-perpezac_le_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19162-19410-perpezac_le_noir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19162-19410-perpezac_le_noir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19162-19410-perpezac_le_noir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19162-19410-perpezac_le_noir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19163-19190-le_pescher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19163-19190-le_pescher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19163-19190-le_pescher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19163-19190-le_pescher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19164-19290-peyrelevade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19164-19290-peyrelevade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19164-19290-peyrelevade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19164-19290-peyrelevade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19165-19260-peyrissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19165-19260-peyrissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19165-19260-peyrissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19165-19260-peyrissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19166-19450-pierrefitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19166-19450-pierrefitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19166-19450-pierrefitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19166-19450-pierrefitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19167-19200-confolent_port_dieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19167-19200-confolent_port_dieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19167-19200-confolent_port_dieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19167-19200-confolent_port_dieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19168-19170-pradines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19168-19170-pradines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19168-19170-pradines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19168-19170-pradines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19169-19120-puy_d_arnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19169-19120-puy_d_arnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19169-19120-puy_d_arnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19169-19120-puy_d_arnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19170-19120-queyssac_les_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19170-19120-queyssac_les_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19170-19120-queyssac_les_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19170-19120-queyssac_les_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19171-19430-reygade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19171-19430-reygade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19171-19430-reygade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19171-19430-reygade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19172-19260-rilhac_treignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19172-19260-rilhac_treignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19172-19260-rilhac_treignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19172-19260-rilhac_treignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19173-19220-rilhac_xaintrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19173-19220-rilhac_xaintrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19173-19220-rilhac_xaintrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19173-19220-rilhac_xaintrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19174-19320-la_roche_canillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19174-19320-la_roche_canillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19174-19320-la_roche_canillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19174-19320-la_roche_canillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19175-19160-roche_le_peyroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19175-19160-roche_le_peyroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19175-19160-roche_le_peyroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19175-19160-roche_le_peyroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19176-19300-rosiers_d_egletons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19176-19300-rosiers_d_egletons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19176-19300-rosiers_d_egletons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19176-19300-rosiers_d_egletons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19177-19350-rosiers_de_juillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19177-19350-rosiers_de_juillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19177-19350-rosiers_de_juillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19177-19350-rosiers_de_juillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19178-19270-sadroc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19178-19270-sadroc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19178-19270-sadroc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19178-19270-sadroc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19179-19500-saillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19179-19500-saillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19179-19500-saillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19179-19500-saillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19180-19200-saint_angel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19180-19200-saint_angel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19180-19200-saint_angel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19180-19200-saint_angel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19181-19390-saint_augustin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19181-19390-saint_augustin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19181-19390-saint_augustin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19181-19390-saint_augustin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19182-19130-saint_aulaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19182-19130-saint_aulaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19182-19130-saint_aulaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19182-19130-saint_aulaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19184-19500-saint_bazile_de_meyssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19184-19500-saint_bazile_de_meyssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19184-19500-saint_bazile_de_meyssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19184-19500-saint_bazile_de_meyssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19186-19380-saint_bonnet_elvert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19186-19380-saint_bonnet_elvert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19186-19380-saint_bonnet_elvert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19186-19380-saint_bonnet_elvert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19187-19130-saint_bonnet_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19187-19130-saint_bonnet_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19187-19130-saint_bonnet_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19187-19130-saint_bonnet_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19188-19410-saint_bonnet_l_enfantier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19188-19410-saint_bonnet_l_enfantier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19188-19410-saint_bonnet_l_enfantier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19188-19410-saint_bonnet_l_enfantier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19189-19430-saint_bonnet_les_tours_de_merle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19189-19430-saint_bonnet_les_tours_de_merle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19189-19430-saint_bonnet_les_tours_de_merle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19189-19430-saint_bonnet_les_tours_de_merle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19190-19200-saint_bonnet_pres_bort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19190-19200-saint_bonnet_pres_bort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19190-19200-saint_bonnet_pres_bort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19190-19200-saint_bonnet_pres_bort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19191-19600-saint_cernin_de_larche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19191-19600-saint_cernin_de_larche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19191-19600-saint_cernin_de_larche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19191-19600-saint_cernin_de_larche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19192-19380-saint_chamant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19192-19380-saint_chamant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19192-19380-saint_chamant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19192-19380-saint_chamant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19193-19220-saint_cirgues_la_loutre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19193-19220-saint_cirgues_la_loutre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19193-19220-saint_cirgues_la_loutre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19193-19220-saint_cirgues_la_loutre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19194-19700-saint_clement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19194-19700-saint_clement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19194-19700-saint_clement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19194-19700-saint_clement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19195-19130-saint_cyprien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19195-19130-saint_cyprien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19195-19130-saint_cyprien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19195-19130-saint_cyprien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19196-19130-saint_cyr_la_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19196-19130-saint_cyr_la_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19196-19130-saint_cyr_la_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19196-19130-saint_cyr_la_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19198-19210-saint_eloy_les_tuileries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19198-19210-saint_eloy_les_tuileries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19198-19210-saint_eloy_les_tuileries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19198-19210-saint_eloy_les_tuileries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19199-19200-saint_etienne_aux_clos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19199-19200-saint_etienne_aux_clos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19199-19200-saint_etienne_aux_clos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19199-19200-saint_etienne_aux_clos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19200-19160-saint_etienne_la_geneste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19200-19160-saint_etienne_la_geneste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19200-19160-saint_etienne_la_geneste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19200-19160-saint_etienne_la_geneste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19201-19200-saint_exupery_les_roches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19201-19200-saint_exupery_les_roches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19201-19200-saint_exupery_les_roches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19201-19200-saint_exupery_les_roches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19202-19270-sainte_fereole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19202-19270-sainte_fereole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19202-19270-sainte_fereole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19202-19270-sainte_fereole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19203-19490-sainte_fortunade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19203-19490-sainte_fortunade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19203-19490-sainte_fortunade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19203-19490-sainte_fortunade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19204-19200-saint_frejoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19204-19200-saint_frejoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19204-19200-saint_frejoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19204-19200-saint_frejoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19205-19220-saint_geniez_o_merle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19205-19220-saint_geniez_o_merle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19205-19220-saint_geniez_o_merle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19205-19220-saint_geniez_o_merle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19206-19290-saint_germain_lavolps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19206-19290-saint_germain_lavolps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19206-19290-saint_germain_lavolps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19206-19290-saint_germain_lavolps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19207-19330-saint_germain_les_vergnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19207-19330-saint_germain_les_vergnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19207-19330-saint_germain_les_vergnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19207-19330-saint_germain_les_vergnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19208-19550-saint_hilaire_foissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19208-19550-saint_hilaire_foissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19208-19550-saint_hilaire_foissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19208-19550-saint_hilaire_foissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19209-19170-saint_hilaire_les_courbes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19209-19170-saint_hilaire_les_courbes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19209-19170-saint_hilaire_les_courbes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19209-19170-saint_hilaire_les_courbes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19210-19160-saint_hilaire_luc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19210-19160-saint_hilaire_luc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19210-19160-saint_hilaire_luc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19210-19160-saint_hilaire_luc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19211-19560-saint_hilaire_peyroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19211-19560-saint_hilaire_peyroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19211-19560-saint_hilaire_peyroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19211-19560-saint_hilaire_peyroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19212-19400-saint_hilaire_taurieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19212-19400-saint_hilaire_taurieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19212-19400-saint_hilaire_taurieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19212-19400-saint_hilaire_taurieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19213-19700-saint_jal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19213-19700-saint_jal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19213-19700-saint_jal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19213-19700-saint_jal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19214-19220-saint_julien_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19214-19220-saint_julien_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19214-19220-saint_julien_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19214-19220-saint_julien_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19215-19430-saint_julien_le_pelerin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19215-19430-saint_julien_le_pelerin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19215-19430-saint_julien_le_pelerin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19215-19430-saint_julien_le_pelerin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19216-19210-saint_julien_le_vendomois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19216-19210-saint_julien_le_vendomois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19216-19210-saint_julien_le_vendomois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19216-19210-saint_julien_le_vendomois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19217-19500-saint_julien_maumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19217-19500-saint_julien_maumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19217-19500-saint_julien_maumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19217-19500-saint_julien_maumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19219-19160-sainte_marie_lapanouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19219-19160-sainte_marie_lapanouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19219-19160-sainte_marie_lapanouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19219-19160-sainte_marie_lapanouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19220-19150-saint_martial_de_gimel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19220-19150-saint_martial_de_gimel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19220-19150-saint_martial_de_gimel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19220-19150-saint_martial_de_gimel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19221-19400-saint_martial_entraygues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19221-19400-saint_martial_entraygues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19221-19400-saint_martial_entraygues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19221-19400-saint_martial_entraygues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19222-19320-saint_martin_la_meanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19222-19320-saint_martin_la_meanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19222-19320-saint_martin_la_meanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19222-19320-saint_martin_la_meanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19223-19210-saint_martin_sepert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19223-19210-saint_martin_sepert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19223-19210-saint_martin_sepert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19223-19210-saint_martin_sepert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19225-19320-saint_merd_de_lapleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19225-19320-saint_merd_de_lapleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19225-19320-saint_merd_de_lapleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19225-19320-saint_merd_de_lapleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19226-19170-saint_merd_les_oussines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19226-19170-saint_merd_les_oussines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19226-19170-saint_merd_les_oussines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19226-19170-saint_merd_les_oussines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19227-19330-saint_mexant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19227-19330-saint_mexant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19227-19330-saint_mexant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19227-19330-saint_mexant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19228-19160-saint_pantaleon_de_lapleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19228-19160-saint_pantaleon_de_lapleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19228-19160-saint_pantaleon_de_lapleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19228-19160-saint_pantaleon_de_lapleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19229-19600-saint_pantaleon_de_larche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19229-19600-saint_pantaleon_de_larche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19229-19600-saint_pantaleon_de_larche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19229-19600-saint_pantaleon_de_larche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19230-19210-saint_pardoux_corbier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19230-19210-saint_pardoux_corbier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19230-19210-saint_pardoux_corbier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19230-19210-saint_pardoux_corbier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19231-19320-saint_pardoux_la_croisille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19231-19320-saint_pardoux_la_croisille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19231-19320-saint_pardoux_la_croisille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19231-19320-saint_pardoux_la_croisille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19232-19200-saint_pardoux_le_neuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19232-19200-saint_pardoux_le_neuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19232-19200-saint_pardoux_le_neuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19232-19200-saint_pardoux_le_neuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19233-19200-saint_pardoux_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19233-19200-saint_pardoux_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19233-19200-saint_pardoux_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19233-19200-saint_pardoux_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19234-19270-saint_pardoux_l_ortigier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19234-19270-saint_pardoux_l_ortigier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19234-19270-saint_pardoux_l_ortigier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19234-19270-saint_pardoux_l_ortigier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19235-19150-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19235-19150-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19235-19150-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19235-19150-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19236-19800-saint_priest_de_gimel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19236-19800-saint_priest_de_gimel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19236-19800-saint_priest_de_gimel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19236-19800-saint_priest_de_gimel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19237-19220-saint_privat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19237-19220-saint_privat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19237-19220-saint_privat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19237-19220-saint_privat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19238-19290-saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19238-19290-saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19238-19290-saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19238-19290-saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19239-19310-saint_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19239-19310-saint_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19239-19310-saint_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19239-19310-saint_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19240-19700-saint_salvadour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19240-19700-saint_salvadour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19240-19700-saint_salvadour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19240-19700-saint_salvadour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19241-19290-saint_setiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19241-19290-saint_setiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19241-19290-saint_setiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19241-19290-saint_setiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19242-19130-saint_solve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19242-19130-saint_solve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19242-19130-saint_solve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19242-19130-saint_solve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19243-19230-saint_sornin_lavolps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19243-19230-saint_sornin_lavolps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19243-19230-saint_sornin_lavolps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19243-19230-saint_sornin_lavolps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19244-19250-saint_sulpice_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19244-19250-saint_sulpice_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19244-19250-saint_sulpice_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19244-19250-saint_sulpice_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19245-19380-saint_sylvain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19245-19380-saint_sylvain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19245-19380-saint_sylvain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19245-19380-saint_sylvain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19246-19240-saint_viance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19246-19240-saint_viance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19246-19240-saint_viance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19246-19240-saint_viance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19247-19200-saint_victour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19247-19200-saint_victour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19247-19200-saint_victour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19247-19200-saint_victour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19248-19140-saint_ybard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19248-19140-saint_ybard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19248-19140-saint_ybard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19248-19140-saint_ybard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19249-19300-saint_yrieix_le_dejalat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19249-19300-saint_yrieix_le_dejalat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19249-19300-saint_yrieix_le_dejalat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19249-19300-saint_yrieix_le_dejalat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19250-19510-salon_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19250-19510-salon_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19250-19510-salon_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19250-19510-salon_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19251-19800-sarran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19251-19800-sarran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19251-19800-sarran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19251-19800-sarran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19252-19110-sarroux___saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19252-19110-sarroux___saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19252-19110-sarroux___saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19252-19110-sarroux___saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19253-19310-segonzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19253-19310-segonzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19253-19310-segonzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19253-19310-segonzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19254-19230-segur_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19254-19230-segur_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19254-19230-segur_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19254-19230-segur_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19255-19700-seilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19255-19700-seilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19255-19700-seilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19255-19700-seilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19256-19160-serandon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19256-19160-serandon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19256-19160-serandon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19256-19160-serandon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19257-19190-serilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19257-19190-serilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19257-19190-serilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19257-19190-serilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19258-19220-servieres_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19258-19220-servieres_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19258-19220-servieres_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19258-19220-servieres_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19259-19430-sexcles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19259-19430-sexcles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19259-19430-sexcles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19259-19430-sexcles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19260-19120-sioniac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19260-19120-sioniac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19260-19120-sioniac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19260-19120-sioniac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19261-19290-sornac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19261-19290-sornac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19261-19290-sornac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19261-19290-sornac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19262-19370-soudaine_lavinadiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19262-19370-soudaine_lavinadiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19262-19370-soudaine_lavinadiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19262-19370-soudaine_lavinadiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19263-19300-soudeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19263-19300-soudeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19263-19300-soudeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19263-19300-soudeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19264-19550-soursac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19264-19550-soursac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19264-19550-soursac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19264-19550-soursac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19265-19170-tarnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19265-19170-tarnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19265-19170-tarnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19265-19170-tarnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19266-19200-thalamy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19266-19200-thalamy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19266-19200-thalamy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19266-19200-thalamy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19268-19170-toy_viam/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19268-19170-toy_viam/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19268-19170-toy_viam/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19268-19170-toy_viam/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19269-19260-treignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19269-19260-treignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19269-19260-treignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19269-19260-treignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19270-19230-troche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19270-19230-troche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19270-19230-troche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19270-19230-troche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19271-19120-tudeils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19271-19120-tudeils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19271-19120-tudeils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19271-19120-tudeils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19272-19000-tulle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19272-19000-tulle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19272-19000-tulle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19272-19000-tulle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19273-19500-turenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19273-19500-turenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19273-19500-turenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19273-19500-turenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19274-19270-ussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19274-19270-ussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19274-19270-ussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19274-19270-ussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19275-19200-ussel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19275-19200-ussel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19275-19200-ussel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19275-19200-ussel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19276-19140-uzerche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19276-19140-uzerche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19276-19140-uzerche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19276-19140-uzerche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19277-19200-valiergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19277-19200-valiergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19277-19200-valiergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19277-19200-valiergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19278-19240-varetz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19278-19240-varetz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19278-19240-varetz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19278-19240-varetz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19279-19130-vars_sur_roseix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19279-19130-vars_sur_roseix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19279-19130-vars_sur_roseix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19279-19130-vars_sur_roseix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19280-19120-vegennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19280-19120-vegennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19280-19120-vegennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19280-19120-vegennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19281-19260-veix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19281-19260-veix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19281-19260-veix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19281-19260-veix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19283-19200-veyrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19283-19200-veyrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19283-19200-veyrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19283-19200-veyrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19284-19170-viam/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19284-19170-viam/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19284-19170-viam/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19284-19170-viam/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19285-19410-vigeois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19285-19410-vigeois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19285-19410-vigeois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19285-19410-vigeois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19286-19130-vignols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19286-19130-vignols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19286-19130-vignols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19286-19130-vignols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19287-19800-vitrac_sur_montane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19287-19800-vitrac_sur_montane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19287-19800-vitrac_sur_montane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19287-19800-vitrac_sur_montane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19288-19130-voutezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19288-19130-voutezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19288-19130-voutezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19288-19130-voutezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19289-19310-yssandon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19289-19310-yssandon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19289-19310-yssandon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt19-correze/commune19289-19310-yssandon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-21.xml
+++ b/public/sitemaps/sitemap-21.xml
@@ -5,1408 +5,2812 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21001-21700-agencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21001-21700-agencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21001-21700-agencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21001-21700-agencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21002-21410-agey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21002-21410-agey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21002-21410-agey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21002-21410-agey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21003-21121-ahuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21003-21121-ahuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21003-21121-ahuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21003-21121-ahuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21004-21510-aignay_le_duc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21004-21510-aignay_le_duc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21004-21510-aignay_le_duc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21004-21510-aignay_le_duc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21005-21110-aiserey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21005-21110-aiserey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21005-21110-aiserey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21005-21110-aiserey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21006-21400-aisey_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21006-21400-aisey_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21006-21400-aisey_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21006-21400-aisey_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21007-21390-aisy_sous_thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21007-21390-aisy_sous_thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21007-21390-aisy_sous_thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21007-21390-aisy_sous_thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21008-21150-alise_sainte_reine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21008-21150-alise_sainte_reine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21008-21150-alise_sainte_reine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21008-21150-alise_sainte_reine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21009-21230-allerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21009-21230-allerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21009-21230-allerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21009-21230-allerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21010-21420-aloxe_corton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21010-21420-aloxe_corton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21010-21420-aloxe_corton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21010-21420-aloxe_corton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21011-21450-ampilly_les_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21011-21450-ampilly_les_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21011-21450-ampilly_les_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21011-21450-ampilly_les_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21012-21400-ampilly_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21012-21400-ampilly_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21012-21400-ampilly_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21012-21400-ampilly_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21013-21410-ancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21013-21410-ancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21013-21410-ancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21013-21410-ancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21014-21360-antheuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21014-21360-antheuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21014-21360-antheuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21014-21360-antheuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21015-21230-antigny_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21015-21230-antigny_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21015-21230-antigny_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21015-21230-antigny_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21016-21310-arceau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21016-21310-arceau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21016-21310-arceau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21016-21310-arceau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21017-21700-arcenant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21017-21700-arcenant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21017-21700-arcenant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21017-21700-arcenant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21018-21410-arcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21018-21410-arcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21018-21410-arcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21018-21410-arcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21020-21320-arconcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21020-21320-arconcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21020-21320-arconcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21020-21320-arconcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21021-21560-arc_sur_tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21021-21560-arc_sur_tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21021-21560-arc_sur_tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21021-21560-arc_sur_tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21022-21700-argilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21022-21700-argilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21022-21700-argilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21022-21700-argilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21023-21230-arnay_le_duc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21023-21230-arnay_le_duc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21023-21230-arnay_le_duc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21023-21230-arnay_le_duc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21024-21350-arnay_sous_vitteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21024-21350-arnay_sous_vitteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21024-21350-arnay_sous_vitteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21024-21350-arnay_sous_vitteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21025-21500-arrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21025-21500-arrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21025-21500-arrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21025-21500-arrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21026-21500-asnieres_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21026-21500-asnieres_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21026-21500-asnieres_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21026-21500-asnieres_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21027-21380-asnieres_les_dijon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21027-21380-asnieres_les_dijon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21027-21380-asnieres_les_dijon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21027-21380-asnieres_les_dijon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21028-21130-athee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21028-21130-athee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21028-21130-athee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21028-21130-athee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21029-21500-athie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21029-21500-athie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21029-21500-athie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21029-21500-athie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21030-21360-aubaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21030-21360-aubaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21030-21360-aubaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21030-21360-aubaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21031-21170-aubigny_en_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21031-21170-aubigny_en_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21031-21170-aubigny_en_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21031-21170-aubigny_en_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21032-21340-aubigny_la_ronce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21032-21340-aubigny_la_ronce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21032-21340-aubigny_la_ronce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21032-21340-aubigny_la_ronce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21033-21540-aubigny_les_sombernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21033-21540-aubigny_les_sombernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21033-21540-aubigny_les_sombernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21033-21540-aubigny_les_sombernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21034-21570-autricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21034-21570-autricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21034-21570-autricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21034-21570-autricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21035-21250-auvillars_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21035-21250-auvillars_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21035-21250-auvillars_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21035-21250-auvillars_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21036-21360-auxant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21036-21360-auxant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21036-21360-auxant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21036-21360-auxant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21037-21190-auxey_duresses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21037-21190-auxey_duresses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21037-21190-auxey_duresses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21037-21190-auxey_duresses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21038-21130-auxonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21038-21130-auxonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21038-21130-auxonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21038-21130-auxonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21039-21120-avelanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21039-21120-avelanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21039-21120-avelanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21039-21120-avelanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21040-21350-avosnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21040-21350-avosnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21040-21350-avosnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21040-21350-avosnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21041-21580-avot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21041-21580-avot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21041-21580-avot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21041-21580-avot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21042-21700-bagnot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21042-21700-bagnot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21042-21700-bagnot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21042-21700-bagnot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21043-21450-baigneux_les_juifs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21043-21450-baigneux_les_juifs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21043-21450-baigneux_les_juifs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21043-21450-baigneux_les_juifs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21044-21330-balot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21044-21330-balot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21044-21330-balot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21044-21330-balot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21045-21410-barbirey_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21045-21410-barbirey_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21045-21410-barbirey_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21045-21410-barbirey_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21046-21430-bard_le_regulier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21046-21430-bard_le_regulier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21046-21430-bard_le_regulier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21046-21430-bard_le_regulier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21047-21460-bard_les_epoisses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21047-21460-bard_les_epoisses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21047-21460-bard_les_epoisses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21047-21460-bard_les_epoisses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21048-21910-barges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21048-21910-barges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21048-21910-barges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21048-21910-barges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21049-21580-barjon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21049-21580-barjon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21049-21580-barjon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21049-21580-barjon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21050-21340-baubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21050-21340-baubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21050-21340-baubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21050-21340-baubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21051-21410-baulme_la_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21051-21410-baulme_la_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21051-21410-baulme_la_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21051-21410-baulme_la_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21052-21510-beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21052-21510-beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21052-21510-beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21052-21510-beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21053-21310-beaumont_sur_vingeanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21053-21310-beaumont_sur_vingeanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21053-21310-beaumont_sur_vingeanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21053-21310-beaumont_sur_vingeanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21054-21200-beaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21054-21200-beaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21054-21200-beaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21054-21200-beaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21055-21510-beaunotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21055-21510-beaunotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21055-21510-beaunotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21055-21510-beaunotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21056-21310-beire_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21056-21310-beire_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21056-21310-beire_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21056-21310-beire_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21057-21110-beire_le_fort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21057-21110-beire_le_fort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21057-21110-beire_le_fort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21057-21110-beire_le_fort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21058-21570-belan_sur_ource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21058-21570-belan_sur_ource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21058-21570-belan_sur_ource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21058-21570-belan_sur_ource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21059-21490-bellefond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21059-21490-bellefond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21059-21490-bellefond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21059-21490-bellefond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21060-21310-belleneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21060-21310-belleneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21060-21310-belleneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21060-21310-belleneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21061-21510-bellenod_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21061-21510-bellenod_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21061-21510-bellenod_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21061-21510-bellenod_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21062-21320-bellenot_sous_pouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21062-21320-bellenot_sous_pouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21062-21320-bellenot_sous_pouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21062-21320-bellenot_sous_pouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21063-21290-beneuvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21063-21290-beneuvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21063-21290-beneuvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21063-21290-beneuvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21064-21500-benoisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21064-21500-benoisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21064-21500-benoisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21064-21500-benoisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21065-21360-bessey_en_chaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21065-21360-bessey_en_chaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21065-21360-bessey_en_chaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21065-21360-bessey_en_chaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21066-21360-bessey_la_cour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21066-21360-bessey_la_cour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21066-21360-bessey_la_cour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21066-21360-bessey_la_cour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21067-21110-bessey_les_citeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21067-21110-bessey_les_citeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21067-21110-bessey_les_citeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21067-21110-bessey_les_citeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21068-21320-beurey_bauguay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21068-21320-beurey_bauguay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21068-21320-beurey_bauguay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21068-21320-beurey_bauguay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21069-21350-beurizot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21069-21350-beurizot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21069-21350-beurizot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21069-21350-beurizot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21070-21220-bevy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21070-21220-bevy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21070-21220-bevy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21070-21220-bevy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21071-21310-beze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21071-21310-beze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21071-21310-beze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21071-21310-beze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21072-21310-bezouotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21072-21310-bezouotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21072-21310-bezouotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21072-21310-bezouotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21074-21130-billey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21074-21130-billey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21074-21130-billey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21074-21130-billey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21075-21450-billy_les_chanceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21075-21450-billy_les_chanceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21075-21450-billy_les_chanceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21075-21450-billy_les_chanceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21076-21270-binges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21076-21270-binges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21076-21270-binges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21076-21270-binges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21077-21520-bissey_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21077-21520-bissey_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21077-21520-bissey_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21077-21520-bissey_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21078-21330-bissey_la_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21078-21330-bissey_la_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21078-21330-bissey_la_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21078-21330-bissey_la_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21079-21310-blagny_sur_vingeanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21079-21310-blagny_sur_vingeanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21079-21310-blagny_sur_vingeanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21079-21310-blagny_sur_vingeanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21080-21540-blaisy_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21080-21540-blaisy_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21080-21540-blaisy_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21080-21540-blaisy_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21081-21540-blaisy_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21081-21540-blaisy_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21081-21540-blaisy_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21081-21540-blaisy_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21082-21320-blancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21082-21320-blancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21082-21320-blancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21082-21320-blancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21083-21430-blanot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21083-21430-blanot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21083-21430-blanot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21083-21430-blanot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21084-21690-source_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21084-21690-source_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21084-21690-source_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21084-21690-source_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21085-21440-bligny_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21085-21440-bligny_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21085-21440-bligny_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21085-21440-bligny_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21086-21200-bligny_les_beaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21086-21200-bligny_les_beaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21086-21200-bligny_les_beaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21086-21200-bligny_les_beaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21087-21360-bligny_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21087-21360-bligny_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21087-21360-bligny_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21087-21360-bligny_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21088-21700-boncourt_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21088-21700-boncourt_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21088-21700-boncourt_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21088-21700-boncourt_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21089-21250-bonnencontre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21089-21250-bonnencontre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21089-21250-bonnencontre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21089-21250-bonnencontre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21090-21520-boudreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21090-21520-boudreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21090-21520-boudreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21090-21520-boudreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21091-21360-bouhey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21091-21360-bouhey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21091-21360-bouhey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21091-21360-bouhey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21092-21420-bouilland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21092-21420-bouilland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21092-21420-bouilland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21092-21420-bouilland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21093-21330-bouix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21093-21330-bouix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21093-21330-bouix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21093-21330-bouix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21094-21610-bourberain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21094-21610-bourberain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21094-21610-bourberain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21094-21610-bourberain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21095-21250-bousselange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21095-21250-bousselange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21095-21250-bousselange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21095-21250-bousselange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21096-21260-boussenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21096-21260-boussenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21096-21260-boussenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21096-21260-boussenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21097-21350-boussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21097-21350-boussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21097-21350-boussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21097-21350-boussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21098-21690-boux_sous_salmaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21098-21690-boux_sous_salmaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21098-21690-boux_sous_salmaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21098-21690-boux_sous_salmaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21099-21200-bouze_les_beaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21099-21200-bouze_les_beaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21099-21200-bouze_les_beaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21099-21200-bouze_les_beaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21100-21350-brain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21100-21350-brain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21100-21350-brain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21100-21350-brain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21101-21390-braux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21101-21390-braux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21101-21390-braux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21101-21390-braux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21102-21430-brazey_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21102-21430-brazey_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21102-21430-brazey_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21102-21430-brazey_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21103-21470-brazey_en_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21103-21470-brazey_en_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21103-21470-brazey_en_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21103-21470-brazey_en_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21104-21400-bremur_et_vaurois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21104-21400-bremur_et_vaurois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21104-21400-bremur_et_vaurois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21104-21400-bremur_et_vaurois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21105-21560-bressey_sur_tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21105-21560-bressey_sur_tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21105-21560-bressey_sur_tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21105-21560-bressey_sur_tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21106-21110-breteniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21106-21110-breteniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21106-21110-breteniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21106-21110-breteniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21107-21490-bretigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21107-21490-bretigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21107-21490-bretigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21107-21490-bretigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21108-21390-brianny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21108-21390-brianny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21108-21390-brianny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21108-21390-brianny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21109-21570-brion_sur_ource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21109-21570-brion_sur_ource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21109-21570-brion_sur_ource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21109-21570-brion_sur_ource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21110-21220-brochon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21110-21220-brochon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21110-21220-brochon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21110-21220-brochon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21111-21490-brognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21111-21490-brognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21111-21490-brognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21111-21490-brognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21112-21250-broin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21112-21250-broin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21112-21250-broin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21112-21250-broin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21113-21220-broindon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21113-21220-broindon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21113-21220-broindon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21113-21220-broindon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21114-21500-buffon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21114-21500-buffon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21114-21500-buffon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21114-21500-buffon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21115-21400-buncey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21115-21400-buncey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21115-21400-buncey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21115-21400-buncey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21116-21290-bure_les_templiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21116-21290-bure_les_templiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21116-21290-bure_les_templiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21116-21290-bure_les_templiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21117-21510-busseaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21117-21510-busseaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21117-21510-busseaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21117-21510-busseaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21118-21580-busserotte_et_montenaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21118-21580-busserotte_et_montenaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21118-21580-busserotte_et_montenaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21118-21580-busserotte_et_montenaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21119-21580-bussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21119-21580-bussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21119-21580-bussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21119-21580-bussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21120-21360-la_bussiere_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21120-21360-la_bussiere_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21120-21360-la_bussiere_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21120-21360-la_bussiere_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21121-21540-bussy_la_pesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21121-21540-bussy_la_pesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21121-21540-bussy_la_pesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21121-21540-bussy_la_pesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21122-21150-bussy_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21122-21150-bussy_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21122-21150-bussy_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21122-21150-bussy_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21123-21290-buxerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21123-21290-buxerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21123-21290-buxerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21123-21290-buxerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21124-21430-censerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21124-21430-censerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21124-21430-censerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21124-21430-censerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21125-21330-cerilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21125-21330-cerilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21125-21330-cerilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21125-21330-cerilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21126-21110-cessey_sur_tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21126-21110-cessey_sur_tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21126-21110-cessey_sur_tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21126-21110-cessey_sur_tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21127-21120-chaignay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21127-21120-chaignay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21127-21120-chaignay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21127-21120-chaignay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21128-21320-chailly_sur_armancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21128-21320-chailly_sur_armancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21128-21320-chailly_sur_armancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21128-21320-chailly_sur_armancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21129-21290-chambain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21129-21290-chambain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21129-21290-chambain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21129-21290-chambain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21130-21110-chambeire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21130-21110-chambeire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21130-21110-chambeire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21130-21110-chambeire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21131-21250-chamblanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21131-21250-chamblanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21131-21250-chamblanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21131-21250-chamblanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21132-21220-chamboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21132-21220-chamboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21132-21220-chamboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21132-21220-chamboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21133-21220-chambolle_musigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21133-21220-chambolle_musigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21133-21220-chambolle_musigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21133-21220-chambolle_musigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21134-21400-chamesson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21134-21400-chamesson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21134-21400-chamesson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21134-21400-chamesson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21135-21310-champagne_sur_vingeanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21135-21310-champagne_sur_vingeanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21135-21310-champagne_sur_vingeanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21135-21310-champagne_sur_vingeanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21136-21440-champagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21136-21440-champagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21136-21440-champagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21136-21440-champagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21137-21500-champ_d_oiseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21137-21500-champ_d_oiseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21137-21500-champ_d_oiseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21137-21500-champ_d_oiseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21138-21130-champdotre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21138-21130-champdotre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21138-21130-champdotre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21138-21130-champdotre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21139-21210-champeau_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21139-21210-champeau_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21139-21210-champeau_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21139-21210-champeau_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21140-21230-champignolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21140-21230-champignolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21140-21230-champignolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21140-21230-champignolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21141-21690-champrenault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21141-21690-champrenault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21141-21690-champrenault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21141-21690-champrenault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21142-21440-chanceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21142-21440-chanceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21142-21440-chanceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21142-21440-chanceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21143-21330-channay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21143-21330-channay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21143-21330-channay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21143-21330-channay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21144-21690-charencey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21144-21690-charencey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21144-21690-charencey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21144-21690-charencey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21145-21140-charigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21145-21140-charigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21145-21140-charigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21145-21140-charigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21146-21310-charmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21146-21310-charmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21146-21310-charmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21146-21310-charmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21147-21350-charny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21147-21350-charny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21147-21350-charny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21147-21350-charny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21148-21170-charrey_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21148-21170-charrey_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21148-21170-charrey_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21148-21170-charrey_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21149-21400-charrey_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21149-21400-charrey_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21149-21400-charrey_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21149-21400-charrey_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21150-21190-chassagne_montrachet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21150-21190-chassagne_montrachet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21150-21190-chassagne_montrachet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21150-21190-chassagne_montrachet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21151-21150-chassey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21151-21150-chassey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21151-21150-chassey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21151-21150-chassey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21152-21320-chateauneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21152-21320-chateauneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21152-21320-chateauneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21152-21320-chateauneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21153-21320-chatellenot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21153-21320-chatellenot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21153-21320-chatellenot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21153-21320-chatellenot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21154-21400-chatillon_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21154-21400-chatillon_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21154-21400-chatillon_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21154-21400-chatillon_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21155-21360-chaudenay_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21155-21360-chaudenay_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21155-21360-chaudenay_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21155-21360-chaudenay_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21156-21360-chaudenay_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21156-21360-chaudenay_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21156-21360-chaudenay_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21156-21360-chaudenay_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21157-21290-chaugey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21157-21290-chaugey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21157-21290-chaugey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21157-21290-chaugey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21158-21610-chaume_et_courchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21158-21610-chaume_et_courchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21158-21610-chaume_et_courchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21158-21610-chaume_et_courchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21159-21520-la_chaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21159-21520-la_chaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21159-21520-la_chaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21159-21520-la_chaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21160-21450-chaume_les_baigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21160-21450-chaume_les_baigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21160-21450-chaume_les_baigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21160-21450-chaume_les_baigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21161-21400-chaumont_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21161-21400-chaumont_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21161-21400-chaumont_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21161-21400-chaumont_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21162-21700-chaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21162-21700-chaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21162-21700-chaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21162-21700-chaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21163-21260-chazeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21163-21260-chazeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21163-21260-chazeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21163-21260-chazeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21164-21320-chazilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21164-21320-chazilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21164-21320-chazilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21164-21320-chazilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21165-21400-chemin_d_aisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21165-21400-chemin_d_aisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21165-21400-chemin_d_aisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21165-21400-chemin_d_aisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21166-21300-chenove/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21166-21300-chenove/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21166-21300-chenove/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21166-21300-chenove/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21167-21310-cheuge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21167-21310-cheuge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21167-21310-cheuge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21167-21310-cheuge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21168-21540-chevannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21168-21540-chevannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21168-21540-chevannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21168-21540-chevannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21169-21220-chevannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21169-21220-chevannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21169-21220-chevannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21169-21220-chevannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21170-21200-chevigny_en_valiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21170-21200-chevigny_en_valiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21170-21200-chevigny_en_valiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21170-21200-chevigny_en_valiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21171-21800-chevigny_saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21171-21800-chevigny_saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21171-21800-chevigny_saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21171-21800-chevigny_saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21172-21820-chivres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21172-21820-chivres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21172-21820-chivres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21172-21820-chivres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21173-21200-chorey_les_beaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21173-21200-chorey_les_beaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21173-21200-chorey_les_beaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21173-21200-chorey_les_beaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21175-21270-cirey_les_pontailler/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21175-21270-cirey_les_pontailler/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21175-21270-cirey_les_pontailler/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21175-21270-cirey_les_pontailler/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21176-21320-civry_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21176-21320-civry_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21176-21320-civry_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21176-21320-civry_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21177-21390-clamerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21177-21390-clamerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21177-21390-clamerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21177-21390-clamerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21178-21220-valforet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21178-21220-valforet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21178-21220-valforet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21178-21220-valforet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21179-21490-clenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21179-21490-clenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21179-21490-clenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21179-21490-clenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21180-21270-clery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21180-21270-clery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21180-21270-clery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21180-21270-clery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21181-21230-clomot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21181-21230-clomot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21181-21230-clomot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21181-21230-clomot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21182-21220-collonges_les_bevy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21182-21220-collonges_les_bevy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21182-21220-collonges_les_bevy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21182-21220-collonges_les_bevy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21183-21110-collonges_les_premieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21183-21110-collonges_les_premieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21183-21110-collonges_les_premieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21183-21110-collonges_les_premieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21184-21360-colombier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21184-21360-colombier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21184-21360-colombier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21184-21360-colombier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21185-21200-combertault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21185-21200-combertault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21185-21200-combertault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21185-21200-combertault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21186-21700-comblanchien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21186-21700-comblanchien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21186-21700-comblanchien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21186-21700-comblanchien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21187-21320-commarin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21187-21320-commarin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21187-21320-commarin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21187-21320-commarin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21189-21250-corberon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21189-21250-corberon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21189-21250-corberon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21189-21250-corberon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21190-21190-corcelles_les_arts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21190-21190-corcelles_les_arts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21190-21190-corcelles_les_arts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21190-21190-corcelles_les_arts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21191-21910-corcelles_les_citeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21191-21910-corcelles_les_citeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21191-21910-corcelles_les_citeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21191-21910-corcelles_les_citeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21192-21160-corcelles_les_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21192-21160-corcelles_les_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21192-21160-corcelles_les_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21192-21160-corcelles_les_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21193-21250-corgengoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21193-21250-corgengoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21193-21250-corgengoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21193-21250-corgengoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21194-21700-corgoloin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21194-21700-corgoloin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21194-21700-corgoloin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21194-21700-corgoloin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21195-21340-cormot_vauchignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21195-21340-cormot_vauchignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21195-21340-cormot_vauchignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21195-21340-cormot_vauchignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21196-21190-corpeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21196-21190-corpeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21196-21190-corpeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21196-21190-corpeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21197-21150-corpoyer_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21197-21150-corpoyer_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21197-21150-corpoyer_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21197-21150-corpoyer_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21198-21460-corrombles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21198-21460-corrombles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21198-21460-corrombles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21198-21460-corrombles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21199-21460-corsaint/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21199-21460-corsaint/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21199-21460-corsaint/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21199-21460-corsaint/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21200-21160-couchey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21200-21160-couchey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21200-21160-couchey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21200-21160-couchey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21201-21400-coulmier_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21201-21400-coulmier_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21201-21400-coulmier_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21201-21400-coulmier_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21202-21520-courban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21202-21520-courban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21202-21520-courban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21202-21520-courban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21203-21460-courcelles_fremoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21203-21460-courcelles_fremoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21203-21460-courcelles_fremoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21203-21460-courcelles_fremoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21204-21500-courcelles_les_montbard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21204-21500-courcelles_les_montbard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21204-21500-courcelles_les_montbard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21204-21500-courcelles_les_montbard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21205-21140-courcelles_les_semur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21205-21140-courcelles_les_semur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21205-21140-courcelles_les_semur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21205-21140-courcelles_les_semur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21207-21580-courlon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21207-21580-courlon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21207-21580-courlon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21207-21580-courlon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21208-21120-courtivron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21208-21120-courtivron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21208-21120-courtivron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21208-21120-courtivron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21209-21560-couternon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21209-21560-couternon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21209-21560-couternon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21209-21560-couternon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21210-21320-creancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21210-21320-creancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21210-21320-creancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21210-21320-creancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21211-21120-crecey_sur_tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21211-21120-crecey_sur_tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21211-21120-crecey_sur_tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21211-21120-crecey_sur_tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21212-21500-crepand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21212-21500-crepand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21212-21500-crepand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21212-21500-crepand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21213-21800-crimolois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21213-21800-crimolois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21213-21800-crimolois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21213-21800-crimolois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21214-21360-crugey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21214-21360-crugey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21214-21360-crugey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21214-21360-crugey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21215-21310-cuiserey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21215-21310-cuiserey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21215-21310-cuiserey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21215-21310-cuiserey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21216-21230-culetre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21216-21230-culetre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21216-21230-culetre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21216-21230-culetre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21217-21220-curley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21217-21220-curley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21217-21220-curley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21217-21220-curley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21218-21380-curtil_saint_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21218-21380-curtil_saint_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21218-21380-curtil_saint_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21218-21380-curtil_saint_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21219-21220-curtil_vergy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21219-21220-curtil_vergy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21219-21220-curtil_vergy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21219-21220-curtil_vergy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21220-21580-cussey_les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21220-21580-cussey_les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21220-21580-cussey_les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21220-21580-cussey_les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21221-21360-cussy_la_colonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21221-21360-cussy_la_colonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21221-21360-cussy_la_colonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21221-21360-cussy_la_colonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21222-21230-cussy_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21222-21230-cussy_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21222-21230-cussy_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21222-21230-cussy_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21223-21121-daix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21223-21121-daix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21223-21121-daix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21223-21121-daix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21224-21350-dampierre_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21224-21350-dampierre_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21224-21350-dampierre_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21224-21350-dampierre_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21225-21310-dampierre_et_flee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21225-21310-dampierre_et_flee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21225-21310-dampierre_et_flee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21225-21310-dampierre_et_flee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21226-21150-darcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21226-21150-darcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21226-21150-darcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21226-21150-darcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21227-21121-darois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21227-21121-darois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21227-21121-darois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21227-21121-darois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21228-21220-detain_et_bruant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21228-21220-detain_et_bruant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21228-21220-detain_et_bruant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21228-21220-detain_et_bruant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21229-21430-diancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21229-21430-diancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21229-21430-diancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21229-21430-diancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21230-21120-dienay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21230-21120-dienay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21230-21120-dienay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21230-21120-dienay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21231-21000-dijon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21231-21000-dijon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21231-21000-dijon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21231-21000-dijon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21232-21390-dompierre_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21232-21390-dompierre_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21232-21390-dompierre_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21232-21390-dompierre_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21233-21270-drambon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21233-21270-drambon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21233-21270-drambon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21233-21270-drambon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21234-21540-dree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21234-21540-dree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21234-21540-dree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21234-21540-dree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21235-21510-duesme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21235-21510-duesme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21235-21510-duesme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21235-21510-duesme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21236-21190-ebaty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21236-21190-ebaty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21236-21190-ebaty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21236-21190-ebaty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21237-21510-echalot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21237-21510-echalot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21237-21510-echalot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21237-21510-echalot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21238-21540-echannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21238-21540-echannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21238-21540-echannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21238-21540-echannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21239-21170-echenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21239-21170-echenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21239-21170-echenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21239-21170-echenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21240-21120-echevannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21240-21120-echevannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21240-21120-echevannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21240-21120-echevannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21241-21420-echevronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21241-21420-echevronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21241-21420-echevronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21241-21420-echevronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21242-21110-echigey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21242-21110-echigey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21242-21110-echigey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21242-21110-echigey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21243-21360-ecutigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21243-21360-ecutigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21243-21360-ecutigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21243-21360-ecutigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21244-21320-eguilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21244-21320-eguilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21244-21320-eguilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21244-21320-eguilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21245-21380-epagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21245-21380-epagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21245-21380-epagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21245-21380-epagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21246-21220-epernay_sous_gevrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21246-21220-epernay_sous_gevrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21246-21220-epernay_sous_gevrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21246-21220-epernay_sous_gevrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21247-21460-epoisses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21247-21460-epoisses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21247-21460-epoisses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21247-21460-epoisses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21248-21500-eringes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21248-21500-eringes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21248-21500-eringes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21248-21500-eringes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21249-21170-esbarres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21249-21170-esbarres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21249-21170-esbarres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21249-21170-esbarres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21250-21290-essarois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21250-21290-essarois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21250-21290-essarois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21250-21290-essarois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21251-21320-essey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21251-21320-essey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21251-21320-essey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21251-21320-essey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21252-21500-etais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21252-21500-etais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21252-21500-etais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21252-21500-etais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21253-21510-etalante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21253-21510-etalante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21253-21510-etalante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21253-21510-etalante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21254-21220-l_etang_vergy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21254-21220-l_etang_vergy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21254-21220-l_etang_vergy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21254-21220-l_etang_vergy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21255-21121-etaules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21255-21121-etaules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21255-21121-etaules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21255-21121-etaules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21256-21270-etevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21256-21270-etevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21256-21270-etevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21256-21270-etevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21257-21450-etormay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21257-21450-etormay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21257-21450-etormay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21257-21450-etormay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21258-21400-etrochey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21258-21400-etrochey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21258-21400-etrochey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21258-21400-etrochey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21259-21500-fain_les_montbard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21259-21500-fain_les_montbard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21259-21500-fain_les_montbard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21259-21500-fain_les_montbard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21260-21500-fain_les_moutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21260-21500-fain_les_moutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21260-21500-fain_les_moutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21260-21500-fain_les_moutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21261-21110-fauverney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21261-21110-fauverney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21261-21110-fauverney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21261-21110-fauverney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21262-21290-faverolles_les_lucey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21262-21290-faverolles_les_lucey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21262-21290-faverolles_les_lucey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21262-21290-faverolles_les_lucey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21263-21600-fenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21263-21600-fenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21263-21600-fenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21263-21600-fenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21264-21230-le_fete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21264-21230-le_fete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21264-21230-le_fete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21264-21230-le_fete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21265-21220-fixin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21265-21220-fixin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21265-21220-fixin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21265-21220-fixin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21266-21490-flacey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21266-21490-flacey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21266-21490-flacey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21266-21490-flacey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21267-21640-flagey_echezeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21267-21640-flagey_echezeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21267-21640-flagey_echezeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21267-21640-flagey_echezeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21268-21130-flagey_les_auxonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21268-21130-flagey_les_auxonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21268-21130-flagey_les_auxonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21268-21130-flagey_les_auxonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21269-21130-flammerans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21269-21130-flammerans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21269-21130-flammerans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21269-21130-flammerans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21270-21160-flavignerot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21270-21160-flavignerot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21270-21160-flavignerot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21270-21160-flavignerot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21271-21150-flavigny_sur_ozerain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21271-21150-flavigny_sur_ozerain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21271-21150-flavigny_sur_ozerain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21271-21150-flavigny_sur_ozerain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21272-21140-le_val_larrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21272-21140-le_val_larrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21272-21140-le_val_larrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21272-21140-le_val_larrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21272-21390-le_val_larrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21272-21390-le_val_larrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21272-21390-le_val_larrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21272-21390-le_val_larrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21273-21410-fleurey_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21273-21410-fleurey_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21273-21410-fleurey_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21273-21410-fleurey_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21274-21230-foissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21274-21230-foissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21274-21230-foissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21274-21230-foissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21275-21260-foncegrive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21275-21260-foncegrive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21275-21260-foncegrive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21275-21260-foncegrive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21276-21450-fontaines_en_duesmois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21276-21450-fontaines_en_duesmois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21276-21450-fontaines_en_duesmois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21276-21450-fontaines_en_duesmois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21277-21610-fontaine_francaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21277-21610-fontaine_francaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21277-21610-fontaine_francaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21277-21610-fontaine_francaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21278-21121-fontaine_les_dijon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21278-21121-fontaine_les_dijon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21278-21121-fontaine_les_dijon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21278-21121-fontaine_les_dijon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21279-21330-fontaines_les_seches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21279-21330-fontaines_les_seches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21279-21330-fontaines_les_seches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21279-21330-fontaines_les_seches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21280-21390-fontangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21280-21390-fontangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21280-21390-fontangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21280-21390-fontangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21281-21610-fontenelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21281-21610-fontenelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21281-21610-fontenelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21281-21610-fontenelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21282-21460-forleans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21282-21460-forleans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21282-21460-forleans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21282-21460-forleans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21283-21580-fraignot_et_vesvrotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21283-21580-fraignot_et_vesvrotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21283-21580-fraignot_et_vesvrotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21283-21580-fraignot_et_vesvrotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21284-21440-francheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21284-21440-francheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21284-21440-francheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21284-21440-francheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21285-21170-franxault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21285-21170-franxault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21285-21170-franxault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21285-21170-franxault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21286-21120-frenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21286-21120-frenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21286-21120-frenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21286-21120-frenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21287-21500-fresnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21287-21500-fresnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21287-21500-fresnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21287-21500-fresnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21288-21150-frolois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21288-21150-frolois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21288-21150-frolois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21288-21150-frolois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21289-21700-fussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21289-21700-fussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21289-21700-fussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21289-21700-fussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21290-21120-gemeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21290-21120-gemeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21290-21120-gemeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21290-21120-gemeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21291-21140-genay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21291-21140-genay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21291-21140-genay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21291-21140-genay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21292-21110-genlis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21292-21110-genlis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21292-21110-genlis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21292-21110-genlis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21293-21410-gergueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21293-21410-gergueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21293-21410-gergueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21293-21410-gergueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21294-21700-gerland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21294-21700-gerland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21294-21700-gerland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21294-21700-gerland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21295-21220-gevrey_chambertin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21295-21220-gevrey_chambertin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21295-21220-gevrey_chambertin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21295-21220-gevrey_chambertin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21296-21520-gevrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21296-21520-gevrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21296-21520-gevrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21296-21520-gevrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21297-21640-gilly_les_citeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21297-21640-gilly_les_citeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21297-21640-gilly_les_citeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21297-21640-gilly_les_citeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21298-21350-gissey_le_vieil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21298-21350-gissey_le_vieil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21298-21350-gissey_le_vieil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21298-21350-gissey_le_vieil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21299-21150-gissey_sous_flavigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21299-21150-gissey_sous_flavigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21299-21150-gissey_sous_flavigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21299-21150-gissey_sous_flavigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21300-21410-gissey_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21300-21410-gissey_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21300-21410-gissey_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21300-21410-gissey_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21301-21250-glanon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21301-21250-glanon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21301-21250-glanon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21301-21250-glanon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21302-21400-gommeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21302-21400-gommeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21302-21400-gommeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21302-21400-gommeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21303-21520-les_goulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21303-21520-les_goulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21303-21520-les_goulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21303-21520-les_goulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21304-21580-grancey_le_chateau_neuvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21304-21580-grancey_le_chateau_neuvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21304-21580-grancey_le_chateau_neuvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21304-21580-grancey_le_chateau_neuvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21305-21570-grancey_sur_ource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21305-21570-grancey_sur_ource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21305-21570-grancey_sur_ource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21305-21570-grancey_sur_ource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21306-21540-grenant_les_sombernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21306-21540-grenant_les_sombernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21306-21540-grenant_les_sombernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21306-21540-grenant_les_sombernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21307-21150-gresigny_sainte_reine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21307-21150-gresigny_sainte_reine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21307-21150-gresigny_sainte_reine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21307-21150-gresigny_sainte_reine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21308-21150-grignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21308-21150-grignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21308-21150-grignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21308-21150-grignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21309-21330-griselles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21309-21330-griselles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21309-21330-griselles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21309-21330-griselles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21310-21540-grosbois_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21310-21540-grosbois_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21310-21540-grosbois_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21310-21540-grosbois_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21311-21250-grosbois_les_tichey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21311-21250-grosbois_les_tichey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21311-21250-grosbois_les_tichey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21311-21250-grosbois_les_tichey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21312-21290-gurgy_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21312-21290-gurgy_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21312-21290-gurgy_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21312-21290-gurgy_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21313-21290-gurgy_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21313-21290-gurgy_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21313-21290-gurgy_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21313-21290-gurgy_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21314-21150-hauteroche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21314-21150-hauteroche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21314-21150-hauteroche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21314-21150-hauteroche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21315-21121-hauteville_les_dijon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21315-21121-hauteville_les_dijon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21315-21121-hauteville_les_dijon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21315-21121-hauteville_les_dijon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21316-21270-heuilley_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21316-21270-heuilley_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21316-21270-heuilley_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21316-21270-heuilley_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21317-21120-is_sur_tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21317-21120-is_sur_tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21317-21120-is_sur_tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21317-21120-is_sur_tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21319-21110-izeure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21319-21110-izeure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21319-21110-izeure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21319-21110-izeure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21320-21110-izier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21320-21110-izier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21320-21110-izier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21320-21110-izier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21321-21150-jailly_les_moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21321-21150-jailly_les_moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21321-21150-jailly_les_moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21321-21150-jailly_les_moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21322-21250-jallanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21322-21250-jallanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21322-21250-jallanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21322-21250-jallanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21323-21310-jancigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21323-21310-jancigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21323-21310-jancigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21323-21310-jancigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21324-21460-jeux_les_bard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21324-21460-jeux_les_bard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21324-21460-jeux_les_bard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21324-21460-jeux_les_bard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21325-21230-jouey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21325-21230-jouey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21325-21230-jouey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21325-21230-jouey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21326-21450-jours_les_baigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21326-21450-jours_les_baigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21326-21450-jours_les_baigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21326-21450-jours_les_baigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21327-21340-val_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21327-21340-val_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21327-21340-val_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21327-21340-val_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21328-21210-juillenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21328-21210-juillenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21328-21210-juillenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21328-21210-juillenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21329-21140-juilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21329-21140-juilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21329-21140-juilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21329-21140-juilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21330-21110-labergement_foigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21330-21110-labergement_foigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21330-21110-labergement_foigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21330-21110-labergement_foigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21331-21130-labergement_les_auxonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21331-21130-labergement_les_auxonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21331-21130-labergement_les_auxonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21331-21130-labergement_les_auxonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21332-21820-labergement_les_seurre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21332-21820-labergement_les_seurre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21332-21820-labergement_les_seurre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21332-21820-labergement_les_seurre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21333-21250-labruyere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21333-21250-labruyere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21333-21250-labruyere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21333-21250-labruyere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21334-21230-lacanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21334-21230-lacanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21334-21230-lacanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21334-21230-lacanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21335-21210-lacour_d_arcenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21335-21210-lacour_d_arcenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21335-21210-lacour_d_arcenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21335-21210-lacour_d_arcenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21336-21330-laignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21336-21330-laignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21336-21330-laignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21336-21330-laignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21337-21760-lamarche_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21337-21760-lamarche_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21337-21760-lamarche_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21337-21760-lamarche_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21338-21440-lamargelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21338-21440-lamargelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21338-21440-lamargelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21338-21440-lamargelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21339-21370-lantenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21339-21370-lantenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21339-21370-lantenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21339-21370-lantenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21340-21250-lanthes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21340-21250-lanthes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21340-21250-lanthes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21340-21250-lanthes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21341-21140-lantilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21341-21140-lantilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21341-21140-lantilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21341-21140-lantilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21342-21170-laperriere_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21342-21170-laperriere_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21342-21170-laperriere_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21342-21170-laperriere_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21343-21330-larrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21343-21330-larrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21343-21330-larrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21343-21330-larrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21344-21250-lechatelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21344-21250-lechatelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21344-21250-lechatelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21344-21250-lechatelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21345-21440-lery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21345-21440-lery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21345-21440-lery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21345-21440-lery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21346-21290-leuglay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21346-21290-leuglay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21346-21290-leuglay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21346-21290-leuglay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21347-21200-levernois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21347-21200-levernois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21347-21200-levernois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21347-21200-levernois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21348-21610-licey_sur_vingeanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21348-21610-licey_sur_vingeanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21348-21610-licey_sur_vingeanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21348-21610-licey_sur_vingeanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21349-21430-liernais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21349-21430-liernais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21349-21430-liernais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21349-21430-liernais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21350-21520-lignerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21350-21520-lignerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21350-21520-lignerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21350-21520-lignerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21351-21110-longchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21351-21110-longchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21351-21110-longchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21351-21110-longchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21352-21110-longeault_pluvault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21352-21110-longeault_pluvault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21352-21110-longeault_pluvault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21352-21110-longeault_pluvault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21353-21110-longecourt_en_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21353-21110-longecourt_en_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21353-21110-longecourt_en_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21353-21110-longecourt_en_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21354-21230-longecourt_les_culetre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21354-21230-longecourt_les_culetre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21354-21230-longecourt_les_culetre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21354-21230-longecourt_les_culetre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21355-21600-longvic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21355-21600-longvic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21355-21600-longvic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21355-21600-longvic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21356-21170-losne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21356-21170-losne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21356-21170-losne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21356-21170-losne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21357-21520-louesme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21357-21520-louesme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21357-21520-louesme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21357-21520-louesme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21358-21150-lucenay_le_duc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21358-21150-lucenay_le_duc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21358-21150-lucenay_le_duc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21358-21150-lucenay_le_duc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21359-21290-lucey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21359-21290-lucey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21359-21290-lucey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21359-21290-lucey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21360-21360-lusigny_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21360-21360-lusigny_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21360-21360-lusigny_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21360-21360-lusigny_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21361-21120-lux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21361-21120-lux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21361-21120-lux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21361-21120-lux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21362-21320-maconge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21362-21320-maconge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21362-21320-maconge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21362-21320-maconge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21363-21230-magnien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21363-21230-magnien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21363-21230-magnien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21363-21230-magnien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21364-21450-magny_lambert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21364-21450-magny_lambert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21364-21450-magny_lambert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21364-21450-magny_lambert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21365-21140-magny_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21365-21140-magny_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21365-21140-magny_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21365-21140-magny_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21366-21170-magny_les_aubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21366-21170-magny_les_aubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21366-21170-magny_les_aubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21366-21170-magny_les_aubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21367-21130-magny_montarlot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21367-21130-magny_montarlot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21367-21130-magny_montarlot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21367-21130-magny_montarlot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21368-21700-magny_les_villers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21368-21700-magny_les_villers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21368-21700-magny_les_villers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21368-21700-magny_les_villers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21369-21310-magny_saint_medard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21369-21310-magny_saint_medard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21369-21310-magny_saint_medard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21369-21310-magny_saint_medard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21370-21110-magny_sur_tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21370-21110-magny_sur_tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21370-21110-magny_sur_tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21370-21110-magny_sur_tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21371-21130-les_maillys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21371-21130-les_maillys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21371-21130-les_maillys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21371-21130-les_maillys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21372-21400-maisey_le_duc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21372-21400-maisey_le_duc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21372-21400-maisey_le_duc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21372-21400-maisey_le_duc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21373-21410-malain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21373-21410-malain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21373-21410-malain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21373-21410-malain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21374-21230-maligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21374-21230-maligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21374-21230-maligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21374-21230-maligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21375-21430-manlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21375-21430-manlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21375-21430-manlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21375-21430-manlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21376-21270-marandeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21376-21270-marandeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21376-21270-marandeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21376-21270-marandeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21377-21350-marcellois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21377-21350-marcellois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21377-21350-marcellois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21377-21350-marcellois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21378-21330-marcenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21378-21330-marcenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21378-21330-marcenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21378-21330-marcenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21379-21430-marcheseuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21379-21430-marcheseuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21379-21430-marcheseuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21379-21430-marcheseuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21380-21390-marcigny_sous_thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21380-21390-marcigny_sous_thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21380-21390-marcigny_sous_thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21380-21390-marcigny_sous_thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21381-21350-marcilly_et_dracy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21381-21350-marcilly_et_dracy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21381-21350-marcilly_et_dracy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21381-21350-marcilly_et_dracy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21382-21320-marcilly_ogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21382-21320-marcilly_ogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21382-21320-marcilly_ogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21382-21320-marcilly_ogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21383-21120-marcilly_sur_tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21383-21120-marcilly_sur_tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21383-21120-marcilly_sur_tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21383-21120-marcilly_sur_tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21384-21700-marey_les_fussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21384-21700-marey_les_fussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21384-21700-marey_les_fussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21384-21700-marey_les_fussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21385-21120-marey_sur_tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21385-21120-marey_sur_tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21385-21120-marey_sur_tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21385-21120-marey_sur_tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21386-21150-marigny_le_cahouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21386-21150-marigny_le_cahouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21386-21150-marigny_le_cahouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21386-21150-marigny_le_cahouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21387-21200-marigny_les_reullee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21387-21200-marigny_les_reullee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21387-21200-marigny_les_reullee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21387-21200-marigny_les_reullee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21388-21110-marliens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21388-21110-marliens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21388-21110-marliens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21388-21110-marliens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21389-21500-marmagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21389-21500-marmagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21389-21500-marmagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21389-21500-marmagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21390-21160-marsannay_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21390-21160-marsannay_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21390-21160-marsannay_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21390-21160-marsannay_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21391-21380-marsannay_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21391-21380-marsannay_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21391-21380-marsannay_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21391-21380-marsannay_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21392-21320-martrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21392-21320-martrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21392-21320-martrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21392-21320-martrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21393-21400-massingy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21393-21400-massingy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21393-21400-massingy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21393-21400-massingy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21394-21140-massingy_les_semur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21394-21140-massingy_les_semur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21394-21140-massingy_les_semur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21394-21140-massingy_les_semur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21395-21350-massingy_les_vitteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21395-21350-massingy_les_vitteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21395-21350-massingy_les_vitteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21395-21350-massingy_les_vitteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21396-21510-mauvilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21396-21510-mauvilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21396-21510-mauvilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21396-21510-mauvilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21397-21190-mavilly_mandelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21397-21190-mavilly_mandelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21397-21190-mavilly_mandelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21397-21190-mavilly_mandelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21398-21270-maxilly_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21398-21270-maxilly_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21398-21270-maxilly_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21398-21270-maxilly_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21399-21320-meilly_sur_rouvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21399-21320-meilly_sur_rouvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21399-21320-meilly_sur_rouvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21399-21320-meilly_sur_rouvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21400-21580-le_meix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21400-21580-le_meix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21400-21580-le_meix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21400-21580-le_meix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21401-21190-meloisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21401-21190-meloisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21401-21190-meloisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21401-21190-meloisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21402-21290-menesble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21402-21290-menesble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21402-21290-menesble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21402-21290-menesble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21403-21430-menessaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21403-21430-menessaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21403-21430-menessaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21403-21430-menessaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21404-21150-menetreux_le_pitois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21404-21150-menetreux_le_pitois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21404-21150-menetreux_le_pitois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21404-21150-menetreux_le_pitois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21405-21190-merceuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21405-21190-merceuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21405-21190-merceuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21405-21190-merceuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21406-21540-mesmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21406-21540-mesmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21406-21540-mesmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21406-21540-mesmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21407-21220-messanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21407-21220-messanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21407-21220-messanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21407-21220-messanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21408-21380-messigny_et_vantoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21408-21380-messigny_et_vantoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21408-21380-messigny_et_vantoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21408-21380-messigny_et_vantoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21409-21700-meuilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21409-21700-meuilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21409-21700-meuilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21409-21700-meuilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21410-21510-meulson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21410-21510-meulson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21410-21510-meulson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21410-21510-meulson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21411-21200-meursanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21411-21200-meursanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21411-21200-meursanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21411-21200-meursanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21412-21190-meursault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21412-21190-meursault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21412-21190-meursault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21412-21190-meursault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21413-21140-millery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21413-21140-millery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21413-21140-millery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21413-21140-millery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21414-21230-mimeure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21414-21230-mimeure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21414-21230-mimeure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21414-21230-mimeure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21415-21510-minot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21415-21510-minot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21415-21510-minot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21415-21510-minot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21416-21310-mirebeau_sur_beze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21416-21310-mirebeau_sur_beze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21416-21310-mirebeau_sur_beze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21416-21310-mirebeau_sur_beze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21417-21210-missery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21417-21210-missery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21417-21210-missery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21417-21210-missery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21418-21510-moitron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21418-21510-moitron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21418-21510-moitron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21418-21510-moitron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21419-21330-molesme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21419-21330-molesme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21419-21330-molesme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21419-21330-molesme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21420-21340-molinot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21420-21340-molinot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21420-21340-molinot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21420-21340-molinot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21421-21120-moloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21421-21120-moloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21421-21120-moloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21421-21120-moloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21422-21210-molphey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21422-21210-molphey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21422-21210-molphey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21422-21210-molphey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21423-21200-montagny_les_beaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21423-21200-montagny_les_beaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21423-21200-montagny_les_beaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21423-21200-montagny_les_beaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21424-21250-montagny_les_seurre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21424-21250-montagny_les_seurre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21424-21250-montagny_les_seurre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21424-21250-montagny_les_seurre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21425-21500-montbard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21425-21500-montbard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21425-21500-montbard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21425-21500-montbard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21426-21460-montberthault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21426-21460-montberthault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21426-21460-montberthault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21426-21460-montberthault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21427-21360-montceau_et_echarnant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21427-21360-montceau_et_echarnant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21427-21360-montceau_et_echarnant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21427-21360-montceau_et_echarnant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21428-21190-monthelie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21428-21190-monthelie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21428-21190-monthelie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21428-21190-monthelie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21429-21500-montigny_montfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21429-21500-montigny_montfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21429-21500-montigny_montfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21429-21500-montigny_montfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21430-21390-montigny_saint_barthelemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21430-21390-montigny_saint_barthelemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21430-21390-montigny_saint_barthelemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21430-21390-montigny_saint_barthelemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21431-21140-montigny_sur_armancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21431-21140-montigny_sur_armancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21431-21140-montigny_sur_armancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21431-21140-montigny_sur_armancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21432-21520-montigny_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21432-21520-montigny_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21432-21520-montigny_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21432-21520-montigny_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21433-21610-montigny_mornay_villeneuve_sur_vingeanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21433-21610-montigny_mornay_villeneuve_sur_vingeanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21433-21610-montigny_mornay_villeneuve_sur_vingeanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21433-21610-montigny_mornay_villeneuve_sur_vingeanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21434-21210-montlay_en_auxois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21434-21210-montlay_en_auxois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21434-21210-montlay_en_auxois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21434-21210-montlay_en_auxois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21435-21400-montliot_et_courcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21435-21400-montliot_et_courcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21435-21400-montliot_et_courcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21435-21400-montliot_et_courcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21436-21250-montmain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21436-21250-montmain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21436-21250-montmain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21436-21250-montmain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21437-21270-montmancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21437-21270-montmancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21437-21270-montmancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21437-21270-montmancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21438-21290-montmoyen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21438-21290-montmoyen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21438-21290-montmoyen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21438-21290-montmoyen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21439-21540-montoillot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21439-21540-montoillot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21439-21540-montoillot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21439-21540-montoillot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21440-21170-montot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21440-21170-montot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21440-21170-montot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21440-21170-montot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21441-21320-mont_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21441-21320-mont_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21441-21320-mont_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21441-21320-mont_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21442-21220-morey_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21442-21220-morey_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21442-21220-morey_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21442-21220-morey_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21444-21400-mosson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21444-21400-mosson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21444-21400-mosson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21444-21400-mosson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21445-21210-la_motte_ternant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21445-21210-la_motte_ternant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21445-21210-la_motte_ternant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21445-21210-la_motte_ternant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21446-21500-moutiers_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21446-21500-moutiers_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21446-21500-moutiers_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21446-21500-moutiers_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21447-21230-musigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21447-21230-musigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21447-21230-musigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21447-21230-musigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21448-21150-mussy_la_fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21448-21150-mussy_la_fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21448-21150-mussy_la_fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21448-21150-mussy_la_fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21449-21390-nan_sous_thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21449-21390-nan_sous_thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21449-21390-nan_sous_thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21449-21390-nan_sous_thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21450-21190-nantoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21450-21190-nantoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21450-21190-nantoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21450-21190-nantoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21451-21330-nesle_et_massoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21451-21330-nesle_et_massoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21451-21330-nesle_et_massoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21451-21330-nesle_et_massoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21452-21800-neuilly_les_dijon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21452-21800-neuilly_les_dijon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21452-21800-neuilly_les_dijon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21452-21800-neuilly_les_dijon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21454-21330-nicey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21454-21330-nicey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21454-21330-nicey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21454-21330-nicey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21455-21400-nod_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21455-21400-nod_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21455-21400-nod_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21455-21400-nod_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21456-21500-nogent_les_montbard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21456-21500-nogent_les_montbard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21456-21500-nogent_les_montbard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21456-21500-nogent_les_montbard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21457-21390-noidan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21457-21390-noidan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21457-21390-noidan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21457-21390-noidan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21458-21910-noiron_sous_gevrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21458-21910-noiron_sous_gevrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21458-21910-noiron_sous_gevrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21458-21910-noiron_sous_gevrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21459-21310-noiron_sur_beze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21459-21310-noiron_sur_beze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21459-21310-noiron_sur_beze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21459-21310-noiron_sur_beze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21460-21400-noiron_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21460-21400-noiron_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21460-21400-noiron_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21460-21400-noiron_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21461-21340-nolay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21461-21340-nolay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21461-21340-nolay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21461-21340-nolay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21462-21490-norges_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21462-21490-norges_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21462-21490-norges_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21462-21490-norges_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21463-21390-normier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21463-21390-normier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21463-21390-normier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21463-21390-normier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21464-21700-nuits_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21464-21700-nuits_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21464-21700-nuits_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21464-21700-nuits_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21465-21400-obtree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21465-21400-obtree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21465-21400-obtree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21465-21400-obtree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21466-21450-oigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21466-21450-oigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21466-21450-oigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21466-21450-oigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21467-21310-oisilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21467-21310-oisilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21467-21310-oisilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21467-21310-oisilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21468-21610-orain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21468-21610-orain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21468-21610-orain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21468-21610-orain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21469-21490-orgeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21469-21490-orgeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21469-21490-orgeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21469-21490-orgeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21470-21510-origny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21470-21510-origny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21470-21510-origny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21470-21510-origny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21471-21450-orret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21471-21450-orret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21471-21450-orret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21471-21450-orret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21472-21260-orville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21472-21260-orville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21472-21260-orville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21472-21260-orville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21473-21600-ouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21473-21600-ouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21473-21600-ouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21473-21600-ouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21474-21250-pagny_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21474-21250-pagny_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21474-21250-pagny_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21474-21250-pagny_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21475-21250-pagny_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21475-21250-pagny_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21475-21250-pagny_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21475-21250-pagny_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21476-21360-painblanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21476-21360-painblanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21476-21360-painblanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21476-21360-painblanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21477-21540-panges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21477-21540-panges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21477-21540-panges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21477-21540-panges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21478-21370-pasques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21478-21370-pasques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21478-21370-pasques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21478-21370-pasques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21479-21440-pellerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21479-21440-pellerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21479-21440-pellerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21479-21440-pellerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21480-21420-pernand_vergelesses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21480-21420-pernand_vergelesses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21480-21420-pernand_vergelesses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21480-21420-pernand_vergelesses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21481-21160-perrigny_les_dijon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21481-21160-perrigny_les_dijon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21481-21160-perrigny_les_dijon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21481-21160-perrigny_les_dijon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21482-21270-perrigny_sur_l_ognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21482-21270-perrigny_sur_l_ognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21482-21270-perrigny_sur_l_ognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21482-21270-perrigny_sur_l_ognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21483-21120-pichanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21483-21120-pichanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21483-21120-pichanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21483-21120-pichanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21484-21500-planay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21484-21500-planay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21484-21500-planay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21484-21500-planay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21485-21370-plombieres_les_dijon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21485-21370-plombieres_les_dijon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21485-21370-plombieres_les_dijon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21485-21370-plombieres_les_dijon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21487-21110-pluvet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21487-21110-pluvet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21487-21110-pluvet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21487-21110-pluvet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21488-21330-poincon_les_larrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21488-21330-poincon_les_larrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21488-21330-poincon_les_larrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21488-21330-poincon_les_larrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21489-21440-poiseul_la_grange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21489-21440-poiseul_la_grange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21489-21440-poiseul_la_grange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21489-21440-poiseul_la_grange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21490-21450-poiseul_la_ville_et_laperriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21490-21450-poiseul_la_ville_et_laperriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21490-21450-poiseul_la_ville_et_laperriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21490-21450-poiseul_la_ville_et_laperriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21491-21120-poiseul_les_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21491-21120-poiseul_les_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21491-21120-poiseul_les_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21491-21120-poiseul_les_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21492-21630-pommard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21492-21630-pommard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21492-21630-pommard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21492-21630-pommard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21493-21130-poncey_les_athee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21493-21130-poncey_les_athee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21493-21130-poncey_les_athee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21493-21130-poncey_les_athee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21494-21440-poncey_sur_l_ignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21494-21440-poncey_sur_l_ignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21494-21440-poncey_sur_l_ignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21494-21440-poncey_sur_l_ignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21495-21130-pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21495-21130-pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21495-21130-pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21495-21130-pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21496-21270-pontailler_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21496-21270-pontailler_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21496-21270-pontailler_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21496-21270-pontailler_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21497-21140-pont_et_massene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21497-21140-pont_et_massene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21497-21140-pont_et_massene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21497-21140-pont_et_massene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21498-21350-posanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21498-21350-posanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21498-21350-posanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21498-21350-posanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21499-21400-pothieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21499-21400-pothieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21499-21400-pothieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21499-21400-pothieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21500-21150-pouillenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21500-21150-pouillenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21500-21150-pouillenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21500-21150-pouillenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21501-21320-pouilly_en_auxois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21501-21320-pouilly_en_auxois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21501-21320-pouilly_en_auxois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21501-21320-pouilly_en_auxois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21502-21250-pouilly_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21502-21250-pouilly_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21502-21250-pouilly_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21502-21250-pouilly_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21503-21610-pouilly_sur_vingeanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21503-21610-pouilly_sur_vingeanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21503-21610-pouilly_sur_vingeanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21503-21610-pouilly_sur_vingeanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21504-21410-pralon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21504-21410-pralon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21504-21410-pralon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21504-21410-pralon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21505-21390-precy_sous_thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21505-21390-precy_sous_thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21505-21390-precy_sous_thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21505-21390-precy_sous_thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21506-21700-premeaux_prissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21506-21700-premeaux_prissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21506-21700-premeaux_prissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21506-21700-premeaux_prissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21507-21110-premieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21507-21110-premieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21507-21110-premieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21507-21110-premieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21508-21370-prenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21508-21370-prenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21508-21370-prenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21508-21370-prenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21510-21400-prusly_sur_ource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21510-21400-prusly_sur_ource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21510-21400-prusly_sur_ource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21510-21400-prusly_sur_ource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21511-21400-puits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21511-21400-puits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21511-21400-puits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21511-21400-puits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21512-21190-puligny_montrachet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21512-21190-puligny_montrachet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21512-21190-puligny_montrachet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21512-21190-puligny_montrachet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21514-21510-quemigny_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21514-21510-quemigny_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21514-21510-quemigny_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21514-21510-quemigny_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21515-21800-quetigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21515-21800-quetigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21515-21800-quetigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21515-21800-quetigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21516-21500-quincerot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21516-21500-quincerot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21516-21500-quincerot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21516-21500-quincerot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21517-21700-quincey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21517-21700-quincey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21517-21700-quincey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21517-21700-quincey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21518-21500-quincy_le_vicomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21518-21500-quincy_le_vicomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21518-21500-quincy_le_vicomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21518-21500-quincy_le_vicomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21519-21290-recey_sur_ource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21519-21290-recey_sur_ource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21519-21290-recey_sur_ource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21519-21290-recey_sur_ource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21520-21540-remilly_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21520-21540-remilly_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21520-21540-remilly_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21520-21540-remilly_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21521-21560-remilly_sur_tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21521-21560-remilly_sur_tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21521-21560-remilly_sur_tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21521-21560-remilly_sur_tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21522-21310-reneve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21522-21310-reneve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21522-21310-reneve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21522-21310-reneve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21523-21220-reulle_vergy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21523-21220-reulle_vergy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21523-21220-reulle_vergy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21523-21220-reulle_vergy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21524-21570-riel_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21524-21570-riel_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21524-21570-riel_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21524-21570-riel_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21525-21530-la_roche_en_brenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21525-21530-la_roche_en_brenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21525-21530-la_roche_en_brenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21525-21530-la_roche_en_brenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21526-21510-rochefort_sur_brevon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21526-21510-rochefort_sur_brevon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21526-21510-rochefort_sur_brevon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21526-21510-rochefort_sur_brevon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21527-21340-la_rochepot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21527-21340-la_rochepot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21527-21340-la_rochepot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21527-21340-la_rochepot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21528-21150-la_roche_vanneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21528-21150-la_roche_vanneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21528-21150-la_roche_vanneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21528-21150-la_roche_vanneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21529-21390-roilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21529-21390-roilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21529-21390-roilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21529-21390-roilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21530-21500-rougemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21530-21500-rougemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21530-21500-rougemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21530-21500-rougemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21531-21530-rouvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21531-21530-rouvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21531-21530-rouvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21531-21530-rouvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21532-21110-rouvres_en_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21532-21110-rouvres_en_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21532-21110-rouvres_en_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21532-21110-rouvres_en_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21533-21320-rouvres_sous_meilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21533-21320-rouvres_sous_meilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21533-21320-rouvres_sous_meilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21533-21320-rouvres_sous_meilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21534-21200-ruffey_les_beaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21534-21200-ruffey_les_beaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21534-21200-ruffey_les_beaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21534-21200-ruffey_les_beaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21535-21490-ruffey_les_echirey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21535-21490-ruffey_les_echirey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21535-21490-ruffey_les_echirey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21535-21490-ruffey_les_echirey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21536-21260-sacquenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21536-21260-sacquenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21536-21260-sacquenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21536-21260-sacquenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21537-21350-saffres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21537-21350-saffres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21537-21350-saffres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21537-21350-saffres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21538-21530-saint_andeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21538-21530-saint_andeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21538-21530-saint_andeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21538-21530-saint_andeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21539-21540-saint_anthot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21539-21540-saint_anthot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21539-21540-saint_anthot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21539-21540-saint_anthot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21540-21850-saint_apollinaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21540-21850-saint_apollinaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21540-21850-saint_apollinaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21540-21850-saint_apollinaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21541-21190-saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21541-21190-saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21541-21190-saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21541-21190-saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21542-21700-saint_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21542-21700-saint_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21542-21700-saint_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21542-21700-saint_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21543-21290-saint_broing_les_moines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21543-21290-saint_broing_les_moines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21543-21290-saint_broing_les_moines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21543-21290-saint_broing_les_moines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21544-21350-sainte_colombe_en_auxois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21544-21350-sainte_colombe_en_auxois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21544-21350-sainte_colombe_en_auxois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21544-21350-sainte_colombe_en_auxois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21545-21400-sainte_colombe_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21545-21400-sainte_colombe_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21545-21400-sainte_colombe_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21545-21400-sainte_colombe_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21546-21210-saint_didier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21546-21210-saint_didier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21546-21210-saint_didier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21546-21210-saint_didier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21547-21140-saint_euphrone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21547-21140-saint_euphrone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21547-21140-saint_euphrone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21547-21140-saint_euphrone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21548-21530-saint_germain_de_modeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21548-21530-saint_germain_de_modeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21548-21530-saint_germain_de_modeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21548-21530-saint_germain_de_modeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21549-21510-saint_germain_le_rocheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21549-21510-saint_germain_le_rocheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21549-21510-saint_germain_le_rocheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21549-21510-saint_germain_le_rocheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21550-21500-saint_germain_les_senailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21550-21500-saint_germain_les_senailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21550-21500-saint_germain_les_senailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21550-21500-saint_germain_les_senailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21552-21690-saint_helier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21552-21690-saint_helier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21552-21690-saint_helier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21552-21690-saint_helier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21553-21410-saint_jean_de_boeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21553-21410-saint_jean_de_boeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21553-21410-saint_jean_de_boeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21553-21410-saint_jean_de_boeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21554-21170-saint_jean_de_losne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21554-21170-saint_jean_de_losne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21554-21170-saint_jean_de_losne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21554-21170-saint_jean_de_losne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21555-21490-saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21555-21490-saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21555-21490-saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21555-21490-saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21556-21270-saint_leger_triey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21556-21270-saint_leger_triey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21556-21270-saint_leger_triey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21556-21270-saint_leger_triey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21557-21450-saint_marc_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21557-21450-saint_marc_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21557-21450-saint_marc_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21557-21450-saint_marc_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21558-21200-sainte_marie_la_blanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21558-21200-sainte_marie_la_blanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21558-21200-sainte_marie_la_blanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21558-21200-sainte_marie_la_blanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21559-21410-sainte_marie_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21559-21410-sainte_marie_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21559-21410-sainte_marie_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21559-21410-sainte_marie_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21560-21210-saint_martin_de_la_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21560-21210-saint_martin_de_la_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21560-21210-saint_martin_de_la_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21560-21210-saint_martin_de_la_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21561-21440-saint_martin_du_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21561-21440-saint_martin_du_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21561-21440-saint_martin_du_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21561-21440-saint_martin_du_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21562-21610-saint_maurice_sur_vingeanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21562-21610-saint_maurice_sur_vingeanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21562-21610-saint_maurice_sur_vingeanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21562-21610-saint_maurice_sur_vingeanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21563-21540-saint_mesmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21563-21540-saint_mesmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21563-21540-saint_mesmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21563-21540-saint_mesmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21564-21700-saint_nicolas_les_citeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21564-21700-saint_nicolas_les_citeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21564-21700-saint_nicolas_les_citeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21564-21700-saint_nicolas_les_citeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21565-21220-saint_philibert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21565-21220-saint_philibert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21565-21220-saint_philibert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21565-21220-saint_philibert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21566-21230-saint_pierre_en_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21566-21230-saint_pierre_en_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21566-21230-saint_pierre_en_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21566-21230-saint_pierre_en_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21567-21230-saint_prix_les_arnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21567-21230-saint_prix_les_arnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21567-21230-saint_prix_les_arnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21567-21230-saint_prix_les_arnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21568-21500-saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21568-21500-saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21568-21500-saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21568-21500-saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21569-21190-saint_romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21569-21190-saint_romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21569-21190-saint_romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21569-21190-saint_romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21570-21320-sainte_sabine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21570-21320-sainte_sabine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21570-21320-sainte_sabine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21570-21320-sainte_sabine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21571-21270-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21571-21270-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21571-21270-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21571-21270-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21572-21130-saint_seine_en_bache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21572-21130-saint_seine_en_bache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21572-21130-saint_seine_en_bache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21572-21130-saint_seine_en_bache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21573-21440-saint_seine_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21573-21440-saint_seine_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21573-21440-saint_seine_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21573-21440-saint_seine_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21574-21610-saint_seine_sur_vingeanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21574-21610-saint_seine_sur_vingeanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21574-21610-saint_seine_sur_vingeanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21574-21610-saint_seine_sur_vingeanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21575-21170-saint_symphorien_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21575-21170-saint_symphorien_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21575-21170-saint_symphorien_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21575-21170-saint_symphorien_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21576-21350-saint_thibault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21576-21350-saint_thibault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21576-21350-saint_thibault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21576-21350-saint_thibault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21577-21170-saint_usage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21577-21170-saint_usage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21577-21170-saint_usage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21577-21170-saint_usage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21578-21410-saint_victor_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21578-21410-saint_victor_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21578-21410-saint_victor_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21578-21410-saint_victor_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21579-21580-salives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21579-21580-salives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21579-21580-salives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21579-21580-salives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21580-21690-salmaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21580-21690-salmaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21580-21690-salmaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21580-21690-salmaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21581-21170-samerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21581-21170-samerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21581-21170-samerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21581-21170-samerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21582-21590-santenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21582-21590-santenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21582-21590-santenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21582-21590-santenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21583-21340-santosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21583-21340-santosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21583-21340-santosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21583-21340-santosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21584-21210-saulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21584-21210-saulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21584-21210-saulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21584-21210-saulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21585-21910-saulon_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21585-21910-saulon_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21585-21910-saulon_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21585-21910-saulon_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21586-21910-saulon_la_rue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21586-21910-saulon_la_rue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21586-21910-saulon_la_rue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21586-21910-saulon_la_rue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21587-21120-saulx_le_duc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21587-21120-saulx_le_duc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21587-21120-saulx_le_duc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21587-21120-saulx_le_duc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21588-21360-saussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21588-21360-saussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21588-21360-saussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21588-21360-saussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21589-21380-saussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21589-21380-saussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21589-21380-saussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21589-21380-saussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21590-21420-savigny_les_beaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21590-21420-savigny_les_beaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21590-21420-savigny_les_beaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21590-21420-savigny_les_beaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21591-21380-savigny_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21591-21380-savigny_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21591-21380-savigny_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21591-21380-savigny_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21592-21540-savigny_sous_malain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21592-21540-savigny_sous_malain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21592-21540-savigny_sous_malain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21592-21540-savigny_sous_malain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21593-21430-savilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21593-21430-savilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21593-21430-savilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21593-21430-savilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21594-21500-savoisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21594-21500-savoisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21594-21500-savoisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21594-21500-savoisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21595-21310-savolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21595-21310-savolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21595-21310-savolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21595-21310-savolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21596-21910-savouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21596-21910-savouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21596-21910-savouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21596-21910-savouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21597-21220-segrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21597-21220-segrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21597-21220-segrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21597-21220-segrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21598-21150-seigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21598-21150-seigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21598-21150-seigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21598-21150-seigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21599-21260-selongey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21599-21260-selongey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21599-21260-selongey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21599-21260-selongey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21600-21320-semarey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21600-21320-semarey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21600-21320-semarey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21600-21320-semarey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21601-21220-semezanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21601-21220-semezanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21601-21220-semezanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21601-21220-semezanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21602-21450-semond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21602-21450-semond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21602-21450-semond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21602-21450-semond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21603-21140-semur_en_auxois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21603-21140-semur_en_auxois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21603-21140-semur_en_auxois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21603-21140-semur_en_auxois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21604-21500-senailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21604-21500-senailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21604-21500-senailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21604-21500-senailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21605-21800-sennecey_les_dijon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21605-21800-sennecey_les_dijon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21605-21800-sennecey_les_dijon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21605-21800-sennecey_les_dijon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21606-21550-ladoix_serrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21606-21550-ladoix_serrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21606-21550-ladoix_serrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21606-21550-ladoix_serrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21607-21250-seurre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21607-21250-seurre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21607-21250-seurre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21607-21250-seurre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21608-21530-sincey_les_rouvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21608-21530-sincey_les_rouvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21608-21530-sincey_les_rouvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21608-21530-sincey_les_rouvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21609-21110-soirans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21609-21110-soirans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21609-21110-soirans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21609-21110-soirans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21610-21270-soissons_sur_nacey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21610-21270-soissons_sur_nacey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21610-21270-soissons_sur_nacey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21610-21270-soissons_sur_nacey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21611-21540-sombernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21611-21540-sombernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21611-21540-sombernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21611-21540-sombernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21612-21140-souhey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21612-21140-souhey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21612-21140-souhey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21612-21140-souhey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21613-21350-soussey_sur_brionne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21613-21350-soussey_sur_brionne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21613-21350-soussey_sur_brionne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21613-21350-soussey_sur_brionne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21614-21120-spoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21614-21120-spoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21614-21120-spoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21614-21120-spoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21615-21430-sussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21615-21430-sussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21615-21430-sussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21615-21430-sussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21616-21190-tailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21616-21190-tailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21616-21190-tailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21616-21190-tailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21617-21240-talant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21617-21240-talant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21617-21240-talant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21617-21240-talant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21618-21270-talmay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21618-21270-talmay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21618-21270-talmay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21618-21270-talmay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21619-21310-tanay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21619-21310-tanay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21619-21310-tanay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21619-21310-tanay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21620-21120-tarsul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21620-21120-tarsul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21620-21120-tarsul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21620-21120-tarsul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21622-21110-tart_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21622-21110-tart_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21622-21110-tart_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21622-21110-tart_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21623-21110-tart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21623-21110-tart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21623-21110-tart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21623-21110-tart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21624-21270-tellecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21624-21270-tellecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21624-21270-tellecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21624-21270-tellecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21625-21220-ternant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21625-21220-ternant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21625-21220-ternant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21625-21220-ternant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21626-21290-terrefondree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21626-21290-terrefondree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21626-21290-terrefondree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21626-21290-terrefondree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21627-21150-thenissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21627-21150-thenissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21627-21150-thenissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21627-21150-thenissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21628-21570-thoires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21628-21570-thoires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21628-21570-thoires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21628-21570-thoires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21629-21210-thoisy_la_berchere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21629-21210-thoisy_la_berchere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21629-21210-thoisy_la_berchere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21629-21210-thoisy_la_berchere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21630-21320-thoisy_le_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21630-21320-thoisy_le_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21630-21320-thoisy_le_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21630-21320-thoisy_le_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21631-21360-thomirey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21631-21360-thomirey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21631-21360-thomirey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21631-21360-thomirey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21632-21110-thorey_en_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21632-21110-thorey_en_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21632-21110-thorey_en_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21632-21110-thorey_en_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21633-21350-thorey_sous_charny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21633-21350-thorey_sous_charny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21633-21350-thorey_sous_charny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21633-21350-thorey_sous_charny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21634-21360-thorey_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21634-21360-thorey_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21634-21360-thorey_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21634-21360-thorey_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21635-21460-thoste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21635-21460-thoste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21635-21460-thoste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21635-21460-thoste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21636-21340-thury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21636-21340-thury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21636-21340-thury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21636-21340-thury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21637-21250-tichey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21637-21250-tichey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21637-21250-tichey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21637-21250-tichey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21638-21120-til_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21638-21120-til_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21638-21120-til_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21638-21120-til_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21639-21130-tillenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21639-21130-tillenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21639-21130-tillenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21639-21130-tillenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21640-21460-torcy_et_pouligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21640-21460-torcy_et_pouligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21640-21460-torcy_et_pouligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21640-21460-torcy_et_pouligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21641-21500-touillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21641-21500-touillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21641-21500-touillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21641-21500-touillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21642-21460-toutry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21642-21460-toutry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21642-21460-toutry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21642-21460-toutry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21643-21130-treclun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21643-21130-treclun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21643-21130-treclun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21643-21130-treclun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21644-21310-trocheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21644-21310-trocheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21644-21310-trocheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21644-21310-trocheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21645-21170-trouhans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21645-21170-trouhans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21645-21170-trouhans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21645-21170-trouhans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21646-21440-trouhaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21646-21440-trouhaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21646-21440-trouhaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21646-21440-trouhaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21647-21250-trugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21647-21250-trugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21647-21250-trugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21647-21250-trugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21648-21540-turcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21648-21540-turcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21648-21540-turcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21648-21540-turcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21649-21350-uncey_le_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21649-21350-uncey_le_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21649-21350-uncey_le_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21649-21350-uncey_le_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21650-21220-urcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21650-21220-urcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21650-21220-urcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21650-21220-urcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21651-21121-val_suzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21651-21121-val_suzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21651-21121-val_suzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21651-21121-val_suzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21652-21320-vandenesse_en_auxois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21652-21320-vandenesse_en_auxois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21652-21320-vandenesse_en_auxois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21652-21320-vandenesse_en_auxois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21653-21400-vannaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21653-21400-vannaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21653-21400-vannaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21653-21400-vannaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21655-21400-vanvey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21655-21400-vanvey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21655-21400-vanvey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21655-21400-vanvey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21656-21110-varanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21656-21110-varanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21656-21110-varanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21656-21110-varanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21657-21490-varois_et_chaignot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21657-21490-varois_et_chaignot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21657-21490-varois_et_chaignot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21657-21490-varois_et_chaignot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21659-21440-vaux_saules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21659-21440-vaux_saules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21659-21440-vaux_saules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21659-21440-vaux_saules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21660-21360-veilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21660-21360-veilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21660-21360-veilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21660-21360-veilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21661-21370-velars_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21661-21370-velars_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21661-21370-velars_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21661-21370-velars_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21662-21350-velogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21662-21350-velogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21662-21350-velogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21662-21350-velogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21663-21150-venarey_les_laumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21663-21150-venarey_les_laumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21663-21150-venarey_les_laumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21663-21150-venarey_les_laumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21664-21330-verdonnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21664-21330-verdonnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21664-21330-verdonnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21664-21330-verdonnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21665-21260-vernois_les_vesvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21665-21260-vernois_les_vesvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21665-21260-vernois_les_vesvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21665-21260-vernois_les_vesvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21666-21120-vernot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21666-21120-vernot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21666-21120-vernot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21666-21120-vernot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21667-21260-veronnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21667-21260-veronnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21667-21260-veronnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21667-21260-veronnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21669-21540-verrey_sous_dree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21669-21540-verrey_sous_dree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21669-21540-verrey_sous_dree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21669-21540-verrey_sous_dree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21670-21690-verrey_sous_salmaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21670-21690-verrey_sous_salmaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21670-21690-verrey_sous_salmaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21670-21690-verrey_sous_salmaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21671-21330-vertault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21671-21330-vertault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21671-21330-vertault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21671-21330-vertault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21672-21350-vesvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21672-21350-vesvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21672-21350-vesvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21672-21350-vesvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21673-21360-veuvey_sur_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21673-21360-veuvey_sur_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21673-21360-veuvey_sur_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21673-21360-veuvey_sur_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21674-21520-veuxhaulles_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21674-21520-veuxhaulles_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21674-21520-veuxhaulles_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21674-21520-veuxhaulles_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21675-21430-vianges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21675-21430-vianges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21675-21430-vianges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21675-21430-vianges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21676-21140-vic_de_chassenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21676-21140-vic_de_chassenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21676-21140-vic_de_chassenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21676-21140-vic_de_chassenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21677-21360-vic_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21677-21360-vic_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21677-21360-vic_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21677-21360-vic_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21678-21390-vic_sous_thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21678-21390-vic_sous_thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21678-21390-vic_sous_thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21678-21390-vic_sous_thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21679-21540-vieilmoulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21679-21540-vieilmoulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21679-21540-vieilmoulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21679-21540-vieilmoulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21680-21270-vielverge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21680-21270-vielverge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21680-21270-vielverge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21680-21270-vielverge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21681-21460-vieux_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21681-21460-vieux_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21681-21460-vieux_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21681-21460-vieux_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21682-21310-vievigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21682-21310-vievigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21682-21310-vievigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21682-21310-vievigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21683-21230-vievy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21683-21230-vievy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21683-21230-vievy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21683-21230-vievy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21684-21200-vignoles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21684-21200-vignoles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21684-21200-vignoles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21684-21200-vignoles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21685-21450-villaines_en_duesmois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21685-21450-villaines_en_duesmois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21685-21450-villaines_en_duesmois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21685-21450-villaines_en_duesmois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21686-21500-villaines_les_prevotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21686-21500-villaines_les_prevotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21686-21500-villaines_les_prevotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21686-21500-villaines_les_prevotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21687-21210-villargoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21687-21210-villargoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21687-21210-villargoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21687-21210-villargoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21688-21700-villars_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21688-21700-villars_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21688-21700-villars_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21688-21700-villars_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21689-21140-villars_et_villenotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21689-21140-villars_et_villenotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21689-21140-villars_et_villenotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21689-21140-villars_et_villenotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21690-21350-villeberny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21690-21350-villeberny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21690-21350-villeberny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21690-21350-villeberny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21691-21700-villebichot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21691-21700-villebichot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21691-21700-villebichot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21691-21700-villebichot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21692-21120-villecomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21692-21120-villecomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21692-21120-villecomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21692-21120-villecomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21693-21330-villedieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21693-21330-villedieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21693-21330-villedieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21693-21330-villedieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21694-21350-villeferry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21694-21350-villeferry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21694-21350-villeferry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21694-21350-villeferry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21695-21450-la_villeneuve_les_convers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21695-21450-la_villeneuve_les_convers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21695-21450-la_villeneuve_les_convers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21695-21450-la_villeneuve_les_convers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21696-21140-villeneuve_sous_charigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21696-21140-villeneuve_sous_charigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21696-21140-villeneuve_sous_charigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21696-21140-villeneuve_sous_charigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21698-21700-villers_la_faye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21698-21700-villers_la_faye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21698-21700-villers_la_faye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21698-21700-villers_la_faye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21699-21130-villers_les_pots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21699-21130-villers_les_pots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21699-21130-villers_les_pots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21699-21130-villers_les_pots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21700-21400-villers_patras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21700-21400-villers_patras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21700-21400-villers_patras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21700-21400-villers_patras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21701-21130-villers_rotin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21701-21130-villers_rotin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21701-21130-villers_rotin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21701-21130-villers_rotin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21702-21120-villey_sur_tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21702-21120-villey_sur_tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21702-21120-villey_sur_tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21702-21120-villey_sur_tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21703-21430-villiers_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21703-21430-villiers_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21703-21430-villiers_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21703-21430-villiers_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21704-21400-villiers_le_duc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21704-21400-villiers_le_duc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21704-21400-villiers_le_duc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21704-21400-villiers_le_duc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21705-21690-villotte_saint_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21705-21690-villotte_saint_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21705-21690-villotte_saint_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21705-21690-villotte_saint_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21706-21400-villotte_sur_ource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21706-21400-villotte_sur_ource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21706-21400-villotte_sur_ource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21706-21400-villotte_sur_ource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21707-21350-villy_en_auxois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21707-21350-villy_en_auxois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21707-21350-villy_en_auxois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21707-21350-villy_en_auxois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21708-21250-villy_le_moutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21708-21250-villy_le_moutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21708-21250-villy_le_moutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21708-21250-villy_le_moutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21709-21500-viserny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21709-21500-viserny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21709-21500-viserny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21709-21500-viserny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21710-21350-vitteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21710-21350-vitteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21710-21350-vitteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21710-21350-vitteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21711-21400-vix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21711-21400-vix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21711-21400-vix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21711-21400-vix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21712-21190-volnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21712-21190-volnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21712-21190-volnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21712-21190-volnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21713-21270-vonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21713-21270-vonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21713-21270-vonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21713-21270-vonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21714-21700-vosne_romanee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21714-21700-vosne_romanee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21714-21700-vosne_romanee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21714-21700-vosne_romanee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21715-21230-voudenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21715-21230-voudenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21715-21230-voudenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21715-21230-voudenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21716-21640-vougeot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21716-21640-vougeot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21716-21640-vougeot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21716-21640-vougeot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21717-21290-voulaines_les_templiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21717-21290-voulaines_les_templiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21717-21290-voulaines_les_templiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt21-cote_d_or/commune21717-21290-voulaines_les_templiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-22.xml
+++ b/public/sitemaps/sitemap-22.xml
@@ -5,704 +5,1404 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22001-22460-allineuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22001-22460-allineuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22001-22460-allineuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22001-22460-allineuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22002-22400-andel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22002-22400-andel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22002-22400-andel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22002-22400-andel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22003-22100-aucaleuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22003-22100-aucaleuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22003-22100-aucaleuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22003-22100-aucaleuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22004-22140-begard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22004-22140-begard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22004-22140-begard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22004-22140-begard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22005-22810-belle_isle_en_terre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22005-22810-belle_isle_en_terre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22005-22810-belle_isle_en_terre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22005-22810-belle_isle_en_terre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22006-22140-berhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22006-22140-berhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22006-22140-berhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22006-22140-berhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22008-22100-bobital/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22008-22100-bobital/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22008-22100-bobital/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22008-22100-bobital/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22009-22320-le_bodeo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22009-22320-le_bodeo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22009-22320-le_bodeo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22009-22320-le_bodeo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22011-22170-boqueho/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22011-22170-boqueho/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22011-22170-boqueho/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22011-22170-boqueho/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22012-22240-la_bouillie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22012-22240-la_bouillie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22012-22240-la_bouillie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22012-22240-la_bouillie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22013-22390-bourbriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22013-22390-bourbriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22013-22390-bourbriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22013-22390-bourbriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22014-22130-bourseul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22014-22130-bourseul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22014-22130-bourseul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22014-22130-bourseul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22015-22510-brehand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22015-22510-brehand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22015-22510-brehand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22015-22510-brehand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22016-22870-ile_de_brehat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22016-22870-ile_de_brehat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22016-22870-ile_de_brehat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22016-22870-ile_de_brehat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22018-22140-brelidy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22018-22140-brelidy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22018-22140-brelidy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22018-22140-brelidy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22019-22170-bringolo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22019-22170-bringolo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22019-22170-bringolo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22019-22170-bringolo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22020-22250-broons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22020-22250-broons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22020-22250-broons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22020-22250-broons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22021-22100-brusvily/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22021-22100-brusvily/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22021-22100-brusvily/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22021-22100-brusvily/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22023-22160-bulat_pestivien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22023-22160-bulat_pestivien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22023-22160-bulat_pestivien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22023-22160-bulat_pestivien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22024-22160-calanhel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22024-22160-calanhel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22024-22160-calanhel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22024-22160-calanhel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22025-22160-callac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22025-22160-callac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22025-22160-callac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22025-22160-callac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22026-22100-calorguen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22026-22100-calorguen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22026-22100-calorguen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22026-22100-calorguen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22027-22210-le_cambout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22027-22210-le_cambout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22027-22210-le_cambout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22027-22210-le_cambout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22028-22450-camlez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22028-22450-camlez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22028-22450-camlez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22028-22450-camlez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22029-22480-canihuel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22029-22480-canihuel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22029-22480-canihuel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22029-22480-canihuel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22030-22300-caouennec_lanvezeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22030-22300-caouennec_lanvezeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22030-22300-caouennec_lanvezeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22030-22300-caouennec_lanvezeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22031-22160-carnoet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22031-22160-carnoet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22031-22160-carnoet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22031-22160-carnoet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22032-22350-caulnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22032-22350-caulnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22032-22350-caulnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22032-22350-caulnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22033-22530-caurel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22033-22530-caurel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22033-22530-caurel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22033-22530-caurel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22034-22140-cavan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22034-22140-cavan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22034-22140-cavan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22034-22140-cavan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22035-22630-les_champs_geraux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22035-22630-les_champs_geraux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22035-22630-les_champs_geraux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22035-22630-les_champs_geraux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22036-22350-la_chapelle_blanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22036-22350-la_chapelle_blanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22036-22350-la_chapelle_blanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22036-22350-la_chapelle_blanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22037-22160-la_chapelle_neuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22037-22160-la_chapelle_neuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22037-22160-la_chapelle_neuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22037-22160-la_chapelle_neuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22039-22210-la_cheze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22039-22210-la_cheze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22039-22210-la_cheze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22039-22210-la_cheze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22040-22970-coadout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22040-22970-coadout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22040-22970-coadout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22040-22970-coadout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22041-22140-coatascorn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22041-22140-coatascorn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22041-22140-coatascorn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22041-22140-coatascorn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22042-22450-coatreven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22042-22450-coatreven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22042-22450-coatreven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22042-22450-coatreven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22043-22210-coetlogon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22043-22210-coetlogon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22043-22210-coetlogon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22043-22210-coetlogon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22044-22400-coetmieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22044-22400-coetmieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22044-22400-coetmieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22044-22400-coetmieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22045-22800-cohiniac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22045-22800-cohiniac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22045-22800-cohiniac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22045-22800-cohiniac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22046-22330-le_mene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22046-22330-le_mene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22046-22330-le_mene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22046-22330-le_mene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22047-22320-corlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22047-22320-corlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22047-22320-corlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22047-22320-corlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22048-22130-corseul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22048-22130-corseul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22048-22130-corseul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22048-22130-corseul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22049-22130-crehen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22049-22130-crehen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22049-22130-crehen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22049-22130-crehen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22050-22100-dinan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22050-22100-dinan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22050-22100-dinan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22050-22100-dinan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22052-22160-duault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22052-22160-duault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22052-22160-duault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22052-22160-duault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22053-22250-ereac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22053-22250-ereac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22053-22250-ereac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22053-22250-ereac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22054-22430-erquy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22054-22430-erquy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22054-22430-erquy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22054-22430-erquy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22055-22520-binic_etables_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22055-22520-binic_etables_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22055-22520-binic_etables_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22055-22520-binic_etables_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22055-22680-binic_etables_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22055-22680-binic_etables_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22055-22680-binic_etables_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22055-22680-binic_etables_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22056-22630-evran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22056-22630-evran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22056-22630-evran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22056-22630-evran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22057-22290-le_faouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22057-22290-le_faouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22057-22290-le_faouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22057-22290-le_faouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22059-22800-le_foeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22059-22800-le_foeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22059-22800-le_foeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22059-22800-le_foeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22060-22150-gausson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22060-22150-gausson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22060-22150-gausson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22060-22150-gausson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22061-22110-glomel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22061-22110-glomel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22061-22110-glomel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22061-22110-glomel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22062-22230-gomene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22062-22230-gomene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22062-22230-gomene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22062-22230-gomene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22063-22290-gommenec_h/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22063-22290-gommenec_h/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22063-22290-gommenec_h/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22063-22290-gommenec_h/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22064-22570-gouarec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22064-22570-gouarec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22064-22570-gouarec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22064-22570-gouarec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22065-22290-goudelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22065-22290-goudelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22065-22290-goudelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22065-22290-goudelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22067-22200-graces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22067-22200-graces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22067-22200-graces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22067-22200-graces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22068-22460-grace_uzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22068-22460-grace_uzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22068-22460-grace_uzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22068-22460-grace_uzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22069-22350-guenroc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22069-22350-guenroc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22069-22350-guenroc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22069-22350-guenroc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22070-22200-guingamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22070-22200-guingamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22070-22200-guingamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22070-22200-guingamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22071-22350-guitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22071-22350-guitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22071-22350-guitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22071-22350-guitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22072-22390-gurunhuel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22072-22390-gurunhuel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22072-22390-gurunhuel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22072-22390-gurunhuel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22073-22320-la_harmoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22073-22320-la_harmoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22073-22320-la_harmoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22073-22320-la_harmoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22074-22320-le_haut_corlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22074-22320-le_haut_corlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22074-22320-le_haut_corlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22074-22320-le_haut_corlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22075-22600-hemonstoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22075-22600-hemonstoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22075-22600-hemonstoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22075-22600-hemonstoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22076-22550-henanbihen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22076-22550-henanbihen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22076-22550-henanbihen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22076-22550-henanbihen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22077-22400-henansal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22077-22400-henansal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22077-22400-henansal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22077-22400-henansal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22079-22150-henon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22079-22150-henon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22079-22150-henon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22079-22150-henon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22081-22120-hillion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22081-22120-hillion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22081-22120-hillion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22081-22120-hillion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22082-22100-le_hingle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22082-22100-le_hingle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22082-22100-le_hingle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22082-22100-le_hingle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22083-22230-illifaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22083-22230-illifaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22083-22230-illifaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22083-22230-illifaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22084-22270-jugon_les_lacs___commune_nouvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22084-22270-jugon_les_lacs___commune_nouvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22084-22270-jugon_les_lacs___commune_nouvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22084-22270-jugon_les_lacs___commune_nouvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22085-22610-kerbors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22085-22610-kerbors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22085-22610-kerbors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22085-22610-kerbors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22086-22500-kerfot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22086-22500-kerfot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22086-22500-kerfot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22086-22500-kerfot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22087-22110-kergrist_moelou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22087-22110-kergrist_moelou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22087-22110-kergrist_moelou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22087-22110-kergrist_moelou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22088-22480-kerien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22088-22480-kerien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22088-22480-kerien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22088-22480-kerien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22090-22450-kermaria_sulard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22090-22450-kermaria_sulard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22090-22450-kermaria_sulard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22090-22450-kermaria_sulard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22091-22140-kermoroc_h/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22091-22140-kermoroc_h/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22091-22140-kermoroc_h/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22091-22140-kermoroc_h/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22092-22480-kerpert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22092-22480-kerpert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22092-22480-kerpert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22092-22480-kerpert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22093-22400-lamballe_armor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22093-22400-lamballe_armor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22093-22400-lamballe_armor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22093-22400-lamballe_armor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22094-22770-lancieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22094-22770-lancieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22094-22770-lancieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22094-22770-lancieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22095-22140-landebaeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22095-22140-landebaeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22095-22140-landebaeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22095-22140-landebaeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22096-22130-landebia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22096-22130-landebia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22096-22130-landebia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22096-22130-landebia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22097-22980-la_landec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22097-22980-la_landec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22097-22980-la_landec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22097-22980-la_landec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22098-22400-landehen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22098-22400-landehen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22098-22400-landehen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22098-22400-landehen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22099-22800-lanfains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22099-22800-lanfains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22099-22800-lanfains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22099-22800-lanfains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22101-22450-langoat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22101-22450-langoat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22101-22450-langoat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22101-22450-langoat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22103-22490-langrolay_sur_rance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22103-22490-langrolay_sur_rance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22103-22490-langrolay_sur_rance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22103-22490-langrolay_sur_rance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22104-22980-languedias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22104-22980-languedias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22104-22980-languedias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22104-22980-languedias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22105-22130-languenan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22105-22130-languenan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22105-22130-languenan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22105-22130-languenan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22106-22360-langueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22106-22360-langueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22106-22360-langueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22106-22360-langueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22107-22570-bon_repos_sur_blavet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22107-22570-bon_repos_sur_blavet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22107-22570-bon_repos_sur_blavet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22107-22570-bon_repos_sur_blavet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22108-22290-lanleff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22108-22290-lanleff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22108-22290-lanleff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22108-22290-lanleff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22109-22580-lanloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22109-22580-lanloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22109-22580-lanloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22109-22580-lanloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22110-22300-lanmerin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22110-22300-lanmerin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22110-22300-lanmerin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22110-22300-lanmerin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22111-22610-lanmodez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22111-22610-lanmodez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22111-22610-lanmodez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22111-22610-lanmodez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22112-22290-lannebert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22112-22290-lannebert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22112-22290-lannebert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22112-22290-lannebert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22113-22300-lannion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22113-22300-lannion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22113-22300-lannion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22113-22300-lannion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22114-22250-lanrelas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22114-22250-lanrelas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22114-22250-lanrelas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22114-22250-lanrelas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22115-22480-lanrivain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22115-22480-lanrivain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22115-22480-lanrivain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22115-22480-lanrivain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22116-22170-lanrodec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22116-22170-lanrodec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22116-22170-lanrodec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22116-22170-lanrodec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22117-22410-lantic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22117-22410-lantic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22117-22410-lantic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22117-22410-lantic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22118-22100-lanvallay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22118-22100-lanvallay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22118-22100-lanvallay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22118-22100-lanvallay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22119-22420-lanvellec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22119-22420-lanvellec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22119-22420-lanvellec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22119-22420-lanvellec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22121-22290-lanvollon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22121-22290-lanvollon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22121-22290-lanvollon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22121-22290-lanvollon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22122-22230-laurenan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22122-22230-laurenan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22122-22230-laurenan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22122-22230-laurenan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22124-22570-lescouet_gouarec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22124-22570-lescouet_gouarec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22124-22570-lescouet_gouarec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22124-22570-lescouet_gouarec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22126-22800-le_leslay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22126-22800-le_leslay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22126-22800-le_leslay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22126-22800-le_leslay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22127-22740-lezardrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22127-22740-lezardrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22127-22740-lezardrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22127-22740-lezardrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22128-22340-locarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22128-22340-locarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22128-22340-locarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22128-22340-locarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22129-22810-loc_envel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22129-22810-loc_envel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22129-22810-loc_envel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22129-22810-loc_envel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22131-22780-loguivy_plougras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22131-22780-loguivy_plougras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22131-22780-loguivy_plougras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22131-22780-loguivy_plougras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22132-22160-lohuec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22132-22160-lohuec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22132-22160-lohuec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22132-22160-lohuec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22133-22230-loscouet_sur_meu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22133-22230-loscouet_sur_meu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22133-22230-loscouet_sur_meu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22133-22230-loscouet_sur_meu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22134-22700-louannec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22134-22700-louannec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22134-22700-louannec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22134-22700-louannec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22135-22540-louargat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22135-22540-louargat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22135-22540-louargat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22135-22540-louargat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22136-22600-loudeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22136-22600-loudeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22136-22600-loudeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22136-22600-loudeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22137-22340-mael_carhaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22137-22340-mael_carhaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22137-22340-mael_carhaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22137-22340-mael_carhaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22138-22160-mael_pestivien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22138-22160-mael_pestivien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22138-22160-mael_pestivien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22138-22160-mael_pestivien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22139-22480-magoar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22139-22480-magoar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22139-22480-magoar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22139-22480-magoar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22140-22640-la_malhoure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22140-22640-la_malhoure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22140-22640-la_malhoure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22140-22640-la_malhoure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22141-22450-mantallot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22141-22450-mantallot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22141-22450-mantallot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22141-22450-mantallot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22143-22550-matignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22143-22550-matignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22143-22550-matignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22143-22550-matignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22144-22440-la_meaugon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22144-22440-la_meaugon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22144-22440-la_meaugon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22144-22440-la_meaugon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22145-22270-megrit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22145-22270-megrit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22145-22270-megrit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22145-22270-megrit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22146-22110-mellionnec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22146-22110-mellionnec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22146-22110-mellionnec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22146-22110-mellionnec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22147-22230-merdrignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22147-22230-merdrignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22147-22230-merdrignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22147-22230-merdrignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22148-22230-merillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22148-22230-merillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22148-22230-merillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22148-22230-merillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22149-22460-merleac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22149-22460-merleac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22149-22460-merleac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22149-22460-merleac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22150-22200-le_merzer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22150-22200-le_merzer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22150-22200-le_merzer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22150-22200-le_merzer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22152-22220-minihy_treguier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22152-22220-minihy_treguier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22152-22220-minihy_treguier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22152-22220-minihy_treguier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22153-22510-moncontour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22153-22510-moncontour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22153-22510-moncontour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22153-22510-moncontour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22155-22600-la_motte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22155-22600-la_motte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22155-22600-la_motte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22155-22600-la_motte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22156-22200-mousteru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22156-22200-mousteru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22156-22200-mousteru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22156-22200-mousteru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22157-22340-le_moustoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22157-22340-le_moustoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22157-22340-le_moustoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22157-22340-le_moustoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22158-22530-guerledan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22158-22530-guerledan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22158-22530-guerledan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22158-22530-guerledan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22160-22400-noyal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22160-22400-noyal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22160-22400-noyal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22160-22400-noyal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22161-22200-pabu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22161-22200-pabu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22161-22200-pabu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22161-22200-pabu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22162-22500-paimpol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22162-22500-paimpol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22162-22500-paimpol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22162-22500-paimpol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22163-22340-paule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22163-22340-paule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22163-22340-paule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22163-22340-paule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22164-22540-pedernec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22164-22540-pedernec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22164-22540-pedernec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22164-22540-pedernec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22165-22510-penguily/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22165-22510-penguily/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22165-22510-penguily/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22165-22510-penguily/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22166-22710-penvenan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22166-22710-penvenan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22166-22710-penvenan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22166-22710-penvenan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22168-22700-perros_guirec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22168-22700-perros_guirec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22168-22700-perros_guirec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22168-22700-perros_guirec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22169-22480-peumerit_quintin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22169-22480-peumerit_quintin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22169-22480-peumerit_quintin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22169-22480-peumerit_quintin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22170-22800-plaine_haute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22170-22800-plaine_haute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22170-22800-plaine_haute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22170-22800-plaine_haute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22171-22940-plaintel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22171-22940-plaintel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22171-22940-plaintel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22171-22940-plaintel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22172-22130-plancoet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22172-22130-plancoet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22172-22130-plancoet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22172-22130-plancoet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22174-22550-pleboulle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22174-22550-pleboulle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22174-22550-pleboulle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22174-22550-pleboulle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22175-22270-pledeliac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22175-22270-pledeliac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22175-22270-pledeliac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22175-22270-pledeliac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22176-22960-pledran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22176-22960-pledran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22176-22960-pledran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22176-22960-pledran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22177-22290-pleguien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22177-22290-pleguien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22177-22290-pleguien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22177-22290-pleguien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22178-22290-plehedel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22178-22290-plehedel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22178-22290-plehedel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22178-22290-plehedel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22179-22240-frehel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22179-22240-frehel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22179-22240-frehel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22179-22240-frehel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22180-22980-plelan_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22180-22980-plelan_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22180-22980-plelan_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22180-22980-plelan_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22181-22570-plelauff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22181-22570-plelauff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22181-22570-plelauff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22181-22570-plelauff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22182-22170-plelo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22182-22170-plelo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22182-22170-plelo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22182-22170-plelo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22183-22210-plemet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22183-22210-plemet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22183-22210-plemet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22183-22210-plemet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22184-22150-plemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22184-22150-plemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22184-22150-plemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22184-22150-plemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22185-22640-plenee_jugon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22185-22640-plenee_jugon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22185-22640-plenee_jugon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22185-22640-plenee_jugon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22186-22370-pleneuf_val_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22186-22370-pleneuf_val_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22186-22370-pleneuf_val_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22186-22370-pleneuf_val_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22187-22190-plerin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22187-22190-plerin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22187-22190-plerin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22187-22190-plerin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22188-22170-plerneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22188-22170-plerneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22188-22170-plerneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22188-22170-plerneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22189-22720-plesidy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22189-22720-plesidy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22189-22720-plesidy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22189-22720-plesidy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22190-22490-pleslin_trigavou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22190-22490-pleslin_trigavou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22190-22490-pleslin_trigavou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22190-22490-pleslin_trigavou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22193-22640-plestan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22193-22640-plestan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22193-22640-plestan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22193-22640-plestan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22194-22310-plestin_les_greves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22194-22310-plestin_les_greves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22194-22310-plestin_les_greves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22194-22310-plestin_les_greves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22195-22610-pleubian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22195-22610-pleubian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22195-22610-pleubian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22195-22610-pleubian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22196-22740-pleudaniel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22196-22740-pleudaniel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22196-22740-pleudaniel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22196-22740-pleudaniel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22197-22690-pleudihen_sur_rance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22197-22690-pleudihen_sur_rance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22197-22690-pleudihen_sur_rance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22197-22690-pleudihen_sur_rance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22198-22560-pleumeur_bodou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22198-22560-pleumeur_bodou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22198-22560-pleumeur_bodou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22198-22560-pleumeur_bodou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22199-22740-pleumeur_gautier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22199-22740-pleumeur_gautier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22199-22740-pleumeur_gautier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22199-22740-pleumeur_gautier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22200-22130-pleven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22200-22130-pleven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22200-22130-pleven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22200-22130-pleven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22201-22240-plevenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22201-22240-plevenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22201-22240-plevenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22201-22240-plevenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22202-22340-plevin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22202-22340-plevin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22202-22340-plevin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22202-22340-plevin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22203-22150-ploeuc_l_hermitage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22203-22150-ploeuc_l_hermitage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22203-22150-ploeuc_l_hermitage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22203-22150-ploeuc_l_hermitage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22204-22260-ploezal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22204-22260-ploezal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22204-22260-ploezal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22204-22260-ploezal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22205-22130-plorec_sur_arguenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22205-22130-plorec_sur_arguenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22205-22130-plorec_sur_arguenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22205-22130-plorec_sur_arguenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22206-22170-chatelaudren_plouagat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22206-22170-chatelaudren_plouagat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22206-22170-chatelaudren_plouagat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22206-22170-chatelaudren_plouagat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22207-22420-plouaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22207-22420-plouaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22207-22420-plouaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22207-22420-plouaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22208-22830-plouasne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22208-22830-plouasne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22208-22830-plouasne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22208-22830-plouasne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22209-22650-beaussais_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22209-22650-beaussais_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22209-22650-beaussais_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22209-22650-beaussais_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22210-22620-ploubazlanec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22210-22620-ploubazlanec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22210-22620-ploubazlanec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22210-22620-ploubazlanec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22211-22300-ploubezre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22211-22300-ploubezre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22211-22300-ploubezre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22211-22300-ploubezre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22212-22260-plouec_du_trieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22212-22260-plouec_du_trieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22212-22260-plouec_du_trieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22212-22260-plouec_du_trieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22213-22490-plouer_sur_rance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22213-22490-plouer_sur_rance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22213-22490-plouer_sur_rance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22213-22490-plouer_sur_rance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22214-22470-plouezec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22214-22470-plouezec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22214-22470-plouezec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22214-22470-plouezec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22215-22440-ploufragan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22215-22440-ploufragan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22215-22440-ploufragan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22215-22440-ploufragan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22216-22810-plougonver/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22216-22810-plougonver/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22216-22810-plougonver/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22216-22810-plougonver/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22217-22780-plougras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22217-22780-plougras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22217-22780-plougras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22217-22780-plougras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22218-22820-plougrescant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22218-22820-plougrescant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22218-22820-plougrescant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22218-22820-plougrescant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22219-22150-plouguenast_langast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22219-22150-plouguenast_langast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22219-22150-plouguenast_langast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22219-22150-plouguenast_langast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22220-22110-plouguernevel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22220-22110-plouguernevel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22220-22110-plouguernevel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22220-22110-plouguernevel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22221-22220-plouguiel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22221-22220-plouguiel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22221-22220-plouguiel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22221-22220-plouguiel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22222-22580-plouha/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22222-22580-plouha/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22222-22580-plouha/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22222-22580-plouha/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22223-22200-plouisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22223-22200-plouisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22223-22200-plouisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22223-22200-plouisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22224-22300-ploulec_h/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22224-22300-ploulec_h/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22224-22300-ploulec_h/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22224-22300-ploulec_h/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22225-22970-ploumagoar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22225-22970-ploumagoar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22225-22970-ploumagoar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22225-22970-ploumagoar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22226-22300-ploumilliau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22226-22300-ploumilliau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22226-22300-ploumilliau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22226-22300-ploumilliau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22227-22780-plounerin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22227-22780-plounerin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22227-22780-plounerin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22227-22780-plounerin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22228-22810-plounevez_moedec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22228-22810-plounevez_moedec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22228-22810-plounevez_moedec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22228-22810-plounevez_moedec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22229-22110-plounevez_quintin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22229-22110-plounevez_quintin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22229-22110-plounevez_quintin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22229-22110-plounevez_quintin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22231-22160-plourac_h/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22231-22160-plourac_h/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22231-22160-plourac_h/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22231-22160-plourac_h/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22232-22410-plourhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22232-22410-plourhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22232-22410-plourhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22232-22410-plourhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22233-22860-plourivo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22233-22860-plourivo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22233-22860-plourivo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22233-22860-plourivo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22234-22170-plouvara/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22234-22170-plouvara/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22234-22170-plouvara/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22234-22170-plouvara/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22235-22420-plouzelambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22235-22420-plouzelambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22235-22420-plouzelambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22235-22420-plouzelambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22236-22290-pludual/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22236-22290-pludual/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22236-22290-pludual/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22236-22290-pludual/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22237-22130-pluduno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22237-22130-pluduno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22237-22130-pluduno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22237-22130-pluduno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22238-22310-plufur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22238-22310-plufur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22238-22310-plufur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22238-22310-plufur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22239-22350-plumaudan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22239-22350-plumaudan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22239-22350-plumaudan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22239-22350-plumaudan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22240-22250-plumaugat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22240-22250-plumaugat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22240-22250-plumaugat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22240-22250-plumaugat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22241-22210-plumieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22241-22210-plumieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22241-22210-plumieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22241-22210-plumieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22242-22240-plurien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22242-22240-plurien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22242-22240-plurien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22242-22240-plurien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22243-22160-plusquellec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22243-22160-plusquellec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22243-22160-plusquellec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22243-22160-plusquellec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22244-22320-plussulien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22244-22320-plussulien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22244-22320-plussulien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22244-22320-plussulien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22245-22140-pluzunet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22245-22140-pluzunet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22245-22140-pluzunet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22245-22140-pluzunet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22246-22120-pommeret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22246-22120-pommeret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22246-22120-pommeret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22246-22120-pommeret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22248-22200-pommerit_le_vicomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22248-22200-pommerit_le_vicomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22248-22200-pommerit_le_vicomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22248-22200-pommerit_le_vicomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22249-22390-pont_melvez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22249-22390-pont_melvez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22249-22390-pont_melvez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22249-22390-pont_melvez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22250-22260-pontrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22250-22260-pontrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22250-22260-pontrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22250-22260-pontrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22251-22590-pordic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22251-22590-pordic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22251-22590-pordic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22251-22590-pordic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22254-22140-prat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22254-22140-prat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22254-22140-prat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22254-22140-prat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22255-22210-la_prenessaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22255-22210-la_prenessaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22255-22210-la_prenessaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22255-22210-la_prenessaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22256-22260-quemper_guezennec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22256-22260-quemper_guezennec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22256-22260-quemper_guezennec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22256-22260-quemper_guezennec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22257-22450-quemperven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22257-22450-quemperven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22257-22450-quemperven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22257-22450-quemperven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22258-22120-quessoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22258-22120-quessoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22258-22120-quessoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22258-22120-quessoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22259-22100-quevert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22259-22100-quevert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22259-22100-quevert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22259-22100-quevert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22260-22460-le_quillio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22260-22460-le_quillio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22260-22460-le_quillio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22260-22460-le_quillio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22261-22400-quintenic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22261-22400-quintenic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22261-22400-quintenic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22261-22400-quintenic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22262-22800-quintin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22262-22800-quintin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22262-22800-quintin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22262-22800-quintin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22263-22630-le_quiou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22263-22630-le_quiou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22263-22630-le_quiou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22263-22630-le_quiou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22264-22450-la_roche_jaudy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22264-22450-la_roche_jaudy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22264-22450-la_roche_jaudy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22264-22450-la_roche_jaudy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22265-22300-rospez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22265-22300-rospez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22265-22300-rospez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22265-22300-rospez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22266-22110-rostrenen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22266-22110-rostrenen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22266-22110-rostrenen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22266-22110-rostrenen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22267-22250-rouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22267-22250-rouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22267-22250-rouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22267-22250-rouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22268-22550-ruca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22268-22550-ruca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22268-22550-ruca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22268-22550-ruca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22269-22260-runan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22269-22260-runan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22269-22260-runan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22269-22260-runan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22271-22390-saint_adrien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22271-22390-saint_adrien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22271-22390-saint_adrien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22271-22390-saint_adrien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22272-22200-saint_agathon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22272-22200-saint_agathon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22272-22200-saint_agathon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22272-22200-saint_agathon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22273-22400-saint_alban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22273-22400-saint_alban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22273-22400-saint_alban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22273-22400-saint_alban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22274-22630-saint_andre_des_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22274-22630-saint_andre_des_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22274-22630-saint_andre_des_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22274-22630-saint_andre_des_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22275-22600-saint_barnabe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22275-22600-saint_barnabe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22275-22600-saint_barnabe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22275-22600-saint_barnabe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22276-22800-saint_bihy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22276-22800-saint_bihy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22276-22800-saint_bihy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22276-22800-saint_bihy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22277-22800-saint_brandan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22277-22800-saint_brandan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22277-22800-saint_brandan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22277-22800-saint_brandan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22278-22000-saint_brieuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22278-22000-saint_brieuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22278-22000-saint_brieuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22278-22000-saint_brieuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22279-22600-saint_caradec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22279-22600-saint_caradec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22279-22600-saint_caradec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22279-22600-saint_caradec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22280-22100-saint_carne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22280-22100-saint_carne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22280-22100-saint_carne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22280-22100-saint_carne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22281-22150-saint_carreuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22281-22150-saint_carreuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22281-22150-saint_carreuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22281-22150-saint_carreuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22282-22380-saint_cast_le_guildo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22282-22380-saint_cast_le_guildo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22282-22380-saint_cast_le_guildo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22282-22380-saint_cast_le_guildo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22283-22260-saint_clet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22283-22260-saint_clet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22283-22260-saint_clet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22283-22260-saint_clet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22284-22480-saint_connan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22284-22480-saint_connan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22284-22480-saint_connan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22284-22480-saint_connan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22285-22530-saint_connec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22285-22530-saint_connec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22285-22530-saint_connec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22285-22530-saint_connec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22286-22400-saint_denoual/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22286-22400-saint_denoual/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22286-22400-saint_denoual/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22286-22400-saint_denoual/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22287-22800-saint_donan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22287-22800-saint_donan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22287-22800-saint_donan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22287-22800-saint_donan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22288-22210-saint_etienne_du_gue_de_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22288-22210-saint_etienne_du_gue_de_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22288-22210-saint_etienne_du_gue_de_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22288-22210-saint_etienne_du_gue_de_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22289-22720-saint_fiacre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22289-22720-saint_fiacre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22289-22720-saint_fiacre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22289-22720-saint_fiacre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22291-22800-saint_gildas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22291-22800-saint_gildas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22291-22800-saint_gildas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22291-22800-saint_gildas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22293-22290-saint_gilles_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22293-22290-saint_gilles_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22293-22290-saint_gilles_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22293-22290-saint_gilles_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22294-22480-saint_gilles_pligeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22294-22480-saint_gilles_pligeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22294-22480-saint_gilles_pligeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22294-22480-saint_gilles_pligeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22295-22530-saint_gilles_vieux_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22295-22530-saint_gilles_vieux_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22295-22530-saint_gilles_vieux_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22295-22530-saint_gilles_vieux_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22296-22510-saint_glen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22296-22510-saint_glen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22296-22510-saint_glen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22296-22510-saint_glen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22299-22100-saint_helen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22299-22100-saint_helen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22299-22100-saint_helen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22299-22100-saint_helen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22300-22460-saint_herve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22300-22460-saint_herve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22300-22460-saint_herve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22300-22460-saint_herve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22302-22750-saint_jacut_de_la_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22302-22750-saint_jacut_de_la_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22302-22750-saint_jacut_de_la_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22302-22750-saint_jacut_de_la_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22304-22170-saint_jean_kerdaniel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22304-22170-saint_jean_kerdaniel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22304-22170-saint_jean_kerdaniel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22304-22170-saint_jean_kerdaniel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22305-22350-saint_jouan_de_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22305-22350-saint_jouan_de_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22305-22350-saint_jouan_de_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22305-22350-saint_jouan_de_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22306-22630-saint_judoce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22306-22630-saint_judoce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22306-22630-saint_judoce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22306-22630-saint_judoce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22307-22940-saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22307-22940-saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22307-22940-saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22307-22940-saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22308-22630-saint_juvat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22308-22630-saint_juvat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22308-22630-saint_juvat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22308-22630-saint_juvat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22309-22230-saint_launeuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22309-22230-saint_launeuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22309-22230-saint_launeuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22309-22230-saint_launeuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22310-22140-saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22310-22140-saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22310-22140-saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22310-22140-saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22311-22130-saint_lormel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22311-22130-saint_lormel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22311-22130-saint_lormel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22311-22130-saint_lormel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22312-22350-saint_maden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22312-22350-saint_maden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22312-22350-saint_maden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22312-22350-saint_maden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22313-22320-saint_martin_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22313-22320-saint_martin_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22313-22320-saint_martin_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22313-22320-saint_martin_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22314-22600-saint_maudan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22314-22600-saint_maudan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22314-22600-saint_maudan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22314-22600-saint_maudan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22315-22980-saint_maudez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22315-22980-saint_maudez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22315-22980-saint_maudez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22315-22980-saint_maudez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22316-22320-saint_mayeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22316-22320-saint_mayeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22316-22320-saint_mayeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22316-22320-saint_mayeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22317-22980-saint_meloir_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22317-22980-saint_meloir_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22317-22980-saint_meloir_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22317-22980-saint_meloir_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22318-22980-saint_michel_de_plelan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22318-22980-saint_michel_de_plelan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22318-22980-saint_michel_de_plelan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22318-22980-saint_michel_de_plelan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22319-22300-saint_michel_en_greve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22319-22300-saint_michel_en_greve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22319-22300-saint_michel_en_greve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22319-22300-saint_michel_en_greve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22320-22160-saint_nicodeme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22320-22160-saint_nicodeme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22320-22160-saint_nicodeme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22320-22160-saint_nicodeme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22321-22480-saint_nicolas_du_pelem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22321-22480-saint_nicolas_du_pelem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22321-22480-saint_nicolas_du_pelem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22321-22480-saint_nicolas_du_pelem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22322-22720-saint_pever/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22322-22720-saint_pever/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22322-22720-saint_pever/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22322-22720-saint_pever/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22323-22550-saint_potan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22323-22550-saint_potan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22323-22550-saint_potan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22323-22550-saint_potan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22324-22700-saint_quay_perros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22324-22700-saint_quay_perros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22324-22700-saint_quay_perros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22324-22700-saint_quay_perros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22325-22410-saint_quay_portrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22325-22410-saint_quay_portrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22325-22410-saint_quay_portrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22325-22410-saint_quay_portrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22326-22270-saint_rieul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22326-22270-saint_rieul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22326-22270-saint_rieul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22326-22270-saint_rieul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22327-22100-saint_samson_sur_rance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22327-22100-saint_samson_sur_rance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22327-22100-saint_samson_sur_rance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22327-22100-saint_samson_sur_rance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22328-22160-saint_servais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22328-22160-saint_servais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22328-22160-saint_servais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22328-22160-saint_servais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22330-22460-saint_thelo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22330-22460-saint_thelo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22330-22460-saint_thelo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22330-22460-saint_thelo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22331-22480-sainte_trephine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22331-22480-sainte_trephine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22331-22480-sainte_trephine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22331-22480-sainte_trephine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22332-22510-saint_trimoel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22332-22510-saint_trimoel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22332-22510-saint_trimoel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22332-22510-saint_trimoel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22333-22230-saint_vran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22333-22230-saint_vran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22333-22230-saint_vran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22333-22230-saint_vran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22334-22570-saint_igeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22334-22570-saint_igeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22334-22570-saint_igeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22334-22570-saint_igeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22335-22720-senven_lehart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22335-22720-senven_lehart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22335-22720-senven_lehart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22335-22720-senven_lehart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22337-22250-sevignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22337-22250-sevignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22337-22250-sevignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22337-22250-sevignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22338-22200-squiffiec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22338-22200-squiffiec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22338-22200-squiffiec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22338-22200-squiffiec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22339-22100-taden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22339-22100-taden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22339-22100-taden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22339-22100-taden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22340-22140-tonquedec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22340-22140-tonquedec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22340-22140-tonquedec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22340-22140-tonquedec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22341-22640-tramain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22341-22640-tramain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22341-22640-tramain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22341-22640-tramain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22342-22980-trebedan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22342-22980-trebedan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22342-22980-trebedan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22342-22980-trebedan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22343-22560-trebeurden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22343-22560-trebeurden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22343-22560-trebeurden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22343-22560-trebeurden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22344-22340-trebrivan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22344-22340-trebrivan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22344-22340-trebrivan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22344-22340-trebrivan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22345-22510-trebry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22345-22510-trebry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22345-22510-trebry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22345-22510-trebry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22346-22510-tredaniel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22346-22510-tredaniel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22346-22510-tredaniel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22346-22510-tredaniel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22347-22220-tredarzec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22347-22220-tredarzec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22347-22220-tredarzec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22347-22220-tredarzec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22348-22250-tredias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22348-22250-tredias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22348-22250-tredias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22348-22250-tredias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22349-22300-tredrez_locquemeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22349-22300-tredrez_locquemeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22349-22300-tredrez_locquemeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22349-22300-tredrez_locquemeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22350-22310-treduder/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22350-22310-treduder/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22350-22310-treduder/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22350-22310-treduder/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22351-22340-treffrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22351-22340-treffrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22351-22340-treffrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22351-22340-treffrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22352-22630-trefumel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22352-22630-trefumel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22352-22630-trefumel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22352-22630-trefumel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22353-22730-tregastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22353-22730-tregastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22353-22730-tregastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22353-22730-tregastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22354-22540-treglamus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22354-22540-treglamus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22354-22540-treglamus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22354-22540-treglamus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22356-22590-tregomeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22356-22590-tregomeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22356-22590-tregomeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22356-22590-tregomeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22358-22200-tregonneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22358-22200-tregonneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22358-22200-tregonneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22358-22200-tregonneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22359-22420-tregrom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22359-22420-tregrom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22359-22420-tregrom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22359-22420-tregrom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22360-22950-tregueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22360-22950-tregueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22360-22950-tregueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22360-22950-tregueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22361-22290-treguidel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22361-22290-treguidel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22361-22290-treguidel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22361-22290-treguidel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22362-22220-treguier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22362-22220-treguier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22362-22220-treguier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22362-22220-treguier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22363-22660-trelevern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22363-22660-trelevern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22363-22660-trelevern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22363-22660-trelevern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22364-22100-trelivan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22364-22100-trelivan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22364-22100-trelivan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22364-22100-trelivan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22365-22110-tremargat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22365-22110-tremargat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22365-22110-tremargat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22365-22110-tremargat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22366-22310-tremel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22366-22310-tremel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22366-22310-tremel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22366-22310-tremel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22368-22490-tremereuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22368-22490-tremereuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22368-22490-tremereuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22368-22490-tremereuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22369-22250-tremeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22369-22250-tremeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22369-22250-tremeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22369-22250-tremeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22370-22290-tremeven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22370-22290-tremeven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22370-22290-tremeven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22370-22290-tremeven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22371-22230-tremorel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22371-22230-tremorel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22371-22230-tremorel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22371-22230-tremorel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22372-22440-tremuson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22372-22440-tremuson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22372-22440-tremuson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22372-22440-tremuson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22373-22340-treogan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22373-22340-treogan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22373-22340-treogan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22373-22340-treogan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22375-22290-tressignaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22375-22290-tressignaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22375-22290-tressignaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22375-22290-tressignaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22376-22600-treve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22376-22600-treve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22376-22600-treve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22376-22600-treve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22377-22410-treveneuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22377-22410-treveneuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22377-22410-treveneuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22377-22410-treveneuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22378-22290-treverec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22378-22290-treverec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22378-22290-treverec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22378-22290-treverec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22379-22660-trevou_treguignec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22379-22660-trevou_treguignec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22379-22660-trevou_treguignec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22379-22660-trevou_treguignec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22380-22100-trevron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22380-22100-trevron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22380-22100-trevron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22380-22100-trevron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22381-22450-trezeny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22381-22450-trezeny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22381-22450-trezeny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22381-22450-trezeny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22383-22450-troguery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22383-22450-troguery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22383-22450-troguery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22383-22450-troguery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22384-22460-uzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22384-22460-uzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22384-22460-uzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22384-22460-uzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22385-22690-la_vicomte_sur_rance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22385-22690-la_vicomte_sur_rance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22385-22690-la_vicomte_sur_rance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22385-22690-la_vicomte_sur_rance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22386-22800-le_vieux_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22386-22800-le_vieux_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22386-22800-le_vieux_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22386-22800-le_vieux_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22387-22420-le_vieux_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22387-22420-le_vieux_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22387-22420-le_vieux_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22387-22420-le_vieux_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22388-22980-vilde_guingalan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22388-22980-vilde_guingalan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22388-22980-vilde_guingalan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22388-22980-vilde_guingalan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22389-22120-yffiniac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22389-22120-yffiniac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22389-22120-yffiniac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22389-22120-yffiniac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22390-22930-yvias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22390-22930-yvias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22390-22930-yvias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22390-22930-yvias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22391-22350-yvignac_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22391-22350-yvignac_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22391-22350-yvignac_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt22-cotes_d_armor/commune22391-22350-yvignac_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-23.xml
+++ b/public/sitemaps/sitemap-23.xml
@@ -5,518 +5,1032 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23001-23150-ahun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23001-23150-ahun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23001-23150-ahun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23001-23150-ahun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23002-23380-ajain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23002-23380-ajain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23002-23380-ajain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23002-23380-ajain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23003-23200-alleyrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23003-23200-alleyrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23003-23200-alleyrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23003-23200-alleyrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23004-23000-anzeme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23004-23000-anzeme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23004-23000-anzeme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23004-23000-anzeme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23005-23700-arfeuille_chatain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23005-23700-arfeuille_chatain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23005-23700-arfeuille_chatain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23005-23700-arfeuille_chatain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23006-23210-arrenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23006-23210-arrenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23006-23210-arrenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23006-23210-arrenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23007-23480-ars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23007-23480-ars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23007-23480-ars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23007-23480-ars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23008-23200-aubusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23008-23200-aubusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23008-23200-aubusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23008-23200-aubusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23009-23170-auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23009-23170-auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23009-23170-auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23009-23170-auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23010-23210-augeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23010-23210-augeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23010-23210-augeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23010-23210-augeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23011-23210-aulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23011-23210-aulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23011-23210-aulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23011-23210-aulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23012-23400-auriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23012-23400-auriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23012-23400-auriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23012-23400-auriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23013-23700-auzances/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23013-23700-auzances/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23013-23700-auzances/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23013-23700-auzances/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23014-23210-azat_chatenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23014-23210-azat_chatenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23014-23210-azat_chatenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23014-23210-azat_chatenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23015-23160-azerables/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23015-23160-azerables/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23015-23160-azerables/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23015-23160-azerables/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23016-23120-banize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23016-23120-banize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23016-23120-banize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23016-23120-banize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23017-23260-basville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23017-23260-basville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23017-23260-basville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23017-23260-basville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23018-23160-bazelat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23018-23160-bazelat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23018-23160-bazelat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23018-23160-bazelat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23019-23260-beissat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23019-23260-beissat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23019-23260-beissat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23019-23260-beissat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23020-23190-bellegarde_en_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23020-23190-bellegarde_en_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23020-23190-bellegarde_en_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23020-23190-bellegarde_en_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23021-23210-benevent_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23021-23210-benevent_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23021-23210-benevent_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23021-23210-benevent_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23022-23270-betete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23022-23270-betete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23022-23270-betete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23022-23270-betete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23023-23140-blaudeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23023-23140-blaudeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23023-23140-blaudeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23023-23140-blaudeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23024-23200-blessac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23024-23200-blessac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23024-23200-blessac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23024-23200-blessac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23025-23220-bonnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23025-23220-bonnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23025-23220-bonnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23025-23220-bonnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23026-23230-bord_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23026-23230-bord_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23026-23230-bord_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23026-23230-bord_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23027-23400-bosmoreau_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23027-23400-bosmoreau_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23027-23400-bosmoreau_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23027-23400-bosmoreau_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23028-23200-bosroger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23028-23200-bosroger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23028-23200-bosroger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23028-23200-bosroger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23029-23220-le_bourg_d_hem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23029-23220-le_bourg_d_hem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23029-23220-le_bourg_d_hem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23029-23220-le_bourg_d_hem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23030-23400-bourganeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23030-23400-bourganeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23030-23400-bourganeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23030-23400-bourganeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23031-23600-boussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23031-23600-boussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23031-23600-boussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23031-23600-boussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23032-23600-boussac_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23032-23600-boussac_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23032-23600-boussac_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23032-23600-boussac_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23033-23000-la_brionne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23033-23000-la_brionne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23033-23000-la_brionne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23033-23000-la_brionne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23034-23700-brousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23034-23700-brousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23034-23700-brousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23034-23700-brousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23035-23170-budeliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23035-23170-budeliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23035-23170-budeliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23035-23170-budeliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23036-23320-bussiere_dunoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23036-23320-bussiere_dunoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23036-23320-bussiere_dunoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23036-23320-bussiere_dunoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23037-23700-bussiere_nouvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23037-23700-bussiere_nouvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23037-23700-bussiere_nouvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23037-23700-bussiere_nouvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23038-23600-bussiere_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23038-23600-bussiere_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23038-23600-bussiere_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23038-23600-bussiere_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23039-23800-la_celle_dunoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23039-23800-la_celle_dunoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23039-23800-la_celle_dunoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23039-23800-la_celle_dunoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23040-23230-la_celle_sous_gouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23040-23230-la_celle_sous_gouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23040-23230-la_celle_sous_gouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23040-23230-la_celle_sous_gouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23041-23350-la_cellette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23041-23350-la_cellette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23041-23350-la_cellette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23041-23350-la_cellette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23042-23210-ceyroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23042-23210-ceyroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23042-23210-ceyroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23042-23210-ceyroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23043-23480-chamberaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23043-23480-chamberaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23043-23480-chamberaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23043-23480-chamberaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23044-23220-chambon_sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23044-23220-chambon_sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23044-23220-chambon_sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23044-23220-chambon_sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23045-23170-chambon_sur_voueize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23045-23170-chambon_sur_voueize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23045-23170-chambon_sur_voueize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23045-23170-chambon_sur_voueize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23046-23110-chambonchard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23046-23110-chambonchard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23046-23110-chambonchard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23046-23110-chambonchard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23047-23240-chamborand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23047-23240-chamborand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23047-23240-chamborand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23047-23240-chamborand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23048-23190-champagnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23048-23190-champagnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23048-23190-champagnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23048-23190-champagnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23049-23220-champsanglard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23049-23220-champsanglard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23049-23220-champsanglard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23049-23220-champsanglard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23050-23160-la_chapelle_baloue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23050-23160-la_chapelle_baloue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23050-23160-la_chapelle_baloue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23050-23160-la_chapelle_baloue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23051-23250-la_chapelle_saint_martial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23051-23250-la_chapelle_saint_martial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23051-23250-la_chapelle_saint_martial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23051-23250-la_chapelle_saint_martial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23052-23000-la_chapelle_taillefert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23052-23000-la_chapelle_taillefert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23052-23000-la_chapelle_taillefert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23052-23000-la_chapelle_taillefert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23053-23700-chard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23053-23700-chard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23053-23700-chard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23053-23700-chard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23054-23700-charron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23054-23700-charron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23054-23700-charron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23054-23700-charron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23055-23700-chatelard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23055-23700-chatelard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23055-23700-chatelard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23055-23700-chatelard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23056-23430-chatelus_le_marcheix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23056-23430-chatelus_le_marcheix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23056-23430-chatelus_le_marcheix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23056-23430-chatelus_le_marcheix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23057-23270-chatelus_malvaleix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23057-23270-chatelus_malvaleix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23057-23270-chatelus_malvaleix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23057-23270-chatelus_malvaleix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23058-23130-le_chauchet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23058-23130-le_chauchet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23058-23130-le_chauchet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23058-23130-le_chauchet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23059-23200-la_chaussade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23059-23200-la_chaussade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23059-23200-la_chaussade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23059-23200-la_chaussade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23060-23250-chavanat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23060-23250-chavanat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23060-23250-chavanat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23060-23250-chavanat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23061-23130-chenerailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23061-23130-chenerailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23061-23130-chenerailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23061-23130-chenerailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23062-23220-cheniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23062-23220-cheniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23062-23220-cheniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23062-23220-cheniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23063-23500-clairavaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23063-23500-clairavaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23063-23500-clairavaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23063-23500-clairavaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23064-23270-clugnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23064-23270-clugnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23064-23270-clugnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23064-23270-clugnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23065-23800-colondannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23065-23800-colondannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23065-23800-colondannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23065-23800-colondannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23066-23700-le_compas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23066-23700-le_compas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23066-23700-le_compas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23066-23700-le_compas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23067-23100-la_courtine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23067-23100-la_courtine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23067-23100-la_courtine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23067-23100-la_courtine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23068-23140-cressat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23068-23140-cressat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23068-23140-cressat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23068-23140-cressat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23069-23260-crocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23069-23260-crocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23069-23260-crocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23069-23260-crocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23070-23160-crozant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23070-23160-crozant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23070-23160-crozant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23070-23160-crozant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23071-23500-croze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23071-23500-croze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23071-23500-croze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23071-23500-croze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23072-23140-domeyrot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23072-23140-domeyrot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23072-23140-domeyrot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23072-23140-domeyrot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23073-23700-dontreix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23073-23700-dontreix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23073-23700-dontreix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23073-23700-dontreix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23074-23480-le_donzeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23074-23480-le_donzeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23074-23480-le_donzeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23074-23480-le_donzeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23075-23800-dun_le_palestel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23075-23800-dun_le_palestel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23075-23800-dun_le_palestel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23075-23800-dun_le_palestel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23076-23110-evaux_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23076-23110-evaux_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23076-23110-evaux_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23076-23110-evaux_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23077-23340-faux_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23077-23340-faux_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23077-23340-faux_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23077-23340-faux_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23078-23400-faux_mazuras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23078-23400-faux_mazuras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23078-23400-faux_mazuras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23078-23400-faux_mazuras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23079-23500-felletin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23079-23500-felletin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23079-23500-felletin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23079-23500-felletin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23080-23100-feniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23080-23100-feniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23080-23100-feniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23080-23100-feniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23081-23260-flayat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23081-23260-flayat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23081-23260-flayat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23081-23260-flayat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23082-23320-fleurat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23082-23320-fleurat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23082-23320-fleurat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23082-23320-fleurat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23083-23110-fontanieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23083-23110-fontanieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23083-23110-fontanieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23083-23110-fontanieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23084-23360-la_foret_du_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23084-23360-la_foret_du_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23084-23360-la_foret_du_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23084-23360-la_foret_du_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23086-23480-franseches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23086-23480-franseches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23086-23480-franseches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23086-23480-franseches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23087-23450-fresselines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23087-23450-fresselines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23087-23450-fresselines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23087-23450-fresselines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23088-23320-gartempe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23088-23320-gartempe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23088-23320-gartempe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23088-23320-gartempe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23089-23350-genouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23089-23350-genouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23089-23350-genouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23089-23350-genouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23090-23340-gentioux_pigerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23090-23340-gentioux_pigerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23090-23340-gentioux_pigerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23090-23340-gentioux_pigerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23091-23500-gioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23091-23500-gioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23091-23500-gioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23091-23500-gioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23092-23380-glenic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23092-23380-glenic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23092-23380-glenic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23092-23380-glenic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23093-23230-gouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23093-23230-gouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23093-23230-gouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23093-23230-gouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23095-23240-le_grand_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23095-23240-le_grand_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23095-23240-le_grand_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23095-23240-le_grand_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23096-23000-gueret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23096-23000-gueret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23096-23000-gueret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23096-23000-gueret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23097-23130-issoudun_letrieix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23097-23130-issoudun_letrieix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23097-23130-issoudun_letrieix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23097-23130-issoudun_letrieix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23098-23270-jalesches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23098-23270-jalesches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23098-23270-jalesches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23098-23270-jalesches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23099-23250-janaillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23099-23250-janaillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23099-23250-janaillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23099-23250-janaillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23100-23140-jarnages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23100-23140-jarnages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23100-23140-jarnages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23100-23140-jarnages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23101-23220-jouillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23101-23220-jouillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23101-23220-jouillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23101-23220-jouillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23102-23270-ladapeyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23102-23270-ladapeyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23102-23270-ladapeyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23102-23270-ladapeyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23103-23800-lafat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23103-23800-lafat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23103-23800-lafat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23103-23800-lafat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23104-23600-lavaufranche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23104-23600-lavaufranche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23104-23600-lavaufranche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23104-23600-lavaufranche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23105-23150-lavaveix_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23105-23150-lavaveix_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23105-23150-lavaveix_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23105-23150-lavaveix_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23106-23170-lepaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23106-23170-lepaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23106-23170-lepaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23106-23170-lepaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23107-23150-lepinas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23107-23150-lepinas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23107-23150-lepinas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23107-23150-lepinas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23108-23600-leyrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23108-23600-leyrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23108-23600-leyrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23108-23600-leyrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23109-23220-linard_malval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23109-23220-linard_malval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23109-23220-linard_malval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23109-23220-linard_malval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23110-23700-lioux_les_monges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23110-23700-lioux_les_monges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23110-23700-lioux_les_monges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23110-23700-lioux_les_monges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23111-23240-lizieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23111-23240-lizieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23111-23240-lizieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23111-23240-lizieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23112-23360-lourdoueix_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23112-23360-lourdoueix_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23112-23360-lourdoueix_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23112-23360-lourdoueix_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23113-23190-lupersat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23113-23190-lupersat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23113-23190-lupersat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23113-23190-lupersat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23114-23170-lussat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23114-23170-lussat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23114-23170-lussat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23114-23170-lussat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23115-23260-magnat_l_etrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23115-23260-magnat_l_etrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23115-23260-magnat_l_etrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23115-23260-magnat_l_etrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23116-23700-mainsat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23116-23700-mainsat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23116-23700-mainsat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23116-23700-mainsat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23117-23800-maison_feyne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23117-23800-maison_feyne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23117-23800-maison_feyne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23117-23800-maison_feyne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23118-23150-maisonnisses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23118-23150-maisonnisses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23118-23150-maisonnisses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23118-23150-maisonnisses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23119-23260-malleret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23119-23260-malleret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23119-23260-malleret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23119-23260-malleret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23120-23600-malleret_boussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23120-23600-malleret_boussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23120-23600-malleret_boussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23120-23600-malleret_boussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23122-23400-mansat_la_courriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23122-23400-mansat_la_courriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23122-23400-mansat_la_courriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23122-23400-mansat_la_courriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23123-23700-les_mars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23123-23700-les_mars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23123-23700-les_mars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23123-23700-les_mars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23124-23210-marsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23124-23210-marsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23124-23210-marsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23124-23210-marsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23125-23100-le_mas_d_artige/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23125-23100-le_mas_d_artige/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23125-23100-le_mas_d_artige/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23125-23100-le_mas_d_artige/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23127-23190-mautes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23127-23190-mautes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23127-23190-mautes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23127-23190-mautes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23128-23150-mazeirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23128-23150-mazeirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23128-23150-mazeirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23128-23150-mazeirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23129-23260-la_maziere_aux_bons_hommes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23129-23260-la_maziere_aux_bons_hommes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23129-23260-la_maziere_aux_bons_hommes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23129-23260-la_maziere_aux_bons_hommes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23130-23360-measnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23130-23360-measnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23130-23360-measnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23130-23360-measnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23131-23420-merinchal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23131-23420-merinchal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23131-23420-merinchal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23131-23420-merinchal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23132-23320-montaigut_le_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23132-23320-montaigut_le_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23132-23320-montaigut_le_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23132-23320-montaigut_le_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23133-23400-montboucher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23133-23400-montboucher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23133-23400-montboucher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23133-23400-montboucher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23134-23460-le_monteil_au_vicomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23134-23460-le_monteil_au_vicomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23134-23460-le_monteil_au_vicomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23134-23460-le_monteil_au_vicomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23136-23220-mortroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23136-23220-mortroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23136-23220-mortroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23136-23220-mortroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23137-23210-mourioux_vieilleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23137-23210-mourioux_vieilleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23137-23210-mourioux_vieilleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23137-23210-mourioux_vieilleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23138-23150-moutier_d_ahun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23138-23150-moutier_d_ahun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23138-23150-moutier_d_ahun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23138-23150-moutier_d_ahun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23139-23220-moutier_malcard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23139-23220-moutier_malcard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23139-23220-moutier_malcard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23139-23220-moutier_malcard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23140-23200-moutier_rozeille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23140-23200-moutier_rozeille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23140-23200-moutier_rozeille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23140-23200-moutier_rozeille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23141-23800-naillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23141-23800-naillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23141-23800-naillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23141-23800-naillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23142-23200-neoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23142-23200-neoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23142-23200-neoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23142-23200-neoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23143-23300-noth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23143-23300-noth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23143-23300-noth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23143-23300-noth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23144-23500-la_nouaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23144-23500-la_nouaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23144-23500-la_nouaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23144-23500-la_nouaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23145-23170-nouhant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23145-23170-nouhant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23145-23170-nouhant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23145-23170-nouhant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23146-23600-nouzerines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23146-23600-nouzerines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23146-23600-nouzerines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23146-23600-nouzerines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23147-23360-nouzerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23147-23360-nouzerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23147-23360-nouzerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23147-23360-nouzerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23148-23350-nouziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23148-23350-nouziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23148-23350-nouziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23148-23350-nouziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23149-23140-parsac_rimondeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23149-23140-parsac_rimondeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23149-23140-parsac_rimondeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23149-23140-parsac_rimondeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23150-23000-peyrabout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23150-23000-peyrabout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23150-23000-peyrabout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23150-23000-peyrabout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23151-23130-peyrat_la_noniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23151-23130-peyrat_la_noniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23151-23130-peyrat_la_noniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23151-23130-peyrat_la_noniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23152-23130-pierrefitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23152-23130-pierrefitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23152-23130-pierrefitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23152-23130-pierrefitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23154-23140-pionnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23154-23140-pionnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23154-23140-pionnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23154-23140-pionnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23155-23250-pontarion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23155-23250-pontarion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23155-23250-pontarion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23155-23250-pontarion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23156-23260-pontcharraud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23156-23260-pontcharraud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23156-23260-pontcharraud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23156-23260-pontcharraud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23157-23250-la_pouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23157-23250-la_pouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23157-23250-la_pouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23157-23250-la_pouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23158-23500-poussanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23158-23500-poussanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23158-23500-poussanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23158-23500-poussanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23159-23130-puy_malsignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23159-23130-puy_malsignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23159-23130-puy_malsignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23159-23130-puy_malsignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23160-23110-reterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23160-23110-reterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23160-23110-reterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23160-23110-reterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23162-23270-roches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23162-23270-roches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23162-23270-roches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23162-23270-roches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23164-23700-rougnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23164-23700-rougnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23164-23700-rougnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23164-23700-rougnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23165-23460-royere_de_vassiviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23165-23460-royere_de_vassiviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23165-23460-royere_de_vassiviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23165-23460-royere_de_vassiviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23166-23800-sagnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23166-23800-sagnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23166-23800-sagnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23166-23800-sagnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23167-23110-sannat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23167-23110-sannat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23167-23110-sannat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23167-23110-sannat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23168-23250-sardent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23168-23250-sardent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23168-23250-sardent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23168-23250-sardent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23169-23000-la_sauniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23169-23000-la_sauniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23169-23000-la_sauniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23169-23000-la_sauniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23170-23000-savennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23170-23000-savennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23170-23000-savennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23170-23000-savennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23171-23700-sermur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23171-23700-sermur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23171-23700-sermur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23171-23700-sermur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23172-23190-la_serre_bussiere_vieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23172-23190-la_serre_bussiere_vieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23172-23190-la_serre_bussiere_vieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23172-23190-la_serre_bussiere_vieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23173-23250-soubrebost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23173-23250-soubrebost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23173-23250-soubrebost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23173-23250-soubrebost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23174-23600-soumans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23174-23600-soumans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23174-23600-soumans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23174-23600-soumans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23175-23150-sous_parsat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23175-23150-sous_parsat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23175-23150-sous_parsat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23175-23150-sous_parsat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23176-23300-la_souterraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23176-23300-la_souterraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23176-23300-la_souterraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23176-23300-la_souterraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23177-23300-saint_agnant_de_versillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23177-23300-saint_agnant_de_versillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23177-23300-saint_agnant_de_versillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23177-23300-saint_agnant_de_versillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23178-23260-saint_agnant_pres_crocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23178-23260-saint_agnant_pres_crocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23178-23260-saint_agnant_pres_crocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23178-23260-saint_agnant_pres_crocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23179-23200-saint_alpinien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23179-23200-saint_alpinien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23179-23200-saint_alpinien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23179-23200-saint_alpinien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23180-23200-saint_amand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23180-23200-saint_amand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23180-23200-saint_amand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23180-23200-saint_amand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23181-23400-saint_amand_jartoudeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23181-23400-saint_amand_jartoudeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23181-23400-saint_amand_jartoudeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23181-23400-saint_amand_jartoudeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23182-23200-saint_avit_de_tardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23182-23200-saint_avit_de_tardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23182-23200-saint_avit_de_tardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23182-23200-saint_avit_de_tardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23183-23480-saint_avit_le_pauvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23183-23480-saint_avit_le_pauvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23183-23480-saint_avit_le_pauvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23183-23480-saint_avit_le_pauvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23184-23260-saint_bard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23184-23260-saint_bard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23184-23260-saint_bard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23184-23260-saint_bard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23185-23130-saint_chabrais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23185-23130-saint_chabrais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23185-23130-saint_chabrais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23185-23130-saint_chabrais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23186-23000-saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23186-23000-saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23186-23000-saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23186-23000-saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23187-23130-saint_dizier_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23187-23130-saint_dizier_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23187-23130-saint_dizier_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23187-23130-saint_dizier_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23188-23270-saint_dizier_les_domaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23188-23270-saint_dizier_les_domaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23188-23270-saint_dizier_les_domaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23188-23270-saint_dizier_les_domaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23189-23400-saint_dizier_masbaraud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23189-23400-saint_dizier_masbaraud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23189-23400-saint_dizier_masbaraud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23189-23400-saint_dizier_masbaraud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23190-23190-saint_domet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23190-23190-saint_domet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23190-23190-saint_domet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23190-23190-saint_domet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23191-23000-saint_eloi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23191-23000-saint_eloi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23191-23000-saint_eloi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23191-23000-saint_eloi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23192-23290-fursac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23192-23290-fursac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23192-23290-fursac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23192-23290-fursac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23193-23000-sainte_feyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23193-23000-sainte_feyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23193-23000-sainte_feyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23193-23000-sainte_feyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23194-23500-sainte_feyre_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23194-23500-sainte_feyre_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23194-23500-sainte_feyre_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23194-23500-sainte_feyre_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23195-23000-saint_fiel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23195-23000-saint_fiel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23195-23000-saint_fiel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23195-23000-saint_fiel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23196-23500-saint_frion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23196-23500-saint_frion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23196-23500-saint_frion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23196-23500-saint_frion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23197-23250-saint_georges_la_pouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23197-23250-saint_georges_la_pouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23197-23250-saint_georges_la_pouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23197-23250-saint_georges_la_pouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23198-23500-saint_georges_nigremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23198-23500-saint_georges_nigremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23198-23500-saint_georges_nigremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23198-23500-saint_georges_nigremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23199-23160-saint_germain_beaupre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23199-23160-saint_germain_beaupre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23199-23160-saint_germain_beaupre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23199-23160-saint_germain_beaupre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23200-23430-saint_goussaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23200-23430-saint_goussaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23200-23430-saint_goussaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23200-23430-saint_goussaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23201-23150-saint_hilaire_la_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23201-23150-saint_hilaire_la_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23201-23150-saint_hilaire_la_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23201-23150-saint_hilaire_la_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23202-23250-saint_hilaire_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23202-23250-saint_hilaire_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23202-23250-saint_hilaire_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23202-23250-saint_hilaire_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23203-23110-saint_julien_la_genete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23203-23110-saint_julien_la_genete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23203-23110-saint_julien_la_genete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23203-23110-saint_julien_la_genete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23204-23130-saint_julien_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23204-23130-saint_julien_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23204-23130-saint_julien_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23204-23130-saint_julien_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23205-23400-saint_junien_la_bregere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23205-23400-saint_junien_la_bregere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23205-23400-saint_junien_la_bregere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23205-23400-saint_junien_la_bregere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23206-23000-saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23206-23000-saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23206-23000-saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23206-23000-saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23207-23300-saint_leger_bridereix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23207-23300-saint_leger_bridereix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23207-23300-saint_leger_bridereix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23207-23300-saint_leger_bridereix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23208-23000-saint_leger_le_gueretois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23208-23000-saint_leger_le_gueretois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23208-23000-saint_leger_le_gueretois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23208-23000-saint_leger_le_gueretois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23209-23130-saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23209-23130-saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23209-23130-saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23209-23130-saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23210-23200-saint_maixant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23210-23200-saint_maixant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23210-23200-saint_maixant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23210-23200-saint_maixant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23211-23200-saint_marc_a_frongier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23211-23200-saint_marc_a_frongier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23211-23200-saint_marc_a_frongier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23211-23200-saint_marc_a_frongier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23212-23460-saint_marc_a_loubaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23212-23460-saint_marc_a_loubaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23212-23460-saint_marc_a_loubaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23212-23460-saint_marc_a_loubaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23213-23600-saint_marien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23213-23600-saint_marien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23213-23600-saint_marien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23213-23600-saint_marien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23214-23150-saint_martial_le_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23214-23150-saint_martial_le_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23214-23150-saint_martial_le_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23214-23150-saint_martial_le_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23215-23100-saint_martial_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23215-23100-saint_martial_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23215-23100-saint_martial_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23215-23100-saint_martial_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23216-23460-saint_martin_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23216-23460-saint_martin_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23216-23460-saint_martin_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23216-23460-saint_martin_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23217-23430-saint_martin_sainte_catherine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23217-23430-saint_martin_sainte_catherine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23217-23430-saint_martin_sainte_catherine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23217-23430-saint_martin_sainte_catherine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23218-23260-saint_maurice_pres_crocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23218-23260-saint_maurice_pres_crocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23218-23260-saint_maurice_pres_crocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23218-23260-saint_maurice_pres_crocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23219-23300-saint_maurice_la_souterraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23219-23300-saint_maurice_la_souterraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23219-23300-saint_maurice_la_souterraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23219-23300-saint_maurice_la_souterraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23220-23200-saint_medard_la_rochette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23220-23200-saint_medard_la_rochette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23220-23200-saint_medard_la_rochette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23220-23200-saint_medard_la_rochette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23221-23100-saint_merd_la_breuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23221-23100-saint_merd_la_breuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23221-23100-saint_merd_la_breuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23221-23100-saint_merd_la_breuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23222-23480-saint_michel_de_veisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23222-23480-saint_michel_de_veisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23222-23480-saint_michel_de_veisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23222-23480-saint_michel_de_veisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23223-23400-saint_moreil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23223-23400-saint_moreil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23223-23400-saint_moreil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23223-23400-saint_moreil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23224-23100-saint_oradoux_de_chirouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23224-23100-saint_oradoux_de_chirouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23224-23100-saint_oradoux_de_chirouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23224-23100-saint_oradoux_de_chirouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23225-23260-saint_oradoux_pres_crocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23225-23260-saint_oradoux_pres_crocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23225-23260-saint_oradoux_pres_crocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23225-23260-saint_oradoux_pres_crocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23226-23260-saint_pardoux_d_arnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23226-23260-saint_pardoux_d_arnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23226-23260-saint_pardoux_d_arnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23226-23260-saint_pardoux_d_arnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23227-23400-saint_pardoux_morterolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23227-23400-saint_pardoux_morterolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23227-23400-saint_pardoux_morterolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23227-23400-saint_pardoux_morterolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23228-23200-saint_pardoux_le_neuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23228-23200-saint_pardoux_le_neuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23228-23200-saint_pardoux_le_neuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23228-23200-saint_pardoux_le_neuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23229-23150-saint_pardoux_les_cards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23229-23150-saint_pardoux_les_cards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23229-23150-saint_pardoux_les_cards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23229-23150-saint_pardoux_les_cards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23230-23430-saint_pierre_cherignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23230-23430-saint_pierre_cherignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23230-23430-saint_pierre_cherignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23230-23430-saint_pierre_cherignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23232-23460-saint_pierre_bellevue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23232-23460-saint_pierre_bellevue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23232-23460-saint_pierre_bellevue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23232-23460-saint_pierre_bellevue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23233-23600-saint_pierre_le_bost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23233-23600-saint_pierre_le_bost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23233-23600-saint_pierre_le_bost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23233-23600-saint_pierre_le_bost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23234-23110-saint_priest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23234-23110-saint_priest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23234-23110-saint_priest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23234-23110-saint_priest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23235-23300-saint_priest_la_feuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23235-23300-saint_priest_la_feuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23235-23300-saint_priest_la_feuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23235-23300-saint_priest_la_feuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23236-23240-saint_priest_la_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23236-23240-saint_priest_la_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23236-23240-saint_priest_la_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23236-23240-saint_priest_la_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23237-23400-saint_priest_palus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23237-23400-saint_priest_palus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23237-23400-saint_priest_palus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23237-23400-saint_priest_palus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23238-23500-saint_quentin_la_chabanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23238-23500-saint_quentin_la_chabanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23238-23500-saint_quentin_la_chabanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23238-23500-saint_quentin_la_chabanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23239-23160-saint_sebastien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23239-23160-saint_sebastien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23239-23160-saint_sebastien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23239-23160-saint_sebastien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23240-23600-saint_silvain_bas_le_roc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23240-23600-saint_silvain_bas_le_roc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23240-23600-saint_silvain_bas_le_roc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23240-23600-saint_silvain_bas_le_roc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23241-23190-saint_silvain_bellegarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23241-23190-saint_silvain_bellegarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23241-23190-saint_silvain_bellegarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23241-23190-saint_silvain_bellegarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23242-23320-saint_silvain_montaigut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23242-23320-saint_silvain_montaigut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23242-23320-saint_silvain_montaigut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23242-23320-saint_silvain_montaigut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23243-23140-saint_silvain_sous_toulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23243-23140-saint_silvain_sous_toulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23243-23140-saint_silvain_sous_toulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23243-23140-saint_silvain_sous_toulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23244-23800-saint_sulpice_le_dunois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23244-23800-saint_sulpice_le_dunois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23244-23800-saint_sulpice_le_dunois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23244-23800-saint_sulpice_le_dunois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23245-23000-saint_sulpice_le_gueretois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23245-23000-saint_sulpice_le_gueretois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23245-23000-saint_sulpice_le_gueretois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23245-23000-saint_sulpice_le_gueretois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23246-23480-saint_sulpice_les_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23246-23480-saint_sulpice_les_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23246-23480-saint_sulpice_les_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23246-23480-saint_sulpice_les_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23247-23320-saint_vaury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23247-23320-saint_vaury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23247-23320-saint_vaury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23247-23320-saint_vaury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23248-23000-saint_victor_en_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23248-23000-saint_victor_en_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23248-23000-saint_victor_en_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23248-23000-saint_victor_en_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23249-23460-saint_yrieix_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23249-23460-saint_yrieix_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23249-23460-saint_yrieix_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23249-23460-saint_yrieix_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23250-23150-saint_yrieix_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23250-23150-saint_yrieix_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23250-23150-saint_yrieix_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23250-23150-saint_yrieix_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23251-23170-tardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23251-23170-tardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23251-23170-tardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23251-23170-tardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23252-23350-tercillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23252-23350-tercillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23252-23350-tercillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23252-23350-tercillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23253-23250-thauron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23253-23250-thauron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23253-23250-thauron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23253-23250-thauron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23254-23600-toulx_sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23254-23600-toulx_sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23254-23600-toulx_sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23254-23600-toulx_sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23255-23230-trois_fonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23255-23230-trois_fonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23255-23230-trois_fonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23255-23230-trois_fonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23257-23120-valliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23257-23120-valliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23257-23120-valliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23257-23120-valliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23258-23300-vareilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23258-23300-vareilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23258-23300-vareilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23258-23300-vareilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23259-23170-verneiges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23259-23170-verneiges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23259-23170-verneiges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23259-23170-verneiges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23260-23250-vidaillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23260-23250-vidaillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23260-23250-vidaillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23260-23250-vidaillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23261-23170-viersat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23261-23170-viersat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23261-23170-viersat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23261-23170-viersat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23262-23140-vigeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23262-23140-vigeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23262-23140-vigeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23262-23140-vigeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23263-23800-villard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23263-23800-villard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23263-23800-villard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23263-23800-villard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23264-23340-la_villedieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23264-23340-la_villedieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23264-23340-la_villedieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23264-23340-la_villedieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23265-23260-la_villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23265-23260-la_villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23265-23260-la_villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23265-23260-la_villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23266-23260-la_villetelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23266-23260-la_villetelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23266-23260-la_villetelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt23-creuse/commune23266-23260-la_villetelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-24.xml
+++ b/public/sitemaps/sitemap-24.xml
@@ -5,1038 +5,2072 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24001-24300-abjat_sur_bandiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24001-24300-abjat_sur_bandiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24001-24300-abjat_sur_bandiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24001-24300-abjat_sur_bandiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24002-24460-agonac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24002-24460-agonac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24002-24460-agonac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24002-24460-agonac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24004-24210-ajat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24004-24210-ajat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24004-24210-ajat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24004-24210-ajat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24005-24480-alles_sur_dordogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24005-24480-alles_sur_dordogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24005-24480-alles_sur_dordogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24005-24480-alles_sur_dordogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24006-24220-allas_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24006-24220-allas_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24006-24220-allas_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24006-24220-allas_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24007-24600-allemans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24007-24600-allemans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24007-24600-allemans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24007-24600-allemans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24008-24270-angoisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24008-24270-angoisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24008-24270-angoisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24008-24270-angoisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24009-24160-anlhiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24009-24160-anlhiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24009-24160-anlhiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24009-24160-anlhiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24010-24430-annesse_et_beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24010-24430-annesse_et_beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24010-24430-annesse_et_beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24010-24430-annesse_et_beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24011-24420-antonne_et_trigonant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24011-24420-antonne_et_trigonant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24011-24420-antonne_et_trigonant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24011-24420-antonne_et_trigonant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24012-24590-archignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24012-24590-archignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24012-24590-archignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24012-24590-archignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24014-24290-aubas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24014-24290-aubas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24014-24290-aubas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24014-24290-aubas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24015-24260-audrix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24015-24260-audrix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24015-24260-audrix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24015-24260-audrix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24016-24300-augignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24016-24300-augignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24016-24300-augignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24016-24300-augignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24018-24290-auriac_du_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24018-24290-auriac_du_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24018-24290-auriac_du_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24018-24290-auriac_du_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24019-24210-azerat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24019-24210-azerat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24019-24210-azerat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24019-24210-azerat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24020-24210-la_bachellerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24020-24210-la_bachellerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24020-24210-la_bachellerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24020-24210-la_bachellerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24021-24390-badefols_d_ans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24021-24390-badefols_d_ans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24021-24390-badefols_d_ans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24021-24390-badefols_d_ans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24022-24150-badefols_sur_dordogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24022-24150-badefols_sur_dordogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24022-24150-badefols_sur_dordogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24022-24150-badefols_sur_dordogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24023-24150-baneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24023-24150-baneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24023-24150-baneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24023-24150-baneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24024-24560-bardou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24024-24560-bardou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24024-24560-bardou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24024-24560-bardou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24025-24210-bars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24025-24210-bars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24025-24210-bars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24025-24210-bars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24026-24330-bassillac_et_auberoche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24026-24330-bassillac_et_auberoche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24026-24330-bassillac_et_auberoche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24026-24330-bassillac_et_auberoche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24026-24640-bassillac_et_auberoche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24026-24640-bassillac_et_auberoche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24026-24640-bassillac_et_auberoche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24026-24640-bassillac_et_auberoche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24027-24150-bayac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24027-24150-bayac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24027-24150-bayac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24027-24150-bayac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24028-24440-beaumontois_en_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24028-24440-beaumontois_en_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24028-24440-beaumontois_en_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24028-24440-beaumontois_en_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24029-24400-beaupouyet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24029-24400-beaupouyet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24029-24400-beaupouyet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24029-24400-beaupouyet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24030-24120-beauregard_de_terrasson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24030-24120-beauregard_de_terrasson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24030-24120-beauregard_de_terrasson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24030-24120-beauregard_de_terrasson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24031-24140-beauregard_et_bassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24031-24140-beauregard_et_bassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24031-24140-beauregard_et_bassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24031-24140-beauregard_et_bassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24032-24400-beauronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24032-24400-beauronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24032-24400-beauronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24032-24400-beauronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24034-24140-beleymas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24034-24140-beleymas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24034-24140-beleymas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24034-24140-beleymas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24035-24170-pays_de_belves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24035-24170-pays_de_belves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24035-24170-pays_de_belves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24035-24170-pays_de_belves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24036-24220-berbiguieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24036-24220-berbiguieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24036-24220-berbiguieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24036-24220-berbiguieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24037-24100-bergerac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24037-24100-bergerac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24037-24100-bergerac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24037-24100-bergerac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24038-24320-bertric_buree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24038-24320-bertric_buree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24038-24320-bertric_buree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24038-24320-bertric_buree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24039-24550-besse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24039-24550-besse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24039-24550-besse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24039-24550-besse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24040-24220-beynac_et_cazenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24040-24220-beynac_et_cazenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24040-24220-beynac_et_cazenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24040-24220-beynac_et_cazenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24042-24310-biras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24042-24310-biras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24042-24310-biras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24042-24310-biras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24043-24540-biron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24043-24540-biron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24043-24540-biron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24043-24540-biron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24045-24560-boisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24045-24560-boisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24045-24560-boisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24045-24560-boisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24046-24390-boisseuilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24046-24390-boisseuilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24046-24390-boisseuilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24046-24390-boisseuilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24048-24230-bonneville_et_saint_avit_de_fumadieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24048-24230-bonneville_et_saint_avit_de_fumadieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24048-24230-bonneville_et_saint_avit_de_fumadieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24048-24230-bonneville_et_saint_avit_de_fumadieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24050-24590-borreze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24050-24590-borreze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24050-24590-borreze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24050-24590-borreze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24051-24130-bosset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24051-24130-bosset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24051-24130-bosset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24051-24130-bosset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24052-24480-bouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24052-24480-bouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24052-24480-bouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24052-24480-bouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24053-24750-boulazac_isle_manoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24053-24750-boulazac_isle_manoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24053-24750-boulazac_isle_manoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24053-24750-boulazac_isle_manoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24053-24330-boulazac_isle_manoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24053-24330-boulazac_isle_manoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24053-24330-boulazac_isle_manoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24053-24330-boulazac_isle_manoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24054-24560-bouniagues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24054-24560-bouniagues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24054-24560-bouniagues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24054-24560-bouniagues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24055-24310-bourdeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24055-24310-bourdeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24055-24310-bourdeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24055-24310-bourdeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24056-24300-le_bourdeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24056-24300-le_bourdeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24056-24300-le_bourdeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24056-24300-le_bourdeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24057-24320-bourg_des_maisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24057-24320-bourg_des_maisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24057-24320-bourg_des_maisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24057-24320-bourg_des_maisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24058-24600-bourg_du_bost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24058-24600-bourg_du_bost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24058-24600-bourg_du_bost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24058-24600-bourg_du_bost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24059-24400-bourgnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24059-24400-bourgnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24059-24400-bourgnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24059-24400-bourgnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24060-24150-bourniquel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24060-24150-bourniquel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24060-24150-bourniquel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24060-24150-bourniquel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24061-24110-bourrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24061-24110-bourrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24061-24110-bourrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24061-24110-bourrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24062-24320-bouteilles_saint_sebastien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24062-24320-bouteilles_saint_sebastien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24062-24320-bouteilles_saint_sebastien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24062-24320-bouteilles_saint_sebastien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24063-24250-bouzic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24063-24250-bouzic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24063-24250-bouzic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24063-24250-bouzic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24310-brantome_en_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24310-brantome_en_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24310-brantome_en_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24310-brantome_en_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24530-brantome_en_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24530-brantome_en_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24530-brantome_en_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24530-brantome_en_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24460-brantome_en_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24460-brantome_en_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24460-brantome_en_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24064-24460-brantome_en_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24066-24210-brouchaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24066-24210-brouchaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24066-24210-brouchaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24066-24210-brouchaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24067-24260-le_bugue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24067-24260-le_bugue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24067-24260-le_bugue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24067-24260-le_bugue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24068-24480-le_buisson_de_cadouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24068-24480-le_buisson_de_cadouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24068-24480-le_buisson_de_cadouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24068-24480-le_buisson_de_cadouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24069-24350-bussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24069-24350-bussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24069-24350-bussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24069-24350-bussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24070-24360-busserolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24070-24360-busserolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24070-24360-busserolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24070-24360-busserolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24071-24360-bussiere_badil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24071-24360-bussiere_badil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24071-24360-bussiere_badil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24071-24360-bussiere_badil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24073-24150-cales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24073-24150-cales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24073-24150-cales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24073-24150-cales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24074-24370-calviac_en_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24074-24370-calviac_en_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24074-24370-calviac_en_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24074-24370-calviac_en_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24075-24550-campagnac_les_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24075-24550-campagnac_les_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24075-24550-campagnac_les_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24075-24550-campagnac_les_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24076-24260-campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24076-24260-campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24076-24260-campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24076-24260-campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24077-24140-campsegret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24077-24140-campsegret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24077-24140-campsegret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24077-24140-campsegret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24080-24540-capdrot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24080-24540-capdrot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24080-24540-capdrot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24080-24540-capdrot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24081-24370-carlux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24081-24370-carlux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24081-24370-carlux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24081-24370-carlux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24082-24200-carsac_aillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24082-24200-carsac_aillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24082-24200-carsac_aillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24082-24200-carsac_aillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24083-24610-carsac_de_gurson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24083-24610-carsac_de_gurson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24083-24610-carsac_de_gurson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24083-24610-carsac_de_gurson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24084-24170-carves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24084-24170-carves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24084-24170-carves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24084-24170-carves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24085-24120-la_cassagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24085-24120-la_cassagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24085-24120-la_cassagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24085-24120-la_cassagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24086-24250-castelnaud_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24086-24250-castelnaud_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24086-24250-castelnaud_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24086-24250-castelnaud_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24087-24220-castels_et_bezenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24087-24220-castels_et_bezenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24087-24220-castels_et_bezenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24087-24220-castels_et_bezenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24088-24150-cause_de_clerans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24088-24150-cause_de_clerans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24088-24150-cause_de_clerans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24088-24150-cause_de_clerans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24089-24370-cazoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24089-24370-cazoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24089-24370-cazoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24089-24370-cazoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24090-24600-celles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24090-24600-celles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24090-24600-celles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24090-24600-celles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24091-24250-cenac_et_saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24091-24250-cenac_et_saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24091-24250-cenac_et_saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24091-24250-cenac_et_saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24094-24380-chalagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24094-24380-chalagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24094-24380-chalagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24094-24380-chalagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24095-24800-chalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24095-24800-chalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24095-24800-chalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24095-24800-chalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24096-24530-champagnac_de_belair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24096-24530-champagnac_de_belair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24096-24530-champagnac_de_belair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24096-24530-champagnac_de_belair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24097-24320-champagne_et_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24097-24320-champagne_et_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24097-24320-champagne_et_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24097-24320-champagne_et_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24098-24750-champcevinel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24098-24750-champcevinel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24098-24750-champcevinel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24098-24750-champcevinel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24100-24360-champniers_et_reilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24100-24360-champniers_et_reilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24100-24360-champniers_et_reilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24100-24360-champniers_et_reilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24101-24470-champs_romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24101-24470-champs_romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24101-24470-champs_romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24101-24470-champs_romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24102-24650-chancelade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24102-24650-chancelade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24102-24650-chancelade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24102-24650-chancelade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24104-24190-chanterac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24104-24190-chanterac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24104-24190-chanterac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24104-24190-chanterac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24105-24320-chapdeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24105-24320-chapdeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24105-24320-chapdeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24105-24320-chapdeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24106-24290-la_chapelle_aubareil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24106-24290-la_chapelle_aubareil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24106-24290-la_chapelle_aubareil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24106-24290-la_chapelle_aubareil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24107-24530-la_chapelle_faucher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24107-24530-la_chapelle_faucher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24107-24530-la_chapelle_faucher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24107-24530-la_chapelle_faucher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24108-24350-la_chapelle_gonaguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24108-24350-la_chapelle_gonaguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24108-24350-la_chapelle_gonaguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24108-24350-la_chapelle_gonaguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24109-24320-la_chapelle_gresignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24109-24320-la_chapelle_gresignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24109-24320-la_chapelle_gresignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24109-24320-la_chapelle_gresignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24110-24320-la_chapelle_montabourlet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24110-24320-la_chapelle_montabourlet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24110-24320-la_chapelle_montabourlet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24110-24320-la_chapelle_montabourlet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24111-24300-la_chapelle_montmoreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24111-24300-la_chapelle_montmoreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24111-24300-la_chapelle_montmoreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24111-24300-la_chapelle_montmoreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24113-24390-la_chapelle_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24113-24390-la_chapelle_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24113-24390-la_chapelle_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24113-24390-la_chapelle_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24114-24600-chassaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24114-24600-chassaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24114-24600-chassaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24114-24600-chassaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24115-24460-chateau_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24115-24460-chateau_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24115-24460-chateau_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24115-24460-chateau_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24116-24120-chatres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24116-24120-chatres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24116-24120-chatres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24116-24120-chatres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24117-24120-les_coteaux_perigourdins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24117-24120-les_coteaux_perigourdins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24117-24120-les_coteaux_perigourdins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24117-24120-les_coteaux_perigourdins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24119-24320-cherval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24119-24320-cherval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24119-24320-cherval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24119-24320-cherval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24120-24390-cherveix_cubas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24120-24390-cherveix_cubas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24120-24390-cherveix_cubas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24120-24390-cherveix_cubas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24121-24640-chourgnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24121-24640-chourgnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24121-24640-chourgnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24121-24640-chourgnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24122-24170-cladech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24122-24170-cladech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24122-24170-cladech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24122-24170-cladech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24123-24140-clermont_de_beauregard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24123-24140-clermont_de_beauregard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24123-24140-clermont_de_beauregard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24123-24140-clermont_de_beauregard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24124-24160-clermont_d_excideuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24124-24160-clermont_d_excideuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24124-24160-clermont_d_excideuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24124-24160-clermont_d_excideuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24126-24560-colombier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24126-24560-colombier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24126-24560-colombier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24126-24560-colombier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24128-24600-comberanche_et_epeluche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24128-24600-comberanche_et_epeluche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24128-24600-comberanche_et_epeluche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24128-24600-comberanche_et_epeluche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24129-24530-condat_sur_trincou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24129-24530-condat_sur_trincou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24129-24530-condat_sur_trincou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24129-24530-condat_sur_trincou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24130-24570-condat_sur_vezere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24130-24570-condat_sur_vezere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24130-24570-condat_sur_vezere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24130-24570-condat_sur_vezere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24131-24300-connezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24131-24300-connezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24131-24300-connezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24131-24300-connezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24132-24560-conne_de_labarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24132-24560-conne_de_labarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24132-24560-conne_de_labarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24132-24560-conne_de_labarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24133-24450-la_coquille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24133-24450-la_coquille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24133-24450-la_coquille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24133-24450-la_coquille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24134-24800-corgnac_sur_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24134-24800-corgnac_sur_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24134-24800-corgnac_sur_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24134-24800-corgnac_sur_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24135-24750-cornille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24135-24750-cornille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24135-24750-cornille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24135-24750-cornille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24136-24390-coubjours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24136-24390-coubjours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24136-24390-coubjours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24136-24390-coubjours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24137-24420-coulaures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24137-24420-coulaures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24137-24420-coulaures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24137-24420-coulaures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24138-24660-coulounieix_chamiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24138-24660-coulounieix_chamiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24138-24660-coulounieix_chamiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24138-24660-coulounieix_chamiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24139-24430-coursac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24139-24430-coursac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24139-24430-coursac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24139-24430-coursac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24140-24520-cours_de_pile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24140-24520-cours_de_pile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24140-24520-cours_de_pile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24140-24520-cours_de_pile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24141-24320-coutures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24141-24320-coutures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24141-24320-coutures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24141-24320-coutures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24142-24220-coux_et_bigaroque_mouzens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24142-24220-coux_et_bigaroque_mouzens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24142-24220-coux_et_bigaroque_mouzens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24142-24220-coux_et_bigaroque_mouzens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24143-24150-couze_et_saint_front/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24143-24150-couze_et_saint_front/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24143-24150-couze_et_saint_front/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24143-24150-couze_et_saint_front/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24144-24350-creyssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24144-24350-creyssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24144-24350-creyssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24144-24350-creyssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24145-24100-creysse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24145-24100-creysse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24145-24100-creysse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24145-24100-creysse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24146-24380-creyssensac_et_pissot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24146-24380-creyssensac_et_pissot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24146-24380-creyssensac_et_pissot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24146-24380-creyssensac_et_pissot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24147-24640-cubjac_auvezere_val_d_ans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24147-24640-cubjac_auvezere_val_d_ans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24147-24640-cubjac_auvezere_val_d_ans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24147-24640-cubjac_auvezere_val_d_ans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24148-24240-cuneges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24148-24240-cuneges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24148-24240-cuneges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24148-24240-cuneges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24150-24250-daglan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24150-24250-daglan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24150-24250-daglan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24150-24250-daglan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24151-24170-doissat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24151-24170-doissat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24151-24170-doissat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24151-24170-doissat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24152-24250-domme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24152-24250-domme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24152-24250-domme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24152-24250-domme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24153-24120-la_dornac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24153-24120-la_dornac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24153-24120-la_dornac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24153-24120-la_dornac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24154-24350-douchapt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24154-24350-douchapt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24154-24350-douchapt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24154-24350-douchapt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24155-24140-douville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24155-24140-douville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24155-24140-douville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24155-24140-douville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24156-24330-la_douze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24156-24330-la_douze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24156-24330-la_douze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24156-24330-la_douze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24157-24190-douzillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24157-24190-douzillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24157-24190-douzillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24157-24190-douzillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24158-24270-dussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24158-24270-dussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24158-24270-dussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24158-24270-dussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24159-24410-echourgnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24159-24410-echourgnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24159-24410-echourgnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24159-24410-echourgnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24160-24380-eglise_neuve_de_vergt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24160-24380-eglise_neuve_de_vergt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24160-24380-eglise_neuve_de_vergt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24160-24380-eglise_neuve_de_vergt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24161-24400-eglise_neuve_d_issac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24161-24400-eglise_neuve_d_issac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24161-24400-eglise_neuve_d_issac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24161-24400-eglise_neuve_d_issac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24162-24420-escoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24162-24420-escoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24162-24420-escoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24162-24420-escoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24163-24360-etouars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24163-24360-etouars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24163-24360-etouars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24163-24360-etouars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24164-24160-excideuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24164-24160-excideuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24164-24160-excideuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24164-24160-excideuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24165-24700-eygurande_et_gardedeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24165-24700-eygurande_et_gardedeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24165-24700-eygurande_et_gardedeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24165-24700-eygurande_et_gardedeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24167-24500-eymet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24167-24500-eymet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24167-24500-eymet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24167-24500-eymet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24168-24560-plaisance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24168-24560-plaisance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24168-24560-plaisance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24168-24560-plaisance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24171-24800-eyzerac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24171-24800-eyzerac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24171-24800-eyzerac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24171-24800-eyzerac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24172-24620-les_eyzies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24172-24620-les_eyzies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24172-24620-les_eyzies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24172-24620-les_eyzies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24172-24260-les_eyzies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24172-24260-les_eyzies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24172-24260-les_eyzies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24172-24260-les_eyzies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24174-24290-fanlac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24174-24290-fanlac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24174-24290-fanlac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24174-24290-fanlac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24175-24290-les_farges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24175-24290-les_farges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24175-24290-les_farges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24175-24290-les_farges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24176-24560-faurilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24176-24560-faurilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24176-24560-faurilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24176-24560-faurilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24177-24560-faux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24177-24560-faux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24177-24560-faux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24177-24560-faux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24179-24120-la_feuillade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24179-24120-la_feuillade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24179-24120-la_feuillade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24179-24120-la_feuillade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24180-24450-firbeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24180-24450-firbeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24180-24450-firbeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24180-24450-firbeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24182-24130-le_fleix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24182-24130-le_fleix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24182-24130-le_fleix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24182-24130-le_fleix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24183-24580-fleurac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24183-24580-fleurac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24183-24580-fleurac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24183-24580-fleurac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24184-24250-florimont_gaumier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24184-24250-florimont_gaumier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24184-24250-florimont_gaumier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24184-24250-florimont_gaumier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24186-24500-fonroque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24186-24500-fonroque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24186-24500-fonroque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24186-24500-fonroque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24188-24210-fossemagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24188-24210-fossemagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24188-24210-fossemagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24188-24210-fossemagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24189-33220-fougueyrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24189-33220-fougueyrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24189-33220-fougueyrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24189-33220-fougueyrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24190-24380-fouleix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24190-24380-fouleix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24190-24380-fouleix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24190-24380-fouleix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24191-24130-fraisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24191-24130-fraisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24191-24130-fraisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24191-24130-fraisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24192-24210-gabillou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24192-24210-gabillou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24192-24210-gabillou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24192-24210-gabillou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24193-24240-gageac_et_rouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24193-24240-gageac_et_rouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24193-24240-gageac_et_rouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24193-24240-gageac_et_rouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24194-24680-gardonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24194-24680-gardonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24194-24680-gardonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24194-24680-gardonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24195-24540-gaugeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24195-24540-gaugeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24195-24540-gaugeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24195-24540-gaugeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24196-24160-genis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24196-24160-genis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24196-24160-genis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24196-24160-genis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24197-24130-ginestet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24197-24130-ginestet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24197-24130-ginestet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24197-24130-ginestet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24199-24320-gout_rossignol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24199-24320-gout_rossignol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24199-24320-gout_rossignol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24199-24320-gout_rossignol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24200-24350-grand_brassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24200-24350-grand_brassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24200-24350-grand_brassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24200-24350-grand_brassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24202-24390-granges_d_ans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24202-24390-granges_d_ans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24202-24390-granges_d_ans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24202-24390-granges_d_ans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24205-24110-grignols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24205-24110-grignols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24205-24110-grignols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24205-24110-grignols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24206-24170-grives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24206-24170-grives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24206-24170-grives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24206-24170-grives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24207-24250-grolejac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24207-24250-grolejac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24207-24250-grolejac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24207-24250-grolejac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24208-24380-grun_bordas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24208-24380-grun_bordas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24208-24380-grun_bordas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24208-24380-grun_bordas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24209-24300-hautefaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24209-24300-hautefaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24209-24300-hautefaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24209-24300-hautefaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24210-24390-hautefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24210-24390-hautefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24210-24390-hautefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24210-24390-hautefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24211-24400-issac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24211-24400-issac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24211-24400-issac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24211-24400-issac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24212-24560-issigeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24212-24560-issigeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24212-24560-issigeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24212-24560-issigeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24213-24140-jaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24213-24140-jaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24213-24140-jaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24213-24140-jaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24214-24300-javerlhac_et_la_chapelle_saint_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24214-24300-javerlhac_et_la_chapelle_saint_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24214-24300-javerlhac_et_la_chapelle_saint_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24214-24300-javerlhac_et_la_chapelle_saint_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24215-24590-jayac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24215-24590-jayac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24215-24590-jayac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24215-24590-jayac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24216-24410-la_jemaye_ponteyraud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24216-24410-la_jemaye_ponteyraud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24216-24410-la_jemaye_ponteyraud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24216-24410-la_jemaye_ponteyraud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24217-24260-journiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24217-24260-journiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24217-24260-journiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24217-24260-journiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24218-24630-jumilhac_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24218-24630-jumilhac_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24218-24630-jumilhac_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24218-24630-jumilhac_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24220-24380-lacropte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24220-24380-lacropte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24220-24380-lacropte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24220-24380-lacropte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24221-24340-rudeau_ladosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24221-24340-rudeau_ladosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24221-24340-rudeau_ladosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24221-24340-rudeau_ladosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24222-24130-la_force/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24222-24130-la_force/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24222-24130-la_force/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24222-24130-la_force/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24223-24150-lalinde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24223-24150-lalinde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24223-24150-lalinde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24223-24150-lalinde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24224-24520-lamonzie_montastruc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24224-24520-lamonzie_montastruc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24224-24520-lamonzie_montastruc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24224-24520-lamonzie_montastruc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24225-24680-lamonzie_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24225-24680-lamonzie_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24225-24680-lamonzie_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24225-24680-lamonzie_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24226-24230-lamothe_montravel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24226-24230-lamothe_montravel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24226-24230-lamothe_montravel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24226-24230-lamothe_montravel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24227-24270-lanouaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24227-24270-lanouaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24227-24270-lanouaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24227-24270-lanouaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24228-24150-lanquais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24228-24150-lanquais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24228-24150-lanquais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24228-24150-lanquais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24229-24570-le_lardin_saint_lazare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24229-24570-le_lardin_saint_lazare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24229-24570-le_lardin_saint_lazare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24229-24570-le_lardin_saint_lazare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24230-24170-larzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24230-24170-larzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24230-24170-larzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24230-24170-larzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24231-24540-lavalade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24231-24540-lavalade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24231-24540-lavalade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24231-24540-lavalade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24232-24550-lavaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24232-24550-lavaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24232-24550-lavaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24232-24550-lavaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24234-24400-les_leches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24234-24400-les_leches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24234-24400-les_leches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24234-24400-les_leches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24236-24110-leguillac_de_l_auche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24236-24110-leguillac_de_l_auche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24236-24110-leguillac_de_l_auche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24236-24110-leguillac_de_l_auche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24237-24100-lembras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24237-24100-lembras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24237-24100-lembras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24237-24100-lembras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24238-24800-lempzours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24238-24800-lempzours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24238-24800-lempzours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24238-24800-lempzours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24240-24510-limeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24240-24510-limeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24240-24510-limeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24240-24510-limeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24241-24210-limeyrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24241-24210-limeyrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24241-24210-limeyrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24241-24210-limeyrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24242-24520-liorac_sur_louyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24242-24520-liorac_sur_louyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24242-24520-liorac_sur_louyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24242-24520-liorac_sur_louyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24243-24350-lisle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24243-24350-lisle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24243-24350-lisle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24243-24350-lisle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24244-24540-lolme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24244-24540-lolme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24244-24540-lolme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24244-24540-lolme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24245-24550-loubejac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24245-24550-loubejac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24245-24550-loubejac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24245-24550-loubejac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24246-24130-lunas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24246-24130-lunas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24246-24130-lunas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24246-24130-lunas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24247-24320-lusignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24247-24320-lusignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24247-24320-lusignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24247-24320-lusignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24248-24300-lussas_et_nontronneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24248-24300-lussas_et_nontronneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24248-24300-lussas_et_nontronneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24248-24300-lussas_et_nontronneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24251-24110-manzac_sur_vern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24251-24110-manzac_sur_vern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24251-24110-manzac_sur_vern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24251-24110-manzac_sur_vern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24252-24200-marcillac_saint_quentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24252-24200-marcillac_saint_quentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24252-24200-marcillac_saint_quentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24252-24200-marcillac_saint_quentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24253-24340-mareuil_en_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24253-24340-mareuil_en_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24253-24340-mareuil_en_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24253-24340-mareuil_en_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24254-24220-marnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24254-24220-marnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24254-24220-marnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24254-24220-marnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24255-24620-marquay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24255-24620-marquay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24255-24620-marquay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24255-24620-marquay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24256-24430-marsac_sur_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24256-24430-marsac_sur_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24256-24430-marsac_sur_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24256-24430-marsac_sur_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24257-24540-marsales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24257-24540-marsales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24257-24540-marsales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24257-24540-marsales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24259-24140-eyraud_crempse_maurens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24259-24140-eyraud_crempse_maurens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24259-24140-eyraud_crempse_maurens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24259-24140-eyraud_crempse_maurens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24259-24130-eyraud_crempse_maurens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24259-24130-eyraud_crempse_maurens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24259-24130-eyraud_crempse_maurens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24259-24130-eyraud_crempse_maurens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24260-24150-mauzac_et_grand_castang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24260-24150-mauzac_et_grand_castang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24260-24150-mauzac_et_grand_castang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24260-24150-mauzac_et_grand_castang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24261-24260-mauzens_et_miremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24261-24260-mauzens_et_miremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24261-24260-mauzens_et_miremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24261-24260-mauzens_et_miremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24262-24420-mayac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24262-24420-mayac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24262-24420-mayac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24262-24420-mayac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24263-24550-mazeyrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24263-24550-mazeyrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24263-24550-mazeyrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24263-24550-mazeyrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24264-24700-menesplet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24264-24700-menesplet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24264-24700-menesplet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24264-24700-menesplet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24266-24350-mensignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24266-24350-mensignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24266-24350-mensignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24266-24350-mensignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24267-24240-mescoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24267-24240-mescoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24267-24240-mescoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24267-24240-mescoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24268-24220-meyrals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24268-24220-meyrals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24268-24220-meyrals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24268-24220-meyrals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24269-24450-mialet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24269-24450-mialet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24269-24450-mialet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24269-24450-mialet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24271-24470-milhac_de_nontron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24271-24470-milhac_de_nontron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24271-24470-milhac_de_nontron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24271-24470-milhac_de_nontron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24272-24610-minzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24272-24610-minzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24272-24610-minzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24272-24610-minzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24273-24480-molieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24273-24480-molieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24273-24480-molieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24273-24480-molieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24274-24240-monbazillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24274-24240-monbazillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24274-24240-monbazillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24274-24240-monbazillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24276-24240-monestier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24276-24240-monestier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24276-24240-monestier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24276-24240-monestier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24277-24130-monfaucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24277-24130-monfaucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24277-24130-monfaucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24277-24130-monfaucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24278-24560-monmadales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24278-24560-monmadales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24278-24560-monmadales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24278-24560-monmadales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24279-24560-monmarves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24279-24560-monmarves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24279-24560-monmarves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24279-24560-monmarves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24280-24540-monpazier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24280-24540-monpazier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24280-24540-monpazier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24280-24540-monpazier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24281-24440-monsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24281-24440-monsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24281-24440-monsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24281-24440-monsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24282-24560-monsaguel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24282-24560-monsaguel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24282-24560-monsaguel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24282-24560-monsaguel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24284-24210-montagnac_d_auberoche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24284-24210-montagnac_d_auberoche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24284-24210-montagnac_d_auberoche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24284-24210-montagnac_d_auberoche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24285-24140-montagnac_la_crempse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24285-24140-montagnac_la_crempse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24285-24140-montagnac_la_crempse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24285-24140-montagnac_la_crempse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24286-24350-montagrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24286-24350-montagrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24286-24350-montagrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24286-24350-montagrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24287-24560-montaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24287-24560-montaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24287-24560-montaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24287-24560-montaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24288-24230-montazeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24288-24230-montazeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24288-24230-montazeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24288-24230-montazeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24289-24230-montcaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24289-24230-montcaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24289-24230-montcaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24289-24230-montcaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24290-24440-montferrand_du_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24290-24440-montferrand_du_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24290-24440-montferrand_du_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24290-24440-montferrand_du_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24291-24290-montignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24291-24290-montignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24291-24290-montignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24291-24290-montignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24292-24610-montpeyroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24292-24610-montpeyroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24292-24610-montpeyroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24292-24610-montpeyroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24293-24170-monplaisant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24293-24170-monplaisant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24293-24170-monplaisant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24293-24170-monplaisant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24294-24700-montpon_menesterol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24294-24700-montpon_menesterol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24294-24700-montpon_menesterol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24294-24700-montpon_menesterol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24295-24110-montrem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24295-24110-montrem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24295-24110-montrem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24295-24110-montrem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24296-24520-mouleydier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24296-24520-mouleydier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24296-24520-mouleydier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24296-24520-mouleydier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24297-24700-moulin_neuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24297-24700-moulin_neuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24297-24700-moulin_neuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24297-24700-moulin_neuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24299-24400-mussidan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24299-24400-mussidan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24299-24400-mussidan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24299-24400-mussidan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24300-24250-nabirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24300-24250-nabirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24300-24250-nabirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24300-24250-nabirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24301-24590-nadaillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24301-24590-nadaillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24301-24590-nadaillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24301-24590-nadaillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24302-24390-nailhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24302-24390-nailhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24302-24390-nailhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24302-24390-nailhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24303-24320-nanteuil_auriac_de_bourzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24303-24320-nanteuil_auriac_de_bourzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24303-24320-nanteuil_auriac_de_bourzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24303-24320-nanteuil_auriac_de_bourzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24304-24800-nantheuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24304-24800-nantheuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24304-24800-nantheuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24304-24800-nantheuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24305-24800-nanthiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24305-24800-nanthiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24305-24800-nanthiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24305-24800-nanthiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24306-24230-nastringues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24306-24230-nastringues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24306-24230-nastringues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24306-24230-nastringues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24307-24440-naussannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24307-24440-naussannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24307-24440-naussannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24307-24440-naussannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24308-24460-negrondes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24308-24460-negrondes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24308-24460-negrondes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24308-24460-negrondes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24309-24190-neuvic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24309-24190-neuvic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24309-24190-neuvic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24309-24190-neuvic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24311-24300-nontron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24311-24300-nontron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24311-24300-nontron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24311-24300-nontron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24660-sanilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24660-sanilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24660-sanilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24660-sanilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24380-sanilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24380-sanilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24380-sanilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24380-sanilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24750-sanilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24750-sanilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24750-sanilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24312-24750-sanilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24313-24170-orliac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24313-24170-orliac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24313-24170-orliac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24313-24170-orliac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24314-24370-orliaguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24314-24370-orliaguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24314-24370-orliaguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24314-24370-orliaguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24316-24410-parcoul_chenaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24316-24410-parcoul_chenaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24316-24410-parcoul_chenaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24316-24410-parcoul_chenaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24317-24590-paulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24317-24590-paulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24317-24590-paulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24317-24590-paulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24318-24510-paunat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24318-24510-paunat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24318-24510-paunat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24318-24510-paunat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24319-24310-paussac_et_saint_vivien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24319-24310-paussac_et_saint_vivien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24319-24310-paussac_et_saint_vivien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24319-24310-paussac_et_saint_vivien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24320-24270-payzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24320-24270-payzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24320-24270-payzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24320-24270-payzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24321-24120-pazayac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24321-24120-pazayac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24321-24120-pazayac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24321-24120-pazayac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24322-24000-perigueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24322-24000-perigueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24322-24000-perigueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24322-24000-perigueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24323-24600-petit_bersac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24323-24600-petit_bersac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24323-24600-petit_bersac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24323-24600-petit_bersac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24324-24210-peyrignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24324-24210-peyrignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24324-24210-peyrignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24324-24210-peyrignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24325-24370-peyrillac_et_millac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24325-24370-peyrillac_et_millac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24325-24370-peyrillac_et_millac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24325-24370-peyrillac_et_millac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24326-24620-peyzac_le_moustier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24326-24620-peyzac_le_moustier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24326-24620-peyzac_le_moustier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24326-24620-peyzac_le_moustier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24327-24510-pezuls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24327-24510-pezuls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24327-24510-pezuls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24327-24510-pezuls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24328-24360-piegut_pluviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24328-24360-piegut_pluviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24328-24360-piegut_pluviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24328-24360-piegut_pluviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24329-24700-le_pizou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24329-24700-le_pizou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24329-24700-le_pizou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24329-24700-le_pizou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24330-24580-plazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24330-24580-plazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24330-24580-plazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24330-24580-plazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24331-24240-pomport/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24331-24240-pomport/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24331-24240-pomport/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24331-24240-pomport/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24334-24150-pontours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24334-24150-pontours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24334-24150-pontours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24334-24150-pontours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24335-33220-port_sainte_foy_et_ponchapt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24335-33220-port_sainte_foy_et_ponchapt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24335-33220-port_sainte_foy_et_ponchapt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24335-33220-port_sainte_foy_et_ponchapt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24336-24370-prats_de_carlux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24336-24370-prats_de_carlux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24336-24370-prats_de_carlux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24336-24370-prats_de_carlux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24337-24550-prats_du_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24337-24550-prats_du_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24337-24550-prats_du_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24337-24550-prats_du_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24338-24150-pressignac_vicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24338-24150-pressignac_vicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24338-24150-pressignac_vicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24338-24150-pressignac_vicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24339-24160-preyssac_d_excideuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24339-24160-preyssac_d_excideuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24339-24160-preyssac_d_excideuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24339-24160-preyssac_d_excideuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24340-24130-prigonrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24340-24130-prigonrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24340-24130-prigonrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24340-24130-prigonrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24341-24200-proissans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24341-24200-proissans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24341-24200-proissans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24341-24200-proissans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24345-24140-queyssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24345-24140-queyssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24345-24140-queyssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24345-24140-queyssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24346-24530-quinsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24346-24530-quinsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24346-24530-quinsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24346-24530-quinsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24347-24440-rampieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24347-24440-rampieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24347-24440-rampieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24347-24440-rampieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24348-24500-razac_d_eymet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24348-24500-razac_d_eymet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24348-24500-razac_d_eymet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24348-24500-razac_d_eymet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24349-24240-razac_de_saussignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24349-24240-razac_de_saussignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24349-24240-razac_de_saussignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24349-24240-razac_de_saussignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24350-24430-razac_sur_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24350-24430-razac_sur_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24350-24430-razac_sur_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24350-24430-razac_sur_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24351-24240-ribagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24351-24240-ribagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24351-24240-ribagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24351-24240-ribagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24352-24600-riberac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24352-24600-riberac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24352-24600-riberac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24352-24600-riberac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24353-24340-la_rochebeaucourt_et_argentine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24353-24340-la_rochebeaucourt_et_argentine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24353-24340-la_rochebeaucourt_et_argentine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24353-24340-la_rochebeaucourt_et_argentine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24354-24490-la_roche_chalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24354-24490-la_roche_chalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24354-24490-la_roche_chalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24354-24490-la_roche_chalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24355-24250-la_roque_gageac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24355-24250-la_roque_gageac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24355-24250-la_roque_gageac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24355-24250-la_roque_gageac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24356-24580-rouffignac_saint_cernin_de_reilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24356-24580-rouffignac_saint_cernin_de_reilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24356-24580-rouffignac_saint_cernin_de_reilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24356-24580-rouffignac_saint_cernin_de_reilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24357-24240-rouffignac_de_sigoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24357-24240-rouffignac_de_sigoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24357-24240-rouffignac_de_sigoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24357-24240-rouffignac_de_sigoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24359-24500-sadillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24359-24500-sadillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24359-24500-sadillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24359-24500-sadillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24360-24170-sagelat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24360-24170-sagelat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24360-24170-sagelat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24360-24170-sagelat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24361-24520-saint_agne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24361-24520-saint_agne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24361-24520-saint_agne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24361-24520-saint_agne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24362-24510-val_de_louyre_et_caudeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24362-24510-val_de_louyre_et_caudeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24362-24510-val_de_louyre_et_caudeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24362-24510-val_de_louyre_et_caudeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24362-24380-val_de_louyre_et_caudeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24362-24380-val_de_louyre_et_caudeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24362-24380-val_de_louyre_et_caudeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24362-24380-val_de_louyre_et_caudeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24364-24290-coly_saint_amand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24364-24290-coly_saint_amand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24364-24290-coly_saint_amand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24364-24290-coly_saint_amand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24364-24120-coly_saint_amand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24364-24120-coly_saint_amand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24364-24120-coly_saint_amand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24364-24120-coly_saint_amand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24365-24380-saint_amand_de_vergt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24365-24380-saint_amand_de_vergt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24365-24380-saint_amand_de_vergt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24365-24380-saint_amand_de_vergt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24366-24200-saint_andre_d_allas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24366-24200-saint_andre_d_allas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24366-24200-saint_andre_d_allas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24366-24200-saint_andre_d_allas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24367-24190-saint_andre_de_double/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24367-24190-saint_andre_de_double/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24367-24190-saint_andre_de_double/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24367-24190-saint_andre_de_double/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24370-24230-saint_antoine_de_breuilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24370-24230-saint_antoine_de_breuilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24370-24230-saint_antoine_de_breuilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24370-24230-saint_antoine_de_breuilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24371-24110-saint_aquilin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24371-24110-saint_aquilin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24371-24110-saint_aquilin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24371-24110-saint_aquilin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24372-24110-saint_astier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24372-24110-saint_astier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24372-24110-saint_astier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24372-24110-saint_astier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24373-24500-saint_aubin_de_cadelech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24373-24500-saint_aubin_de_cadelech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24373-24500-saint_aubin_de_cadelech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24373-24500-saint_aubin_de_cadelech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24374-24560-saint_aubin_de_lanquais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24374-24560-saint_aubin_de_lanquais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24374-24560-saint_aubin_de_lanquais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24374-24560-saint_aubin_de_lanquais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24375-24250-saint_aubin_de_nabirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24375-24250-saint_aubin_de_nabirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24375-24250-saint_aubin_de_nabirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24375-24250-saint_aubin_de_nabirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24376-24410-saint_aulaye_puymangou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24376-24410-saint_aulaye_puymangou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24376-24410-saint_aulaye_puymangou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24376-24410-saint_aulaye_puymangou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24377-24260-saint_avit_de_vialard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24377-24260-saint_avit_de_vialard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24377-24260-saint_avit_de_vialard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24377-24260-saint_avit_de_vialard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24378-24540-saint_avit_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24378-24540-saint_avit_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24378-24540-saint_avit_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24378-24540-saint_avit_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24379-24440-saint_avit_senieur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24379-24440-saint_avit_senieur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24379-24440-saint_avit_senieur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24379-24440-saint_avit_senieur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24380-24700-saint_barthelemy_de_bellegarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24380-24700-saint_barthelemy_de_bellegarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24380-24700-saint_barthelemy_de_bellegarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24380-24700-saint_barthelemy_de_bellegarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24381-24360-saint_barthelemy_de_bussiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24381-24360-saint_barthelemy_de_bussiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24381-24360-saint_barthelemy_de_bussiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24381-24360-saint_barthelemy_de_bussiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24382-24150-saint_capraise_de_lalinde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24382-24150-saint_capraise_de_lalinde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24382-24150-saint_capraise_de_lalinde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24382-24150-saint_capraise_de_lalinde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24383-24500-saint_capraise_d_eymet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24383-24500-saint_capraise_d_eymet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24383-24500-saint_capraise_d_eymet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24383-24500-saint_capraise_d_eymet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24384-24540-saint_cassien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24384-24540-saint_cassien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24384-24540-saint_cassien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24384-24540-saint_cassien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24385-24560-saint_cernin_de_labarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24385-24560-saint_cernin_de_labarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24385-24560-saint_cernin_de_labarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24385-24560-saint_cernin_de_labarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24386-24550-saint_cernin_de_l_herm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24386-24550-saint_cernin_de_l_herm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24386-24550-saint_cernin_de_l_herm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24386-24550-saint_cernin_de_l_herm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24388-24260-saint_chamassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24388-24260-saint_chamassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24388-24260-saint_chamassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24388-24260-saint_chamassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24390-24330-saint_crepin_d_auberoche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24390-24330-saint_crepin_d_auberoche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24390-24330-saint_crepin_d_auberoche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24390-24330-saint_crepin_d_auberoche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24392-24590-saint_crepin_et_carlucet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24392-24590-saint_crepin_et_carlucet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24392-24590-saint_crepin_et_carlucet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24392-24590-saint_crepin_et_carlucet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24393-24440-sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24393-24440-sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24393-24440-sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24393-24440-sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24394-24340-sainte_croix_de_mareuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24394-24340-sainte_croix_de_mareuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24394-24340-sainte_croix_de_mareuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24394-24340-sainte_croix_de_mareuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24395-24250-saint_cybranet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24395-24250-saint_cybranet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24395-24250-saint_cybranet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24395-24250-saint_cybranet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24396-24220-saint_cyprien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24396-24220-saint_cyprien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24396-24220-saint_cyprien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24396-24220-saint_cyprien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24397-24270-saint_cyr_les_champagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24397-24270-saint_cyr_les_champagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24397-24270-saint_cyr_les_champagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24397-24270-saint_cyr_les_champagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24398-24360-saint_estephe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24398-24360-saint_estephe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24398-24360-saint_estephe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24398-24360-saint_estephe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24399-24400-saint_etienne_de_puycorbier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24399-24400-saint_etienne_de_puycorbier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24399-24400-saint_etienne_de_puycorbier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24399-24400-saint_etienne_de_puycorbier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24401-24640-sainte_eulalie_d_ans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24401-24640-sainte_eulalie_d_ans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24401-24640-sainte_eulalie_d_ans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24401-24640-sainte_eulalie_d_ans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24403-24340-saint_felix_de_bourdeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24403-24340-saint_felix_de_bourdeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24403-24340-saint_felix_de_bourdeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24403-24340-saint_felix_de_bourdeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24404-24260-saint_felix_de_reillac_et_mortemart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24404-24260-saint_felix_de_reillac_et_mortemart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24404-24260-saint_felix_de_reillac_et_mortemart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24404-24260-saint_felix_de_reillac_et_mortemart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24405-24510-saint_felix_de_villadeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24405-24510-saint_felix_de_villadeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24405-24510-saint_felix_de_villadeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24405-24510-saint_felix_de_villadeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24406-24170-sainte_foy_de_belves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24406-24170-sainte_foy_de_belves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24406-24170-sainte_foy_de_belves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24406-24170-sainte_foy_de_belves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24407-24510-sainte_foy_de_longas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24407-24510-sainte_foy_de_longas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24407-24510-sainte_foy_de_longas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24407-24510-sainte_foy_de_longas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24408-24460-saint_front_d_alemps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24408-24460-saint_front_d_alemps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24408-24460-saint_front_d_alemps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24408-24460-saint_front_d_alemps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24409-24400-saint_front_de_pradoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24409-24400-saint_front_de_pradoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24409-24400-saint_front_de_pradoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24409-24400-saint_front_de_pradoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24410-24300-saint_front_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24410-24300-saint_front_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24410-24300-saint_front_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24410-24300-saint_front_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24411-24300-saint_front_sur_nizonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24411-24300-saint_front_sur_nizonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24411-24300-saint_front_sur_nizonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24411-24300-saint_front_sur_nizonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24412-24590-saint_genies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24412-24590-saint_genies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24412-24590-saint_genies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24412-24590-saint_genies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24413-24130-saint_georges_blancaneix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24413-24130-saint_georges_blancaneix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24413-24130-saint_georges_blancaneix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24413-24130-saint_georges_blancaneix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24414-24140-saint_georges_de_montclard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24414-24140-saint_georges_de_montclard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24414-24140-saint_georges_de_montclard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24414-24140-saint_georges_de_montclard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24415-24700-saint_geraud_de_corps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24415-24700-saint_geraud_de_corps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24415-24700-saint_geraud_de_corps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24415-24700-saint_geraud_de_corps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24416-24170-saint_germain_de_belves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24416-24170-saint_germain_de_belves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24416-24170-saint_germain_de_belves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24416-24170-saint_germain_de_belves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24417-24160-saint_germain_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24417-24160-saint_germain_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24417-24160-saint_germain_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24417-24160-saint_germain_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24418-24190-saint_germain_du_salembre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24418-24190-saint_germain_du_salembre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24418-24190-saint_germain_du_salembre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24418-24190-saint_germain_du_salembre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24419-24520-saint_germain_et_mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24419-24520-saint_germain_et_mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24419-24520-saint_germain_et_mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24419-24520-saint_germain_et_mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24420-24400-saint_gery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24420-24400-saint_gery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24420-24400-saint_gery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24420-24400-saint_gery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24421-24330-saint_geyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24421-24330-saint_geyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24421-24330-saint_geyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24421-24330-saint_geyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24422-24140-saint_hilaire_d_estissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24422-24140-saint_hilaire_d_estissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24422-24140-saint_hilaire_d_estissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24422-24140-saint_hilaire_d_estissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24423-24500-saint_julien_innocence_eulalie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24423-24500-saint_julien_innocence_eulalie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24423-24500-saint_julien_innocence_eulalie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24423-24500-saint_julien_innocence_eulalie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24424-24190-saint_jean_d_ataux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24424-24190-saint_jean_d_ataux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24424-24190-saint_jean_d_ataux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24424-24190-saint_jean_d_ataux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24425-24800-saint_jean_de_cole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24425-24800-saint_jean_de_cole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24425-24800-saint_jean_de_cole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24425-24800-saint_jean_de_cole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24426-24140-saint_jean_d_estissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24426-24140-saint_jean_d_estissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24426-24140-saint_jean_d_estissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24426-24140-saint_jean_d_estissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24428-24800-saint_jory_de_chalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24428-24800-saint_jory_de_chalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24428-24800-saint_jory_de_chalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24428-24800-saint_jory_de_chalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24429-24160-saint_jory_las_bloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24429-24160-saint_jory_las_bloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24429-24160-saint_jory_las_bloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24429-24160-saint_jory_las_bloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24432-24370-saint_julien_de_lampon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24432-24370-saint_julien_de_lampon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24432-24370-saint_julien_de_lampon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24432-24370-saint_julien_de_lampon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24434-24320-saint_just/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24434-24320-saint_just/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24434-24320-saint_just/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24434-24320-saint_just/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24436-24400-saint_laurent_des_hommes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24436-24400-saint_laurent_des_hommes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24436-24400-saint_laurent_des_hommes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24436-24400-saint_laurent_des_hommes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24437-24100-saint_laurent_des_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24437-24100-saint_laurent_des_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24437-24100-saint_laurent_des_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24437-24100-saint_laurent_des_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24438-24170-saint_laurent_la_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24438-24170-saint_laurent_la_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24438-24170-saint_laurent_la_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24438-24170-saint_laurent_la_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24441-24560-saint_leon_d_issigeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24441-24560-saint_leon_d_issigeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24441-24560-saint_leon_d_issigeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24441-24560-saint_leon_d_issigeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24442-24110-saint_leon_sur_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24442-24110-saint_leon_sur_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24442-24110-saint_leon_sur_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24442-24110-saint_leon_sur_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24443-24290-saint_leon_sur_vezere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24443-24290-saint_leon_sur_vezere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24443-24290-saint_leon_sur_vezere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24443-24290-saint_leon_sur_vezere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24444-24400-saint_louis_en_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24444-24400-saint_louis_en_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24444-24400-saint_louis_en_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24444-24400-saint_louis_en_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24445-24510-saint_marcel_du_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24445-24510-saint_marcel_du_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24445-24510-saint_marcel_du_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24445-24510-saint_marcel_du_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24446-24540-saint_marcory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24446-24540-saint_marcory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24446-24540-saint_marcory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24446-24540-saint_marcory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24448-24160-saint_martial_d_albarede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24448-24160-saint_martial_d_albarede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24448-24160-saint_martial_d_albarede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24448-24160-saint_martial_d_albarede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24449-24700-saint_martial_d_artenset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24449-24700-saint_martial_d_artenset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24449-24700-saint_martial_d_artenset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24449-24700-saint_martial_d_artenset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24450-24250-saint_martial_de_nabirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24450-24250-saint_martial_de_nabirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24450-24250-saint_martial_de_nabirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24450-24250-saint_martial_de_nabirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24451-24300-saint_martial_de_valette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24451-24300-saint_martial_de_valette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24451-24300-saint_martial_de_valette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24451-24300-saint_martial_de_valette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24452-24320-saint_martial_viveyrol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24452-24320-saint_martial_viveyrol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24452-24320-saint_martial_viveyrol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24452-24320-saint_martial_viveyrol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24453-24800-saint_martin_de_fressengeas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24453-24800-saint_martin_de_fressengeas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24453-24800-saint_martin_de_fressengeas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24453-24800-saint_martin_de_fressengeas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24454-24610-saint_martin_de_gurson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24454-24610-saint_martin_de_gurson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24454-24610-saint_martin_de_gurson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24454-24610-saint_martin_de_gurson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24455-24600-saint_martin_de_riberac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24455-24600-saint_martin_de_riberac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24455-24600-saint_martin_de_riberac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24455-24600-saint_martin_de_riberac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24456-24140-saint_martin_des_combes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24456-24140-saint_martin_des_combes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24456-24140-saint_martin_des_combes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24456-24140-saint_martin_des_combes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24457-24400-saint_martin_l_astier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24457-24400-saint_martin_l_astier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24457-24400-saint_martin_l_astier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24457-24400-saint_martin_l_astier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24458-24300-saint_martin_le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24458-24300-saint_martin_le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24458-24300-saint_martin_le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24458-24300-saint_martin_le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24459-24380-saint_maime_de_pereyrol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24459-24380-saint_maime_de_pereyrol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24459-24380-saint_maime_de_pereyrol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24459-24380-saint_maime_de_pereyrol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24460-24600-saint_meard_de_drone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24460-24600-saint_meard_de_drone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24460-24600-saint_meard_de_drone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24460-24600-saint_meard_de_drone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24461-24610-saint_meard_de_gurcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24461-24610-saint_meard_de_gurcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24461-24610-saint_meard_de_gurcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24461-24610-saint_meard_de_gurcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24462-24400-saint_medard_de_mussidan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24462-24400-saint_medard_de_mussidan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24462-24400-saint_medard_de_mussidan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24462-24400-saint_medard_de_mussidan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24463-24160-saint_medard_d_excideuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24463-24160-saint_medard_d_excideuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24463-24160-saint_medard_d_excideuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24463-24160-saint_medard_d_excideuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24464-24270-saint_mesmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24464-24270-saint_mesmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24464-24270-saint_mesmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24464-24270-saint_mesmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24465-24400-saint_michel_de_double/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24465-24400-saint_michel_de_double/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24465-24400-saint_michel_de_double/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24465-24400-saint_michel_de_double/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24466-24230-saint_michel_de_montaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24466-24230-saint_michel_de_montaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24466-24230-saint_michel_de_montaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24466-24230-saint_michel_de_montaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24468-24380-saint_michel_de_villadeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24468-24380-saint_michel_de_villadeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24468-24380-saint_michel_de_villadeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24468-24380-saint_michel_de_villadeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24470-24370-sainte_mondane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24470-24370-sainte_mondane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24470-24370-sainte_mondane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24470-24370-sainte_mondane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24471-24200-sainte_nathalene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24471-24200-sainte_nathalene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24471-24200-sainte_nathalene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24471-24200-sainte_nathalene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24472-24520-saint_nexans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24472-24520-saint_nexans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24472-24520-saint_nexans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24472-24520-saint_nexans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24473-24210-sainte_orse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24473-24210-sainte_orse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24473-24210-sainte_orse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24473-24210-sainte_orse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24474-24530-saint_pancrace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24474-24530-saint_pancrace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24474-24530-saint_pancrace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24474-24530-saint_pancrace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24476-24160-saint_pantaly_d_excideuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24476-24160-saint_pantaly_d_excideuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24476-24160-saint_pantaly_d_excideuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24476-24160-saint_pantaly_d_excideuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24477-24600-saint_pardoux_de_drone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24477-24600-saint_pardoux_de_drone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24477-24600-saint_pardoux_de_drone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24477-24600-saint_pardoux_de_drone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24478-24170-saint_pardoux_et_vielvic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24478-24170-saint_pardoux_et_vielvic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24478-24170-saint_pardoux_et_vielvic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24478-24170-saint_pardoux_et_vielvic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24479-24470-saint_pardoux_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24479-24470-saint_pardoux_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24479-24470-saint_pardoux_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24479-24470-saint_pardoux_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24480-24380-saint_paul_de_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24480-24380-saint_paul_de_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24480-24380-saint_paul_de_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24480-24380-saint_paul_de_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24481-24800-saint_paul_la_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24481-24800-saint_paul_la_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24481-24800-saint_paul_la_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24481-24800-saint_paul_la_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24482-24320-saint_paul_lizonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24482-24320-saint_paul_lizonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24482-24320-saint_paul_lizonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24482-24320-saint_paul_lizonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24483-24560-saint_perdoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24483-24560-saint_perdoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24483-24560-saint_perdoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24483-24560-saint_perdoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24484-24330-saint_pierre_de_chignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24484-24330-saint_pierre_de_chignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24484-24330-saint_pierre_de_chignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24484-24330-saint_pierre_de_chignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24485-24800-saint_pierre_de_cole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24485-24800-saint_pierre_de_cole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24485-24800-saint_pierre_de_cole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24485-24800-saint_pierre_de_cole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24486-24450-saint_pierre_de_frugie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24486-24450-saint_pierre_de_frugie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24486-24450-saint_pierre_de_frugie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24486-24450-saint_pierre_de_frugie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24487-24130-saint_pierre_d_eyraud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24487-24130-saint_pierre_d_eyraud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24487-24130-saint_pierre_d_eyraud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24487-24130-saint_pierre_d_eyraud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24488-24170-saint_pompont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24488-24170-saint_pompont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24488-24170-saint_pompont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24488-24170-saint_pompont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24489-24450-saint_priest_les_fougeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24489-24450-saint_priest_les_fougeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24489-24450-saint_priest_les_fougeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24489-24450-saint_priest_les_fougeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24490-24410-saint_privat_en_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24490-24410-saint_privat_en_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24490-24410-saint_privat_en_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24490-24410-saint_privat_en_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24491-24210-saint_rabier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24491-24210-saint_rabier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24491-24210-saint_rabier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24491-24210-saint_rabier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24492-24560-sainte_radegonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24492-24560-sainte_radegonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24492-24560-sainte_radegonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24492-24560-sainte_radegonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24493-24160-saint_raphael/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24493-24160-saint_raphael/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24493-24160-saint_raphael/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24493-24160-saint_raphael/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24494-24700-saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24494-24700-saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24494-24700-saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24494-24700-saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24495-24540-saint_romain_de_monpazier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24495-24540-saint_romain_de_monpazier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24495-24540-saint_romain_de_monpazier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24495-24540-saint_romain_de_monpazier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24496-24800-saint_romain_et_saint_clement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24496-24800-saint_romain_et_saint_clement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24496-24800-saint_romain_et_saint_clement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24496-24800-saint_romain_et_saint_clement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24498-24470-saint_saud_lacoussiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24498-24470-saint_saud_lacoussiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24498-24470-saint_saud_lacoussiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24498-24470-saint_saud_lacoussiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24499-24520-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24499-24520-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24499-24520-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24499-24520-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24500-24700-saint_sauveur_lalande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24500-24700-saint_sauveur_lalande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24500-24700-saint_sauveur_lalande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24500-24700-saint_sauveur_lalande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24501-24230-saint_seurin_de_prats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24501-24230-saint_seurin_de_prats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24501-24230-saint_seurin_de_prats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24501-24230-saint_seurin_de_prats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24502-24190-saint_severin_d_estissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24502-24190-saint_severin_d_estissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24502-24190-saint_severin_d_estissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24502-24190-saint_severin_d_estissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24504-24600-saint_sulpice_de_roumagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24504-24600-saint_sulpice_de_roumagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24504-24600-saint_sulpice_de_roumagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24504-24600-saint_sulpice_de_roumagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24505-24800-saint_sulpice_d_excideuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24505-24800-saint_sulpice_d_excideuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24505-24800-saint_sulpice_d_excideuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24505-24800-saint_sulpice_d_excideuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24507-24160-sainte_trie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24507-24160-sainte_trie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24507-24160-sainte_trie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24507-24160-sainte_trie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24508-24350-saint_victor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24508-24350-saint_victor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24508-24350-saint_victor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24508-24350-saint_victor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24509-24190-saint_vincent_de_connezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24509-24190-saint_vincent_de_connezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24509-24190-saint_vincent_de_connezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24509-24190-saint_vincent_de_connezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24510-24220-saint_vincent_de_cosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24510-24220-saint_vincent_de_cosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24510-24220-saint_vincent_de_cosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24510-24220-saint_vincent_de_cosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24511-24410-saint_vincent_jalmoutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24511-24410-saint_vincent_jalmoutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24511-24410-saint_vincent_jalmoutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24511-24410-saint_vincent_jalmoutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24512-24200-saint_vincent_le_paluel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24512-24200-saint_vincent_le_paluel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24512-24200-saint_vincent_le_paluel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24512-24200-saint_vincent_le_paluel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24513-24420-saint_vincent_sur_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24513-24420-saint_vincent_sur_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24513-24420-saint_vincent_sur_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24513-24420-saint_vincent_sur_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24514-24230-saint_vivien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24514-24230-saint_vivien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24514-24230-saint_vivien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24514-24230-saint_vivien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24515-24160-salagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24515-24160-salagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24515-24160-salagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24515-24160-salagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24516-24590-salignac_eyvigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24516-24590-salignac_eyvigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24516-24590-salignac_eyvigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24516-24590-salignac_eyvigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24517-24170-salles_de_belves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24517-24170-salles_de_belves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24517-24170-salles_de_belves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24517-24170-salles_de_belves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24518-24380-salon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24518-24380-salon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24518-24380-salon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24518-24380-salon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24519-24270-sarlande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24519-24270-sarlande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24519-24270-sarlande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24519-24270-sarlande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24520-24200-sarlat_la_caneda/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24520-24200-sarlat_la_caneda/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24520-24200-sarlat_la_caneda/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24520-24200-sarlat_la_caneda/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24521-24420-sarliac_sur_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24521-24420-sarliac_sur_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24521-24420-sarliac_sur_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24521-24420-sarliac_sur_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24522-24800-sarrazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24522-24800-sarrazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24522-24800-sarrazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24522-24800-sarrazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24523-24240-saussignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24523-24240-saussignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24523-24240-saussignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24523-24240-saussignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24524-24260-savignac_de_miremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24524-24260-savignac_de_miremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24524-24260-savignac_de_miremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24524-24260-savignac_de_miremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24525-24300-savignac_de_nontron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24525-24300-savignac_de_nontron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24525-24300-savignac_de_nontron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24525-24300-savignac_de_nontron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24526-24270-savignac_ledrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24526-24270-savignac_ledrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24526-24270-savignac_ledrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24526-24270-savignac_ledrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24527-24420-savignac_les_eglises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24527-24420-savignac_les_eglises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24527-24420-savignac_les_eglises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24527-24420-savignac_les_eglises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24528-24300-sceau_saint_angel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24528-24300-sceau_saint_angel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24528-24300-sceau_saint_angel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24528-24300-sceau_saint_angel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24529-24600-segonzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24529-24600-segonzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24529-24600-segonzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24529-24600-segonzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24531-24290-sergeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24531-24290-sergeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24531-24290-sergeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24531-24290-sergeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24532-24500-serres_et_montguyard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24532-24500-serres_et_montguyard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24532-24500-serres_et_montguyard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24532-24500-serres_et_montguyard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24533-24410-servanches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24533-24410-servanches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24533-24410-servanches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24533-24410-servanches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24534-24240-sigoules_et_flaugeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24534-24240-sigoules_et_flaugeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24534-24240-sigoules_et_flaugeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24534-24240-sigoules_et_flaugeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24535-24370-simeyrols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24535-24370-simeyrols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24535-24370-simeyrols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24535-24370-simeyrols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24536-24500-singleyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24536-24500-singleyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24536-24500-singleyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24536-24500-singleyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24537-24600-siorac_de_riberac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24537-24600-siorac_de_riberac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24537-24600-siorac_de_riberac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24537-24600-siorac_de_riberac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24538-24170-siorac_en_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24538-24170-siorac_en_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24538-24170-siorac_en_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24538-24170-siorac_en_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24540-24420-sorges_et_ligueux_en_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24540-24420-sorges_et_ligueux_en_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24540-24420-sorges_et_ligueux_en_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24540-24420-sorges_et_ligueux_en_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24540-24460-sorges_et_ligueux_en_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24540-24460-sorges_et_ligueux_en_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24540-24460-sorges_et_ligueux_en_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24540-24460-sorges_et_ligueux_en_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24541-24360-soudat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24541-24360-soudat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24541-24360-soudat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24541-24360-soudat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24542-24540-soulaures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24542-24540-soulaures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24542-24540-soulaures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24542-24540-soulaures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24543-24400-sourzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24543-24400-sourzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24543-24400-sourzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24543-24400-sourzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24544-24620-tamnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24544-24620-tamnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24544-24620-tamnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24544-24620-tamnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24545-24390-teillots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24545-24390-teillots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24545-24390-teillots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24545-24390-teillots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24546-24390-temple_laguyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24546-24390-temple_laguyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24546-24390-temple_laguyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24546-24390-temple_laguyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24547-24120-terrasson_lavilledieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24547-24120-terrasson_lavilledieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24547-24120-terrasson_lavilledieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24547-24120-terrasson_lavilledieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24548-24300-teyjat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24548-24300-teyjat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24548-24300-teyjat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24548-24300-teyjat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24549-24240-thenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24549-24240-thenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24549-24240-thenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24549-24240-thenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24550-24210-thenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24550-24210-thenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24550-24210-thenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24550-24210-thenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24551-24800-thiviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24551-24800-thiviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24551-24800-thiviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24551-24800-thiviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24552-24290-thonac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24552-24290-thonac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24552-24290-thonac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24552-24290-thonac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24553-24350-tocane_saint_apre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24553-24350-tocane_saint_apre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24553-24350-tocane_saint_apre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24553-24350-tocane_saint_apre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24554-24320-la_tour_blanche_cercles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24554-24320-la_tour_blanche_cercles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24554-24320-la_tour_blanche_cercles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24554-24320-la_tour_blanche_cercles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24555-24390-tourtoirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24555-24390-tourtoirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24555-24390-tourtoirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24555-24390-tourtoirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24557-24750-trelissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24557-24750-trelissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24557-24750-trelissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24557-24750-trelissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24558-24510-tremolat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24558-24510-tremolat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24558-24510-tremolat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24558-24510-tremolat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24559-24620-tursac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24559-24620-tursac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24559-24620-tursac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24559-24620-tursac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24560-24480-urval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24560-24480-urval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24560-24480-urval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24560-24480-urval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24562-24190-vallereuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24562-24190-vallereuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24562-24190-vallereuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24562-24190-vallereuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24563-24290-valojoulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24563-24290-valojoulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24563-24290-valojoulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24563-24290-valojoulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24564-24600-vanxains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24564-24600-vanxains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24564-24600-vanxains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24564-24600-vanxains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24565-24360-varaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24565-24360-varaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24565-24360-varaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24565-24360-varaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24566-24150-varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24566-24150-varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24566-24150-varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24566-24150-varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24567-24800-vaunac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24567-24800-vaunac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24567-24800-vaunac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24567-24800-vaunac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24568-24230-velines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24568-24230-velines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24568-24230-velines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24568-24230-velines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24569-24320-vendoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24569-24320-vendoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24569-24320-vendoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24569-24320-vendoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24570-24520-verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24570-24520-verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24570-24520-verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24570-24520-verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24571-24380-vergt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24571-24380-vergt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24571-24380-vergt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24571-24380-vergt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24572-24540-vergt_de_biron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24572-24540-vergt_de_biron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24572-24540-vergt_de_biron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24572-24540-vergt_de_biron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24573-24320-verteillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24573-24320-verteillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24573-24320-verteillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24573-24320-verteillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24574-24370-veyrignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24574-24370-veyrignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24574-24370-veyrignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24574-24370-veyrignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24575-24250-veyrines_de_domme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24575-24250-veyrines_de_domme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24575-24250-veyrines_de_domme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24575-24250-veyrines_de_domme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24576-24380-veyrines_de_vergt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24576-24380-veyrines_de_vergt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24576-24380-veyrines_de_vergt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24576-24380-veyrines_de_vergt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24577-24220-vezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24577-24220-vezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24577-24220-vezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24577-24220-vezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24580-24120-villac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24580-24120-villac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24580-24120-villac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24580-24120-villac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24581-24140-villamblard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24581-24140-villamblard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24581-24140-villamblard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24581-24140-villamblard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24582-24530-villars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24582-24530-villars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24582-24530-villars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24582-24530-villars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24584-24610-villefranche_de_lonchat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24584-24610-villefranche_de_lonchat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24584-24610-villefranche_de_lonchat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24584-24610-villefranche_de_lonchat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24585-24550-villefranche_du_perigord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24585-24550-villefranche_du_perigord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24585-24550-villefranche_du_perigord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24585-24550-villefranche_du_perigord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24586-24600-villetoureix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24586-24600-villetoureix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24586-24600-villetoureix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24586-24600-villetoureix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24587-24200-vitrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24587-24200-vitrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24587-24200-vitrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt24-dordogne/commune24587-24200-vitrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-25.xml
+++ b/public/sitemaps/sitemap-25.xml
@@ -5,1162 +5,2320 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25001-25320-abbans_dessous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25001-25320-abbans_dessous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25001-25320-abbans_dessous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25001-25320-abbans_dessous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25002-25440-abbans_dessus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25002-25440-abbans_dessus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25002-25440-abbans_dessus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25002-25440-abbans_dessus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25003-25340-abbenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25003-25340-abbenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25003-25340-abbenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25003-25340-abbenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25004-25310-abbevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25004-25310-abbevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25004-25310-abbevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25004-25310-abbevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25005-25250-accolans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25005-25250-accolans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25005-25250-accolans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25005-25250-accolans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25006-25360-adam_les_passavant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25006-25360-adam_les_passavant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25006-25360-adam_les_passavant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25006-25360-adam_les_passavant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25007-25530-adam_les_vercel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25007-25530-adam_les_vercel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25007-25530-adam_les_vercel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25007-25530-adam_les_vercel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25008-25750-aibre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25008-25750-aibre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25008-25750-aibre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25008-25750-aibre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25009-25360-aissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25009-25360-aissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25009-25360-aissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25009-25360-aissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25011-25490-allenjoie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25011-25490-allenjoie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25011-25490-allenjoie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25011-25490-allenjoie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25012-25300-les_allies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25012-25300-les_allies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25012-25300-les_allies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25012-25300-les_allies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25013-25550-allondans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25013-25550-allondans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25013-25550-allondans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25013-25550-allondans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25014-25220-amagney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25014-25220-amagney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25014-25220-amagney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25014-25220-amagney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25015-25330-amancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25015-25330-amancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25015-25330-amancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25015-25330-amancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25016-25330-amathay_vesigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25016-25330-amathay_vesigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25016-25330-amathay_vesigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25016-25330-amathay_vesigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25017-25330-amondans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25017-25330-amondans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25017-25330-amondans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25017-25330-amondans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25018-25340-anteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25018-25340-anteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25018-25340-anteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25018-25340-anteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25019-25250-appenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25019-25250-appenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25019-25250-appenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25019-25250-appenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25020-25400-arbouans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25020-25400-arbouans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25020-25400-arbouans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25020-25400-arbouans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25021-25610-arc_et_senans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25021-25610-arc_et_senans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25021-25610-arc_et_senans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25021-25610-arc_et_senans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25022-25750-arcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25022-25750-arcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25022-25750-arcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25022-25750-arcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25024-25300-arcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25024-25300-arcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25024-25300-arcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25024-25300-arcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25025-25520-arc_sous_cicon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25025-25520-arc_sous_cicon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25025-25520-arc_sous_cicon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25025-25520-arc_sous_cicon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25026-25270-arc_sous_montenot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25026-25270-arc_sous_montenot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25026-25270-arc_sous_montenot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25026-25270-arc_sous_montenot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25029-25520-aubonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25029-25520-aubonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25029-25520-aubonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25029-25520-aubonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25030-25170-audeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25030-25170-audeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25030-25170-audeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25030-25170-audeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25031-25400-audincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25031-25400-audincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25031-25400-audincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25031-25400-audincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25032-25110-autechaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25032-25110-autechaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25032-25110-autechaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25032-25110-autechaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25033-25150-autechaux_roide/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25033-25150-autechaux_roide/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25033-25150-autechaux_roide/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25033-25150-autechaux_roide/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25035-25870-les_auxons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25035-25870-les_auxons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25035-25870-les_auxons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25035-25870-les_auxons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25036-25720-avanne_aveney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25036-25720-avanne_aveney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25036-25720-avanne_aveney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25036-25720-avanne_aveney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25038-25680-avilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25038-25680-avilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25038-25680-avilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25038-25680-avilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25039-25690-avoudrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25039-25690-avoudrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25039-25690-avoudrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25039-25690-avoudrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25040-25490-badevel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25040-25490-badevel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25040-25490-badevel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25040-25490-badevel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25041-25560-bannans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25041-25560-bannans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25041-25560-bannans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25041-25560-bannans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25042-25210-le_barboux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25042-25210-le_barboux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25042-25210-le_barboux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25042-25210-le_barboux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25043-25420-bart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25043-25420-bart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25043-25420-bart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25043-25420-bart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25044-25440-bartherans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25044-25440-bartherans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25044-25440-bartherans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25044-25440-bartherans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25045-25640-battenans_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25045-25640-battenans_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25045-25640-battenans_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25045-25640-battenans_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25046-25380-battenans_varin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25046-25380-battenans_varin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25046-25380-battenans_varin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25046-25380-battenans_varin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25047-25110-baume_les_dames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25047-25110-baume_les_dames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25047-25110-baume_les_dames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25047-25110-baume_les_dames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25048-25550-bavans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25048-25550-bavans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25048-25550-bavans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25048-25550-bavans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25049-25470-belfays/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25049-25470-belfays/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25049-25470-belfays/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25049-25470-belfays/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25050-25500-le_belieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25050-25500-le_belieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25050-25500-le_belieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25050-25500-le_belieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25051-25380-belleherbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25051-25380-belleherbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25051-25380-belleherbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25051-25380-belleherbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25052-25530-belmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25052-25530-belmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25052-25530-belmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25052-25530-belmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25053-25430-belvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25053-25430-belvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25053-25430-belvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25053-25430-belvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25054-25420-berche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25054-25420-berche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25054-25420-berche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25054-25420-berche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25055-25410-berthelange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25055-25410-berthelange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25055-25410-berthelange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25055-25410-berthelange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25056-25000-besancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25056-25000-besancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25056-25000-besancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25056-25000-besancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25057-25200-bethoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25057-25200-bethoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25057-25200-bethoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25057-25200-bethoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25058-25720-beure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25058-25720-beure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25058-25720-beure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25058-25720-beure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25059-25250-beutal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25059-25250-beutal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25059-25250-beutal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25059-25250-beutal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25060-25520-bians_les_usiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25060-25520-bians_les_usiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25060-25520-bians_les_usiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25060-25520-bians_les_usiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25061-25190-bief/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25061-25190-bief/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25061-25190-bief/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25061-25190-bief/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25062-25210-le_bizot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25062-25210-le_bizot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25062-25210-le_bizot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25062-25210-le_bizot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25063-25310-blamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25063-25310-blamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25063-25310-blamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25063-25310-blamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25065-25640-blarians/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25065-25640-blarians/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25065-25640-blarians/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25065-25640-blarians/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25066-25250-blussangeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25066-25250-blussangeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25066-25250-blussangeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25066-25250-blussangeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25067-25250-blussans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25067-25250-blussans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25067-25250-blussans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25067-25250-blussans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25070-25330-bolandoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25070-25330-bolandoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25070-25330-bolandoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25070-25330-bolandoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25071-25230-bondeval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25071-25230-bondeval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25071-25230-bondeval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25071-25230-bondeval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25072-25680-bonnal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25072-25680-bonnal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25072-25680-bonnal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25072-25680-bonnal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25073-25870-bonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25073-25870-bonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25073-25870-bonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25073-25870-bonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25074-25210-bonnetage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25074-25210-bonnetage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25074-25210-bonnetage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25074-25210-bonnetage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25075-25560-bonnevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25075-25560-bonnevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25075-25560-bonnevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25075-25560-bonnevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25077-25210-la_bosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25077-25210-la_bosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25077-25210-la_bosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25077-25210-la_bosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25078-25360-bouclans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25078-25360-bouclans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25078-25360-bouclans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25078-25360-bouclans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25079-25560-boujailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25079-25560-boujailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25079-25560-boujailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25079-25560-boujailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25082-25150-bourguignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25082-25150-bourguignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25082-25150-bourguignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25082-25150-bourguignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25083-25250-bournois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25083-25250-bournois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25083-25250-bournois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25083-25250-bournois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25084-25320-boussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25084-25320-boussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25084-25320-boussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25084-25320-boussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25085-25560-bouverans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25085-25560-bouverans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25085-25560-bouverans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25085-25560-bouverans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25086-25640-braillans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25086-25640-braillans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25086-25640-braillans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25086-25640-braillans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25087-25340-branne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25087-25340-branne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25087-25340-branne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25087-25340-branne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25088-25640-breconchaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25088-25640-breconchaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25088-25640-breconchaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25088-25640-breconchaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25089-25530-bremondans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25089-25530-bremondans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25089-25530-bremondans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25089-25530-bremondans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25090-25440-breres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25090-25440-breres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25090-25440-breres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25090-25440-breres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25091-25120-les_breseux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25091-25120-les_breseux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25091-25120-les_breseux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25091-25120-les_breseux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25092-25640-la_breteniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25092-25640-la_breteniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25092-25640-la_breteniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25092-25640-la_breteniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25093-25250-bretigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25093-25250-bretigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25093-25250-bretigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25093-25250-bretigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25094-25110-bretigney_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25094-25110-bretigney_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25094-25110-bretigney_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25094-25110-bretigney_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25095-25380-bretonvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25095-25380-bretonvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25095-25380-bretonvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25095-25380-bretonvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25096-25240-brey_et_maison_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25096-25240-brey_et_maison_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25096-25240-brey_et_maison_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25096-25240-brey_et_maison_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25097-25600-brognard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25097-25600-brognard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25097-25600-brognard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25097-25600-brognard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25098-25440-buffard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25098-25440-buffard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25098-25440-buffard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25098-25440-buffard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25099-25520-bugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25099-25520-bugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25099-25520-bugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25099-25520-bugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25100-25560-bulle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25100-25560-bulle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25100-25560-bulle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25100-25560-bulle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25101-25170-burgille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25101-25170-burgille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25101-25170-burgille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25101-25170-burgille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25102-25470-burnevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25102-25470-burnevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25102-25470-burnevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25102-25470-burnevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25103-25320-busy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25103-25320-busy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25103-25320-busy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25103-25320-busy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25104-25440-by/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25104-25440-by/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25104-25440-by/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25104-25440-by/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25105-25320-byans_sur_doubs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25105-25320-byans_sur_doubs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25105-25320-byans_sur_doubs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25105-25320-byans_sur_doubs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25106-25290-cademene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25106-25290-cademene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25106-25290-cademene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25106-25290-cademene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25107-25640-cendrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25107-25640-cendrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25107-25640-cendrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25107-25640-cendrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25108-25120-cernay_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25108-25120-cernay_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25108-25120-cernay_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25108-25120-cernay_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25109-25440-cessey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25109-25440-cessey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25109-25440-cessey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25109-25440-cessey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25110-25300-chaffois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25110-25300-chaffois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25110-25300-chaffois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25110-25300-chaffois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25111-25220-chaleze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25111-25220-chaleze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25111-25220-chaleze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25111-25220-chaleze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25112-25220-chalezeule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25112-25220-chalezeule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25112-25220-chalezeule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25112-25220-chalezeule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25113-25380-chamesey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25113-25380-chamesey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25113-25380-chamesey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25113-25380-chamesey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25114-25190-chamesol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25114-25190-chamesol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25114-25190-chamesol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25114-25190-chamesol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25115-25170-champagney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25115-25170-champagney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25115-25170-champagney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25115-25170-champagney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25116-25360-champlive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25116-25360-champlive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25116-25360-champlive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25116-25360-champlive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25117-25640-champoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25117-25640-champoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25117-25640-champoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25117-25640-champoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25119-25170-champvans_les_moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25119-25170-champvans_les_moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25119-25170-champvans_les_moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25119-25170-champvans_les_moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25120-25330-chantrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25120-25330-chantrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25120-25330-chantrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25120-25330-chantrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25121-25240-chapelle_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25121-25240-chapelle_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25121-25240-chapelle_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25121-25240-chapelle_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25122-25270-chapelle_d_huin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25122-25270-chapelle_d_huin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25122-25270-chapelle_d_huin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25122-25270-chapelle_d_huin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25124-25470-charmauvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25124-25470-charmauvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25124-25470-charmauvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25124-25470-charmauvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25125-25380-charmoille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25125-25380-charmoille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25125-25380-charmoille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25125-25380-charmoille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25126-25440-charnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25126-25440-charnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25126-25440-charnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25126-25440-charnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25127-25140-charquemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25127-25140-charquemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25127-25140-charquemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25127-25140-charquemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25129-25290-chassagne_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25129-25290-chassagne_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25129-25290-chassagne_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25129-25290-chassagne_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25130-25840-chateauvieux_les_fosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25130-25840-chateauvieux_les_fosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25130-25840-chateauvieux_les_fosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25130-25840-chateauvieux_les_fosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25131-25240-chatelblanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25131-25240-chatelblanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25131-25240-chatelblanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25131-25240-chatelblanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25132-25640-chatillon_guyotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25132-25640-chatillon_guyotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25132-25640-chatillon_guyotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25132-25640-chatillon_guyotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25133-25870-chatillon_le_duc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25133-25870-chatillon_le_duc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25133-25870-chatillon_le_duc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25133-25870-chatillon_le_duc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25134-25440-chatillon_sur_lison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25134-25440-chatillon_sur_lison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25134-25440-chatillon_sur_lison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25134-25440-chatillon_sur_lison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25136-25170-chaucenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25136-25170-chaucenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25136-25170-chaucenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25136-25170-chaucenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25138-25190-les_terres_de_chaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25138-25190-les_terres_de_chaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25138-25190-les_terres_de_chaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25138-25190-les_terres_de_chaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25139-25650-la_chaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25139-25650-la_chaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25139-25650-la_chaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25139-25650-la_chaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25141-25530-chaux_les_passavant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25141-25530-chaux_les_passavant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25141-25530-chaux_les_passavant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25141-25530-chaux_les_passavant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25142-25240-chaux_neuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25142-25240-chaux_neuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25142-25240-chaux_neuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25142-25240-chaux_neuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25143-25440-chay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25143-25440-chay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25143-25440-chay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25143-25440-chay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25145-25430-chazot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25145-25430-chazot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25145-25430-chazot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25145-25430-chazot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25147-25320-chemaudin_et_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25147-25320-chemaudin_et_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25147-25320-chemaudin_et_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25147-25320-chemaudin_et_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25147-25770-chemaudin_et_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25147-25770-chemaudin_et_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25147-25770-chemaudin_et_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25147-25770-chemaudin_et_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25148-25500-la_chenalotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25148-25500-la_chenalotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25148-25500-la_chenalotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25148-25500-la_chenalotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25149-25440-chenecey_buillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25149-25440-chenecey_buillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25149-25440-chenecey_buillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25149-25440-chenecey_buillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25150-25170-chevigney_sur_l_ognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25150-25170-chevigney_sur_l_ognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25150-25170-chevigney_sur_l_ognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25150-25170-chevigney_sur_l_ognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25151-25530-chevigney_les_vercel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25151-25530-chevigney_les_vercel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25151-25530-chevigney_les_vercel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25151-25530-chevigney_les_vercel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25152-25620-la_chevillotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25152-25620-la_chevillotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25152-25620-la_chevillotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25152-25620-la_chevillotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25153-25870-chevroz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25153-25870-chevroz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25153-25870-chevroz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25153-25870-chevroz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25154-25440-chouzelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25154-25440-chouzelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25154-25440-chouzelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25154-25440-chouzelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25155-25330-cleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25155-25330-cleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25155-25330-cleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25155-25330-cleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25156-25340-pays_de_clerval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25156-25340-pays_de_clerval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25156-25340-pays_de_clerval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25156-25340-pays_de_clerval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25157-25300-la_cluse_et_mijoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25157-25300-la_cluse_et_mijoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25157-25300-la_cluse_et_mijoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25157-25300-la_cluse_et_mijoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25159-25260-colombier_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25159-25260-colombier_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25159-25260-colombier_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25159-25260-colombier_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25160-25500-les_combes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25160-25500-les_combes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25160-25500-les_combes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25160-25500-les_combes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25161-25390-consolation_maisonnettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25161-25390-consolation_maisonnettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25161-25390-consolation_maisonnettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25161-25390-consolation_maisonnettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25162-25410-corcelles_ferrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25162-25410-corcelles_ferrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25162-25410-corcelles_ferrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25162-25410-corcelles_ferrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25163-25640-corcelle_mieslot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25163-25640-corcelle_mieslot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25163-25640-corcelle_mieslot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25163-25640-corcelle_mieslot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25164-25410-corcondray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25164-25410-corcondray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25164-25410-corcondray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25164-25410-corcondray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25166-25360-cotebrune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25166-25360-cotebrune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25166-25360-cotebrune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25166-25360-cotebrune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25170-25420-courcelles_les_montbeliard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25170-25420-courcelles_les_montbeliard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25170-25420-courcelles_les_montbeliard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25170-25420-courcelles_les_montbeliard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25171-25440-courcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25171-25440-courcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25171-25440-courcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25171-25440-courcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25172-25170-courchapon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25172-25170-courchapon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25172-25170-courchapon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25172-25170-courchapon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25173-25380-cour_saint_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25173-25380-cour_saint_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25173-25380-cour_saint_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25173-25380-cour_saint_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25174-25470-courtefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25174-25470-courtefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25174-25470-courtefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25174-25470-courtefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25175-25530-courtetain_et_salans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25175-25530-courtetain_et_salans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25175-25530-courtetain_et_salans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25175-25530-courtetain_et_salans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25176-25560-courvieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25176-25560-courvieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25176-25560-courvieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25176-25560-courvieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25177-25340-crosey_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25177-25340-crosey_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25177-25340-crosey_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25177-25340-crosey_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25178-25340-crosey_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25178-25340-crosey_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25178-25340-crosey_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25178-25340-crosey_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25179-25240-le_crouzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25179-25240-le_crouzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25179-25240-le_crouzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25179-25240-le_crouzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25180-25270-crouzet_migette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25180-25270-crouzet_migette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25180-25270-crouzet_migette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25180-25270-crouzet_migette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25181-25680-cubrial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25181-25680-cubrial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25181-25680-cubrial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25181-25680-cubrial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25182-25680-cubry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25182-25680-cubry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25182-25680-cubry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25182-25680-cubry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25183-25110-cusance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25183-25110-cusance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25183-25110-cusance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25183-25110-cusance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25184-25680-cuse_et_adrisans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25184-25680-cuse_et_adrisans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25184-25680-cuse_et_adrisans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25184-25680-cuse_et_adrisans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25185-25440-cussey_sur_lison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25185-25440-cussey_sur_lison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25185-25440-cussey_sur_lison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25185-25440-cussey_sur_lison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25186-25870-cussey_sur_l_ognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25186-25870-cussey_sur_l_ognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25186-25870-cussey_sur_l_ognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25186-25870-cussey_sur_l_ognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25187-25150-dambelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25187-25150-dambelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25187-25150-dambelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25187-25150-dambelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25188-25600-dambenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25188-25600-dambenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25188-25600-dambenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25188-25600-dambenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25189-25110-dammartin_les_templiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25189-25110-dammartin_les_templiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25189-25110-dammartin_les_templiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25189-25110-dammartin_les_templiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25190-25490-dampierre_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25190-25490-dampierre_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25190-25490-dampierre_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25190-25490-dampierre_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25191-25420-dampierre_sur_le_doubs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25191-25420-dampierre_sur_le_doubs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25191-25420-dampierre_sur_le_doubs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25191-25420-dampierre_sur_le_doubs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25192-25190-dampjoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25192-25190-dampjoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25192-25190-dampjoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25192-25190-dampjoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25193-25450-damprichard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25193-25450-damprichard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25193-25450-damprichard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25193-25450-damprichard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25194-25310-dannemarie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25194-25310-dannemarie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25194-25310-dannemarie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25194-25310-dannemarie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25195-25410-dannemarie_sur_crete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25195-25410-dannemarie_sur_crete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25195-25410-dannemarie_sur_crete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25195-25410-dannemarie_sur_crete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25196-25230-dasle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25196-25230-dasle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25196-25230-dasle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25196-25230-dasle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25197-25960-deluz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25197-25960-deluz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25197-25960-deluz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25197-25960-deluz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25198-25750-desandans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25198-25750-desandans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25198-25750-desandans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25198-25750-desandans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25199-25330-deservillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25199-25330-deservillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25199-25330-deservillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25199-25330-deservillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25200-25870-devecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25200-25870-devecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25200-25870-devecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25200-25870-devecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25201-25300-dommartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25201-25300-dommartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25201-25300-dommartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25201-25300-dommartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25202-25560-dompierre_les_tilleuls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25202-25560-dompierre_les_tilleuls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25202-25560-dompierre_les_tilleuls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25202-25560-dompierre_les_tilleuls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25203-25510-domprel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25203-25510-domprel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25203-25510-domprel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25203-25510-domprel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25204-25300-doubs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25204-25300-doubs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25204-25300-doubs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25204-25300-doubs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25207-25550-dung/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25207-25550-dung/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25207-25550-dung/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25207-25550-dung/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25208-25580-durnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25208-25580-durnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25208-25580-durnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25208-25580-durnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25209-25440-echay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25209-25440-echay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25209-25440-echay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25209-25440-echay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25210-25550-echenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25210-25550-echenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25210-25550-echenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25210-25550-echenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25211-25580-echevannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25211-25580-echevannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25211-25580-echevannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25211-25580-echevannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25212-25480-ecole_valentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25212-25480-ecole_valentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25212-25480-ecole_valentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25212-25480-ecole_valentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25213-25140-les_ecorces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25213-25140-les_ecorces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25213-25140-les_ecorces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25213-25140-les_ecorces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25214-25150-ecot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25214-25150-ecot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25214-25150-ecot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25214-25150-ecot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25215-25640-l_ecouvotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25215-25640-l_ecouvotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25215-25640-l_ecouvotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25215-25640-l_ecouvotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25216-25150-ecurcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25216-25150-ecurcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25216-25150-ecurcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25216-25150-ecurcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25217-25170-emagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25217-25170-emagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25217-25170-emagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25217-25170-emagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25218-25530-epenouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25218-25530-epenouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25218-25530-epenouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25218-25530-epenouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25219-25800-epenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25219-25800-epenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25219-25800-epenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25219-25800-epenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25220-25290-epeugney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25220-25290-epeugney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25220-25290-epeugney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25220-25290-epeugney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25221-25110-esnans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25221-25110-esnans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25221-25110-esnans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25221-25110-esnans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25222-25580-etalans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25222-25580-etalans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25222-25580-etalans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25222-25580-etalans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25222-25620-etalans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25222-25620-etalans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25222-25620-etalans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25222-25620-etalans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25223-25330-eternoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25223-25330-eternoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25223-25330-eternoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25223-25330-eternoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25224-25260-etouvans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25224-25260-etouvans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25224-25260-etouvans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25224-25260-etouvans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25225-25170-etrabonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25225-25170-etrabonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25225-25170-etrabonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25225-25170-etrabonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25226-25250-etrappe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25226-25250-etrappe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25226-25250-etrappe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25226-25250-etrappe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25227-25800-etray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25227-25800-etray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25227-25800-etray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25227-25800-etray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25228-25460-etupes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25228-25460-etupes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25228-25460-etupes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25228-25460-etupes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25229-25520-evillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25229-25520-evillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25229-25520-evillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25229-25520-evillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25230-25400-exincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25230-25400-exincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25230-25400-exincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25230-25400-exincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25231-25530-eysson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25231-25530-eysson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25231-25530-eysson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25231-25530-eysson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25232-25250-faimbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25232-25250-faimbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25232-25250-faimbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25232-25250-faimbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25233-25580-fallerans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25233-25580-fallerans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25233-25580-fallerans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25233-25580-fallerans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25234-25470-ferrieres_le_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25234-25470-ferrieres_le_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25234-25470-ferrieres_le_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25234-25470-ferrieres_le_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25235-25410-ferrieres_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25235-25410-ferrieres_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25235-25410-ferrieres_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25235-25410-ferrieres_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25236-25330-fertans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25236-25330-fertans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25236-25330-fertans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25236-25330-fertans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25237-25490-fesches_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25237-25490-fesches_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25237-25490-fesches_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25237-25490-fesches_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25238-25470-fessevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25238-25470-fessevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25238-25470-fessevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25238-25470-fessevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25239-25190-feule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25239-25190-feule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25239-25190-feule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25239-25190-feule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25240-25500-les_fins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25240-25500-les_fins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25240-25500-les_fins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25240-25500-les_fins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25241-25330-flagey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25241-25330-flagey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25241-25330-flagey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25241-25330-flagey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25242-25640-flagey_rigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25242-25640-flagey_rigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25242-25640-flagey_rigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25242-25640-flagey_rigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25243-25390-flangebouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25243-25390-flangebouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25243-25390-flangebouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25243-25390-flangebouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25244-25190-fleurey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25244-25190-fleurey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25244-25190-fleurey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25244-25190-fleurey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25245-25660-fontain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25245-25660-fontain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25245-25660-fontain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25245-25660-fontain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25245-25720-fontain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25245-25720-fontain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25245-25720-fontain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25245-25720-fontain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25246-25340-fontaine_les_clerval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25246-25340-fontaine_les_clerval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25246-25340-fontaine_les_clerval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25246-25340-fontaine_les_clerval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25247-25340-fontenelle_montby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25247-25340-fontenelle_montby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25247-25340-fontenelle_montby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25247-25340-fontenelle_montby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25248-25210-les_fontenelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25248-25210-les_fontenelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25248-25210-les_fontenelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25248-25210-les_fontenelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25249-25110-fontenotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25249-25110-fontenotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25249-25110-fontenotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25249-25110-fontenotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25251-25110-fourbanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25251-25110-fourbanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25251-25110-fourbanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25251-25110-fourbanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25252-25370-fourcatier_et_maison_neuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25252-25370-fourcatier_et_maison_neuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25252-25370-fourcatier_et_maison_neuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25252-25370-fourcatier_et_maison_neuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25253-25440-fourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25253-25440-fourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25253-25440-fourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25253-25440-fourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25254-25300-les_fourgs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25254-25300-les_fourgs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25254-25300-les_fourgs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25254-25300-les_fourgs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25255-25140-fournet_blancheroche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25255-25140-fournet_blancheroche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25255-25140-fournet_blancheroche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25255-25140-fournet_blancheroche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25256-25140-frambouhans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25256-25140-frambouhans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25256-25140-frambouhans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25256-25140-frambouhans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25257-25170-franey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25257-25170-franey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25257-25170-franey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25257-25170-franey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25258-25770-franois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25258-25770-franois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25258-25770-franois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25258-25770-franois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25259-25560-frasne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25259-25560-frasne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25259-25560-frasne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25259-25560-frasne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25261-25190-froidevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25261-25190-froidevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25261-25190-froidevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25261-25190-froidevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25262-25390-fuans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25262-25390-fuans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25262-25390-fuans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25262-25390-fuans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25263-25240-gellin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25263-25240-gellin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25263-25240-gellin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25263-25240-gellin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25264-25250-gemonval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25264-25250-gemonval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25264-25250-gemonval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25264-25250-gemonval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25265-25870-geneuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25265-25870-geneuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25265-25870-geneuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25265-25870-geneuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25266-25250-geney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25266-25250-geney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25266-25250-geney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25266-25250-geney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25267-25660-gennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25267-25660-gennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25267-25660-gennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25267-25660-gennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25268-25510-germefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25268-25510-germefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25268-25510-germefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25268-25510-germefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25269-25640-germondans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25269-25640-germondans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25269-25640-germondans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25269-25640-germondans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25270-25270-gevresin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25270-25270-gevresin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25270-25270-gevresin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25270-25270-gevresin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25271-25650-gilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25271-25650-gilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25271-25650-gilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25271-25650-gilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25273-25360-glamondans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25273-25360-glamondans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25273-25360-glamondans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25273-25360-glamondans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25274-25310-glay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25274-25310-glay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25274-25310-glay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25274-25310-glay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25275-25190-glere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25275-25190-glere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25275-25190-glere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25275-25190-glere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25276-25340-gondenans_montby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25276-25340-gondenans_montby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25276-25340-gondenans_montby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25276-25340-gondenans_montby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25277-25680-gondenans_les_moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25277-25680-gondenans_les_moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25277-25680-gondenans_les_moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25277-25680-gondenans_les_moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25278-25360-gonsans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25278-25360-gonsans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25278-25360-gonsans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25278-25360-gonsans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25279-25680-gouhelans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25279-25680-gouhelans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25279-25680-gouhelans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25279-25680-gouhelans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25280-25470-goumois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25280-25470-goumois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25280-25470-goumois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25280-25470-goumois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25281-25150-goux_les_dambelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25281-25150-goux_les_dambelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25281-25150-goux_les_dambelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25281-25150-goux_les_dambelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25282-25520-goux_les_usiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25282-25520-goux_les_usiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25282-25520-goux_les_usiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25282-25520-goux_les_usiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25283-25440-goux_sous_landet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25283-25440-goux_sous_landet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25283-25440-goux_sous_landet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25283-25440-goux_sous_landet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25284-25200-grand_charmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25284-25200-grand_charmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25284-25200-grand_charmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25284-25200-grand_charmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25285-25570-grand_combe_chateleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25285-25570-grand_combe_chateleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25285-25570-grand_combe_chateleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25285-25570-grand_combe_chateleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25286-25210-grand_combe_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25286-25210-grand_combe_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25286-25210-grand_combe_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25286-25210-grand_combe_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25287-25320-grandfontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25287-25320-grandfontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25287-25320-grandfontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25287-25320-grandfontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25288-25390-fournets_luisans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25288-25390-fournets_luisans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25288-25390-fournets_luisans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25288-25390-fournets_luisans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25289-25510-grandfontaine_sur_creuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25289-25510-grandfontaine_sur_creuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25289-25510-grandfontaine_sur_creuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25289-25510-grandfontaine_sur_creuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25290-25380-la_grange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25290-25380-la_grange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25290-25380-la_grange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25290-25380-la_grange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25293-25300-granges_narboz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25293-25300-granges_narboz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25293-25300-granges_narboz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25293-25300-granges_narboz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25295-25160-les_grangettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25295-25160-les_grangettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25295-25160-les_grangettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25295-25160-les_grangettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25296-25790-les_gras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25296-25790-les_gras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25296-25790-les_gras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25296-25790-les_gras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25297-25620-le_gratteris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25297-25620-le_gratteris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25297-25620-le_gratteris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25297-25620-le_gratteris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25298-25110-grosbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25298-25110-grosbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25298-25110-grosbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25298-25110-grosbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25299-25110-guillon_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25299-25110-guillon_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25299-25110-guillon_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25299-25110-guillon_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25300-25580-guyans_durnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25300-25580-guyans_durnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25300-25580-guyans_durnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25300-25580-guyans_durnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25301-25390-guyans_vennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25301-25390-guyans_vennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25301-25390-guyans_vennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25301-25390-guyans_vennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25303-25650-hauterive_la_fresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25303-25650-hauterive_la_fresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25303-25650-hauterive_la_fresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25303-25650-hauterive_la_fresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25304-25310-herimoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25304-25310-herimoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25304-25310-herimoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25304-25310-herimoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25305-25620-l_hopital_du_grosbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25305-25620-l_hopital_du_grosbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25305-25620-l_hopital_du_grosbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25305-25620-l_hopital_du_grosbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25306-25340-l_hopital_saint_lieffroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25306-25340-l_hopital_saint_lieffroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25306-25340-l_hopital_saint_lieffroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25306-25340-l_hopital_saint_lieffroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25307-25370-les_hopitaux_neufs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25307-25370-les_hopitaux_neufs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25307-25370-les_hopitaux_neufs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25307-25370-les_hopitaux_neufs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25308-25370-les_hopitaux_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25308-25370-les_hopitaux_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25308-25370-les_hopitaux_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25308-25370-les_hopitaux_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25309-25300-houtaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25309-25300-houtaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25309-25300-houtaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25309-25300-houtaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25310-25680-huanne_montmartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25310-25680-huanne_montmartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25310-25680-huanne_montmartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25310-25680-huanne_montmartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25311-25250-hyemondans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25311-25250-hyemondans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25311-25250-hyemondans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25311-25250-hyemondans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25312-25110-hyevre_magny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25312-25110-hyevre_magny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25312-25110-hyevre_magny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25312-25110-hyevre_magny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25313-25110-hyevre_paroisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25313-25110-hyevre_paroisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25313-25110-hyevre_paroisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25313-25110-hyevre_paroisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25314-25470-indevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25314-25470-indevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25314-25470-indevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25314-25470-indevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25315-25250-l_isle_sur_le_doubs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25315-25250-l_isle_sur_le_doubs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25315-25250-l_isle_sur_le_doubs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25315-25250-l_isle_sur_le_doubs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25316-25550-issans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25316-25550-issans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25316-25550-issans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25316-25550-issans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25317-25170-jallerange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25317-25170-jallerange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25317-25170-jallerange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25317-25170-jallerange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25318-25370-jougne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25318-25370-jougne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25318-25370-jougne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25318-25370-jougne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25320-25160-labergement_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25320-25160-labergement_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25320-25160-labergement_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25320-25160-labergement_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25321-25130-villers_le_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25321-25130-villers_le_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25321-25130-villers_le_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25321-25130-villers_le_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25322-25550-laire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25322-25550-laire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25322-25550-laire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25322-25550-laire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25323-25820-laissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25323-25820-laissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25323-25820-laissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25323-25820-laissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25324-25360-lanans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25324-25360-lanans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25324-25360-lanans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25324-25360-lanans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25325-25530-landresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25325-25530-landresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25325-25530-landresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25325-25530-landresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25326-25170-lantenne_vertiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25326-25170-lantenne_vertiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25326-25170-lantenne_vertiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25326-25170-lantenne_vertiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25327-25250-lanthenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25327-25250-lanthenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25327-25250-lanthenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25327-25250-lanthenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25328-25720-larnod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25328-25720-larnod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25328-25720-larnod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25328-25720-larnod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25329-25210-laval_le_prieure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25329-25210-laval_le_prieure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25329-25210-laval_le_prieure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25329-25210-laval_le_prieure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25330-25440-lavans_quingey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25330-25440-lavans_quingey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25330-25440-lavans_quingey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25330-25440-lavans_quingey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25331-25580-lavans_vuillafans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25331-25580-lavans_vuillafans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25331-25580-lavans_vuillafans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25331-25580-lavans_vuillafans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25332-25170-lavernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25332-25170-lavernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25332-25170-lavernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25332-25170-lavernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25333-25510-laviron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25333-25510-laviron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25333-25510-laviron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25333-25510-laviron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25334-25270-levier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25334-25270-levier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25334-25270-levier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25334-25270-levier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25335-25190-liebvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25335-25190-liebvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25335-25190-liebvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25335-25190-liebvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25336-25440-liesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25336-25440-liesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25336-25440-liesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25336-25440-liesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25338-25330-lizine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25338-25330-lizine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25338-25330-lizine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25338-25330-lizine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25339-25930-lods/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25339-25930-lods/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25339-25930-lods/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25339-25930-lods/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25340-25440-lombard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25340-25440-lombard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25340-25440-lombard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25340-25440-lombard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25341-25110-lomont_sur_crete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25341-25110-lomont_sur_crete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25341-25110-lomont_sur_crete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25341-25110-lomont_sur_crete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25342-25690-longechaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25342-25690-longechaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25342-25690-longechaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25342-25690-longechaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25343-25690-longemaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25343-25690-longemaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25343-25690-longemaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25343-25690-longemaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25344-25380-longevelle_les_russey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25344-25380-longevelle_les_russey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25344-25380-longevelle_les_russey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25344-25380-longevelle_les_russey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25345-25260-longevelle_sur_doubs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25345-25260-longevelle_sur_doubs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25345-25260-longevelle_sur_doubs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25345-25260-longevelle_sur_doubs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25346-25330-longeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25346-25330-longeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25346-25330-longeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25346-25330-longeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25347-25650-la_longeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25347-25650-la_longeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25347-25650-la_longeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25347-25650-la_longeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25348-25370-longevilles_mont_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25348-25370-longevilles_mont_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25348-25370-longevilles_mont_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25348-25370-longevilles_mont_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25349-25390-loray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25349-25390-loray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25349-25390-loray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25349-25390-loray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25350-25260-lougres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25350-25260-lougres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25350-25260-lougres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25350-25260-lougres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25351-25210-le_luhier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25351-25210-le_luhier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25351-25210-le_luhier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25351-25210-le_luhier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25354-25110-luxiol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25354-25110-luxiol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25354-25110-luxiol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25354-25110-luxiol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25355-25360-magny_chatelard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25355-25360-magny_chatelard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25355-25360-magny_chatelard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25355-25360-magny_chatelard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25356-25120-maiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25356-25120-maiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25356-25120-maiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25356-25120-maiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25357-25650-maisons_du_bois_lievremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25357-25650-maisons_du_bois_lievremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25357-25650-maisons_du_bois_lievremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25357-25650-maisons_du_bois_lievremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25359-25330-malans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25359-25330-malans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25359-25330-malans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25359-25330-malans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25360-25620-malbrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25360-25620-malbrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25360-25620-malbrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25360-25620-malbrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25361-25160-malbuisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25361-25160-malbuisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25361-25160-malbuisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25361-25160-malbuisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25362-25160-malpas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25362-25160-malpas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25362-25160-malpas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25362-25160-malpas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25364-25620-mamirolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25364-25620-mamirolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25364-25620-mamirolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25364-25620-mamirolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25365-25250-mancenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25365-25250-mancenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25365-25250-mancenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25365-25250-mancenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25366-25120-mancenans_lizerne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25366-25120-mancenans_lizerne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25366-25120-mancenans_lizerne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25366-25120-mancenans_lizerne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25367-25350-mandeure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25367-25350-mandeure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25367-25350-mandeure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25367-25350-mandeure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25368-25640-marchaux_chaudefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25368-25640-marchaux_chaudefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25368-25640-marchaux_chaudefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25368-25640-marchaux_chaudefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25369-25250-marvelise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25369-25250-marvelise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25369-25250-marvelise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25369-25250-marvelise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25370-25700-mathay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25370-25700-mathay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25370-25700-mathay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25370-25700-mathay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25371-25170-mazerolles_le_salin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25371-25170-mazerolles_le_salin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25371-25170-mazerolles_le_salin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25371-25170-mazerolles_le_salin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25372-25250-mediere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25372-25250-mediere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25372-25250-mediere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25372-25250-mediere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25373-25210-le_memont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25373-25210-le_memont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25373-25210-le_memont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25373-25210-le_memont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25374-25410-mercey_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25374-25410-mercey_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25374-25410-mercey_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25374-25410-mercey_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25375-25660-merey_sous_montrond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25375-25660-merey_sous_montrond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25375-25660-merey_sous_montrond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25375-25660-merey_sous_montrond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25376-25870-merey_vieilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25376-25870-merey_vieilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25376-25870-merey_vieilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25376-25870-merey_vieilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25377-25680-mesandans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25377-25680-mesandans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25377-25680-mesandans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25377-25680-mesandans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25378-25310-meslieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25378-25310-meslieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25378-25310-meslieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25378-25310-meslieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25379-25440-mesmay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25379-25440-mesmay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25379-25440-mesmay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25379-25440-mesmay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25380-25370-metabief/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25380-25370-metabief/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25380-25370-metabief/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25380-25370-metabief/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25381-25480-miserey_salines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25381-25480-miserey_salines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25381-25480-miserey_salines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25381-25480-miserey_salines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25382-25870-moncey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25382-25870-moncey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25382-25870-moncey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25382-25870-moncey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25383-25170-moncley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25383-25170-moncley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25383-25170-moncley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25383-25170-moncley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25384-25680-mondon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25384-25680-mondon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25384-25680-mondon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25384-25680-mondon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25385-25680-montagney_servigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25385-25680-montagney_servigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25385-25680-montagney_servigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25385-25680-montagney_servigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25386-25190-montancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25386-25190-montancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25386-25190-montancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25386-25190-montancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25387-25190-montandon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25387-25190-montandon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25387-25190-montandon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25387-25190-montandon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25388-25200-montbeliard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25388-25200-montbeliard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25388-25200-montbeliard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25388-25200-montbeliard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25389-25210-montbeliardot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25389-25210-montbeliardot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25389-25210-montbeliardot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25389-25210-montbeliardot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25390-25650-montbenoit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25390-25650-montbenoit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25390-25650-montbenoit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25390-25650-montbenoit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25391-25210-mont_de_laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25391-25210-mont_de_laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25391-25210-mont_de_laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25391-25210-mont_de_laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25392-25120-mont_de_vougney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25392-25120-mont_de_vougney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25392-25120-mont_de_vougney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25392-25120-mont_de_vougney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25393-25190-montecheroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25393-25190-montecheroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25393-25190-montecheroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25393-25190-montecheroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25394-25260-montenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25394-25260-montenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25394-25260-montenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25394-25260-montenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25395-25660-montfaucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25395-25660-montfaucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25395-25660-montfaucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25395-25660-montfaucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25397-25320-montferrand_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25397-25320-montferrand_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25397-25320-montferrand_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25397-25320-montferrand_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25398-25650-montflovin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25398-25650-montflovin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25398-25650-montflovin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25398-25650-montflovin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25400-25111-montgesoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25400-25111-montgesoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25400-25111-montgesoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25400-25111-montgesoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25401-25110-montivernage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25401-25110-montivernage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25401-25110-montivernage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25401-25110-montivernage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25402-25190-montjoie_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25402-25190-montjoie_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25402-25190-montjoie_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25402-25190-montjoie_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25403-25500-montlebon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25403-25500-montlebon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25403-25500-montlebon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25403-25500-montlebon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25404-25270-montmahoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25404-25270-montmahoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25404-25270-montmahoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25404-25270-montmahoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25405-25160-montperreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25405-25160-montperreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25405-25160-montperreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25405-25160-montperreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25406-25660-montrond_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25406-25660-montrond_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25406-25660-montrond_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25406-25660-montrond_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25408-25680-montussaint/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25408-25680-montussaint/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25408-25680-montussaint/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25408-25680-montussaint/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25410-25660-morre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25410-25660-morre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25410-25660-morre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25410-25660-morre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25411-25500-morteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25411-25500-morteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25411-25500-morteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25411-25500-morteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25413-25240-mouthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25413-25240-mouthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25413-25240-mouthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25413-25240-mouthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25414-25170-le_moutherot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25414-25170-le_moutherot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25414-25170-le_moutherot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25414-25170-le_moutherot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25415-25920-mouthier_haute_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25415-25920-mouthier_haute_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25415-25920-mouthier_haute_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25415-25920-mouthier_haute_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25416-25440-myon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25416-25440-myon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25416-25440-myon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25416-25440-myon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25417-25360-naisey_les_granges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25417-25360-naisey_les_granges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25417-25360-naisey_les_granges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25417-25360-naisey_les_granges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25418-25360-nancray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25418-25360-nancray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25418-25360-nancray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25418-25360-nancray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25419-25680-nans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25419-25680-nans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25419-25680-nans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25419-25680-nans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25420-25330-nans_sous_sainte_anne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25420-25330-nans_sous_sainte_anne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25420-25330-nans_sous_sainte_anne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25420-25330-nans_sous_sainte_anne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25421-25210-narbief/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25421-25210-narbief/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25421-25210-narbief/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25421-25210-narbief/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25422-25150-neuchatel_urtiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25422-25150-neuchatel_urtiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25422-25150-neuchatel_urtiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25422-25150-neuchatel_urtiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25424-25580-les_premiers_sapins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25424-25580-les_premiers_sapins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25424-25580-les_premiers_sapins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25424-25580-les_premiers_sapins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25425-25500-noel_cerneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25425-25500-noel_cerneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25425-25500-noel_cerneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25425-25500-noel_cerneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25426-25190-noirefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25426-25190-noirefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25426-25190-noirefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25426-25190-noirefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25427-25170-noironte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25427-25170-noironte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25427-25170-noironte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25427-25170-noironte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25428-25600-nommay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25428-25600-nommay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25428-25600-nommay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25428-25600-nommay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25429-25220-novillars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25429-25220-novillars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25429-25220-novillars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25429-25220-novillars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25430-25640-ollans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25430-25640-ollans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25430-25640-ollans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25430-25640-ollans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25431-25250-onans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25431-25250-onans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25431-25250-onans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25431-25250-onans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25432-25390-orchamps_vennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25432-25390-orchamps_vennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25432-25390-orchamps_vennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25432-25390-orchamps_vennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25433-25120-orgeans_blanchefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25433-25120-orgeans_blanchefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25433-25120-orgeans_blanchefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25433-25120-orgeans_blanchefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25434-25290-ornans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25434-25290-ornans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25434-25290-ornans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25434-25290-ornans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25434-25620-ornans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25434-25620-ornans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25434-25620-ornans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25434-25620-ornans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25435-25530-orsans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25435-25530-orsans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25435-25530-orsans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25435-25530-orsans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25436-25430-orve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25436-25430-orve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25436-25430-orve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25436-25430-orve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25437-25360-osse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25437-25360-osse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25437-25360-osse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25437-25360-osse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25438-25410-osselle_routelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25438-25410-osselle_routelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25438-25410-osselle_routelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25438-25410-osselle_routelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25438-25320-osselle_routelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25438-25320-osselle_routelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25438-25320-osselle_routelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25438-25320-osselle_routelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25439-25640-ougney_douvot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25439-25640-ougney_douvot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25439-25640-ougney_douvot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25439-25640-ougney_douvot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25440-25520-ouhans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25440-25520-ouhans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25440-25520-ouhans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25440-25520-ouhans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25441-25530-ouvans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25441-25530-ouvans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25441-25530-ouvans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25441-25530-ouvans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25442-25160-oye_et_pallet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25442-25160-oye_et_pallet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25442-25160-oye_et_pallet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25442-25160-oye_et_pallet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25443-25440-palantine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25443-25440-palantine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25443-25440-palantine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25443-25440-palantine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25444-25870-palise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25444-25870-palise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25444-25870-palise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25444-25870-palise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25445-25440-paroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25445-25440-paroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25445-25440-paroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25445-25440-paroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25446-25360-passavant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25446-25360-passavant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25446-25360-passavant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25446-25360-passavant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25447-25690-passonfontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25447-25690-passonfontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25447-25690-passonfontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25447-25690-passonfontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25448-25170-pelousey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25448-25170-pelousey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25448-25170-pelousey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25448-25170-pelousey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25449-25190-peseux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25449-25190-peseux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25449-25190-peseux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25449-25190-peseux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25450-25440-pessans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25450-25440-pessans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25450-25440-pessans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25450-25440-pessans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25451-25240-petite_chaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25451-25240-petite_chaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25451-25240-petite_chaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25451-25240-petite_chaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25452-25310-pierrefontaine_les_blamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25452-25310-pierrefontaine_les_blamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25452-25310-pierrefontaine_les_blamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25452-25310-pierrefontaine_les_blamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25453-25510-pierrefontaine_les_varans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25453-25510-pierrefontaine_les_varans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25453-25510-pierrefontaine_les_varans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25453-25510-pierrefontaine_les_varans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25454-25480-pirey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25454-25480-pirey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25454-25480-pirey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25454-25480-pirey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25455-25170-placey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25455-25170-placey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25455-25170-placey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25455-25170-placey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25456-25210-plaimbois_du_miroir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25456-25210-plaimbois_du_miroir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25456-25210-plaimbois_du_miroir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25456-25210-plaimbois_du_miroir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25457-25390-plaimbois_vennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25457-25390-plaimbois_vennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25457-25390-plaimbois_vennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25457-25390-plaimbois_vennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25458-25470-les_plains_et_grands_essarts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25458-25470-les_plains_et_grands_essarts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25458-25470-les_plains_et_grands_essarts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25458-25470-les_plains_et_grands_essarts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25459-25160-la_planee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25459-25160-la_planee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25459-25160-la_planee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25459-25160-la_planee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25460-25440-le_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25460-25440-le_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25460-25440-le_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25460-25440-le_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25461-25340-pompierre_sur_doubs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25461-25340-pompierre_sur_doubs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25461-25340-pompierre_sur_doubs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25461-25340-pompierre_sur_doubs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25462-25300-pontarlier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25462-25300-pontarlier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25462-25300-pontarlier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25462-25300-pontarlier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25463-25150-pont_de_roide_vermondans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25463-25150-pont_de_roide_vermondans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25463-25150-pont_de_roide_vermondans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25463-25150-pont_de_roide_vermondans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25464-25240-les_pontets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25464-25240-les_pontets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25464-25240-les_pontets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25464-25240-les_pontets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25465-25110-pont_les_moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25465-25110-pont_les_moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25465-25110-pont_les_moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25465-25110-pont_les_moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25466-25410-pouilley_francais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25466-25410-pouilley_francais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25466-25410-pouilley_francais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25466-25410-pouilley_francais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25467-25115-pouilley_les_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25467-25115-pouilley_les_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25467-25115-pouilley_les_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25467-25115-pouilley_les_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25468-25640-pouligney_lusans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25468-25640-pouligney_lusans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25468-25640-pouligney_lusans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25468-25640-pouligney_lusans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25469-25550-presentevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25469-25550-presentevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25469-25550-presentevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25469-25550-presentevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25470-25250-la_pretiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25470-25250-la_pretiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25470-25250-la_pretiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25470-25250-la_pretiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25471-25380-provenchere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25471-25380-provenchere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25471-25380-provenchere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25471-25380-provenchere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25472-25680-puessans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25472-25680-puessans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25472-25680-puessans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25472-25680-puessans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25473-25720-pugey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25473-25720-pugey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25473-25720-pugey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25473-25720-pugey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25474-25640-le_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25474-25640-le_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25474-25640-le_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25474-25640-le_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25475-25440-quingey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25475-25440-quingey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25475-25440-quingey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25475-25440-quingey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25476-25430-rahon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25476-25430-rahon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25476-25430-rahon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25476-25430-rahon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25477-25320-rancenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25477-25320-rancenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25477-25320-rancenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25477-25320-rancenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25478-25430-randevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25478-25430-randevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25478-25430-randevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25478-25430-randevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25479-25250-rang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25479-25250-rang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25479-25250-rang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25479-25250-rang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25481-25550-raynans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25481-25550-raynans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25481-25550-raynans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25481-25550-raynans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25482-25170-recologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25482-25170-recologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25482-25170-recologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25482-25170-recologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25483-25240-reculfoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25483-25240-reculfoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25483-25240-reculfoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25483-25240-reculfoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25485-25150-remondans_vaivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25485-25150-remondans_vaivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25485-25150-remondans_vaivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25485-25150-remondans_vaivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25486-25160-remoray_boujeons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25486-25160-remoray_boujeons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25486-25160-remoray_boujeons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25486-25160-remoray_boujeons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25487-25520-renedale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25487-25520-renedale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25487-25520-renedale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25487-25520-renedale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25488-25440-rennes_sur_loue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25488-25440-rennes_sur_loue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25488-25440-rennes_sur_loue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25488-25440-rennes_sur_loue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25489-25330-reugney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25489-25330-reugney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25489-25330-reugney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25489-25330-reugney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25490-25640-rigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25490-25640-rigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25490-25640-rigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25490-25640-rigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25491-25640-rignosot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25491-25640-rignosot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25491-25640-rignosot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25491-25640-rignosot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25492-25110-rillans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25492-25110-rillans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25492-25110-rillans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25492-25110-rillans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25493-25560-la_riviere_drugeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25493-25560-la_riviere_drugeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25493-25560-la_riviere_drugeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25493-25560-la_riviere_drugeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25494-25370-rochejean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25494-25370-rochejean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25494-25370-rochejean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25494-25370-rochejean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25495-25220-roche_lez_beaupre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25495-25220-roche_lez_beaupre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25495-25220-roche_lez_beaupre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25495-25220-roche_lez_beaupre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25496-25340-roche_les_clerval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25496-25340-roche_les_clerval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25496-25340-roche_les_clerval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25496-25340-roche_les_clerval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25497-25310-roches_les_blamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25497-25310-roches_les_blamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25497-25310-roches_les_blamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25497-25310-roches_les_blamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25498-25680-rognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25498-25680-rognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25498-25680-rognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25498-25680-rognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25499-25680-romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25499-25680-romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25499-25680-romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25499-25680-romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25500-25440-ronchaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25500-25440-ronchaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25500-25440-ronchaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25500-25440-ronchaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25501-25240-rondefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25501-25240-rondefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25501-25240-rondefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25501-25240-rondefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25502-25410-roset_fluans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25502-25410-roset_fluans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25502-25410-roset_fluans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25502-25410-roset_fluans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25503-25190-rosieres_sur_barbeche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25503-25190-rosieres_sur_barbeche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25503-25190-rosieres_sur_barbeche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25503-25190-rosieres_sur_barbeche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25504-25380-rosureux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25504-25380-rosureux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25504-25380-rosureux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25504-25380-rosureux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25505-25680-rougemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25505-25680-rougemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25505-25680-rougemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25505-25680-rougemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25506-25640-rougemontot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25506-25640-rougemontot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25506-25640-rougemontot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25506-25640-rougemontot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25507-25440-rouhe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25507-25440-rouhe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25507-25440-rouhe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25507-25440-rouhe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25508-25640-roulans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25508-25640-roulans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25508-25640-roulans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25508-25640-roulans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25510-25170-ruffey_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25510-25170-ruffey_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25510-25170-ruffey_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25510-25170-ruffey_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25511-25290-rurey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25511-25290-rurey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25511-25290-rurey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25511-25290-rurey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25512-25210-le_russey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25512-25210-le_russey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25512-25210-le_russey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25512-25210-le_russey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25513-25270-sainte_anne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25513-25270-sainte_anne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25513-25270-sainte_anne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25513-25270-sainte_anne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25514-25370-saint_antoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25514-25370-saint_antoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25514-25370-saint_antoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25514-25370-saint_antoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25515-25300-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25515-25300-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25515-25300-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25515-25300-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25516-25340-saint_georges_armont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25516-25340-saint_georges_armont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25516-25340-saint_georges_armont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25516-25340-saint_georges_armont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25517-25520-saint_gorgon_main/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25517-25520-saint_gorgon_main/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25517-25520-saint_gorgon_main/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25517-25520-saint_gorgon_main/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25518-25640-saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25518-25640-saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25518-25640-saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25518-25640-saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25519-25190-saint_hippolyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25519-25190-saint_hippolyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25519-25190-saint_hippolyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25519-25190-saint_hippolyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25520-25360-saint_juan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25520-25360-saint_juan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25520-25360-saint_juan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25520-25360-saint_juan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25521-25550-saint_julien_les_montbeliard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25521-25550-saint_julien_les_montbeliard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25521-25550-saint_julien_les_montbeliard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25521-25550-saint_julien_les_montbeliard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25522-25210-saint_julien_les_russey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25522-25210-saint_julien_les_russey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25522-25210-saint_julien_les_russey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25522-25210-saint_julien_les_russey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25523-25113-sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25523-25113-sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25523-25113-sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25523-25113-sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25524-25260-saint_maurice_colombier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25524-25260-saint_maurice_colombier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25524-25260-saint_maurice_colombier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25524-25260-saint_maurice_colombier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25525-25160-saint_point_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25525-25160-saint_point_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25525-25160-saint_point_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25525-25160-saint_point_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25526-25630-sainte_suzanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25526-25630-sainte_suzanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25526-25630-sainte_suzanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25526-25630-sainte_suzanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25527-25410-saint_vit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25527-25410-saint_vit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25527-25410-saint_vit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25527-25410-saint_vit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25528-25440-samson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25528-25440-samson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25528-25440-samson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25528-25440-samson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25529-25430-sancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25529-25430-sancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25529-25430-sancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25529-25430-sancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25532-25660-saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25532-25660-saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25532-25660-saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25532-25660-saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25533-25330-saraz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25533-25330-saraz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25533-25330-saraz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25533-25330-saraz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25534-25240-sarrageois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25534-25240-sarrageois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25534-25240-sarrageois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25534-25240-sarrageois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25535-25580-saules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25535-25580-saules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25535-25580-saules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25535-25580-saules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25536-25170-sauvagney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25536-25170-sauvagney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25536-25170-sauvagney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25536-25170-sauvagney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25537-25290-scey_maisieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25537-25290-scey_maisieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25537-25290-scey_maisieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25537-25290-scey_maisieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25538-25110-sechin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25538-25110-sechin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25538-25110-sechin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25538-25110-sechin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25539-25230-seloncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25539-25230-seloncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25539-25230-seloncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25539-25230-seloncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25540-25750-semondans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25540-25750-semondans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25540-25750-semondans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25540-25750-semondans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25541-25270-septfontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25541-25270-septfontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25541-25270-septfontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25541-25270-septfontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25542-25770-serre_les_sapins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25542-25770-serre_les_sapins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25542-25770-serre_les_sapins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25542-25770-serre_les_sapins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25544-25430-servin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25544-25430-servin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25544-25430-servin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25544-25430-servin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25545-25330-silley_amancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25545-25330-silley_amancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25545-25330-silley_amancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25545-25330-silley_amancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25546-25110-silley_blefond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25546-25110-silley_blefond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25546-25110-silley_blefond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25546-25110-silley_blefond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25547-25600-sochaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25547-25600-sochaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25547-25600-sochaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25547-25600-sochaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25548-25190-solemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25548-25190-solemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25548-25190-solemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25548-25190-solemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25549-25520-sombacour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25549-25520-sombacour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25549-25520-sombacour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25549-25520-sombacour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25550-25510-la_sommette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25550-25510-la_sommette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25550-25510-la_sommette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25550-25510-la_sommette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25551-25190-soulce_cernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25551-25190-soulce_cernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25551-25190-soulce_cernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25551-25190-soulce_cernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25552-25250-sourans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25552-25250-sourans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25552-25250-sourans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25552-25250-sourans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25553-25250-soye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25553-25250-soye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25553-25250-soye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25553-25250-soye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25554-25380-surmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25554-25380-surmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25554-25380-surmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25554-25380-surmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25555-25400-taillecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25555-25400-taillecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25555-25400-taillecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25555-25400-taillecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25556-25680-tallans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25556-25680-tallans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25556-25680-tallans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25556-25680-tallans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25557-25870-tallenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25557-25870-tallenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25557-25870-tallenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25557-25870-tallenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25558-25620-tarcenay_foucherans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25558-25620-tarcenay_foucherans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25558-25620-tarcenay_foucherans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25558-25620-tarcenay_foucherans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25559-25470-thiebouhans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25559-25470-thiebouhans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25559-25470-thiebouhans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25559-25470-thiebouhans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25560-25220-thise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25560-25220-thise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25560-25220-thise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25560-25220-thise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25561-25320-thoraise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25561-25320-thoraise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25561-25320-thoraise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25561-25320-thoraise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25562-25310-thulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25562-25310-thulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25562-25310-thulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25562-25310-thulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25563-25870-thurey_le_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25563-25870-thurey_le_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25563-25870-thurey_le_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25563-25870-thurey_le_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25564-25320-torpes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25564-25320-torpes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25564-25320-torpes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25564-25320-torpes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25565-25370-touillon_et_loutelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25565-25370-touillon_et_loutelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25565-25370-touillon_et_loutelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25565-25370-touillon_et_loutelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25566-25640-la_tour_de_scay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25566-25640-la_tour_de_scay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25566-25640-la_tour_de_scay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25566-25640-la_tour_de_scay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25567-25680-tournans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25567-25680-tournans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25567-25680-tournans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25567-25680-tournans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25569-25620-trepot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25569-25620-trepot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25569-25620-trepot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25569-25620-trepot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25570-25680-tressandans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25570-25680-tressandans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25570-25680-tressandans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25570-25680-tressandans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25571-25470-trevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25571-25470-trevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25571-25470-trevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25571-25470-trevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25572-25680-trouvans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25572-25680-trouvans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25572-25680-trouvans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25572-25680-trouvans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25573-25470-urtiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25573-25470-urtiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25573-25470-urtiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25573-25470-urtiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25574-25340-uzelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25574-25340-uzelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25574-25340-uzelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25574-25340-uzelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25575-25220-vaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25575-25220-vaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25575-25220-vaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25575-25220-vaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25578-25800-valdahon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25578-25800-valdahon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25578-25800-valdahon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25578-25800-valdahon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25579-25640-val_de_roulans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25579-25640-val_de_roulans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25579-25640-val_de_roulans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25579-25640-val_de_roulans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25580-25700-valentigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25580-25700-valentigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25580-25700-valentigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25580-25700-valentigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25582-25870-valleroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25582-25870-valleroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25582-25870-valleroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25582-25870-valleroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25583-25190-valonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25583-25190-valonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25583-25190-valonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25583-25190-valonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25584-25190-valoreille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25584-25190-valoreille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25584-25190-valoreille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25584-25190-valoreille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25586-25230-vandoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25586-25230-vandoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25586-25230-vandoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25586-25230-vandoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25588-25380-vaucluse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25588-25380-vaucluse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25588-25380-vaucluse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25588-25380-vaucluse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25589-25380-vauclusotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25589-25380-vauclusotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25589-25380-vauclusotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25589-25380-vauclusotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25590-25360-vaudrivillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25590-25360-vaudrivillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25590-25360-vaudrivillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25590-25360-vaudrivillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25591-25190-vaufrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25591-25190-vaufrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25591-25190-vaufrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25591-25190-vaufrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25592-25160-vaux_et_chantegrue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25592-25160-vaux_et_chantegrue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25592-25160-vaux_et_chantegrue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25592-25160-vaux_et_chantegrue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25594-25410-velesmes_essarts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25594-25410-velesmes_essarts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25594-25410-velesmes_essarts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25594-25410-velesmes_essarts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25595-25430-vellerot_les_belvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25595-25430-vellerot_les_belvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25595-25430-vellerot_les_belvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25595-25430-vellerot_les_belvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25596-25530-vellerot_les_vercel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25596-25530-vellerot_les_vercel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25596-25530-vellerot_les_vercel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25596-25530-vellerot_les_vercel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25597-25430-vellevans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25597-25430-vellevans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25597-25430-vellevans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25597-25430-vellevans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25598-25870-venise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25598-25870-venise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25598-25870-venise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25598-25870-venise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25599-25640-vennans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25599-25640-vennans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25599-25640-vennans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25599-25640-vennans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25600-25390-vennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25600-25390-vennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25600-25390-vennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25600-25390-vennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25601-25530-vercel_villedieu_le_camp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25601-25530-vercel_villedieu_le_camp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25601-25530-vercel_villedieu_le_camp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25601-25530-vercel_villedieu_le_camp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25602-25110-vergranne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25602-25110-vergranne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25602-25110-vergranne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25602-25110-vergranne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25604-25110-verne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25604-25110-verne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25604-25110-verne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25604-25110-verne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25605-25580-vernierfontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25605-25580-vernierfontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25605-25580-vernierfontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25605-25580-vernierfontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25607-25430-vernois_les_belvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25607-25430-vernois_les_belvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25607-25430-vernois_les_belvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25607-25430-vernois_les_belvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25608-25750-le_vernoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25608-25750-le_vernoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25608-25750-le_vernoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25608-25750-le_vernoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25609-25300-verrieres_de_joux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25609-25300-verrieres_de_joux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25609-25300-verrieres_de_joux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25609-25300-verrieres_de_joux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25611-25660-la_veze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25611-25660-la_veze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25611-25660-la_veze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25611-25660-la_veze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25612-25870-vieilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25612-25870-vieilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25612-25870-vieilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25612-25870-vieilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25613-25340-viethorey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25613-25340-viethorey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25613-25340-viethorey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25613-25340-viethorey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25614-25600-vieux_charmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25614-25600-vieux_charmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25614-25600-vieux_charmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25614-25600-vieux_charmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25615-25310-villars_les_blamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25615-25310-villars_les_blamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25615-25310-villars_les_blamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25615-25310-villars_les_blamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25616-25410-villars_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25616-25410-villars_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25616-25410-villars_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25616-25410-villars_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25617-25190-villars_sous_dampjoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25617-25190-villars_sous_dampjoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25617-25190-villars_sous_dampjoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25617-25190-villars_sous_dampjoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25618-25150-villars_sous_ecot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25618-25150-villars_sous_ecot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25618-25150-villars_sous_ecot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25618-25150-villars_sous_ecot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25619-25240-les_villedieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25619-25240-les_villedieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25619-25240-les_villedieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25619-25240-les_villedieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25620-25650-ville_du_pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25620-25650-ville_du_pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25620-25650-ville_du_pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25620-25650-ville_du_pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25621-25270-villeneuve_d_amont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25621-25270-villeneuve_d_amont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25621-25270-villeneuve_d_amont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25621-25270-villeneuve_d_amont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25622-25170-villers_buzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25622-25170-villers_buzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25622-25170-villers_buzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25622-25170-villers_buzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25623-25530-villers_chief/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25623-25530-villers_chief/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25623-25530-villers_chief/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25623-25530-villers_chief/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25624-25640-villers_grelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25624-25640-villers_grelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25624-25640-villers_grelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25624-25640-villers_grelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25625-25510-villers_la_combe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25625-25510-villers_la_combe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25625-25510-villers_la_combe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25625-25510-villers_la_combe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25626-25110-villers_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25626-25110-villers_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25626-25110-villers_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25626-25110-villers_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25627-25270-villers_sous_chalamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25627-25270-villers_sous_chalamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25627-25270-villers_sous_chalamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25627-25270-villers_sous_chalamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25628-25620-villers_sous_montrond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25628-25620-villers_sous_montrond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25628-25620-villers_sous_montrond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25628-25620-villers_sous_montrond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25629-25110-voillans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25629-25110-voillans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25629-25110-voillans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25629-25110-voillans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25630-25580-voires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25630-25580-voires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25630-25580-voires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25630-25580-voires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25631-25320-vorges_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25631-25320-vorges_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25631-25320-vorges_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25631-25320-vorges_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25632-25420-voujeaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25632-25420-voujeaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25632-25420-voujeaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25632-25420-voujeaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25633-25840-vuillafans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25633-25840-vuillafans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25633-25840-vuillafans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25633-25840-vuillafans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25634-25300-vuillecin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25634-25300-vuillecin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25634-25300-vuillecin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25634-25300-vuillecin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25635-25430-vyt_les_belvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25635-25430-vyt_les_belvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25635-25430-vyt_les_belvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt25-doubs/commune25635-25430-vyt_les_belvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-26.xml
+++ b/public/sitemaps/sitemap-26.xml
@@ -5,734 +5,1464 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26001-26150-solaure_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26001-26150-solaure_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26001-26150-solaure_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26001-26150-solaure_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26002-26140-albon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26002-26140-albon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26002-26140-albon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26002-26140-albon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26003-26770-aleyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26003-26770-aleyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26003-26770-aleyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26003-26770-aleyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26004-26300-alixan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26004-26300-alixan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26004-26300-alixan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26004-26300-alixan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26005-26780-allan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26005-26780-allan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26005-26780-allan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26005-26780-allan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26006-26400-allex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26006-26400-allex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26006-26400-allex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26006-26400-allex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26007-26800-ambonil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26007-26800-ambonil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26007-26800-ambonil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26007-26800-ambonil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26008-26200-ancone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26008-26200-ancone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26008-26200-ancone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26008-26200-ancone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26009-26140-andancette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26009-26140-andancette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26009-26140-andancette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26009-26140-andancette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26010-26140-anneyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26010-26140-anneyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26010-26140-anneyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26010-26140-anneyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26011-26400-aouste_sur_sye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26011-26400-aouste_sur_sye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26011-26400-aouste_sur_sye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26011-26400-aouste_sur_sye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26012-26470-arnayon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26012-26470-arnayon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26012-26470-arnayon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26012-26470-arnayon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26013-26110-arpavon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26013-26110-arpavon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26013-26110-arpavon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26013-26110-arpavon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26014-26260-arthemonay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26014-26260-arthemonay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26014-26260-arthemonay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26014-26260-arthemonay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26015-26340-aubenasson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26015-26340-aubenasson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26015-26340-aubenasson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26015-26340-aubenasson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26016-26110-aubres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26016-26110-aubres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26016-26110-aubres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26016-26110-aubres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26017-26340-aucelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26017-26340-aucelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26017-26340-aucelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26017-26340-aucelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26018-26570-aulan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26018-26570-aulan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26018-26570-aulan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26018-26570-aulan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26019-26340-aurel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26019-26340-aurel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26019-26340-aurel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26019-26340-aurel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26020-26400-la_repara_auriples/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26020-26400-la_repara_auriples/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26020-26400-la_repara_auriples/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26020-26400-la_repara_auriples/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26021-26400-autichamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26021-26400-autichamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26021-26400-autichamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26021-26400-autichamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26022-26560-ballons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26022-26560-ballons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26022-26560-ballons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26022-26560-ballons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26023-26300-barbieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26023-26300-barbieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26023-26300-barbieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26023-26300-barbieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26024-26120-barcelonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26024-26120-barcelonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26024-26120-barcelonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26024-26120-barcelonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26025-26310-barnave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26025-26310-barnave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26025-26310-barnave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26025-26310-barnave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26026-26570-barret_de_lioure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26026-26570-barret_de_lioure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26026-26570-barret_de_lioure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26026-26570-barret_de_lioure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26027-26150-barsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26027-26150-barsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26027-26150-barsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26027-26150-barsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26028-26260-bathernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26028-26260-bathernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26028-26260-bathernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26028-26260-bathernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26030-26310-la_batie_des_fonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26030-26310-la_batie_des_fonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26030-26310-la_batie_des_fonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26030-26310-la_batie_des_fonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26031-26160-la_batie_rolland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26031-26160-la_batie_rolland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26031-26160-la_batie_rolland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26031-26160-la_batie_rolland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26032-26120-la_baume_cornillane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26032-26120-la_baume_cornillane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26032-26120-la_baume_cornillane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26032-26120-la_baume_cornillane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26033-26790-la_baume_de_transit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26033-26790-la_baume_de_transit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26033-26790-la_baume_de_transit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26033-26790-la_baume_de_transit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26034-26730-la_baume_d_hostun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26034-26730-la_baume_d_hostun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26034-26730-la_baume_d_hostun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26034-26730-la_baume_d_hostun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26035-26400-beaufort_sur_gervanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26035-26400-beaufort_sur_gervanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26035-26400-beaufort_sur_gervanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26035-26400-beaufort_sur_gervanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26036-26310-beaumont_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26036-26310-beaumont_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26036-26310-beaumont_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26036-26310-beaumont_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26037-26760-beaumont_les_valence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26037-26760-beaumont_les_valence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26037-26760-beaumont_les_valence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26037-26760-beaumont_les_valence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26038-26600-beaumont_monteux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26038-26600-beaumont_monteux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26038-26600-beaumont_monteux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26038-26600-beaumont_monteux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26039-26300-beauregard_baret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26039-26300-beauregard_baret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26039-26300-beauregard_baret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26039-26300-beauregard_baret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26040-26310-beaurieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26040-26310-beaurieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26040-26310-beaurieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26040-26310-beaurieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26041-26240-beausemblant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26041-26240-beausemblant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26041-26240-beausemblant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26041-26240-beausemblant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26042-26800-beauvallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26042-26800-beauvallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26042-26800-beauvallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26042-26800-beauvallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26043-26170-beauvoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26043-26170-beauvoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26043-26170-beauvoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26043-26170-beauvoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26045-26160-la_begude_de_mazenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26045-26160-la_begude_de_mazenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26045-26160-la_begude_de_mazenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26045-26160-la_begude_de_mazenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26046-26110-bellecombe_tarendol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26046-26110-bellecombe_tarendol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26046-26110-bellecombe_tarendol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26046-26110-bellecombe_tarendol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26047-26470-bellegarde_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26047-26470-bellegarde_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26047-26470-bellegarde_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26047-26470-bellegarde_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26048-26170-benivay_ollon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26048-26170-benivay_ollon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26048-26170-benivay_ollon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26048-26170-benivay_ollon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26049-26300-besayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26049-26300-besayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26049-26300-besayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26049-26300-besayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26050-26110-besignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26050-26110-besignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26050-26110-besignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26050-26110-besignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26051-26460-bezaudun_sur_bine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26051-26460-bezaudun_sur_bine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26051-26460-bezaudun_sur_bine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26051-26460-bezaudun_sur_bine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26052-26160-bonlieu_sur_roubion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26052-26160-bonlieu_sur_roubion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26052-26160-bonlieu_sur_roubion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26052-26160-bonlieu_sur_roubion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26054-26790-bouchet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26054-26790-bouchet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26054-26790-bouchet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26054-26790-bouchet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26055-26410-boulc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26055-26410-boulc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26055-26410-boulc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26055-26410-boulc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26056-26460-bourdeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26056-26460-bourdeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26056-26460-bourdeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26056-26460-bourdeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26057-26300-bourg_de_peage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26057-26300-bourg_de_peage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26057-26300-bourg_de_peage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26057-26300-bourg_de_peage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26058-26500-bourg_les_valence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26058-26500-bourg_les_valence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26058-26500-bourg_les_valence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26058-26500-bourg_les_valence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26059-26190-bouvante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26059-26190-bouvante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26059-26190-bouvante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26059-26190-bouvante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26060-26460-bouvieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26060-26460-bouvieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26060-26460-bouvieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26060-26460-bouvieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26061-26260-bren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26061-26260-bren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26061-26260-bren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26061-26260-bren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26062-26340-brette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26062-26340-brette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26062-26340-brette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26062-26340-brette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26063-26170-buis_les_baronnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26063-26170-buis_les_baronnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26063-26170-buis_les_baronnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26063-26170-buis_les_baronnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26064-26120-chabeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26064-26120-chabeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26064-26120-chabeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26064-26120-chabeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26065-26400-chabrillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26065-26400-chabrillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26065-26400-chabrillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26065-26400-chabrillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26066-26190-le_chaffal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26066-26190-le_chaffal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26066-26190-le_chaffal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26066-26190-le_chaffal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26067-26470-chalancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26067-26470-chalancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26067-26470-chalancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26067-26470-chalancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26068-26350-le_chalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26068-26350-le_chalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26068-26350-le_chalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26068-26350-le_chalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26069-26150-chamaloc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26069-26150-chamaloc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26069-26150-chamaloc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26069-26150-chamaloc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26070-26230-chamaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26070-26230-chamaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26070-26230-chamaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26070-26230-chamaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26071-26600-chanos_curson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26071-26600-chanos_curson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26071-26600-chanos_curson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26071-26600-chanos_curson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26072-26600-chantemerle_les_bles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26072-26600-chantemerle_les_bles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26072-26600-chantemerle_les_bles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26072-26600-chantemerle_les_bles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26073-26230-chantemerle_les_grignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26073-26230-chantemerle_les_grignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26073-26230-chantemerle_les_grignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26073-26230-chantemerle_les_grignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26074-26420-la_chapelle_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26074-26420-la_chapelle_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26074-26420-la_chapelle_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26074-26420-la_chapelle_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26075-26470-la_charce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26075-26470-la_charce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26075-26470-la_charce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26075-26470-la_charce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26076-26310-charens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26076-26310-charens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26076-26310-charens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26076-26310-charens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26077-26260-charmes_sur_l_herbasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26077-26260-charmes_sur_l_herbasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26077-26260-charmes_sur_l_herbasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26077-26260-charmes_sur_l_herbasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26078-26450-charols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26078-26450-charols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26078-26450-charols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26078-26450-charols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26079-26300-charpey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26079-26300-charpey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26079-26300-charpey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26079-26300-charpey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26080-26340-chastel_arnaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26080-26340-chastel_arnaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26080-26340-chastel_arnaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26080-26340-chastel_arnaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26081-26120-chateaudouble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26081-26120-chateaudouble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26081-26120-chateaudouble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26081-26120-chateaudouble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26082-26110-chateauneuf_de_bordette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26082-26110-chateauneuf_de_bordette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26082-26110-chateauneuf_de_bordette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26082-26110-chateauneuf_de_bordette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26083-26330-chateauneuf_de_galaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26083-26330-chateauneuf_de_galaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26083-26330-chateauneuf_de_galaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26083-26330-chateauneuf_de_galaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26084-26300-chateauneuf_sur_isere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26084-26300-chateauneuf_sur_isere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26084-26300-chateauneuf_sur_isere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26084-26300-chateauneuf_sur_isere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26085-26780-chateauneuf_du_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26085-26780-chateauneuf_du_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26085-26780-chateauneuf_du_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26085-26780-chateauneuf_du_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26086-26410-chatillon_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26086-26410-chatillon_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26086-26410-chatillon_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26086-26410-chatillon_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26087-26750-chatillon_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26087-26750-chatillon_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26087-26750-chatillon_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26087-26750-chatillon_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26088-26300-chatuzange_le_goubet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26088-26300-chatuzange_le_goubet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26088-26300-chatuzange_le_goubet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26088-26300-chatuzange_le_goubet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26089-26110-chaudebonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26089-26110-chaudebonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26089-26110-chaudebonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26089-26110-chaudebonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26090-26340-la_chaudiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26090-26340-la_chaudiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26090-26340-la_chaudiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26090-26340-la_chaudiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26091-26510-chauvac_laux_montaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26091-26510-chauvac_laux_montaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26091-26510-chauvac_laux_montaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26091-26510-chauvac_laux_montaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26092-26260-chavannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26092-26260-chavannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26092-26260-chavannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26092-26260-chavannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26093-26130-clansayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26093-26130-clansayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26093-26130-clansayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26093-26130-clansayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26094-26240-claveyson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26094-26240-claveyson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26094-26240-claveyson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26094-26240-claveyson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26095-26450-cleon_d_andran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26095-26450-cleon_d_andran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26095-26450-cleon_d_andran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26095-26450-cleon_d_andran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26096-26260-clerieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26096-26260-clerieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26096-26260-clerieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26096-26260-clerieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26097-26270-cliousclat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26097-26270-cliousclat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26097-26270-cliousclat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26097-26270-cliousclat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26098-26400-cobonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26098-26400-cobonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26098-26400-cobonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26098-26400-cobonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26099-26230-colonzelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26099-26230-colonzelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26099-26230-colonzelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26099-26230-colonzelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26100-26120-combovin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26100-26120-combovin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26100-26120-combovin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26100-26120-combovin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26101-26220-comps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26101-26220-comps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26101-26220-comps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26101-26220-comps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26102-26740-condillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26102-26740-condillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26102-26740-condillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26102-26740-condillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26103-26110-condorcet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26103-26110-condorcet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26103-26110-condorcet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26103-26110-condorcet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26104-26510-cornillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26104-26510-cornillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26104-26510-cornillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26104-26510-cornillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26105-26510-cornillon_sur_l_oule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26105-26510-cornillon_sur_l_oule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26105-26510-cornillon_sur_l_oule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26105-26510-cornillon_sur_l_oule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26106-26740-la_coucourde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26106-26740-la_coucourde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26106-26740-la_coucourde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26106-26740-la_coucourde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26107-26350-crepol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26107-26350-crepol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26107-26350-crepol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26107-26350-crepol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26108-26400-crest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26108-26400-crest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26108-26400-crest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26108-26400-crest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26110-26600-crozes_hermitage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26110-26600-crozes_hermitage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26110-26600-crozes_hermitage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26110-26600-crozes_hermitage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26111-26460-crupies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26111-26460-crupies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26111-26460-crupies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26111-26460-crupies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26112-26110-curnier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26112-26110-curnier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26112-26110-curnier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26112-26110-curnier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26113-26150-die/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26113-26150-die/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26113-26150-die/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26113-26150-die/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26114-26220-dieulefit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26114-26220-dieulefit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26114-26220-dieulefit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26114-26220-dieulefit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26115-26400-divajeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26115-26400-divajeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26115-26400-divajeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26115-26400-divajeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26116-26290-donzere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26116-26290-donzere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26116-26290-donzere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26116-26290-donzere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26117-26190-echevis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26117-26190-echevis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26117-26190-echevis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26117-26190-echevis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26118-26210-epinouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26118-26210-epinouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26118-26210-epinouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26118-26210-epinouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26119-26600-erome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26119-26600-erome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26119-26600-erome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26119-26600-erome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26121-26780-espeluche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26121-26780-espeluche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26121-26780-espeluche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26121-26780-espeluche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26122-26340-espenel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26122-26340-espenel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26122-26340-espenel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26122-26340-espenel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26123-26470-establet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26123-26470-establet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26123-26470-establet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26123-26470-establet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26124-26800-etoile_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26124-26800-etoile_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26124-26800-etoile_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26124-26800-etoile_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26125-26400-eurre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26125-26400-eurre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26125-26400-eurre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26125-26400-eurre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26126-26560-eygalayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26126-26560-eygalayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26126-26560-eygalayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26126-26560-eygalayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26127-26170-eygaliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26127-26170-eygaliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26127-26170-eygaliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26127-26170-eygaliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26128-26400-eygluy_escoulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26128-26400-eygluy_escoulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26128-26400-eygluy_escoulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26128-26400-eygluy_escoulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26129-26730-eymeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26129-26730-eymeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26129-26730-eymeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26129-26730-eymeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26130-26110-eyroles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26130-26110-eyroles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26130-26110-eyroles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26130-26110-eyroles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26131-26160-eyzahut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26131-26160-eyzahut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26131-26160-eyzahut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26131-26160-eyzahut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26133-26240-fay_le_clos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26133-26240-fay_le_clos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26133-26240-fay_le_clos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26133-26240-fay_le_clos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26134-26160-felines_sur_rimandoule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26134-26160-felines_sur_rimandoule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26134-26160-felines_sur_rimandoule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26134-26160-felines_sur_rimandoule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26135-26570-ferrassieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26135-26570-ferrassieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26135-26570-ferrassieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26135-26570-ferrassieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26136-26310-val_maravel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26136-26310-val_maravel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26136-26310-val_maravel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26136-26310-val_maravel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26137-26400-francillon_sur_roubion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26137-26400-francillon_sur_roubion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26137-26400-francillon_sur_roubion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26137-26400-francillon_sur_roubion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26138-26700-la_garde_adhemar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26138-26700-la_garde_adhemar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26138-26700-la_garde_adhemar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26138-26700-la_garde_adhemar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26139-26750-genissieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26139-26750-genissieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26139-26750-genissieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26139-26750-genissieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26140-26750-geyssans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26140-26750-geyssans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26140-26750-geyssans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26140-26750-geyssans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26141-26400-gigors_et_lozeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26141-26400-gigors_et_lozeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26141-26400-gigors_et_lozeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26141-26400-gigors_et_lozeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26142-26410-glandage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26142-26410-glandage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26142-26410-glandage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26142-26410-glandage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26143-26530-le_grand_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26143-26530-le_grand_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26143-26530-le_grand_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26143-26530-le_grand_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26144-26400-grane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26144-26400-grane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26144-26400-grane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26144-26400-grane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26145-26290-les_granges_gontardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26145-26290-les_granges_gontardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26145-26290-les_granges_gontardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26145-26290-les_granges_gontardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26146-26230-grignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26146-26230-grignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26146-26230-grignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26146-26230-grignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26147-26470-gumiane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26147-26470-gumiane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26147-26470-gumiane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26147-26470-gumiane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26148-26390-hauterives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26148-26390-hauterives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26148-26390-hauterives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26148-26390-hauterives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26149-26730-hostun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26149-26730-hostun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26149-26730-hostun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26149-26730-hostun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26150-26560-izon_la_bruisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26150-26560-izon_la_bruisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26150-26560-izon_la_bruisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26150-26560-izon_la_bruisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26152-26310-joncheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26152-26310-joncheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26152-26310-joncheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26152-26310-joncheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26153-26560-laborel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26153-26560-laborel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26153-26560-laborel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26153-26560-laborel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26154-26560-lachau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26154-26560-lachau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26154-26560-lachau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26154-26560-lachau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26155-26210-lapeyrouse_mornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26155-26210-lapeyrouse_mornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26155-26210-lapeyrouse_mornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26155-26210-lapeyrouse_mornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26156-26600-larnage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26156-26600-larnage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26156-26600-larnage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26156-26600-larnage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26157-26740-la_laupie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26157-26740-la_laupie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26157-26740-la_laupie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26157-26740-la_laupie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26159-26150-laval_d_aix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26159-26150-laval_d_aix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26159-26150-laval_d_aix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26159-26150-laval_d_aix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26160-26240-laveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26160-26240-laveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26160-26240-laveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26160-26240-laveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26161-26510-lemps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26161-26510-lemps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26161-26510-lemps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26161-26510-lemps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26162-26210-lens_lestang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26162-26210-lens_lestang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26162-26210-lens_lestang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26162-26210-lens_lestang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26163-26190-leoncel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26163-26190-leoncel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26163-26190-leoncel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26163-26190-leoncel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26164-26310-lesches_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26164-26310-lesches_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26164-26310-lesches_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26164-26310-lesches_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26165-26250-livron_sur_drome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26165-26250-livron_sur_drome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26165-26250-livron_sur_drome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26165-26250-livron_sur_drome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26166-26270-loriol_sur_drome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26166-26270-loriol_sur_drome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26166-26270-loriol_sur_drome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26166-26270-loriol_sur_drome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26167-26310-luc_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26167-26310-luc_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26167-26310-luc_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26167-26310-luc_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26168-26620-lus_la_croix_haute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26168-26620-lus_la_croix_haute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26168-26620-lus_la_croix_haute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26168-26620-lus_la_croix_haute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26169-26780-malataverne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26169-26780-malataverne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26169-26780-malataverne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26169-26780-malataverne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26170-26120-malissard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26170-26120-malissard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26170-26120-malissard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26170-26120-malissard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26171-26160-manas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26171-26160-manas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26171-26160-manas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26171-26160-manas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26172-26210-manthes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26172-26210-manthes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26172-26210-manthes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26172-26210-manthes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26173-26300-marches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26173-26300-marches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26173-26300-marches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26173-26300-marches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26174-26260-marges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26174-26260-marges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26174-26260-marges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26174-26260-marges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26175-26150-marignac_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26175-26150-marignac_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26175-26150-marignac_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26175-26150-marignac_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26176-26740-marsanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26176-26740-marsanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26176-26740-marsanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26176-26740-marsanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26177-26260-marsaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26177-26260-marsaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26177-26260-marsaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26177-26260-marsaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26178-26410-menglon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26178-26410-menglon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26178-26410-menglon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26178-26410-menglon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26179-26600-mercurol_veaunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26179-26600-mercurol_veaunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26179-26600-mercurol_veaunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26179-26600-mercurol_veaunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26180-26170-merindol_les_oliviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26180-26170-merindol_les_oliviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26180-26170-merindol_les_oliviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26180-26170-merindol_les_oliviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26181-26560-mevouillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26181-26560-mevouillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26181-26560-mevouillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26181-26560-mevouillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26182-26110-mirabel_aux_baronnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26182-26110-mirabel_aux_baronnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26182-26110-mirabel_aux_baronnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26182-26110-mirabel_aux_baronnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26183-26400-mirabel_et_blacons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26183-26400-mirabel_et_blacons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26183-26400-mirabel_et_blacons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26183-26400-mirabel_et_blacons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26185-26270-mirmande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26185-26270-mirmande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26185-26270-mirmande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26185-26270-mirmande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26186-26310-miscon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26186-26310-miscon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26186-26310-miscon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26186-26310-miscon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26188-26170-mollans_sur_ouveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26188-26170-mollans_sur_ouveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26188-26170-mollans_sur_ouveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26188-26170-mollans_sur_ouveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26189-26170-montauban_sur_l_ouveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26189-26170-montauban_sur_l_ouveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26189-26170-montauban_sur_l_ouveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26189-26170-montauban_sur_l_ouveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26190-26110-montaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26190-26110-montaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26190-26110-montaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26190-26110-montaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26191-26740-montboucher_sur_jabron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26191-26740-montboucher_sur_jabron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26191-26740-montboucher_sur_jabron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26191-26740-montboucher_sur_jabron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26192-26770-montbrison_sur_lez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26192-26770-montbrison_sur_lez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26192-26770-montbrison_sur_lez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26192-26770-montbrison_sur_lez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26193-26570-montbrun_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26193-26570-montbrun_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26193-26570-montbrun_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26193-26570-montbrun_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26194-26350-montchenu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26194-26350-montchenu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26194-26350-montchenu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26194-26350-montchenu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26195-26400-montclar_sur_gervanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26195-26400-montclar_sur_gervanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26195-26400-montclar_sur_gervanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26195-26400-montclar_sur_gervanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26196-26760-monteleger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26196-26760-monteleger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26196-26760-monteleger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26196-26760-monteleger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26197-26120-montelier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26197-26120-montelier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26197-26120-montelier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26197-26120-montelier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26198-26200-montelimar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26198-26200-montelimar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26198-26200-montelimar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26198-26200-montelimar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26199-26510-montferrand_la_fare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26199-26510-montferrand_la_fare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26199-26510-montferrand_la_fare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26199-26510-montferrand_la_fare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26200-26560-montfroc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26200-26560-montfroc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26200-26560-montfroc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26200-26560-montfroc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26201-26170-montguers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26201-26170-montguers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26201-26170-montguers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26201-26170-montguers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26202-26220-montjoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26202-26220-montjoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26202-26220-montjoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26202-26220-montjoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26203-26230-montjoyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26203-26230-montjoyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26203-26230-montjoyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26203-26230-montjoyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26204-26310-montlaur_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26204-26310-montlaur_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26204-26310-montlaur_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26204-26310-montlaur_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26205-26150-montmaur_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26205-26150-montmaur_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26205-26150-montmaur_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26205-26150-montmaur_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26206-26120-montmeyran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26206-26120-montmeyran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26206-26120-montmeyran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26206-26120-montmeyran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26207-26750-montmiral/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26207-26750-montmiral/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26207-26750-montmiral/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26207-26750-montmiral/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26208-26800-montoison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26208-26800-montoison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26208-26800-montoison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26208-26800-montoison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26209-26510-montreal_les_sources/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26209-26510-montreal_les_sources/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26209-26510-montreal_les_sources/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26209-26510-montreal_les_sources/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26210-26350-valherbasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26210-26350-valherbasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26210-26350-valherbasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26210-26350-valherbasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26211-26130-montsegur_sur_lauzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26211-26130-montsegur_sur_lauzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26211-26130-montsegur_sur_lauzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26211-26130-montsegur_sur_lauzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26212-26120-montvendre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26212-26120-montvendre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26212-26120-montvendre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26212-26120-montvendre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26213-26210-moras_en_valloire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26213-26210-moras_en_valloire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26213-26210-moras_en_valloire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26213-26210-moras_en_valloire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26214-26460-mornans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26214-26460-mornans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26214-26460-mornans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26214-26460-mornans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26215-26470-la_motte_chalancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26215-26470-la_motte_chalancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26215-26470-la_motte_chalancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26215-26470-la_motte_chalancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26216-26240-la_motte_de_galaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26216-26240-la_motte_de_galaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26216-26240-la_motte_de_galaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26216-26240-la_motte_de_galaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26217-26190-la_motte_fanjas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26217-26190-la_motte_fanjas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26217-26190-la_motte_fanjas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26217-26190-la_motte_fanjas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26218-26540-mours_saint_eusebe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26218-26540-mours_saint_eusebe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26218-26540-mours_saint_eusebe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26218-26540-mours_saint_eusebe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26219-26240-mureils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26219-26240-mureils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26219-26240-mureils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26219-26240-mureils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26220-26110-nyons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26220-26110-nyons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26220-26110-nyons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26220-26110-nyons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26221-26400-ombleze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26221-26400-ombleze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26221-26400-ombleze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26221-26400-ombleze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26222-26220-orcinas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26222-26220-orcinas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26222-26220-orcinas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26222-26220-orcinas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26223-26190-oriol_en_royans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26223-26190-oriol_en_royans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26223-26190-oriol_en_royans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26223-26190-oriol_en_royans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26224-26120-ourches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26224-26120-ourches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26224-26120-ourches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26224-26120-ourches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26225-26750-parnans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26225-26750-parnans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26225-26750-parnans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26225-26750-parnans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26226-26770-le_pegue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26226-26770-le_pegue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26226-26770-le_pegue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26226-26770-le_pegue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26227-26510-pelonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26227-26510-pelonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26227-26510-pelonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26227-26510-pelonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26228-26340-pennes_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26228-26340-pennes_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26228-26340-pennes_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26228-26340-pennes_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26229-26170-la_penne_sur_l_ouveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26229-26170-la_penne_sur_l_ouveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26229-26170-la_penne_sur_l_ouveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26229-26170-la_penne_sur_l_ouveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26231-26380-peyrins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26231-26380-peyrins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26231-26380-peyrins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26231-26380-peyrins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26232-26120-peyrus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26232-26120-peyrus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26232-26120-peyrus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26232-26120-peyrus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26233-26110-piegon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26233-26110-piegon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26233-26110-piegon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26233-26110-piegon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26234-26400-piegros_la_clastre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26234-26400-piegros_la_clastre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26234-26400-piegros_la_clastre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26234-26400-piegros_la_clastre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26235-26700-pierrelatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26235-26700-pierrelatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26235-26700-pierrelatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26235-26700-pierrelatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26236-26170-pierrelongue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26236-26170-pierrelongue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26236-26170-pierrelongue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26236-26170-pierrelongue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26238-26110-les_pilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26238-26110-les_pilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26238-26110-les_pilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26238-26110-les_pilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26239-26170-plaisians/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26239-26170-plaisians/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26239-26170-plaisians/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26239-26170-plaisians/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26240-26400-plan_de_baix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26240-26400-plan_de_baix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26240-26400-plan_de_baix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26240-26400-plan_de_baix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26241-26460-le_poet_celard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26241-26460-le_poet_celard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26241-26460-le_poet_celard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26241-26460-le_poet_celard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26242-26170-le_poet_en_percip/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26242-26170-le_poet_en_percip/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26242-26170-le_poet_en_percip/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26242-26170-le_poet_en_percip/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26243-26160-le_poet_laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26243-26160-le_poet_laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26243-26160-le_poet_laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26243-26160-le_poet_laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26244-26110-le_poet_sigillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26244-26110-le_poet_sigillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26244-26110-le_poet_sigillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26244-26110-le_poet_sigillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26245-26470-pommerol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26245-26470-pommerol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26245-26470-pommerol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26245-26470-pommerol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26246-26150-ponet_et_saint_auban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26246-26150-ponet_et_saint_auban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26246-26150-ponet_et_saint_auban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26246-26150-ponet_et_saint_auban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26247-26240-ponsas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26247-26240-ponsas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26247-26240-ponsas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26247-26240-ponsas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26248-26150-pontaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26248-26150-pontaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26248-26150-pontaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26248-26150-pontaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26249-26160-pont_de_barret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26249-26160-pont_de_barret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26249-26160-pont_de_barret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26249-26160-pont_de_barret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26250-26600-pont_de_l_isere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26250-26600-pont_de_l_isere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26250-26600-pont_de_l_isere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26250-26600-pont_de_l_isere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26251-26160-portes_en_valdaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26251-26160-portes_en_valdaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26251-26160-portes_en_valdaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26251-26160-portes_en_valdaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26252-26800-portes_les_valence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26252-26800-portes_les_valence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26252-26800-portes_les_valence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26252-26800-portes_les_valence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26253-26310-poyols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26253-26310-poyols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26253-26310-poyols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26253-26310-poyols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26254-26340-pradelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26254-26340-pradelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26254-26340-pradelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26254-26340-pradelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26255-26310-les_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26255-26310-les_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26255-26310-les_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26255-26310-les_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26256-26170-propiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26256-26170-propiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26256-26170-propiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26256-26170-propiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26257-26160-puygiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26257-26160-puygiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26257-26160-puygiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26257-26160-puygiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26258-26450-puy_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26258-26450-puy_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26258-26450-puy_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26258-26450-puy_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26259-26330-ratieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26259-26330-ratieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26259-26330-ratieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26259-26330-ratieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26261-26230-reauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26261-26230-reauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26261-26230-reauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26261-26230-reauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26262-26310-recoubeau_jansac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26262-26310-recoubeau_jansac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26262-26310-recoubeau_jansac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26262-26310-recoubeau_jansac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26263-26570-reilhanette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26263-26570-reilhanette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26263-26570-reilhanette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26263-26570-reilhanette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26264-26510-remuzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26264-26510-remuzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26264-26510-remuzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26264-26510-remuzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26266-26340-rimon_et_savel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26266-26340-rimon_et_savel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26266-26340-rimon_et_savel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26266-26340-rimon_et_savel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26267-26170-rioms/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26267-26170-rioms/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26267-26170-rioms/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26267-26170-rioms/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26268-26160-rochebaudin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26268-26160-rochebaudin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26268-26160-rochebaudin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26268-26160-rochebaudin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26269-26110-rochebrune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26269-26110-rochebrune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26269-26110-rochebrune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26269-26110-rochebrune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26270-26190-rochechinard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26270-26190-rochechinard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26270-26190-rochechinard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26270-26190-rochechinard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26271-26600-la_roche_de_glun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26271-26600-la_roche_de_glun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26271-26600-la_roche_de_glun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26271-26600-la_roche_de_glun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26272-26160-rochefort_en_valdaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26272-26160-rochefort_en_valdaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26272-26160-rochefort_en_valdaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26272-26160-rochefort_en_valdaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26273-26300-rochefort_samson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26273-26300-rochefort_samson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26273-26300-rochefort_samson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26273-26300-rochefort_samson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26274-26340-rochefourchat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26274-26340-rochefourchat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26274-26340-rochefourchat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26274-26340-rochefourchat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26275-26790-rochegude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26275-26790-rochegude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26275-26790-rochegude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26275-26790-rochegude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26276-26770-roche_saint_secret_beconne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26276-26770-roche_saint_secret_beconne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26276-26770-roche_saint_secret_beconne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26276-26770-roche_saint_secret_beconne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26277-26400-la_roche_sur_grane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26277-26400-la_roche_sur_grane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26277-26400-la_roche_sur_grane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26277-26400-la_roche_sur_grane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26278-26170-la_roche_sur_le_buis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26278-26170-la_roche_sur_le_buis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26278-26170-la_roche_sur_le_buis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26278-26170-la_roche_sur_le_buis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26279-26170-la_rochette_du_buis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26279-26170-la_rochette_du_buis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26279-26170-la_rochette_du_buis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26279-26170-la_rochette_du_buis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26281-26100-romans_sur_isere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26281-26100-romans_sur_isere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26281-26100-romans_sur_isere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26281-26100-romans_sur_isere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26282-26150-romeyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26282-26150-romeyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26282-26150-romeyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26282-26150-romeyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26283-26470-rottier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26283-26470-rottier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26283-26470-rottier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26283-26470-rottier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26284-26230-roussas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26284-26230-roussas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26284-26230-roussas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26284-26230-roussas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26285-26770-rousset_les_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26285-26770-rousset_les_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26285-26770-rousset_les_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26285-26770-rousset_les_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26286-26510-roussieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26286-26510-roussieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26286-26510-roussieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26286-26510-roussieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26287-26450-roynac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26287-26450-roynac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26287-26450-roynac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26287-26450-roynac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26288-26510-sahune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26288-26510-sahune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26288-26510-sahune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26288-26510-sahune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26289-26340-saillans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26289-26340-saillans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26289-26340-saillans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26289-26340-saillans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26290-26420-saint_agnan_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26290-26420-saint_agnan_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26290-26420-saint_agnan_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26290-26420-saint_agnan_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26291-26150-saint_andeol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26291-26150-saint_andeol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26291-26150-saint_andeol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26291-26150-saint_andeol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26292-26170-saint_auban_sur_l_ouveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26292-26170-saint_auban_sur_l_ouveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26292-26170-saint_auban_sur_l_ouveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26292-26170-saint_auban_sur_l_ouveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26293-26330-saint_avit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26293-26330-saint_avit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26293-26330-saint_avit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26293-26330-saint_avit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26294-26260-saint_bardoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26294-26260-saint_bardoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26294-26260-saint_bardoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26294-26260-saint_bardoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26295-26240-saint_barthelemy_de_vals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26295-26240-saint_barthelemy_de_vals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26295-26240-saint_barthelemy_de_vals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26295-26240-saint_barthelemy_de_vals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26296-26340-saint_benoit_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26296-26340-saint_benoit_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26296-26340-saint_benoit_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26296-26340-saint_benoit_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26298-26350-saint_christophe_et_le_laris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26298-26350-saint_christophe_et_le_laris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26298-26350-saint_christophe_et_le_laris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26298-26350-saint_christophe_et_le_laris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26299-26150-sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26299-26150-sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26299-26150-sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26299-26150-sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26300-26310-saint_dizier_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26300-26310-saint_dizier_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26300-26310-saint_dizier_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26300-26310-saint_dizier_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26301-26260-saint_donat_sur_l_herbasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26301-26260-saint_donat_sur_l_herbasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26301-26260-saint_donat_sur_l_herbasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26301-26260-saint_donat_sur_l_herbasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26302-26190-sainte_eulalie_en_royans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26302-26190-sainte_eulalie_en_royans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26302-26190-sainte_eulalie_en_royans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26302-26190-sainte_eulalie_en_royans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26303-26170-sainte_euphemie_sur_ouveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26303-26170-sainte_euphemie_sur_ouveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26303-26170-sainte_euphemie_sur_ouveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26303-26170-sainte_euphemie_sur_ouveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26304-26110-saint_ferreol_trente_pas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26304-26110-saint_ferreol_trente_pas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26304-26110-saint_ferreol_trente_pas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26304-26110-saint_ferreol_trente_pas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26305-26160-saint_gervais_sur_roubion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26305-26160-saint_gervais_sur_roubion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26305-26160-saint_gervais_sur_roubion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26305-26160-saint_gervais_sur_roubion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26306-26110-sainte_jalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26306-26110-sainte_jalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26306-26110-sainte_jalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26306-26110-sainte_jalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26307-26190-saint_jean_en_royans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26307-26190-saint_jean_en_royans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26307-26190-saint_jean_en_royans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26307-26190-saint_jean_en_royans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26308-26150-saint_julien_en_quint/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26308-26150-saint_julien_en_quint/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26308-26150-saint_julien_en_quint/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26308-26150-saint_julien_en_quint/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26309-26420-saint_julien_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26309-26420-saint_julien_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26309-26420-saint_julien_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26309-26420-saint_julien_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26310-26350-saint_laurent_d_onay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26310-26350-saint_laurent_d_onay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26310-26350-saint_laurent_d_onay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26310-26350-saint_laurent_d_onay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26311-26190-saint_laurent_en_royans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26311-26190-saint_laurent_en_royans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26311-26190-saint_laurent_en_royans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26311-26190-saint_laurent_en_royans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26312-26740-saint_marcel_les_sauzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26312-26740-saint_marcel_les_sauzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26312-26740-saint_marcel_les_sauzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26312-26740-saint_marcel_les_sauzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26313-26320-saint_marcel_les_valence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26313-26320-saint_marcel_les_valence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26313-26320-saint_marcel_les_valence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26313-26320-saint_marcel_les_valence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26314-26330-saint_martin_d_aout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26314-26330-saint_martin_d_aout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26314-26330-saint_martin_d_aout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26314-26330-saint_martin_d_aout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26315-26420-saint_martin_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26315-26420-saint_martin_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26315-26420-saint_martin_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26315-26420-saint_martin_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26316-26190-saint_martin_le_colonel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26316-26190-saint_martin_le_colonel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26316-26190-saint_martin_le_colonel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26316-26190-saint_martin_le_colonel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26317-26110-saint_maurice_sur_eygues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26317-26110-saint_maurice_sur_eygues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26317-26110-saint_maurice_sur_eygues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26317-26110-saint_maurice_sur_eygues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26318-26510-saint_may/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26318-26510-saint_may/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26318-26510-saint_may/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26318-26510-saint_may/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26319-26750-saint_michel_sur_savasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26319-26750-saint_michel_sur_savasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26319-26750-saint_michel_sur_savasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26319-26750-saint_michel_sur_savasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26320-26190-saint_nazaire_en_royans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26320-26190-saint_nazaire_en_royans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26320-26190-saint_nazaire_en_royans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26320-26190-saint_nazaire_en_royans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26321-26340-saint_nazaire_le_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26321-26340-saint_nazaire_le_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26321-26340-saint_nazaire_le_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26321-26340-saint_nazaire_le_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26322-26770-saint_pantaleon_les_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26322-26770-saint_pantaleon_les_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26322-26770-saint_pantaleon_les_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26322-26770-saint_pantaleon_les_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26323-26750-saint_paul_les_romans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26323-26750-saint_paul_les_romans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26323-26750-saint_paul_les_romans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26323-26750-saint_paul_les_romans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26324-26130-saint_paul_trois_chateaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26324-26130-saint_paul_trois_chateaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26324-26130-saint_paul_trois_chateaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26324-26130-saint_paul_trois_chateaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26325-26140-saint_rambert_d_albon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26325-26140-saint_rambert_d_albon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26325-26140-saint_rambert_d_albon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26325-26140-saint_rambert_d_albon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26326-26130-saint_restitut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26326-26130-saint_restitut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26326-26130-saint_restitut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26326-26130-saint_restitut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26327-26410-saint_roman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26327-26410-saint_roman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26327-26410-saint_roman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26327-26410-saint_roman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26328-26340-saint_sauveur_en_diois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26328-26340-saint_sauveur_en_diois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26328-26340-saint_sauveur_en_diois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26328-26340-saint_sauveur_en_diois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26329-26110-saint_sauveur_gouvernet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26329-26110-saint_sauveur_gouvernet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26329-26110-saint_sauveur_gouvernet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26329-26110-saint_sauveur_gouvernet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26330-26210-saint_sorlin_en_valloire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26330-26210-saint_sorlin_en_valloire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26330-26210-saint_sorlin_en_valloire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26330-26210-saint_sorlin_en_valloire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26331-26190-saint_thomas_en_royans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26331-26190-saint_thomas_en_royans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26331-26190-saint_thomas_en_royans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26331-26190-saint_thomas_en_royans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26332-26240-saint_uze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26332-26240-saint_uze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26332-26240-saint_uze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26332-26240-saint_uze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26333-26240-saint_vallier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26333-26240-saint_vallier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26333-26240-saint_vallier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26333-26240-saint_vallier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26334-26160-salettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26334-26160-salettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26334-26160-salettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26334-26160-salettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26335-26770-salles_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26335-26770-salles_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26335-26770-salles_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26335-26770-salles_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26336-26400-saou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26336-26400-saou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26336-26400-saou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26336-26400-saou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26337-26270-saulce_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26337-26270-saulce_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26337-26270-saulce_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26337-26270-saulce_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26338-26740-sauzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26338-26740-sauzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26338-26740-sauzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26338-26740-sauzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26339-26740-savasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26339-26740-savasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26339-26740-savasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26339-26740-savasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26340-26560-sederon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26340-26560-sederon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26340-26560-sederon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26340-26560-sederon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26341-26600-serves_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26341-26600-serves_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26341-26600-serves_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26341-26600-serves_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26342-26130-solerieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26342-26130-solerieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26342-26130-solerieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26342-26130-solerieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26343-26160-souspierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26343-26160-souspierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26343-26160-souspierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26343-26160-souspierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26344-26400-soyans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26344-26400-soyans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26344-26400-soyans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26344-26400-soyans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26345-26790-suze_la_rousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26345-26790-suze_la_rousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26345-26790-suze_la_rousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26345-26790-suze_la_rousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26346-26400-suze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26346-26400-suze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26346-26400-suze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26346-26400-suze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26347-26600-tain_l_hermitage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26347-26600-tain_l_hermitage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26347-26600-tain_l_hermitage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26347-26600-tain_l_hermitage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26348-26770-taulignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26348-26770-taulignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26348-26770-taulignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26348-26770-taulignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26349-26390-tersanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26349-26390-tersanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26349-26390-tersanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26349-26390-tersanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26350-26220-teyssieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26350-26220-teyssieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26350-26220-teyssieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26350-26220-teyssieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26351-26460-les_tonils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26351-26460-les_tonils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26351-26460-les_tonils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26351-26460-les_tonils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26352-26160-la_touche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26352-26160-la_touche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26352-26160-la_touche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26352-26160-la_touche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26353-26740-les_tourrettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26353-26740-les_tourrettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26353-26740-les_tourrettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26353-26740-les_tourrettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26355-26750-triors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26355-26750-triors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26355-26750-triors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26355-26750-triors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26356-26460-truinas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26356-26460-truinas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26356-26460-truinas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26356-26460-truinas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26357-26790-tulette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26357-26790-tulette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26357-26790-tulette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26357-26790-tulette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26358-26120-upie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26358-26120-upie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26358-26120-upie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26358-26120-upie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26359-26150-vacheres_en_quint/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26359-26150-vacheres_en_quint/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26359-26150-vacheres_en_quint/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26359-26150-vacheres_en_quint/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26360-26230-valaurie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26360-26230-valaurie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26360-26230-valaurie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26360-26230-valaurie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26361-26310-valdrome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26361-26310-valdrome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26361-26310-valdrome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26361-26310-valdrome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26362-26000-valence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26362-26000-valence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26362-26000-valence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26362-26000-valence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26363-26110-valouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26363-26110-valouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26363-26110-valouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26363-26110-valouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26364-26420-vassieux_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26364-26420-vassieux_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26364-26420-vassieux_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26364-26420-vassieux_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26365-26400-vaunaveys_la_rochette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26365-26400-vaunaveys_la_rochette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26365-26400-vaunaveys_la_rochette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26365-26400-vaunaveys_la_rochette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26367-26110-venterol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26367-26110-venterol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26367-26110-venterol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26367-26110-venterol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26368-26340-vercheny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26368-26340-vercheny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26368-26340-vercheny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26368-26340-vercheny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26369-26510-verclause/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26369-26510-verclause/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26369-26510-verclause/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26369-26510-verclause/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26370-26170-vercoiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26370-26170-vercoiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26370-26170-vercoiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26370-26170-vercoiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26371-26340-veronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26371-26340-veronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26371-26340-veronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26371-26340-veronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26372-26560-vers_sur_meouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26372-26560-vers_sur_meouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26372-26560-vers_sur_meouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26372-26560-vers_sur_meouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26373-26220-vesc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26373-26220-vesc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26373-26220-vesc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26373-26220-vesc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26374-05700-villebois_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26374-05700-villebois_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26374-05700-villebois_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26374-05700-villebois_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26375-26560-villefranche_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26375-26560-villefranche_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26375-26560-villefranche_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26375-26560-villefranche_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26376-26510-villeperdrix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26376-26510-villeperdrix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26376-26510-villeperdrix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26376-26510-villeperdrix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26377-26110-vinsobres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26377-26110-vinsobres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26377-26110-vinsobres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26377-26110-vinsobres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26378-26470-volvent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26378-26470-volvent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26378-26470-volvent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26378-26470-volvent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26379-26600-granges_les_beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26379-26600-granges_les_beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26379-26600-granges_les_beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26379-26600-granges_les_beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26380-26600-gervans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26380-26600-gervans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26380-26600-gervans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26380-26600-gervans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26381-26300-jaillans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26381-26300-jaillans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26381-26300-jaillans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26381-26300-jaillans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26382-26300-saint_vincent_la_commanderie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26382-26300-saint_vincent_la_commanderie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26382-26300-saint_vincent_la_commanderie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt26-drome/commune26382-26300-saint_vincent_la_commanderie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-27.xml
+++ b/public/sitemaps/sitemap-27.xml
@@ -5,1218 +5,2432 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27001-27800-aclou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27001-27800-aclou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27001-27800-aclou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27001-27800-aclou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27002-27570-acon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27002-27570-acon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27002-27570-acon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27002-27570-acon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27003-27400-acquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27003-27400-acquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27003-27400-acquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27003-27400-acquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27004-27120-aigleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27004-27120-aigleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27004-27120-aigleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27004-27120-aigleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27005-27600-ailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27005-27600-ailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27005-27600-ailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27005-27600-ailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27006-27500-aizier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27006-27500-aizier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27006-27500-aizier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27006-27500-aizier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27008-27460-alizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27008-27460-alizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27008-27460-alizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27008-27460-alizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27009-27250-ambenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27009-27250-ambenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27009-27250-ambenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27009-27250-ambenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27010-27140-amecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27010-27140-amecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27010-27140-amecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27010-27140-amecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27011-27370-amfreville_saint_amand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27011-27370-amfreville_saint_amand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27011-27370-amfreville_saint_amand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27011-27370-amfreville_saint_amand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27012-27380-amfreville_les_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27012-27380-amfreville_les_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27012-27380-amfreville_les_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27012-27380-amfreville_les_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27013-27380-amfreville_sous_les_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27013-27380-amfreville_sous_les_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27013-27380-amfreville_sous_les_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27013-27380-amfreville_sous_les_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27014-27400-amfreville_sur_iton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27014-27400-amfreville_sur_iton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27014-27400-amfreville_sur_iton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27014-27400-amfreville_sur_iton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27015-27430-ande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27015-27430-ande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27015-27430-ande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27015-27430-ande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27016-27700-les_andelys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27016-27700-les_andelys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27016-27700-les_andelys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27016-27700-les_andelys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27017-27930-angerville_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27017-27930-angerville_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27017-27930-angerville_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27017-27930-angerville_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27018-27290-appeville_annebault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27018-27290-appeville_annebault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27018-27290-appeville_annebault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27018-27290-appeville_annebault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27019-27820-armentieres_sur_avre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27019-27820-armentieres_sur_avre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27019-27820-armentieres_sur_avre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27019-27820-armentieres_sur_avre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27020-27180-arnieres_sur_iton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27020-27180-arnieres_sur_iton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27020-27180-arnieres_sur_iton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27020-27180-arnieres_sur_iton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27021-27260-asnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27021-27260-asnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27021-27260-asnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27021-27260-asnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27022-27940-le_val_d_hazey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27022-27940-le_val_d_hazey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27022-27940-le_val_d_hazey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27022-27940-le_val_d_hazey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27022-27600-le_val_d_hazey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27022-27600-le_val_d_hazey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27022-27600-le_val_d_hazey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27022-27600-le_val_d_hazey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27023-27180-aulnay_sur_iton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27023-27180-aulnay_sur_iton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27023-27180-aulnay_sur_iton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27023-27180-aulnay_sur_iton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27025-27490-autheuil_authouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27025-27490-autheuil_authouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27025-27490-autheuil_authouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27025-27490-autheuil_authouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27026-27420-authevernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27026-27420-authevernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27026-27420-authevernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27026-27420-authevernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27027-27220-les_authieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27027-27220-les_authieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27027-27220-les_authieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27027-27220-les_authieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27028-27290-authou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27028-27290-authou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27028-27290-authou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27028-27290-authou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27031-27930-aviron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27031-27930-aviron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27031-27930-aviron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27031-27930-aviron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27032-27240-chambois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27032-27240-chambois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27032-27240-chambois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27032-27240-chambois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27033-27930-bacquepuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27033-27930-bacquepuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27033-27930-bacquepuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27033-27930-bacquepuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27034-27440-bacqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27034-27440-bacqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27034-27440-bacqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27034-27440-bacqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27035-27260-bailleul_la_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27035-27260-bailleul_la_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27035-27260-bailleul_la_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27035-27260-bailleul_la_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27036-27130-balines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27036-27130-balines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27036-27130-balines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27036-27130-balines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27037-27170-barc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27037-27170-barc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27037-27170-barc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27037-27170-barc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27038-27130-les_barils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27038-27130-les_barils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27038-27130-les_barils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27038-27130-les_barils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27039-27310-barneville_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27039-27310-barneville_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27039-27310-barneville_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27039-27310-barneville_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27040-27170-barquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27040-27170-barquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27040-27170-barquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27040-27170-barquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27042-27230-barville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27042-27230-barville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27042-27230-barville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27042-27230-barville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27043-27160-les_baux_de_breteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27043-27160-les_baux_de_breteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27043-27160-les_baux_de_breteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27043-27160-les_baux_de_breteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27044-27180-les_baux_sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27044-27180-les_baux_sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27044-27180-les_baux_sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27044-27180-les_baux_sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27045-27140-bazincourt_sur_epte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27045-27140-bazincourt_sur_epte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27045-27140-bazincourt_sur_epte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27045-27140-bazincourt_sur_epte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27046-27230-bazoques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27046-27230-bazoques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27046-27230-bazoques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27046-27230-bazoques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27047-27190-beaubray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27047-27190-beaubray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27047-27190-beaubray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27047-27190-beaubray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27048-27480-beauficel_en_lyons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27048-27480-beauficel_en_lyons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27048-27480-beauficel_en_lyons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27048-27480-beauficel_en_lyons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27410-mesnil_en_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27410-mesnil_en_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27410-mesnil_en_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27410-mesnil_en_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27330-mesnil_en_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27330-mesnil_en_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27330-mesnil_en_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27330-mesnil_en_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27270-mesnil_en_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27270-mesnil_en_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27270-mesnil_en_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27049-27270-mesnil_en_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27050-27170-beaumontel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27050-27170-beaumontel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27050-27170-beaumontel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27050-27170-beaumontel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27051-27170-beaumont_le_roger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27051-27170-beaumont_le_roger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27051-27170-beaumont_le_roger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27051-27170-beaumont_le_roger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27052-27800-le_bec_hellouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27052-27800-le_bec_hellouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27052-27800-le_bec_hellouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27052-27800-le_bec_hellouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27053-27370-le_bec_thomas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27053-27370-le_bec_thomas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27053-27370-le_bec_thomas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27053-27370-le_bec_thomas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27054-27160-bemecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27054-27160-bemecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27054-27160-bemecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27054-27160-bemecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27055-27110-berengeville_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27055-27110-berengeville_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27055-27110-berengeville_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27055-27110-berengeville_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27056-27300-bernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27056-27300-bernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27056-27300-bernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27056-27300-bernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27057-27180-bernienville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27057-27180-bernienville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27057-27180-bernienville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27057-27180-bernienville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27059-27660-bernouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27059-27660-bernouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27059-27660-bernouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27059-27660-bernouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27061-27800-berthouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27061-27800-berthouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27061-27800-berthouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27061-27800-berthouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27062-27520-les_monts_du_roumois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27062-27520-les_monts_du_roumois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27062-27520-les_monts_du_roumois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27062-27520-les_monts_du_roumois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27062-27370-les_monts_du_roumois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27062-27370-les_monts_du_roumois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27062-27370-les_monts_du_roumois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27062-27370-les_monts_du_roumois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27063-27170-berville_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27063-27170-berville_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27063-27170-berville_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27063-27170-berville_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27064-27210-berville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27064-27210-berville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27064-27210-berville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27064-27210-berville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27065-27210-beuzeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27065-27210-beuzeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27065-27210-beuzeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27065-27210-beuzeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27066-27480-bezu_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27066-27480-bezu_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27066-27480-bezu_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27066-27480-bezu_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27067-27660-bezu_saint_eloi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27067-27660-bezu_saint_eloi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27067-27660-bezu_saint_eloi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27067-27660-bezu_saint_eloi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27068-27330-bois_anzeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27068-27330-bois_anzeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27068-27330-bois_anzeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27068-27330-bois_anzeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27069-27250-bois_arnault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27069-27250-bois_arnault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27069-27250-bois_arnault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27069-27250-bois_arnault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27070-27150-frenelles_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27070-27150-frenelles_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27070-27150-frenelles_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27070-27150-frenelles_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27070-27700-frenelles_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27070-27700-frenelles_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27070-27700-frenelles_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27070-27700-frenelles_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27071-27260-le_bois_hellain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27071-27260-le_bois_hellain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27071-27260-le_bois_hellain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27071-27260-le_bois_hellain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27072-27620-bois_jerome_saint_ouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27072-27620-bois_jerome_saint_ouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27072-27620-bois_jerome_saint_ouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27072-27620-bois_jerome_saint_ouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27073-27220-bois_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27073-27220-bois_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27073-27220-bois_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27073-27220-bois_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27074-27800-boisney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27074-27800-boisney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27074-27800-boisney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27074-27800-boisney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27075-27330-bois_normand_pres_lyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27075-27330-bois_normand_pres_lyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27075-27330-bois_normand_pres_lyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27075-27330-bois_normand_pres_lyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27076-27120-boisset_les_prevanches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27076-27120-boisset_les_prevanches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27076-27120-boisset_les_prevanches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27076-27120-boisset_les_prevanches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27077-27520-boissey_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27077-27520-boissey_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27077-27520-boissey_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27077-27520-boissey_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27078-27220-la_boissiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27078-27220-la_boissiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27078-27220-la_boissiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27078-27220-la_boissiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27079-27300-boissy_lamberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27079-27300-boissy_lamberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27079-27300-boissy_lamberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27079-27300-boissy_lamberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27081-27120-boncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27081-27120-boncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27081-27120-boncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27081-27120-boncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27082-27190-la_bonneville_sur_iton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27082-27190-la_bonneville_sur_iton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27082-27190-la_bonneville_sur_iton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27082-27190-la_bonneville_sur_iton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27083-27290-bonneville_aptot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27083-27290-bonneville_aptot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27083-27290-bonneville_aptot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27083-27290-bonneville_aptot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27085-27310-flancourt_crescy_en_roumois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27085-27310-flancourt_crescy_en_roumois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27085-27310-flancourt_crescy_en_roumois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27085-27310-flancourt_crescy_en_roumois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27089-27520-thenouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27089-27520-thenouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27089-27520-thenouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27089-27520-thenouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27089-27290-thenouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27089-27290-thenouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27089-27290-thenouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27089-27290-thenouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27090-27670-bosroumois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27090-27670-bosroumois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27090-27670-bosroumois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27090-27670-bosroumois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27091-27310-bosgouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27091-27310-bosgouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27091-27310-bosgouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27091-27310-bosgouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27094-27480-bosquentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27094-27480-bosquentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27094-27480-bosquentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27094-27480-bosquentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27095-27800-bosrobert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27095-27800-bosrobert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27095-27800-bosrobert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27095-27800-bosrobert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27096-27250-les_bottereaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27096-27250-les_bottereaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27096-27250-les_bottereaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27096-27250-les_bottereaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27097-27700-bouafles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27097-27700-bouafles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27097-27700-bouafles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27097-27700-bouafles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27098-27150-bouchevilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27098-27150-bouchevilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27098-27150-bouchevilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27098-27150-bouchevilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27099-27930-le_boulay_morin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27099-27930-le_boulay_morin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27099-27930-le_boulay_morin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27099-27930-le_boulay_morin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27100-27210-boulleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27100-27210-boulleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27100-27210-boulleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27100-27210-boulleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27101-27500-bouquelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27101-27500-bouquelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27101-27500-bouquelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27101-27500-bouquelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27102-27310-bouquetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27102-27310-bouquetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27102-27310-bouquetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27102-27310-bouquetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27103-27310-bourg_achard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27103-27310-bourg_achard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27103-27310-bourg_achard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27103-27310-bourg_achard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27104-27380-bourg_beaudouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27104-27380-bourg_beaudouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27104-27380-bourg_beaudouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27104-27380-bourg_beaudouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27105-27520-grand_bourgtheroulde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27105-27520-grand_bourgtheroulde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27105-27520-grand_bourgtheroulde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27105-27520-grand_bourgtheroulde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27106-27230-bournainville_faverolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27106-27230-bournainville_faverolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27106-27230-bournainville_faverolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27106-27230-bournainville_faverolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27107-27500-bourneville_sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27107-27500-bourneville_sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27107-27500-bourneville_sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27107-27500-bourneville_sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27108-27580-bourth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27108-27580-bourth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27108-27580-bourth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27108-27580-bourth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27109-27170-bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27109-27170-bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27109-27170-bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27109-27170-bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27110-27350-brestot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27110-27350-brestot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27110-27350-brestot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27110-27350-brestot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27111-27220-bretagnolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27111-27220-bretagnolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27111-27220-bretagnolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27111-27220-bretagnolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27112-27160-breteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27112-27160-breteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27112-27160-breteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27112-27160-breteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27113-27800-bretigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27113-27800-bretigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27113-27800-bretigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27113-27800-bretigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27114-27640-breuilpont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27114-27640-breuilpont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27114-27640-breuilpont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27114-27640-breuilpont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27115-27570-breux_sur_avre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27115-27570-breux_sur_avre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27115-27570-breux_sur_avre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27115-27570-breux_sur_avre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27116-27800-brionne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27116-27800-brionne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27116-27800-brionne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27116-27800-brionne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27117-27270-broglie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27117-27270-broglie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27117-27270-broglie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27117-27270-broglie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27118-27930-brosville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27118-27930-brosville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27118-27930-brosville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27118-27930-brosville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27119-27730-bueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27119-27730-bueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27119-27730-bueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27119-27730-bueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27120-27190-burey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27120-27190-burey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27120-27190-burey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27120-27190-burey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27123-27120-caillouet_orgeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27123-27120-caillouet_orgeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27123-27120-caillouet_orgeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27123-27120-caillouet_orgeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27124-27490-cailly_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27124-27490-cailly_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27124-27490-cailly_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27124-27490-cailly_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27125-27800-calleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27125-27800-calleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27125-27800-calleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27125-27800-calleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27126-27500-campigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27126-27500-campigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27126-27500-campigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27126-27500-campigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27127-27400-canappeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27127-27400-canappeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27127-27400-canappeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27127-27400-canappeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27129-27300-caorches_saint_nicolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27129-27300-caorches_saint_nicolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27129-27300-caorches_saint_nicolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27129-27300-caorches_saint_nicolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27130-27270-capelle_les_grands/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27130-27270-capelle_les_grands/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27130-27270-capelle_les_grands/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27130-27270-capelle_les_grands/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27132-27180-cauge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27132-27180-cauge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27132-27180-cauge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27132-27180-cauge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27133-27310-caumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27133-27310-caumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27133-27310-caumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27133-27310-caumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27134-27350-cauverville_en_roumois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27134-27350-cauverville_en_roumois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27134-27350-cauverville_en_roumois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27134-27350-cauverville_en_roumois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27135-27110-cesseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27135-27110-cesseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27135-27110-cesseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27135-27110-cesseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27136-27120-chaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27136-27120-chaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27136-27120-chaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27136-27120-chaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27137-27580-chaise_dieu_du_theil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27137-27580-chaise_dieu_du_theil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27137-27580-chaise_dieu_du_theil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27137-27580-chaise_dieu_du_theil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27138-27270-chamblac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27138-27270-chamblac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27138-27270-chamblac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27138-27270-chamblac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27139-27250-chambord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27139-27250-chambord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27139-27250-chambord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27139-27250-chambord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27140-27120-chambray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27140-27120-chambray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27140-27120-chambray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27140-27120-chambray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27140-27950-chambray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27140-27950-chambray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27140-27950-chambray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27140-27950-chambray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27141-27190-champ_dolent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27141-27190-champ_dolent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27141-27190-champ_dolent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27141-27190-champ_dolent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27142-27600-champenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27142-27600-champenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27142-27600-champenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27142-27600-champenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27144-27220-champigny_la_futelaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27144-27220-champigny_la_futelaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27144-27220-champigny_la_futelaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27144-27220-champigny_la_futelaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27146-27260-la_chapelle_bayvel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27146-27260-la_chapelle_bayvel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27146-27260-la_chapelle_bayvel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27146-27260-la_chapelle_bayvel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27147-27930-la_chapelle_du_bois_des_faulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27147-27930-la_chapelle_du_bois_des_faulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27147-27930-la_chapelle_du_bois_des_faulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27147-27930-la_chapelle_du_bois_des_faulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27148-27270-la_chapelle_gauthier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27148-27270-la_chapelle_gauthier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27148-27270-la_chapelle_gauthier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27148-27270-la_chapelle_gauthier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27149-27230-la_chapelle_hareng/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27149-27230-la_chapelle_hareng/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27149-27230-la_chapelle_hareng/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27149-27230-la_chapelle_hareng/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27151-27380-charleval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27151-27380-charleval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27151-27380-charleval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27151-27380-charleval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27152-27420-chateau_sur_epte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27152-27420-chateau_sur_epte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27152-27420-chateau_sur_epte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27152-27420-chateau_sur_epte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27153-27150-chauvincourt_provemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27153-27150-chauvincourt_provemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27153-27150-chauvincourt_provemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27153-27150-chauvincourt_provemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27154-27220-chavigny_bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27154-27220-chavigny_bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27154-27220-chavigny_bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27154-27220-chavigny_bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27155-27820-chennebrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27155-27820-chennebrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27155-27820-chennebrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27155-27820-chennebrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27156-27250-cheronvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27156-27250-cheronvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27156-27250-cheronvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27156-27250-cheronvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27157-27160-marbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27157-27160-marbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27157-27160-marbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27157-27160-marbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27157-27240-marbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27157-27240-marbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27157-27240-marbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27157-27240-marbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27158-27930-cierrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27158-27930-cierrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27158-27930-cierrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27158-27930-cierrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27161-27180-claville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27161-27180-claville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27161-27180-claville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27161-27180-claville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27162-27190-collandres_quincarnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27162-27190-collandres_quincarnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27162-27190-collandres_quincarnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27162-27190-collandres_quincarnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27163-27500-colletot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27163-27500-colletot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27163-27500-colletot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27163-27500-colletot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27164-27170-combon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27164-27170-combon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27164-27170-combon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27164-27170-combon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27165-27190-conches_en_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27165-27190-conches_en_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27165-27190-conches_en_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27165-27190-conches_en_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27167-27290-conde_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27167-27290-conde_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27167-27290-conde_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27167-27290-conde_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27168-27430-connelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27168-27430-connelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27168-27430-connelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27168-27430-connelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27169-27210-conteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27169-27210-conteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27169-27210-conteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27169-27210-conteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27170-27260-cormeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27170-27260-cormeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27170-27260-cormeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27170-27260-cormeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27171-27120-le_cormier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27171-27120-le_cormier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27171-27120-le_cormier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27171-27120-le_cormier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27173-27300-corneville_la_fouquetiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27173-27300-corneville_la_fouquetiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27173-27300-corneville_la_fouquetiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27173-27300-corneville_la_fouquetiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27174-27500-corneville_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27174-27500-corneville_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27174-27500-corneville_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27174-27500-corneville_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27176-27150-coudray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27176-27150-coudray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27176-27150-coudray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27176-27150-coudray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27177-27220-coudres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27177-27220-coudres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27177-27220-coudres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27177-27220-coudres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27179-27300-courbepine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27179-27300-courbepine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27179-27300-courbepine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27179-27300-courbepine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27180-27940-courcelles_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27180-27940-courcelles_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27180-27940-courcelles_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27180-27940-courcelles_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27181-27320-courdemanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27181-27320-courdemanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27181-27320-courdemanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27181-27320-courdemanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27182-27130-courteilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27182-27130-courteilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27182-27130-courteilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27182-27130-courteilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27183-27750-la_couture_boussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27183-27750-la_couture_boussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27183-27750-la_couture_boussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27183-27750-la_couture_boussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27184-27400-crasville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27184-27400-crasville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27184-27400-crasville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27184-27400-crasville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27185-27110-crestot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27185-27110-crestot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27185-27110-crestot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27185-27110-crestot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27187-27110-criquebeuf_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27187-27110-criquebeuf_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27187-27110-criquebeuf_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27187-27110-criquebeuf_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27188-27340-criquebeuf_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27188-27340-criquebeuf_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27188-27340-criquebeuf_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27188-27340-criquebeuf_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27189-27190-la_croisille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27189-27190-la_croisille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27189-27190-la_croisille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27189-27190-la_croisille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27190-27120-croisy_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27190-27120-croisy_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27190-27120-croisy_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27190-27120-croisy_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27191-27490-clef_vallee_d_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27191-27490-clef_vallee_d_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27191-27490-clef_vallee_d_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27191-27490-clef_vallee_d_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27192-27110-crosville_la_vieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27192-27110-crosville_la_vieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27192-27110-crosville_la_vieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27192-27110-crosville_la_vieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27193-27530-croth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27193-27530-croth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27193-27530-croth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27193-27530-croth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27194-27700-cuverville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27194-27700-cuverville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27194-27700-cuverville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27194-27700-cuverville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27196-27340-les_damps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27196-27340-les_damps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27196-27340-les_damps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27196-27340-les_damps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27198-27240-mesnils_sur_iton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27198-27240-mesnils_sur_iton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27198-27240-mesnils_sur_iton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27198-27240-mesnils_sur_iton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27198-27160-mesnils_sur_iton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27198-27160-mesnils_sur_iton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27198-27160-mesnils_sur_iton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27198-27160-mesnils_sur_iton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27199-27720-dangu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27199-27720-dangu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27199-27720-dangu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27199-27720-dangu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27200-27930-dardez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27200-27930-dardez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27200-27930-dardez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27200-27930-dardez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27201-27110-daubeuf_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27201-27110-daubeuf_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27201-27110-daubeuf_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27201-27110-daubeuf_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27202-27430-daubeuf_pres_vatteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27202-27430-daubeuf_pres_vatteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27202-27430-daubeuf_pres_vatteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27202-27430-daubeuf_pres_vatteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27203-27120-douains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27203-27120-douains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27203-27120-douains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27203-27120-douains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27204-27150-doudeauville_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27204-27150-doudeauville_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27204-27150-doudeauville_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27204-27150-doudeauville_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27205-27380-douville_sur_andelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27205-27380-douville_sur_andelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27205-27380-douville_sur_andelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27205-27380-douville_sur_andelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27206-27320-droisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27206-27320-droisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27206-27320-droisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27206-27320-droisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27207-27230-drucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27207-27230-drucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27207-27230-drucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27207-27230-drucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27208-27230-duranville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27208-27230-duranville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27208-27230-duranville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27208-27230-duranville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27209-27290-ecaquelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27209-27290-ecaquelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27209-27290-ecaquelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27209-27290-ecaquelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27210-27170-ecardenville_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27210-27170-ecardenville_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27210-27170-ecardenville_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27210-27170-ecardenville_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27212-27110-ecauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27212-27110-ecauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27212-27110-ecauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27212-27110-ecauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27630-vexin_sur_epte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27630-vexin_sur_epte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27630-vexin_sur_epte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27630-vexin_sur_epte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27420-vexin_sur_epte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27420-vexin_sur_epte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27420-vexin_sur_epte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27420-vexin_sur_epte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27510-vexin_sur_epte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27510-vexin_sur_epte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27510-vexin_sur_epte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27213-27510-vexin_sur_epte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27214-27440-ecouis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27214-27440-ecouis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27214-27440-ecouis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27214-27440-ecouis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27215-27110-ecquetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27215-27110-ecquetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27215-27110-ecquetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27215-27110-ecquetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27216-27930-emalleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27216-27930-emalleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27216-27930-emalleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27216-27930-emalleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27217-27190-emanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27217-27190-emanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27217-27190-emanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27217-27190-emanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27218-27260-epaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27218-27260-epaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27218-27260-epaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27218-27260-epaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27219-27110-epegard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27219-27110-epegard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27219-27110-epegard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27219-27110-epegard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27220-27730-epieds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27220-27730-epieds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27220-27730-epieds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27220-27730-epieds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27222-27560-epreville_en_lieuvin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27222-27560-epreville_en_lieuvin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27222-27560-epreville_en_lieuvin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27222-27560-epreville_en_lieuvin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27224-27110-epreville_pres_le_neubourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27224-27110-epreville_pres_le_neubourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27224-27110-epreville_pres_le_neubourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27224-27110-epreville_pres_le_neubourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27226-27150-etrepagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27226-27150-etrepagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27226-27150-etrepagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27226-27150-etrepagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27227-27350-etreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27227-27350-etreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27227-27350-etreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27227-27350-etreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27228-27350-eturqueraye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27228-27350-eturqueraye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27228-27350-eturqueraye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27228-27350-eturqueraye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27229-27000-evreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27229-27000-evreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27229-27000-evreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27229-27000-evreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27230-27530-ezy_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27230-27530-ezy_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27230-27530-ezy_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27230-27530-ezy_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27231-27120-fains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27231-27120-fains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27231-27120-fains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27231-27120-fains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27232-27150-farceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27232-27150-farceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27232-27150-farceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27232-27150-farceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27233-27210-fatouville_grestain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27233-27210-fatouville_grestain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27233-27210-fatouville_grestain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27233-27210-fatouville_grestain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27234-27930-fauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27234-27930-fauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27234-27930-fauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27234-27930-fauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27235-27190-faverolles_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27235-27190-faverolles_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27235-27190-faverolles_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27235-27190-faverolles_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27237-27230-le_favril/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27237-27230-le_favril/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27237-27230-le_favril/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27237-27230-le_favril/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27238-27190-ferrieres_haut_clocher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27238-27190-ferrieres_haut_clocher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27238-27190-ferrieres_haut_clocher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27238-27190-ferrieres_haut_clocher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27239-27270-ferrieres_saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27239-27270-ferrieres_saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27239-27270-ferrieres_saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27239-27270-ferrieres_saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27240-27760-la_ferriere_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27240-27760-la_ferriere_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27240-27760-la_ferriere_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27240-27760-la_ferriere_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27241-27110-feuguerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27241-27110-feuguerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27241-27110-feuguerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27241-27110-feuguerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27242-27190-le_fidelaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27242-27190-le_fidelaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27242-27190-le_fidelaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27242-27190-le_fidelaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27243-27210-fiquefleur_equainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27243-27210-fiquefleur_equainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27243-27210-fiquefleur_equainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27243-27210-fiquefleur_equainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27245-27480-fleury_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27245-27480-fleury_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27245-27480-fleury_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27245-27480-fleury_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27246-27380-fleury_sur_andelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27246-27380-fleury_sur_andelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27246-27380-fleury_sur_andelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27246-27380-fleury_sur_andelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27247-27380-flipou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27247-27380-flipou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27247-27380-flipou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27247-27380-flipou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27248-27230-folleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27248-27230-folleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27248-27230-folleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27248-27230-folleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27249-27600-fontaine_bellenger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27249-27600-fontaine_bellenger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27249-27600-fontaine_bellenger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27249-27600-fontaine_bellenger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27251-27470-fontaine_l_abbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27251-27470-fontaine_l_abbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27251-27470-fontaine_l_abbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27251-27470-fontaine_l_abbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27252-27230-fontaine_la_louvet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27252-27230-fontaine_la_louvet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27252-27230-fontaine_la_louvet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27252-27230-fontaine_la_louvet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27254-27120-fontaine_sous_jouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27254-27120-fontaine_sous_jouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27254-27120-fontaine_sous_jouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27254-27120-fontaine_sous_jouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27256-27220-la_foret_du_parc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27256-27220-la_foret_du_parc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27256-27220-la_foret_du_parc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27256-27220-la_foret_du_parc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27258-27210-fort_moville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27258-27210-fort_moville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27258-27210-fort_moville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27258-27210-fort_moville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27259-27220-foucrainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27259-27220-foucrainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27259-27220-foucrainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27259-27220-foucrainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27260-27210-foulbec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27260-27210-foulbec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27260-27210-foulbec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27260-27210-foulbec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27261-27370-fouqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27261-27370-fouqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27261-27370-fouqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27261-27370-fouqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27263-27500-le_perrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27263-27500-le_perrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27263-27500-le_perrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27263-27500-le_perrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27263-27680-le_perrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27263-27680-le_perrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27263-27680-le_perrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27263-27680-le_perrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27266-27800-franqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27266-27800-franqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27266-27800-franqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27266-27800-franqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27267-27290-freneuse_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27267-27290-freneuse_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27267-27290-freneuse_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27267-27290-freneuse_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27269-27260-fresne_cauverville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27269-27260-fresne_cauverville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27269-27260-fresne_cauverville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27269-27260-fresne_cauverville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27271-27220-fresney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27271-27220-fresney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27271-27220-fresney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27271-27220-fresney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27273-27120-gadencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27273-27120-gadencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27273-27120-gadencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27273-27120-gadencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27275-27600-gaillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27275-27600-gaillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27275-27600-gaillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27275-27600-gaillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27276-27150-gamaches_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27276-27150-gamaches_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27276-27150-gamaches_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27276-27150-gamaches_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27277-27220-la_baronnie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27277-27220-la_baronnie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27277-27220-la_baronnie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27277-27220-la_baronnie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27278-27780-garennes_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27278-27780-garennes_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27278-27780-garennes_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27278-27780-garennes_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27279-27620-gasny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27279-27620-gasny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27279-27620-gasny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27279-27620-gasny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27280-27930-gauciel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27280-27930-gauciel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27280-27930-gauciel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27280-27930-gauciel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27281-27190-gaudreville_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27281-27190-gaudreville_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27281-27190-gaudreville_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27281-27190-gaudreville_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27282-27930-gauville_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27282-27930-gauville_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27282-27930-gauville_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27282-27930-gauville_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27284-27140-gisors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27284-27140-gisors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27284-27140-gisors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27284-27140-gisors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27285-27620-giverny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27285-27620-giverny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27285-27620-giverny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27285-27620-giverny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27286-27560-giverville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27286-27560-giverville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27286-27560-giverville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27286-27560-giverville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27287-27190-glisolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27287-27190-glisolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27287-27190-glisolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27287-27190-glisolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27288-27290-glos_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27288-27290-glos_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27288-27290-glos_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27288-27290-glos_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27289-27390-la_goulafriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27289-27390-la_goulafriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27289-27390-la_goulafriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27289-27390-la_goulafriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27290-27170-goupil_othon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27290-27170-goupil_othon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27290-27170-goupil_othon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27290-27170-goupil_othon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27291-27580-gournay_le_guerin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27291-27580-gournay_le_guerin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27291-27580-gournay_le_guerin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27291-27580-gournay_le_guerin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27294-27380-val_d_orger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27294-27380-val_d_orger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27294-27380-val_d_orger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27294-27380-val_d_orger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27294-27440-val_d_orger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27294-27440-val_d_orger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27294-27440-val_d_orger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27294-27440-val_d_orger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27295-27270-grand_camp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27295-27270-grand_camp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27295-27270-grand_camp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27295-27270-grand_camp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27298-27110-graveron_semerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27298-27110-graveron_semerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27298-27110-graveron_semerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27298-27110-graveron_semerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27299-27930-gravigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27299-27930-gravigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27299-27930-gravigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27299-27930-gravigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27300-27170-grosley_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27300-27170-grosley_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27300-27170-grosley_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27300-27170-grosley_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27301-27220-grossoeuvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27301-27220-grossoeuvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27301-27220-grossoeuvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27301-27220-grossoeuvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27302-27370-le_bosc_du_theil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27302-27370-le_bosc_du_theil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27302-27370-le_bosc_du_theil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27302-27370-le_bosc_du_theil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27304-27720-guerny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27304-27720-guerny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27304-27720-guerny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27304-27720-guerny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27306-27930-guichainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27306-27930-guichainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27306-27930-guichainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27306-27930-guichainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27307-27700-guiseniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27307-27700-guiseniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27307-27700-guiseniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27307-27700-guiseniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27309-27220-l_habit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27309-27220-l_habit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27309-27220-l_habit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27309-27220-l_habit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27310-27150-hacqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27310-27150-hacqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27310-27150-hacqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27310-27150-hacqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27311-27800-harcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27311-27800-harcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27311-27800-harcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27311-27800-harcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27312-27120-hardencourt_cocherel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27312-27120-hardencourt_cocherel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27312-27120-hardencourt_cocherel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27312-27120-hardencourt_cocherel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27313-27370-la_harengere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27313-27370-la_harengere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27313-27370-la_harengere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27313-27370-la_harengere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27315-27700-harquency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27315-27700-harquency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27315-27700-harquency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27315-27700-harquency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27316-27350-hauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27316-27350-hauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27316-27350-hauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27316-27350-hauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27317-27350-la_haye_aubree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27317-27350-la_haye_aubree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27317-27350-la_haye_aubree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27317-27350-la_haye_aubree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27318-27800-la_haye_de_calleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27318-27800-la_haye_de_calleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27318-27800-la_haye_de_calleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27318-27800-la_haye_de_calleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27319-27350-la_haye_de_routot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27319-27350-la_haye_de_routot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27319-27350-la_haye_de_routot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27319-27350-la_haye_de_routot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27320-27370-la_haye_du_theil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27320-27370-la_haye_du_theil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27320-27370-la_haye_du_theil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27320-27370-la_haye_du_theil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27321-27400-la_haye_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27321-27400-la_haye_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27321-27400-la_haye_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27321-27400-la_haye_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27322-27400-la_haye_malherbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27322-27400-la_haye_malherbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27322-27400-la_haye_malherbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27322-27400-la_haye_malherbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27323-27330-la_haye_saint_sylvestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27323-27330-la_haye_saint_sylvestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27323-27330-la_haye_saint_sylvestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27323-27330-la_haye_saint_sylvestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27324-27150-hebecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27324-27150-hebecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27324-27150-hebecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27324-27150-hebecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27325-27800-hecmanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27325-27800-hecmanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27325-27800-hecmanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27325-27800-hecmanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27326-27120-hecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27326-27120-hecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27326-27120-hecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27326-27120-hecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27327-27110-hectomare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27327-27110-hectomare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27327-27110-hectomare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27327-27110-hectomare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27329-27700-hennezis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27329-27700-hennezis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27329-27700-hennezis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27329-27700-hennezis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27330-27430-herqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27330-27430-herqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27330-27430-herqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27330-27430-herqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27331-27630-heubecourt_haricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27331-27630-heubecourt_haricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27331-27630-heubecourt_haricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27331-27630-heubecourt_haricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27332-27400-heudebouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27332-27400-heudebouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27332-27400-heudebouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27332-27400-heudebouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27332-27600-heudebouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27332-27600-heudebouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27332-27600-heudebouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27332-27600-heudebouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27333-27860-heudicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27333-27860-heudicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27333-27860-heudicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27333-27860-heudicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27334-27230-heudreville_en_lieuvin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27334-27230-heudreville_en_lieuvin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27334-27230-heudreville_en_lieuvin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27334-27230-heudreville_en_lieuvin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27335-27400-heudreville_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27335-27400-heudreville_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27335-27400-heudreville_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27335-27400-heudreville_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27336-27950-la_heuniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27336-27950-la_heuniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27336-27950-la_heuniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27336-27950-la_heuniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27337-27700-heuqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27337-27700-heuqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27337-27700-heuqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27337-27700-heuqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27338-27910-les_hogues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27338-27910-les_hogues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27338-27910-les_hogues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27338-27910-les_hogues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27339-27400-hondouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27339-27400-hondouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27339-27400-hondouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27339-27400-hondouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27340-27310-honguemare_guenouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27340-27310-honguemare_guenouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27340-27310-honguemare_guenouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27340-27310-honguemare_guenouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27341-27570-l_hosmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27341-27570-l_hosmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27341-27570-l_hosmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27341-27570-l_hosmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27342-27400-houetteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27342-27400-houetteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27342-27400-houetteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27342-27400-houetteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27343-27120-houlbec_cocherel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27343-27120-houlbec_cocherel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27343-27120-houlbec_cocherel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27343-27120-houlbec_cocherel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27345-27410-la_houssaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27345-27410-la_houssaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27345-27410-la_houssaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27345-27410-la_houssaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27346-27440-houville_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27346-27440-houville_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27346-27440-houville_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27346-27440-houville_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27347-27930-huest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27347-27930-huest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27347-27930-huest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27347-27930-huest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27348-27460-igoville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27348-27460-igoville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27348-27460-igoville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27348-27460-igoville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27349-27290-illeville_sur_montfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27349-27290-illeville_sur_montfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27349-27290-illeville_sur_montfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27349-27290-illeville_sur_montfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27350-27770-illiers_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27350-27770-illiers_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27350-27770-illiers_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27350-27770-illiers_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27351-27400-incarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27351-27400-incarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27351-27400-incarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27351-27400-incarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27353-27930-irreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27353-27930-irreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27353-27930-irreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27353-27930-irreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27354-27110-iville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27354-27110-iville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27354-27110-iville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27354-27110-iville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27355-27540-ivry_la_bataille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27355-27540-ivry_la_bataille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27355-27540-ivry_la_bataille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27355-27540-ivry_la_bataille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27358-27120-jouy_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27358-27120-jouy_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27358-27120-jouy_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27358-27120-jouy_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27359-27250-juignettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27359-27250-juignettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27359-27250-juignettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27359-27250-juignettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27360-27220-jumelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27360-27220-jumelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27360-27220-jumelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27360-27220-jumelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27361-27210-la_lande_saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27361-27210-la_lande_saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27361-27210-la_lande_saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27361-27210-la_lande_saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27363-27350-le_landin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27363-27350-le_landin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27363-27350-le_landin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27363-27350-le_landin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27364-27470-launay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27364-27470-launay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27364-27470-launay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27364-27470-launay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27365-27690-lery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27365-27690-lery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27365-27690-lery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27365-27690-lery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27366-27910-letteguives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27366-27910-letteguives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27366-27910-letteguives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27366-27910-letteguives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27367-27560-lieurey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27367-27560-lieurey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27367-27560-lieurey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27367-27560-lieurey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27368-27220-lignerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27368-27220-lignerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27368-27220-lignerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27368-27220-lignerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27369-27480-lilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27369-27480-lilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27369-27480-lilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27369-27480-lilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27370-27440-lisors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27370-27440-lisors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27370-27440-lisors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27370-27440-lisors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27371-27800-livet_sur_authou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27371-27800-livet_sur_authou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27371-27800-livet_sur_authou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27371-27800-livet_sur_authou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27372-27150-longchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27372-27150-longchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27372-27150-longchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27372-27150-longchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27373-27480-lorleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27373-27480-lorleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27373-27480-lorleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27373-27480-lorleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27374-27190-louversey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27374-27190-louversey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27374-27190-louversey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27374-27190-louversey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27375-27400-louviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27375-27400-louviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27375-27400-louviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27375-27400-louviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27376-27650-louye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27376-27650-louye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27376-27650-louye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27376-27650-louye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27377-27480-lyons_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27377-27480-lyons_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27377-27480-lyons_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27377-27480-lyons_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27378-27320-la_madeleine_de_nonancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27378-27320-la_madeleine_de_nonancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27378-27320-la_madeleine_de_nonancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27378-27320-la_madeleine_de_nonancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27379-27150-mainneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27379-27150-mainneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27379-27150-mainneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27379-27150-mainneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27380-27800-malleville_sur_le_bec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27380-27800-malleville_sur_le_bec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27380-27800-malleville_sur_le_bec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27380-27800-malleville_sur_le_bec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27381-27300-malouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27381-27300-malouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27381-27300-malouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27381-27300-malouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27382-27370-mandeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27382-27370-mandeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27382-27370-mandeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27382-27370-mandeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27383-27130-mandres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27383-27130-mandres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27383-27130-mandres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27383-27130-mandres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27384-27210-manneville_la_raoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27384-27210-manneville_la_raoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27384-27210-manneville_la_raoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27384-27210-manneville_la_raoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27385-27500-manneville_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27385-27500-manneville_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27385-27500-manneville_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27385-27500-manneville_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27386-27460-le_manoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27386-27460-le_manoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27386-27460-le_manoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27386-27460-le_manoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27388-27680-marais_vernier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27388-27680-marais_vernier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27388-27680-marais_vernier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27388-27680-marais_vernier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27389-27110-marbeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27389-27110-marbeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27389-27110-marbeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27389-27110-marbeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27390-27320-marcilly_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27390-27320-marcilly_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27390-27320-marcilly_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27390-27320-marcilly_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27391-27810-marcilly_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27391-27810-marcilly_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27391-27810-marcilly_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27391-27810-marcilly_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27392-27150-martagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27392-27150-martagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27392-27150-martagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27392-27150-martagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27393-27210-martainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27393-27210-martainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27393-27210-martainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27393-27210-martainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27394-27340-martot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27394-27340-martot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27394-27340-martot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27394-27340-martot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27395-27390-melicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27395-27390-melicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27395-27390-melicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27395-27390-melicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27396-27850-menesqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27396-27850-menesqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27396-27850-menesqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27396-27850-menesqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27397-27120-menilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27397-27120-menilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27397-27120-menilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27397-27120-menilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27398-27300-menneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27398-27300-menneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27398-27300-menneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27398-27300-menneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27399-27950-mercey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27399-27950-mercey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27399-27950-mercey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27399-27950-mercey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27400-27640-merey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27400-27640-merey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27400-27640-merey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27400-27640-merey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27401-27930-le_mesnil_fuguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27401-27930-le_mesnil_fuguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27401-27930-le_mesnil_fuguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27401-27930-le_mesnil_fuguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27403-27400-le_mesnil_jourdain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27403-27400-le_mesnil_jourdain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27403-27400-le_mesnil_jourdain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27403-27400-le_mesnil_jourdain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27404-27390-mesnil_rousset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27404-27390-mesnil_rousset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27404-27390-mesnil_rousset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27404-27390-mesnil_rousset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27405-27150-mesnil_sous_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27405-27150-mesnil_sous_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27405-27150-mesnil_sous_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27405-27150-mesnil_sous_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27406-27650-mesnil_sur_l_estree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27406-27650-mesnil_sur_l_estree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27406-27650-mesnil_sur_l_estree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27406-27650-mesnil_sur_l_estree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27407-27440-mesnil_verclives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27407-27440-mesnil_verclives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27407-27440-mesnil_verclives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27407-27440-mesnil_verclives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27408-27510-mezieres_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27408-27510-mezieres_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27408-27510-mezieres_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27408-27510-mezieres_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27410-27930-miserey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27410-27930-miserey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27410-27930-miserey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27410-27930-miserey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27411-27320-moisville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27411-27320-moisville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27411-27320-moisville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27411-27320-moisville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27412-27400-terres_de_bord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27412-27400-terres_de_bord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27412-27400-terres_de_bord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27412-27400-terres_de_bord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27412-27340-terres_de_bord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27412-27340-terres_de_bord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27412-27340-terres_de_bord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27412-27340-terres_de_bord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27413-27290-montfort_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27413-27290-montfort_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27413-27290-montfort_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27413-27290-montfort_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27414-27390-montreuil_l_argille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27414-27390-montreuil_l_argille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27414-27390-montreuil_l_argille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27414-27390-montreuil_l_argille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27415-27260-morainville_jouveaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27415-27260-morainville_jouveaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27415-27260-morainville_jouveaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27415-27260-morainville_jouveaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27417-27150-morgny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27417-27150-morgny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27417-27150-morgny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27417-27150-morgny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27418-27800-morsan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27418-27800-morsan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27418-27800-morsan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27418-27800-morsan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27419-27220-mouettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27419-27220-mouettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27419-27220-mouettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27419-27220-mouettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27420-27420-mouflaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27420-27420-mouflaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27420-27420-mouflaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27420-27420-mouflaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27421-27220-mousseaux_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27421-27220-mousseaux_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27421-27220-mousseaux_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27421-27220-mousseaux_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27422-27430-muids/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27422-27430-muids/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27422-27430-muids/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27422-27430-muids/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27423-27650-muzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27423-27650-muzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27423-27650-muzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27423-27650-muzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27424-27190-nagel_seez_mesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27424-27190-nagel_seez_mesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27424-27190-nagel_seez_mesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27424-27190-nagel_seez_mesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27550-nassandres_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27550-nassandres_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27550-nassandres_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27550-nassandres_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27300-nassandres_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27300-nassandres_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27300-nassandres_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27300-nassandres_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27170-nassandres_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27170-nassandres_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27170-nassandres_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27425-27170-nassandres_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27426-27830-neaufles_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27426-27830-neaufles_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27426-27830-neaufles_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27426-27830-neaufles_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27427-27250-neaufles_auvergny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27427-27250-neaufles_auvergny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27427-27250-neaufles_auvergny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27427-27250-neaufles_auvergny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27428-27110-le_neubourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27428-27110-le_neubourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27428-27110-le_neubourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27428-27110-le_neubourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27429-27730-neuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27429-27730-neuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27429-27730-neuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27429-27730-neuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27430-27150-la_neuve_grange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27430-27150-la_neuve_grange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27430-27150-la_neuve_grange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27430-27150-la_neuve_grange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27431-27330-la_neuve_lyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27431-27330-la_neuve_lyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27431-27330-la_neuve_lyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27431-27330-la_neuve_lyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27432-27890-la_neuville_du_bosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27432-27890-la_neuville_du_bosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27432-27890-la_neuville_du_bosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27432-27890-la_neuville_du_bosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27433-27800-neuville_sur_authou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27433-27800-neuville_sur_authou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27433-27800-neuville_sur_authou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27433-27800-neuville_sur_authou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27434-27560-noards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27434-27560-noards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27434-27560-noards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27434-27560-noards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27435-27560-la_noe_poulain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27435-27560-la_noe_poulain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27435-27560-la_noe_poulain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27435-27560-la_noe_poulain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27436-27190-nogent_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27436-27190-nogent_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27436-27190-nogent_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27436-27190-nogent_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27437-27150-nojeon_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27437-27150-nojeon_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27437-27150-nojeon_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27437-27150-nojeon_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27438-27320-nonancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27438-27320-nonancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27438-27320-nonancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27438-27320-nonancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27439-27930-normanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27439-27930-normanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27439-27930-normanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27439-27930-normanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27440-27940-notre_dame_de_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27440-27940-notre_dame_de_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27440-27940-notre_dame_de_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27440-27940-notre_dame_de_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27441-27800-notre_dame_d_epine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27441-27800-notre_dame_d_epine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27441-27800-notre_dame_d_epine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27441-27800-notre_dame_d_epine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27442-27390-notre_dame_du_hamel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27442-27390-notre_dame_du_hamel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27442-27390-notre_dame_du_hamel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27442-27390-notre_dame_du_hamel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27444-27410-le_noyer_en_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27444-27410-le_noyer_en_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27444-27410-le_noyer_en_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27444-27410-le_noyer_en_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27445-27720-noyers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27445-27720-noyers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27445-27720-noyers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27445-27720-noyers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27446-27190-ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27446-27190-ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27446-27190-ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27446-27190-ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27447-27190-le_val_dore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27447-27190-le_val_dore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27447-27190-le_val_dore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27447-27190-le_val_dore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27448-27120-pacy_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27448-27120-pacy_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27448-27120-pacy_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27448-27120-pacy_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27451-27180-parville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27451-27180-parville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27451-27180-parville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27451-27180-parville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27453-27910-perriers_sur_andelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27453-27910-perriers_sur_andelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27453-27910-perriers_sur_andelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27453-27910-perriers_sur_andelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27454-27910-perruel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27454-27910-perruel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27454-27910-perruel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27454-27910-perruel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27455-27230-piencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27455-27230-piencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27455-27230-piencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27455-27230-piencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27456-27400-pinterville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27456-27400-pinterville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27456-27400-pinterville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27456-27400-pinterville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27457-27130-piseux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27457-27130-piseux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27457-27130-piseux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27457-27130-piseux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27458-27590-pitres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27458-27590-pitres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27458-27590-pitres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27458-27590-pitres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27459-27230-les_places/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27459-27230-les_places/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27459-27230-les_places/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27459-27230-les_places/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27460-27300-plainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27460-27300-plainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27460-27300-plainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27460-27300-plainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27462-27230-le_planquay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27462-27230-le_planquay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27462-27230-le_planquay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27462-27230-le_planquay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27463-27300-plasnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27463-27300-plasnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27463-27300-plasnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27463-27300-plasnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27464-27180-le_plessis_grohan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27464-27180-le_plessis_grohan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27464-27180-le_plessis_grohan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27464-27180-le_plessis_grohan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27465-27120-le_plessis_hebert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27465-27120-le_plessis_hebert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27465-27120-le_plessis_hebert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27465-27120-le_plessis_hebert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27466-27170-le_plessis_sainte_opportune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27466-27170-le_plessis_sainte_opportune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27466-27170-le_plessis_sainte_opportune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27466-27170-le_plessis_sainte_opportune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27467-27500-pont_audemer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27467-27500-pont_audemer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27467-27500-pont_audemer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27467-27500-pont_audemer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27468-27290-pont_authou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27468-27290-pont_authou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27468-27290-pont_authou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27468-27290-pont_authou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27469-27340-pont_de_l_arche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27469-27340-pont_de_l_arche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27469-27340-pont_de_l_arche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27469-27340-pont_de_l_arche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27470-27360-pont_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27470-27360-pont_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27470-27360-pont_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27470-27360-pont_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27471-27430-porte_de_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27471-27430-porte_de_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27471-27430-porte_de_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27471-27430-porte_de_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27472-27190-portes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27472-27190-portes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27472-27190-portes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27472-27190-portes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27473-27940-port_mort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27473-27940-port_mort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27473-27940-port_mort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27473-27940-port_mort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27474-27740-poses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27474-27740-poses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27474-27740-poses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27474-27740-poses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27475-27560-la_poterie_mathieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27475-27560-la_poterie_mathieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27475-27560-la_poterie_mathieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27475-27560-la_poterie_mathieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27476-27500-les_preaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27476-27500-les_preaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27476-27500-les_preaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27476-27500-les_preaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27477-27510-pressagny_l_orgueilleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27477-27510-pressagny_l_orgueilleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27477-27510-pressagny_l_orgueilleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27477-27510-pressagny_l_orgueilleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27478-27220-prey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27478-27220-prey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27478-27220-prey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27478-27220-prey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27480-27150-puchay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27480-27150-puchay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27480-27150-puchay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27480-27150-puchay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27481-27130-pullay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27481-27130-pullay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27481-27130-pullay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27481-27130-pullay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27482-27370-la_pyle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27482-27370-la_pyle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27482-27370-la_pyle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27482-27370-la_pyle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27483-27400-quatremare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27483-27400-quatremare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27483-27400-quatremare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27483-27400-quatremare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27485-27680-quillebeuf_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27485-27680-quillebeuf_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27485-27680-quillebeuf_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27485-27680-quillebeuf_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27486-27110-quittebeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27486-27110-quittebeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27486-27110-quittebeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27486-27110-quittebeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27487-27380-radepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27487-27380-radepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27487-27380-radepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27487-27380-radepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27488-27910-renneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27488-27910-renneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27488-27910-renneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27488-27910-renneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27489-27930-reuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27489-27930-reuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27489-27930-reuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27489-27930-reuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27490-27420-richeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27490-27420-richeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27490-27420-richeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27490-27420-richeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27492-27170-romilly_la_puthenaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27492-27170-romilly_la_puthenaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27492-27170-romilly_la_puthenaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27492-27170-romilly_la_puthenaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27493-27610-romilly_sur_andelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27493-27610-romilly_sur_andelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27493-27610-romilly_sur_andelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27493-27610-romilly_sur_andelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27495-27700-la_roquette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27495-27700-la_roquette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27495-27700-la_roquette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27495-27700-la_roquette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27496-27790-rosay_sur_lieure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27496-27790-rosay_sur_lieure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27496-27790-rosay_sur_lieure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27496-27790-rosay_sur_lieure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27497-27350-rougemontiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27497-27350-rougemontiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27497-27350-rougemontiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27497-27350-rougemontiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27498-27110-rouge_perriers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27498-27110-rouge_perriers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27498-27110-rouge_perriers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27498-27110-rouge_perriers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27500-27350-routot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27500-27350-routot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27500-27350-routot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27500-27350-routot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27501-27120-rouvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27501-27120-rouvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27501-27120-rouvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27501-27120-rouvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27502-27250-rugles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27502-27250-rugles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27502-27250-rugles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27502-27250-rugles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27504-27930-sacquenville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27504-27930-sacquenville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27504-27930-sacquenville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27504-27930-sacquenville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27505-27390-saint_agnan_de_cernieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27505-27390-saint_agnan_de_cernieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27505-27390-saint_agnan_de_cernieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27505-27390-saint_agnan_de_cernieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27507-27220-saint_andre_de_l_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27507-27220-saint_andre_de_l_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27507-27220-saint_andre_de_l_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27507-27220-saint_andre_de_l_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27508-27250-saint_antonin_de_sommaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27508-27250-saint_antonin_de_sommaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27508-27250-saint_antonin_de_sommaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27508-27250-saint_antonin_de_sommaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27511-27110-saint_aubin_d_ecrosville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27511-27110-saint_aubin_d_ecrosville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27511-27110-saint_aubin_d_ecrosville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27511-27110-saint_aubin_d_ecrosville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27512-27230-saint_aubin_de_scellon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27512-27230-saint_aubin_de_scellon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27512-27230-saint_aubin_de_scellon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27512-27230-saint_aubin_de_scellon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27514-27270-saint_aubin_du_thenney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27514-27270-saint_aubin_du_thenney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27514-27270-saint_aubin_du_thenney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27514-27270-saint_aubin_du_thenney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27516-27300-treis_sants_en_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27516-27300-treis_sants_en_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27516-27300-treis_sants_en_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27516-27300-treis_sants_en_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27516-27270-treis_sants_en_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27516-27270-treis_sants_en_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27516-27270-treis_sants_en_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27516-27270-treis_sants_en_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27517-27600-saint_aubin_sur_gaillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27517-27600-saint_aubin_sur_gaillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27517-27600-saint_aubin_sur_gaillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27517-27600-saint_aubin_sur_gaillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27518-27680-saint_aubin_sur_quillebeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27518-27680-saint_aubin_sur_quillebeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27518-27680-saint_aubin_sur_quillebeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27518-27680-saint_aubin_sur_quillebeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27520-27450-saint_benoit_des_ombres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27520-27450-saint_benoit_des_ombres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27520-27450-saint_benoit_des_ombres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27520-27450-saint_benoit_des_ombres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27521-27820-saint_christophe_sur_avre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27521-27820-saint_christophe_sur_avre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27521-27820-saint_christophe_sur_avre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27521-27820-saint_christophe_sur_avre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27522-27450-saint_christophe_sur_conde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27522-27450-saint_christophe_sur_conde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27522-27450-saint_christophe_sur_conde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27522-27450-saint_christophe_sur_conde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27524-27110-sainte_colombe_la_commanderie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27524-27110-sainte_colombe_la_commanderie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27524-27110-sainte_colombe_la_commanderie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27524-27110-sainte_colombe_la_commanderie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27525-27950-sainte_colombe_pres_vernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27525-27950-sainte_colombe_pres_vernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27525-27950-sainte_colombe_pres_vernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27525-27950-sainte_colombe_pres_vernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27527-27800-saint_cyr_de_salerne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27527-27800-saint_cyr_de_salerne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27527-27800-saint_cyr_de_salerne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27527-27800-saint_cyr_de_salerne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27528-27100-le_vaudreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27528-27100-le_vaudreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27528-27100-le_vaudreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27528-27100-le_vaudreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27529-27370-saint_cyr_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27529-27370-saint_cyr_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27529-27370-saint_cyr_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27529-27370-saint_cyr_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27530-27390-saint_denis_d_augerons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27530-27390-saint_denis_d_augerons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27530-27390-saint_denis_d_augerons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27530-27390-saint_denis_d_augerons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27531-27520-saint_denis_des_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27531-27520-saint_denis_des_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27531-27520-saint_denis_des_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27531-27520-saint_denis_des_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27533-27140-saint_denis_le_ferment/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27533-27140-saint_denis_le_ferment/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27533-27140-saint_denis_le_ferment/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27533-27140-saint_denis_le_ferment/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27534-27370-saint_didier_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27534-27370-saint_didier_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27534-27370-saint_didier_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27534-27370-saint_didier_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27535-27190-saint_elier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27535-27190-saint_elier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27535-27190-saint_elier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27535-27190-saint_elier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27536-27800-saint_eloi_de_fourques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27536-27800-saint_eloi_de_fourques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27536-27800-saint_eloi_de_fourques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27536-27800-saint_eloi_de_fourques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27536-27520-saint_eloi_de_fourques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27536-27520-saint_eloi_de_fourques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27536-27520-saint_eloi_de_fourques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27536-27520-saint_eloi_de_fourques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27537-27430-saint_etienne_du_vauvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27537-27430-saint_etienne_du_vauvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27537-27430-saint_etienne_du_vauvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27537-27430-saint_etienne_du_vauvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27538-27450-saint_etienne_l_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27538-27450-saint_etienne_l_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27538-27450-saint_etienne_l_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27538-27450-saint_etienne_l_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27539-27920-saint_etienne_sous_bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27539-27920-saint_etienne_sous_bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27539-27920-saint_etienne_sous_bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27539-27920-saint_etienne_sous_bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27540-27620-sainte_genevieve_les_gasny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27540-27620-sainte_genevieve_les_gasny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27540-27620-sainte_genevieve_les_gasny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27540-27620-sainte_genevieve_les_gasny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27541-27560-le_mesnil_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27541-27560-le_mesnil_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27541-27560-le_mesnil_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27541-27560-le_mesnil_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27542-27450-saint_georges_du_vievre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27542-27450-saint_georges_du_vievre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27542-27450-saint_georges_du_vievre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27542-27450-saint_georges_du_vievre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27543-27710-saint_georges_motel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27543-27710-saint_georges_motel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27543-27710-saint_georges_motel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27543-27710-saint_georges_motel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27544-27220-saint_germain_de_fresney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27544-27220-saint_germain_de_fresney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27544-27220-saint_germain_de_fresney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27544-27220-saint_germain_de_fresney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27545-27370-saint_germain_de_pasquier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27545-27370-saint_germain_de_pasquier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27545-27370-saint_germain_de_pasquier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27545-27370-saint_germain_de_pasquier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27546-27930-saint_germain_des_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27546-27930-saint_germain_des_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27546-27930-saint_germain_des_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27546-27930-saint_germain_des_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27547-27230-saint_germain_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27547-27230-saint_germain_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27547-27230-saint_germain_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27547-27230-saint_germain_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27548-27320-saint_germain_sur_avre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27548-27320-saint_germain_sur_avre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27548-27320-saint_germain_sur_avre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27548-27320-saint_germain_sur_avre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27550-27450-saint_gregoire_du_vievre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27550-27450-saint_gregoire_du_vievre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27550-27450-saint_gregoire_du_vievre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27550-27450-saint_gregoire_du_vievre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27552-27270-saint_jean_du_thenney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27552-27270-saint_jean_du_thenney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27552-27270-saint_jean_du_thenney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27552-27270-saint_jean_du_thenney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27553-27600-saint_julien_de_la_liegue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27553-27600-saint_julien_de_la_liegue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27553-27600-saint_julien_de_la_liegue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27553-27600-saint_julien_de_la_liegue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27554-27950-la_chapelle_longueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27554-27950-la_chapelle_longueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27554-27950-la_chapelle_longueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27554-27950-la_chapelle_longueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27555-27220-saint_laurent_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27555-27220-saint_laurent_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27555-27220-saint_laurent_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27555-27220-saint_laurent_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27556-27390-saint_laurent_du_tencement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27556-27390-saint_laurent_du_tencement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27556-27390-saint_laurent_du_tencement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27556-27390-saint_laurent_du_tencement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27557-27300-saint_leger_de_rotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27557-27300-saint_leger_de_rotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27557-27300-saint_leger_de_rotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27557-27300-saint_leger_de_rotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27558-27520-saint_leger_du_gennetey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27558-27520-saint_leger_du_gennetey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27558-27520-saint_leger_du_gennetey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27558-27520-saint_leger_du_gennetey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27560-27930-saint_luc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27560-27930-saint_luc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27560-27930-saint_luc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27560-27930-saint_luc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27561-27210-saint_maclou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27561-27210-saint_maclou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27561-27210-saint_maclou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27561-27210-saint_maclou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27562-27950-saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27562-27950-saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27562-27950-saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27562-27950-saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27563-27500-saint_mards_de_blacarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27563-27500-saint_mards_de_blacarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27563-27500-saint_mards_de_blacarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27563-27500-saint_mards_de_blacarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27564-27230-saint_mards_de_fresne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27564-27230-saint_mards_de_fresne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27564-27230-saint_mards_de_fresne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27564-27230-saint_mards_de_fresne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27565-27160-le_lesme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27565-27160-le_lesme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27565-27160-le_lesme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27565-27160-le_lesme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27567-27150-sainte_marie_de_vatimesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27567-27150-sainte_marie_de_vatimesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27567-27150-sainte_marie_de_vatimesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27567-27150-sainte_marie_de_vatimesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27568-27190-sainte_marthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27568-27190-sainte_marthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27568-27190-sainte_marthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27568-27190-sainte_marthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27569-27300-saint_martin_du_tilleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27569-27300-saint_martin_du_tilleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27569-27300-saint_martin_du_tilleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27569-27300-saint_martin_du_tilleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27570-27930-saint_martin_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27570-27930-saint_martin_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27570-27930-saint_martin_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27570-27930-saint_martin_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27571-27450-saint_martin_saint_firmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27571-27450-saint_martin_saint_firmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27571-27450-saint_martin_saint_firmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27571-27450-saint_martin_saint_firmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27572-27370-saint_meslin_du_bosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27572-27370-saint_meslin_du_bosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27572-27370-saint_meslin_du_bosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27572-27370-saint_meslin_du_bosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27576-27110-sainte_opportune_du_bosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27576-27110-sainte_opportune_du_bosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27576-27110-sainte_opportune_du_bosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27576-27110-sainte_opportune_du_bosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27577-27680-sainte_opportune_la_mare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27577-27680-sainte_opportune_la_mare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27577-27680-sainte_opportune_la_mare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27577-27680-sainte_opportune_la_mare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27578-27160-sainte_marie_d_attez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27578-27160-sainte_marie_d_attez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27578-27160-sainte_marie_d_attez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27578-27160-sainte_marie_d_attez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27579-27370-saint_ouen_de_pontcheuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27579-27370-saint_ouen_de_pontcheuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27579-27370-saint_ouen_de_pontcheuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27579-27370-saint_ouen_de_pontcheuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27580-27310-saint_ouen_de_thouberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27580-27310-saint_ouen_de_thouberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27580-27310-saint_ouen_de_thouberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27580-27310-saint_ouen_de_thouberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27582-27670-saint_ouen_du_tilleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27582-27670-saint_ouen_du_tilleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27582-27670-saint_ouen_du_tilleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27582-27670-saint_ouen_du_tilleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27584-27800-saint_paul_de_fourques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27584-27800-saint_paul_de_fourques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27584-27800-saint_paul_de_fourques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27584-27800-saint_paul_de_fourques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27586-27520-saint_philbert_sur_boissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27586-27520-saint_philbert_sur_boissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27586-27520-saint_philbert_sur_boissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27586-27520-saint_philbert_sur_boissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27587-27290-saint_philbert_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27587-27290-saint_philbert_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27587-27290-saint_philbert_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27587-27290-saint_philbert_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27589-27920-saint_pierre_de_bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27589-27920-saint_pierre_de_bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27589-27920-saint_pierre_de_bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27589-27920-saint_pierre_de_bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27590-27390-saint_pierre_de_cernieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27590-27390-saint_pierre_de_cernieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27590-27390-saint_pierre_de_cernieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27590-27390-saint_pierre_de_cernieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27591-27260-saint_pierre_de_cormeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27591-27260-saint_pierre_de_cormeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27591-27260-saint_pierre_de_cormeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27591-27260-saint_pierre_de_cormeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27592-27800-saint_pierre_de_salerne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27592-27800-saint_pierre_de_salerne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27592-27800-saint_pierre_de_salerne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27592-27800-saint_pierre_de_salerne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27593-27370-saint_pierre_des_fleurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27593-27370-saint_pierre_des_fleurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27593-27370-saint_pierre_des_fleurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27593-27370-saint_pierre_des_fleurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27594-27450-saint_pierre_des_ifs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27594-27450-saint_pierre_des_ifs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27594-27450-saint_pierre_des_ifs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27594-27450-saint_pierre_des_ifs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27595-27370-saint_pierre_du_bosguerard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27595-27370-saint_pierre_du_bosguerard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27595-27370-saint_pierre_du_bosguerard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27595-27370-saint_pierre_du_bosguerard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27597-27210-saint_pierre_du_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27597-27210-saint_pierre_du_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27597-27210-saint_pierre_du_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27597-27210-saint_pierre_du_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27598-27430-saint_pierre_du_vauvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27598-27430-saint_pierre_du_vauvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27598-27430-saint_pierre_du_vauvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27598-27430-saint_pierre_du_vauvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27599-27600-saint_pierre_la_garenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27599-27600-saint_pierre_la_garenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27599-27600-saint_pierre_la_garenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27599-27600-saint_pierre_la_garenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27601-27680-saint_samson_de_la_roque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27601-27680-saint_samson_de_la_roque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27601-27680-saint_samson_de_la_roque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27601-27680-saint_samson_de_la_roque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27602-27180-saint_sebastien_de_morsent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27602-27180-saint_sebastien_de_morsent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27602-27180-saint_sebastien_de_morsent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27602-27180-saint_sebastien_de_morsent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27603-27560-saint_simeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27603-27560-saint_simeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27603-27560-saint_simeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27603-27560-saint_simeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27604-27210-saint_sulpice_de_grimbouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27604-27210-saint_sulpice_de_grimbouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27604-27210-saint_sulpice_de_grimbouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27604-27210-saint_sulpice_de_grimbouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27605-27260-saint_sylvestre_de_cormeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27605-27260-saint_sylvestre_de_cormeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27605-27260-saint_sylvestre_de_cormeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27605-27260-saint_sylvestre_de_cormeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27606-27500-saint_symphorien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27606-27500-saint_symphorien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27606-27500-saint_symphorien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27606-27500-saint_symphorien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27608-27300-saint_victor_de_chretienville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27608-27300-saint_victor_de_chretienville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27608-27300-saint_victor_de_chretienville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27608-27300-saint_victor_de_chretienville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27609-27800-saint_victor_d_epine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27609-27800-saint_victor_d_epine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27609-27800-saint_victor_d_epine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27609-27800-saint_victor_d_epine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27610-27130-saint_victor_sur_avre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27610-27130-saint_victor_sur_avre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27610-27130-saint_victor_sur_avre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27610-27130-saint_victor_sur_avre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27611-27930-saint_vigor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27611-27930-saint_vigor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27611-27930-saint_vigor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27611-27930-saint_vigor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27612-27950-saint_vincent_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27612-27950-saint_vincent_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27612-27950-saint_vincent_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27612-27950-saint_vincent_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27613-27230-saint_vincent_du_boulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27613-27230-saint_vincent_du_boulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27613-27230-saint_vincent_du_boulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27613-27230-saint_vincent_du_boulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27614-27150-sancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27614-27150-sancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27614-27150-sancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27614-27150-sancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27615-27930-sassey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27615-27930-sassey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27615-27930-sassey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27615-27930-sassey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27616-27370-la_saussaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27616-27370-la_saussaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27616-27370-la_saussaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27616-27370-la_saussaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27617-27150-saussay_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27617-27150-saussay_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27617-27150-saussay_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27617-27150-saussay_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27618-27190-sebecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27618-27190-sebecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27618-27190-sebecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27618-27190-sebecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27620-27500-selles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27620-27500-selles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27620-27500-selles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27620-27500-selles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27621-27220-serez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27621-27220-serez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27621-27220-serez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27621-27220-serez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27622-27470-serquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27622-27470-serquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27622-27470-serquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27622-27470-serquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27623-27400-surtauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27623-27400-surtauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27623-27400-surtauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27623-27400-surtauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27624-27400-surville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27624-27400-surville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27624-27400-surville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27624-27400-surville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27625-27420-suzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27625-27420-suzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27625-27420-suzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27625-27420-suzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27627-27230-le_theil_nolent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27627-27230-le_theil_nolent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27627-27230-le_theil_nolent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27627-27230-le_theil_nolent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27629-27230-thiberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27629-27230-thiberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27629-27230-thiberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27629-27230-thiberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27630-27800-thibouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27630-27800-thibouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27630-27800-thibouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27630-27800-thibouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27631-27290-thierville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27631-27290-thierville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27631-27290-thierville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27631-27290-thierville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27632-27150-le_thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27632-27150-le_thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27632-27150-le_thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27632-27150-le_thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27633-27420-les_thilliers_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27633-27420-les_thilliers_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27633-27420-les_thilliers_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27633-27420-les_thilliers_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27635-27700-le_thuit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27635-27700-le_thuit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27635-27700-le_thuit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27635-27700-le_thuit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27638-27370-le_thuit_de_l_oison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27638-27370-le_thuit_de_l_oison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27638-27370-le_thuit_de_l_oison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27638-27370-le_thuit_de_l_oison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27640-27170-tilleul_dame_agnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27640-27170-tilleul_dame_agnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27640-27170-tilleul_dame_agnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27640-27170-tilleul_dame_agnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27641-27110-le_tilleul_lambert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27641-27110-le_tilleul_lambert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27641-27110-le_tilleul_lambert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27641-27110-le_tilleul_lambert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27643-27570-tillieres_sur_avre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27643-27570-tillieres_sur_avre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27643-27570-tillieres_sur_avre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27643-27570-tillieres_sur_avre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27644-27510-tilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27644-27510-tilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27644-27510-tilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27644-27510-tilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27645-27500-tocqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27645-27500-tocqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27645-27500-tocqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27645-27500-tocqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27646-27210-le_torpt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27646-27210-le_torpt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27646-27210-le_torpt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27646-27210-le_torpt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27649-27440-touffreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27649-27440-touffreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27649-27440-touffreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27649-27440-touffreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27650-27180-tournedos_bois_hubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27650-27180-tournedos_bois_hubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27650-27180-tournedos_bois_hubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27650-27180-tournedos_bois_hubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27652-27930-tourneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27652-27930-tourneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27652-27930-tourneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27652-27930-tourneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27654-27370-tourville_la_campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27654-27370-tourville_la_campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27654-27370-tourville_la_campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27654-27370-tourville_la_campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27655-27500-tourville_sur_pont_audemer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27655-27500-tourville_sur_pont_audemer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27655-27500-tourville_sur_pont_audemer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27655-27500-tourville_sur_pont_audemer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27656-27500-toutainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27656-27500-toutainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27656-27500-toutainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27656-27500-toutainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27658-27110-le_tremblay_omonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27658-27110-le_tremblay_omonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27658-27110-le_tremblay_omonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27658-27110-le_tremblay_omonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27659-27930-la_trinite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27659-27930-la_trinite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27659-27930-la_trinite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27659-27930-la_trinite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27660-27270-la_trinite_de_reville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27660-27270-la_trinite_de_reville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27660-27270-la_trinite_de_reville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27660-27270-la_trinite_de_reville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27661-27310-la_trinite_de_thouberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27661-27310-la_trinite_de_thouberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27661-27310-la_trinite_de_thouberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27661-27310-la_trinite_de_thouberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27662-27500-triqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27662-27500-triqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27662-27500-triqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27662-27500-triqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27663-27110-le_troncq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27663-27110-le_troncq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27663-27110-le_troncq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27663-27110-le_troncq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27664-27480-le_tronquay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27664-27480-le_tronquay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27664-27480-le_tronquay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27664-27480-le_tronquay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27665-27680-trouville_la_haule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27665-27680-trouville_la_haule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27665-27680-trouville_la_haule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27665-27680-trouville_la_haule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27666-27400-la_vacherie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27666-27400-la_vacherie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27666-27400-la_vacherie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27666-27400-la_vacherie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27667-27300-valailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27667-27300-valailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27667-27300-valailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27667-27300-valailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27668-27120-le_val_david/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27668-27120-le_val_david/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27668-27120-le_val_david/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27668-27120-le_val_david/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27669-27350-valletot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27669-27350-valletot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27669-27350-valletot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27669-27350-valletot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27670-27380-vandrimare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27670-27380-vandrimare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27670-27380-vandrimare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27670-27380-vandrimare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27671-27210-vannecrocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27671-27210-vannecrocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27671-27210-vannecrocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27671-27210-vannecrocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27672-27910-vascoeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27672-27910-vascoeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27672-27910-vascoeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27672-27910-vascoeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27673-27430-vatteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27673-27430-vatteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27673-27430-vatteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27673-27430-vatteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27674-27120-vaux_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27674-27120-vaux_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27674-27120-vaux_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27674-27120-vaux_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27676-27940-les_trois_lacs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27676-27940-les_trois_lacs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27676-27940-les_trois_lacs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27676-27940-les_trois_lacs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27676-27700-les_trois_lacs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27676-27700-les_trois_lacs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27676-27700-les_trois_lacs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27676-27700-les_trois_lacs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27677-27110-venon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27677-27110-venon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27677-27110-venon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27677-27110-venon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27678-27180-les_ventes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27678-27180-les_ventes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27678-27180-les_ventes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27678-27180-les_ventes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27679-27130-verneuil_d_avre_et_d_iton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27679-27130-verneuil_d_avre_et_d_iton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27679-27130-verneuil_d_avre_et_d_iton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27679-27130-verneuil_d_avre_et_d_iton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27679-27160-verneuil_d_avre_et_d_iton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27679-27160-verneuil_d_avre_et_d_iton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27679-27160-verneuil_d_avre_et_d_iton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27679-27160-verneuil_d_avre_et_d_iton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27680-27390-verneusses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27680-27390-verneusses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27680-27390-verneusses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27680-27390-verneusses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27681-27200-vernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27681-27200-vernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27681-27200-vernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27681-27200-vernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27682-27870-vesly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27682-27870-vesly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27682-27870-vesly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27682-27870-vesly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27683-27700-vezillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27683-27700-vezillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27683-27700-vezillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27683-27700-vezillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27684-27930-le_vieil_evreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27684-27930-le_vieil_evreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27684-27930-le_vieil_evreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27684-27930-le_vieil_evreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27685-27330-la_vieille_lyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27685-27330-la_vieille_lyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27685-27330-la_vieille_lyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27685-27330-la_vieille_lyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27686-27680-vieux_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27686-27680-vieux_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27686-27680-vieux_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27686-27680-vieux_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27689-27120-villegats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27689-27120-villegats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27689-27120-villegats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27689-27120-villegats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27690-27420-villers_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27690-27420-villers_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27690-27420-villers_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27690-27420-villers_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27691-27940-villers_sur_le_roule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27691-27940-villers_sur_le_roule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27691-27940-villers_sur_le_roule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27691-27940-villers_sur_le_roule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27692-27110-villettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27692-27110-villettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27692-27110-villettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27692-27110-villettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27693-27240-sylvains_les_moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27693-27240-sylvains_les_moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27693-27240-sylvains_les_moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27693-27240-sylvains_les_moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27694-27950-villez_sous_bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27694-27950-villez_sous_bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27694-27950-villez_sous_bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27694-27950-villez_sous_bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27695-27110-villez_sur_le_neubourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27695-27110-villez_sur_le_neubourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27695-27110-villez_sur_le_neubourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27695-27110-villez_sur_le_neubourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27696-27640-villiers_en_desoeuvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27696-27640-villiers_en_desoeuvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27696-27640-villiers_en_desoeuvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27696-27640-villiers_en_desoeuvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27697-27400-vironvay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27697-27400-vironvay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27697-27400-vironvay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27697-27400-vironvay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27698-27110-vitot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27698-27110-vitot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27698-27110-vitot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27698-27110-vitot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27699-27520-voiscreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27699-27520-voiscreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27699-27520-voiscreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27699-27520-voiscreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27700-27370-vraiville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27700-27370-vraiville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27700-27370-vraiville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27700-27370-vraiville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27701-27100-val_de_reuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27701-27100-val_de_reuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27701-27100-val_de_reuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt27-eure/commune27701-27100-val_de_reuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-28.xml
+++ b/public/sitemaps/sitemap-28.xml
@@ -5,746 +5,1488 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28001-28410-abondant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28001-28410-abondant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28001-28410-abondant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28001-28410-abondant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28003-28500-allainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28003-28500-allainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28003-28500-allainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28003-28500-allainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28004-28150-allonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28004-28150-allonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28004-28150-allonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28004-28150-allonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28005-28800-alluyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28005-28800-alluyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28005-28800-alluyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28005-28800-alluyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28006-28300-amilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28006-28300-amilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28006-28300-amilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28006-28300-amilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28007-28260-anet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28007-28260-anet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28007-28260-anet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28007-28260-anet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28008-28170-ardelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28008-28170-ardelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28008-28170-ardelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28008-28170-ardelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28009-28700-ardelu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28009-28700-ardelu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28009-28700-ardelu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28009-28700-ardelu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28010-28480-argenvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28010-28480-argenvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28010-28480-argenvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28010-28480-argenvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28012-28290-commune_nouvelle_d_arrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28012-28290-commune_nouvelle_d_arrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28012-28290-commune_nouvelle_d_arrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28012-28290-commune_nouvelle_d_arrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28012-28220-commune_nouvelle_d_arrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28012-28220-commune_nouvelle_d_arrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28012-28220-commune_nouvelle_d_arrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28012-28220-commune_nouvelle_d_arrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28013-28700-aunay_sous_auneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28013-28700-aunay_sous_auneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28013-28700-aunay_sous_auneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28013-28700-aunay_sous_auneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28014-28500-aunay_sous_crecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28014-28500-aunay_sous_crecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28014-28500-aunay_sous_crecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28014-28500-aunay_sous_crecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28015-28700-auneau_bleury_saint_symphorien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28015-28700-auneau_bleury_saint_symphorien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28015-28700-auneau_bleury_saint_symphorien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28015-28700-auneau_bleury_saint_symphorien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28016-28330-les_autels_villevillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28016-28330-les_autels_villevillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28016-28330-les_autels_villevillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28016-28330-les_autels_villevillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28018-28330-authon_du_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28018-28330-authon_du_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28018-28330-authon_du_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28018-28330-authon_du_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28019-28140-baigneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28019-28140-baigneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28019-28140-baigneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28019-28140-baigneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28021-28120-bailleau_le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28021-28120-bailleau_le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28021-28120-bailleau_le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28021-28120-bailleau_le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28022-28300-bailleau_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28022-28300-bailleau_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28022-28300-bailleau_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28022-28300-bailleau_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28023-28320-bailleau_armenonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28023-28320-bailleau_armenonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28023-28320-bailleau_armenonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28023-28320-bailleau_armenonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28024-28630-barjouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28024-28630-barjouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28024-28630-barjouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28024-28630-barjouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28025-28310-barmainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28025-28310-barmainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28025-28310-barmainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28025-28310-barmainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28026-28310-baudreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28026-28310-baudreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28026-28310-baudreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28026-28310-baudreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28027-28330-la_bazoche_gouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28027-28330-la_bazoche_gouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28027-28330-la_bazoche_gouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28027-28330-la_bazoche_gouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28028-28140-bazoches_en_dunois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28028-28140-bazoches_en_dunois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28028-28140-bazoches_en_dunois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28028-28140-bazoches_en_dunois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28029-28140-bazoches_les_hautes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28029-28140-bazoches_les_hautes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28029-28140-bazoches_les_hautes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28029-28140-bazoches_les_hautes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28030-28270-beauche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28030-28270-beauche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28030-28270-beauche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28030-28270-beauche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28031-28480-beaumont_les_autels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28031-28480-beaumont_les_autels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28031-28480-beaumont_les_autels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28031-28480-beaumont_les_autels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28032-28150-beauvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28032-28150-beauvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28032-28150-beauvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28032-28150-beauvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28033-28240-belhomert_guehouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28033-28240-belhomert_guehouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28033-28240-belhomert_guehouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28033-28240-belhomert_guehouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28034-28300-bercheres_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28034-28300-bercheres_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28034-28300-bercheres_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28034-28300-bercheres_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28035-28630-bercheres_les_pierres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28035-28630-bercheres_les_pierres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28035-28630-bercheres_les_pierres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28035-28630-bercheres_les_pierres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28036-28260-bercheres_sur_vesgre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28036-28260-bercheres_sur_vesgre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28036-28260-bercheres_sur_vesgre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28036-28260-bercheres_sur_vesgre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28037-28270-berou_la_mulotiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28037-28270-berou_la_mulotiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28037-28270-berou_la_mulotiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28037-28270-berou_la_mulotiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28038-28330-bethonvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28038-28330-bethonvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28038-28330-bethonvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28038-28330-bethonvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28039-28700-beville_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28039-28700-beville_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28039-28700-beville_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28039-28700-beville_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28040-28190-billancelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28040-28190-billancelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28040-28190-billancelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28040-28190-billancelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28041-28120-blandainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28041-28120-blandainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28041-28120-blandainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28041-28120-blandainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28045-28500-boissy_en_drouais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28045-28500-boissy_en_drouais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28045-28500-boissy_en_drouais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28045-28500-boissy_en_drouais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28046-28340-boissy_les_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28046-28340-boissy_les_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28046-28340-boissy_les_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28046-28340-boissy_les_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28047-28150-boisville_la_saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28047-28150-boisville_la_saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28047-28150-boisville_la_saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28047-28150-boisville_la_saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28048-28360-la_bourdiniere_saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28048-28360-la_bourdiniere_saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28048-28360-la_bourdiniere_saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28048-28360-la_bourdiniere_saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28049-28150-bonce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28049-28150-bonce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28049-28150-bonce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28049-28150-bonce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28050-28260-boncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28050-28260-boncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28050-28260-boncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28050-28260-boncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28051-28800-bonneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28051-28800-bonneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28051-28800-bonneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28051-28800-bonneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28052-28130-bouglainval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28052-28130-bouglainval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28052-28130-bouglainval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28052-28130-bouglainval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28053-28170-le_boullay_les_deux_eglises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28053-28170-le_boullay_les_deux_eglises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28053-28170-le_boullay_les_deux_eglises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28053-28170-le_boullay_les_deux_eglises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28054-28210-le_boullay_mivoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28054-28210-le_boullay_mivoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28054-28210-le_boullay_mivoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28054-28210-le_boullay_mivoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28055-28210-le_boullay_thierry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28055-28210-le_boullay_thierry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28055-28210-le_boullay_thierry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28055-28210-le_boullay_thierry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28056-28410-boutigny_prouais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28056-28410-boutigny_prouais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28056-28410-boutigny_prouais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28056-28410-boutigny_prouais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28057-28800-bouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28057-28800-bouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28057-28800-bouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28057-28800-bouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28058-28210-brechamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28058-28210-brechamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28058-28210-brechamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28058-28210-brechamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28059-28270-brezolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28059-28270-brezolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28059-28270-brezolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28059-28270-brezolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28060-28300-briconville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28060-28300-briconville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28060-28300-briconville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28060-28300-briconville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28061-28160-brou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28061-28160-brou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28061-28160-brou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28061-28160-brou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28062-28410-broue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28062-28410-broue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28062-28410-broue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28062-28410-broue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28064-28410-bu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28064-28410-bu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28064-28410-bu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28064-28410-bu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28065-28800-bullainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28065-28800-bullainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28065-28800-bullainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28065-28800-bullainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28067-28120-cernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28067-28120-cernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28067-28120-cernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28067-28120-cernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28068-28300-challet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28068-28300-challet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28068-28300-challet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28068-28300-challet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28070-28300-champhol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28070-28300-champhol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28070-28300-champhol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28070-28300-champhol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28071-28240-champrond_en_gatine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28071-28240-champrond_en_gatine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28071-28240-champrond_en_gatine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28071-28240-champrond_en_gatine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28072-28400-champrond_en_perchet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28072-28400-champrond_en_perchet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28072-28400-champrond_en_perchet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28072-28400-champrond_en_perchet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28073-28700-champseru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28073-28700-champseru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28073-28700-champseru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28073-28700-champseru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28074-28700-la_chapelle_d_aunainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28074-28700-la_chapelle_d_aunainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28074-28700-la_chapelle_d_aunainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28074-28700-la_chapelle_d_aunainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28075-28200-la_chapelle_du_noyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28075-28200-la_chapelle_du_noyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28075-28200-la_chapelle_du_noyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28075-28200-la_chapelle_du_noyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28076-28500-la_chapelle_forainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28076-28500-la_chapelle_forainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28076-28500-la_chapelle_forainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28076-28500-la_chapelle_forainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28077-28340-la_chapelle_fortin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28077-28340-la_chapelle_fortin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28077-28340-la_chapelle_fortin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28077-28340-la_chapelle_fortin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28078-28330-chapelle_guillaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28078-28330-chapelle_guillaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28078-28330-chapelle_guillaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28078-28330-chapelle_guillaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28079-28290-chapelle_royale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28079-28290-chapelle_royale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28079-28290-chapelle_royale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28079-28290-chapelle_royale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28080-28330-charbonnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28080-28330-charbonnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28080-28330-charbonnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28080-28330-charbonnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28081-28120-charonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28081-28120-charonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28081-28120-charonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28081-28120-charonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28082-28500-charpont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28082-28500-charpont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28082-28500-charpont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28082-28500-charpont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28084-28130-chartainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28084-28130-chartainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28084-28130-chartainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28084-28130-chartainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28085-28000-chartres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28085-28000-chartres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28085-28000-chartres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28085-28000-chartres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28086-28480-chassant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28086-28480-chassant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28086-28480-chassant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28086-28480-chassant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28087-28270-chataincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28087-28270-chataincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28087-28270-chataincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28087-28270-chataincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28088-28200-chateaudun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28088-28200-chateaudun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28088-28200-chateaudun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28088-28200-chateaudun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28089-28170-chateauneuf_en_thymerais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28089-28170-chateauneuf_en_thymerais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28089-28170-chateauneuf_en_thymerais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28089-28170-chateauneuf_en_thymerais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28090-28270-les_chatelets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28090-28270-les_chatelets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28090-28270-les_chatelets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28090-28270-les_chatelets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28091-28120-les_chatelliers_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28091-28120-les_chatelliers_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28091-28120-les_chatelliers_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28091-28120-les_chatelliers_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28092-28700-chatenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28092-28700-chatenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28092-28700-chatenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28092-28700-chatenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28094-28210-chaudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28094-28210-chaudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28094-28210-chaudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28094-28210-chaudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28095-28120-chauffours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28095-28120-chauffours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28095-28120-chauffours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28095-28120-chauffours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28096-28260-la_chaussee_d_ivry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28096-28260-la_chaussee_d_ivry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28096-28260-la_chaussee_d_ivry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28096-28260-la_chaussee_d_ivry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28098-28500-cherisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28098-28500-cherisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28098-28500-cherisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28098-28500-cherisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28099-28190-chuisnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28099-28190-chuisnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28099-28190-chuisnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28099-28190-chuisnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28100-28300-cintray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28100-28300-cintray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28100-28300-cintray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28100-28300-cintray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28102-28300-clevilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28102-28300-clevilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28102-28300-clevilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28102-28300-clevilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28103-28220-cloyes_les_trois_rivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28103-28220-cloyes_les_trois_rivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28103-28220-cloyes_les_trois_rivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28103-28220-cloyes_les_trois_rivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28104-28300-coltainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28104-28300-coltainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28104-28300-coltainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28104-28300-coltainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28105-28480-combres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28105-28480-combres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28105-28480-combres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28105-28480-combres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28106-28200-conie_molitard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28106-28200-conie_molitard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28106-28200-conie_molitard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28106-28200-conie_molitard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28107-28630-corancez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28107-28630-corancez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28107-28630-corancez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28107-28630-corancez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28108-28140-cormainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28108-28140-cormainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28108-28140-cormainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28108-28140-cormainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28109-28240-les_corvees_les_yys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28109-28240-les_corvees_les_yys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28109-28240-les_corvees_les_yys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28109-28240-les_corvees_les_yys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28110-28630-le_coudray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28110-28630-le_coudray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28110-28630-le_coudray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28110-28630-le_coudray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28111-28330-coudray_au_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28111-28330-coudray_au_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28111-28330-coudray_au_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28111-28330-coudray_au_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28113-28210-coulombs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28113-28210-coulombs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28113-28210-coulombs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28113-28210-coulombs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28114-28140-courbehaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28114-28140-courbehaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28114-28140-courbehaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28114-28140-courbehaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28116-28190-courville_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28116-28190-courville_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28116-28190-courville_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28116-28190-courville_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28117-28500-crecy_couve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28117-28500-crecy_couve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28117-28500-crecy_couve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28117-28500-crecy_couve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28118-28210-croisilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28118-28210-croisilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28118-28210-croisilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28118-28210-croisilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28119-28480-la_croix_du_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28119-28480-la_croix_du_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28119-28480-la_croix_du_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28119-28480-la_croix_du_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28120-28270-crucey_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28120-28270-crucey_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28120-28270-crucey_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28120-28270-crucey_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28121-28140-dambron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28121-28140-dambron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28121-28140-dambron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28121-28140-dambron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28122-28360-dammarie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28122-28360-dammarie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28122-28360-dammarie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28122-28360-dammarie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28123-28160-dampierre_sous_brou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28123-28160-dampierre_sous_brou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28123-28160-dampierre_sous_brou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28123-28160-dampierre_sous_brou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28124-28350-dampierre_sur_avre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28124-28350-dampierre_sur_avre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28124-28350-dampierre_sur_avre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28124-28350-dampierre_sur_avre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28126-28800-dancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28126-28800-dancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28126-28800-dancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28126-28800-dancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28127-28160-dangeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28127-28160-dangeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28127-28160-dangeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28127-28160-dangeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28128-28190-dangers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28128-28190-dangers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28128-28190-dangers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28128-28190-dangers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28129-28700-denonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28129-28700-denonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28129-28700-denonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28129-28700-denonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28130-28250-digny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28130-28250-digny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28130-28250-digny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28130-28250-digny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28132-28200-donnemain_saint_mames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28132-28200-donnemain_saint_mames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28132-28200-donnemain_saint_mames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28132-28200-donnemain_saint_mames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28134-28100-dreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28134-28100-dreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28134-28100-dreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28134-28100-dreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28135-28230-droue_sur_drouette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28135-28230-droue_sur_drouette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28135-28230-droue_sur_drouette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28135-28230-droue_sur_drouette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28136-28500-ecluzelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28136-28500-ecluzelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28136-28500-ecluzelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28136-28500-ecluzelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28137-28320-ecrosnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28137-28320-ecrosnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28137-28320-ecrosnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28137-28320-ecrosnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28139-28120-epeautrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28139-28120-epeautrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28139-28120-epeautrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28139-28120-epeautrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28140-28230-epernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28140-28230-epernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28140-28230-epernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28140-28230-epernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28141-28120-ermenonville_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28141-28120-ermenonville_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28141-28120-ermenonville_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28141-28120-ermenonville_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28142-28120-ermenonville_la_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28142-28120-ermenonville_la_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28142-28120-ermenonville_la_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28142-28120-ermenonville_la_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28143-28270-escorpain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28143-28270-escorpain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28143-28270-escorpain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28143-28270-escorpain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28144-28330-les_etilleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28144-28330-les_etilleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28144-28330-les_etilleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28144-28330-les_etilleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28146-28210-faverolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28146-28210-faverolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28146-28210-faverolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28146-28210-faverolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28147-28170-favieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28147-28170-favieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28147-28170-favieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28147-28170-favieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28148-28190-le_favril/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28148-28190-le_favril/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28148-28190-le_favril/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28148-28190-le_favril/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28149-28340-la_ferte_vidame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28149-28340-la_ferte_vidame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28149-28340-la_ferte_vidame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28149-28340-la_ferte_vidame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28151-28270-fessanvilliers_mattanvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28151-28270-fessanvilliers_mattanvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28151-28270-fessanvilliers_mattanvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28151-28270-fessanvilliers_mattanvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28153-28800-flacey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28153-28800-flacey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28153-28800-flacey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28153-28800-flacey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28154-28190-fontaine_la_guyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28154-28190-fontaine_la_guyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28154-28190-fontaine_la_guyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28154-28190-fontaine_la_guyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28155-28170-fontaine_les_ribouts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28155-28170-fontaine_les_ribouts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28155-28170-fontaine_les_ribouts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28155-28170-fontaine_les_ribouts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28156-28240-fontaine_simon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28156-28240-fontaine_simon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28156-28240-fontaine_simon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28156-28240-fontaine_simon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28157-28140-fontenay_sur_conie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28157-28140-fontenay_sur_conie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28157-28140-fontenay_sur_conie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28157-28140-fontenay_sur_conie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28158-28630-fontenay_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28158-28630-fontenay_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28158-28630-fontenay_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28158-28630-fontenay_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28159-28250-la_framboisiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28159-28250-la_framboisiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28159-28250-la_framboisiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28159-28250-la_framboisiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28160-28700-francourville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28160-28700-francourville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28160-28700-francourville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28160-28700-francourville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28161-28160-fraze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28161-28160-fraze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28161-28160-fraze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28161-28160-fraze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28162-28360-fresnay_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28162-28360-fresnay_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28162-28360-fresnay_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28162-28360-fresnay_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28163-28300-fresnay_le_gilmert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28163-28300-fresnay_le_gilmert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28163-28300-fresnay_le_gilmert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28163-28300-fresnay_le_gilmert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28164-28310-fresnay_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28164-28310-fresnay_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28164-28310-fresnay_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28164-28310-fresnay_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28166-28240-friaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28166-28240-friaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28166-28240-friaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28166-28240-friaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28167-28190-frunce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28167-28190-frunce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28167-28190-frunce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28167-28190-frunce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28168-28320-gallardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28168-28320-gallardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28168-28320-gallardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28168-28320-gallardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28169-28700-garancieres_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28169-28700-garancieres_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28169-28700-garancieres_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28169-28700-garancieres_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28170-28500-garancieres_en_drouais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28170-28500-garancieres_en_drouais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28170-28500-garancieres_en_drouais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28170-28500-garancieres_en_drouais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28171-28500-garnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28171-28500-garnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28171-28500-garnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28171-28500-garnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28172-28320-gas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28172-28320-gas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28172-28320-gas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28172-28320-gas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28173-28300-gasville_oiseme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28173-28300-gasville_oiseme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28173-28300-gasville_oiseme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28173-28300-gasville_oiseme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28175-28400-la_gaudaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28175-28400-la_gaudaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28175-28400-la_gaudaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28175-28400-la_gaudaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28176-28800-le_gault_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28176-28800-le_gault_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28176-28800-le_gault_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28176-28800-le_gault_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28177-28630-gellainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28177-28630-gellainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28177-28630-gellainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28177-28630-gellainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28178-28500-germainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28178-28500-germainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28178-28500-germainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28178-28500-germainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28180-28260-gilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28180-28260-gilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28180-28260-gilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28180-28260-gilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28182-28160-gohory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28182-28160-gohory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28182-28160-gohory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28182-28160-gohory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28183-28310-gommerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28183-28310-gommerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28183-28310-gommerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28183-28310-gommerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28183-28700-gommerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28183-28700-gommerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28183-28700-gommerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28183-28700-gommerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28184-28310-gouillons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28184-28310-gouillons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28184-28310-gouillons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28184-28310-gouillons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28185-28410-goussainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28185-28410-goussainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28185-28410-goussainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28185-28410-goussainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28187-28260-guainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28187-28260-guainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28187-28260-guainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28187-28260-guainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28188-28700-le_gue_de_longroi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28188-28700-le_gue_de_longroi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28188-28700-le_gue_de_longroi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28188-28700-le_gue_de_longroi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28189-28310-guilleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28189-28310-guilleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28189-28310-guilleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28189-28310-guilleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28190-28140-guillonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28190-28140-guillonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28190-28140-guillonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28190-28140-guillonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28191-28130-hanches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28191-28130-hanches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28191-28130-hanches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28191-28130-hanches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28192-28480-happonvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28192-28480-happonvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28192-28480-happonvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28192-28480-happonvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28193-28410-havelu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28193-28410-havelu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28193-28410-havelu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28193-28410-havelu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28194-28700-houville_la_branche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28194-28700-houville_la_branche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28194-28700-houville_la_branche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28194-28700-houville_la_branche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28195-28130-houx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28195-28130-houx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28195-28130-houx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28195-28130-houx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28196-28120-illiers_combray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28196-28120-illiers_combray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28196-28120-illiers_combray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28196-28120-illiers_combray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28197-28310-intreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28197-28310-intreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28197-28310-intreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28197-28310-intreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28198-28200-jallans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28198-28200-jallans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28198-28200-jallans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28198-28200-jallans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28199-28310-janville_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28199-28310-janville_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28199-28310-janville_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28199-28310-janville_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28200-28250-jaudrais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28200-28250-jaudrais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28200-28250-jaudrais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28200-28250-jaudrais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28201-28300-jouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28201-28300-jouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28201-28300-jouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28201-28300-jouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28202-28340-lamblore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28202-28340-lamblore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28202-28340-lamblore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28202-28340-lamblore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28203-28190-landelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28203-28190-landelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28203-28190-landelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28203-28190-landelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28206-28270-laons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28206-28270-laons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28206-28270-laons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28206-28270-laons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28207-28700-lethuin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28207-28700-lethuin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28207-28700-lethuin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28207-28700-lethuin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28208-28700-levainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28208-28700-levainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28208-28700-levainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28208-28700-levainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28209-28300-leves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28209-28300-leves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28209-28300-leves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28209-28300-leves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28210-28310-levesville_la_chenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28210-28310-levesville_la_chenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28210-28310-levesville_la_chenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28210-28310-levesville_la_chenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28211-28200-logron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28211-28200-logron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28211-28200-logron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28211-28200-logron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28212-28140-loigny_la_bataille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28212-28140-loigny_la_bataille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28212-28140-loigny_la_bataille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28212-28140-loigny_la_bataille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28213-28210-lormaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28213-28210-lormaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28213-28210-lormaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28213-28210-lormaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28214-28240-la_loupe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28214-28240-la_loupe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28214-28240-la_loupe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28214-28240-la_loupe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28215-28150-louville_la_chenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28215-28150-louville_la_chenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28215-28150-louville_la_chenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28215-28150-louville_la_chenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28216-28500-louvilliers_en_drouais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28216-28500-louvilliers_en_drouais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28216-28500-louvilliers_en_drouais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28216-28500-louvilliers_en_drouais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28217-28250-louvilliers_les_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28217-28250-louvilliers_les_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28217-28250-louvilliers_les_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28217-28250-louvilliers_les_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28218-28110-luce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28218-28110-luce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28218-28110-luce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28218-28110-luce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28219-28480-luigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28219-28480-luigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28219-28480-luigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28219-28480-luigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28219-28160-luigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28219-28160-luigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28219-28160-luigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28219-28160-luigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28220-28600-luisant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28220-28600-luisant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28220-28600-luisant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28220-28600-luisant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28221-28140-lumeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28221-28140-lumeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28221-28140-lumeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28221-28140-lumeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28222-28360-luplante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28222-28360-luplante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28222-28360-luplante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28222-28360-luplante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28223-28500-luray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28223-28500-luray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28223-28500-luray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28223-28500-luray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28225-28120-magny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28225-28120-magny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28225-28120-magny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28225-28120-magny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28226-28170-maillebois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28226-28170-maillebois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28226-28170-maillebois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28226-28170-maillebois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28227-28130-maintenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28227-28130-maintenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28227-28130-maintenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28227-28130-maintenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28229-28300-mainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28229-28300-mainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28229-28300-mainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28229-28300-mainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28230-28700-maisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28230-28700-maisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28230-28700-maisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28230-28700-maisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28231-28270-la_manceliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28231-28270-la_manceliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28231-28270-la_manceliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28231-28270-la_manceliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28232-28240-manou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28232-28240-manou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28232-28240-manou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28232-28240-manou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28233-28200-marboue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28233-28200-marboue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28233-28200-marboue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28233-28200-marboue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28234-28120-marcheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28234-28120-marcheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28234-28120-marcheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28234-28120-marcheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28235-28410-marchezais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28235-28410-marchezais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28235-28410-marchezais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28235-28410-marchezais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28236-28400-arcisses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28236-28400-arcisses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28236-28400-arcisses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28236-28400-arcisses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28237-28400-marolles_les_buis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28237-28400-marolles_les_buis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28237-28400-marolles_les_buis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28237-28400-marolles_les_buis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28239-28500-marville_moutiers_brule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28239-28500-marville_moutiers_brule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28239-28500-marville_moutiers_brule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28239-28500-marville_moutiers_brule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28240-28240-meauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28240-28240-meauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28240-28240-meauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28240-28240-meauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28242-28120-mereglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28242-28120-mereglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28242-28120-mereglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28242-28120-mereglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28243-28310-merouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28243-28310-merouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28243-28310-merouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28243-28310-merouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28245-28120-meslay_le_grenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28245-28120-meslay_le_grenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28245-28120-meslay_le_grenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28245-28120-meslay_le_grenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28246-28360-meslay_le_vidame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28246-28360-meslay_le_vidame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28246-28360-meslay_le_vidame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28246-28360-meslay_le_vidame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28247-28260-le_mesnil_simon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28247-28260-le_mesnil_simon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28247-28260-le_mesnil_simon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28247-28260-le_mesnil_simon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28248-28250-le_mesnil_thomas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28248-28250-le_mesnil_thomas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28248-28250-le_mesnil_thomas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28248-28250-le_mesnil_thomas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28249-28130-mevoisins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28249-28130-mevoisins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28249-28130-mevoisins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28249-28130-mevoisins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28251-28500-mezieres_en_drouais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28251-28500-mezieres_en_drouais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28251-28500-mezieres_en_drouais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28251-28500-mezieres_en_drouais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28252-28480-miermaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28252-28480-miermaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28252-28480-miermaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28252-28480-miermaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28253-28630-mignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28253-28630-mignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28253-28630-mignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28253-28630-mignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28254-28190-mittainvilliers_verigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28254-28190-mittainvilliers_verigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28254-28190-mittainvilliers_verigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28254-28190-mittainvilliers_verigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28255-28700-moinville_la_jeulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28255-28700-moinville_la_jeulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28255-28700-moinville_la_jeulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28255-28700-moinville_la_jeulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28256-28200-moleans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28256-28200-moleans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28256-28200-moleans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28256-28200-moleans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28257-28700-mondonville_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28257-28700-mondonville_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28257-28700-mondonville_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28257-28700-mondonville_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28259-28800-montboissier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28259-28800-montboissier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28259-28800-montboissier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28259-28800-montboissier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28260-28800-montharville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28260-28800-montharville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28260-28800-montharville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28260-28800-montharville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28261-28120-montigny_le_chartif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28261-28120-montigny_le_chartif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28261-28120-montigny_le_chartif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28261-28120-montigny_le_chartif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28263-28270-montigny_sur_avre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28263-28270-montigny_sur_avre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28263-28270-montigny_sur_avre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28263-28270-montigny_sur_avre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28264-28240-montireau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28264-28240-montireau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28264-28240-montireau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28264-28240-montireau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28265-28240-montlandon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28265-28240-montlandon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28265-28240-montlandon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28265-28240-montlandon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28267-28500-montreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28267-28500-montreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28267-28500-montreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28267-28500-montreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28268-28700-morainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28268-28700-morainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28268-28700-morainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28268-28700-morainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28269-28630-morancez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28269-28630-morancez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28269-28630-morancez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28269-28630-morancez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28270-28800-moriers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28270-28800-moriers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28270-28800-moriers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28270-28800-moriers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28271-28340-morvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28271-28340-morvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28271-28340-morvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28271-28340-morvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28272-28160-mottereau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28272-28160-mottereau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28272-28160-mottereau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28272-28160-mottereau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28273-28160-moulhard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28273-28160-moulhard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28273-28160-moulhard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28273-28160-moulhard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28274-28150-moutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28274-28150-moutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28274-28150-moutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28274-28150-moutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28275-28210-neron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28275-28210-neron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28275-28210-neron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28275-28210-neron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28276-28310-neuvy_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28276-28310-neuvy_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28276-28310-neuvy_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28276-28310-neuvy_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28277-28800-neuvy_en_dunois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28277-28800-neuvy_en_dunois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28277-28800-neuvy_en_dunois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28277-28800-neuvy_en_dunois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28278-28630-nogent_le_phaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28278-28630-nogent_le_phaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28278-28630-nogent_le_phaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28278-28630-nogent_le_phaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28279-28210-nogent_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28279-28210-nogent_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28279-28210-nogent_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28279-28210-nogent_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28280-28400-nogent_le_rotrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28280-28400-nogent_le_rotrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28280-28400-nogent_le_rotrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28280-28400-nogent_le_rotrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28281-28120-nogent_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28281-28120-nogent_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28281-28120-nogent_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28281-28120-nogent_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28282-28120-nonvilliers_grandhoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28282-28120-nonvilliers_grandhoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28282-28120-nonvilliers_grandhoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28282-28120-nonvilliers_grandhoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28283-28140-nottonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28283-28140-nottonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28283-28140-nottonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28283-28140-nottonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28284-28310-oinville_saint_liphard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28284-28310-oinville_saint_liphard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28284-28310-oinville_saint_liphard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28284-28310-oinville_saint_liphard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28285-28700-oinville_sous_auneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28285-28700-oinville_sous_auneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28285-28700-oinville_sous_auneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28285-28700-oinville_sous_auneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28286-28120-olle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28286-28120-olle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28286-28120-olle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28286-28120-olle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28287-28140-orgeres_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28287-28140-orgeres_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28287-28140-orgeres_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28287-28140-orgeres_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28289-28210-ormoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28289-28210-ormoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28289-28210-ormoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28289-28210-ormoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28290-28190-orrouer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28290-28190-orrouer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28290-28190-orrouer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28290-28190-orrouer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28291-28150-ouarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28291-28150-ouarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28291-28150-ouarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28291-28150-ouarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28292-28500-ouerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28292-28500-ouerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28292-28500-ouerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28292-28500-ouerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28293-28260-oulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28293-28260-oulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28293-28260-oulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28293-28260-oulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28294-28700-oysonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28294-28700-oysonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28294-28700-oysonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28294-28700-oysonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28296-28140-peronville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28296-28140-peronville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28296-28140-peronville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28296-28140-peronville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28298-28130-pierres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28298-28130-pierres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28298-28130-pierres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28298-28130-pierres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28299-28210-les_pinthieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28299-28210-les_pinthieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28299-28210-les_pinthieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28299-28210-les_pinthieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28300-28310-poinville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28300-28310-poinville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28300-28310-poinville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28300-28310-poinville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28301-28300-poisvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28301-28300-poisvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28301-28300-poisvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28301-28300-poisvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28302-28190-pontgouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28302-28190-pontgouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28302-28190-pontgouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28302-28190-pontgouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28303-28140-poupry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28303-28140-poupry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28303-28140-poupry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28303-28140-poupry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28304-28150-prasville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28304-28150-prasville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28304-28150-prasville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28304-28150-prasville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28305-28800-pre_saint_evroult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28305-28800-pre_saint_evroult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28305-28800-pre_saint_evroult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28305-28800-pre_saint_evroult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28306-28800-pre_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28306-28800-pre_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28306-28800-pre_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28306-28800-pre_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28308-28270-prudemanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28308-28270-prudemanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28308-28270-prudemanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28308-28270-prudemanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28309-28360-prunay_le_gillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28309-28360-prunay_le_gillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28309-28360-prunay_le_gillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28309-28360-prunay_le_gillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28310-28250-la_puisaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28310-28250-la_puisaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28310-28250-la_puisaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28310-28250-la_puisaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28312-28170-puiseux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28312-28170-puiseux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28312-28170-puiseux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28312-28170-puiseux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28313-28150-reclainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28313-28150-reclainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28313-28150-reclainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28313-28150-reclainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28314-28340-les_ressuintes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28314-28340-les_ressuintes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28314-28340-les_ressuintes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28314-28340-les_ressuintes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28315-28270-revercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28315-28270-revercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28315-28270-revercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28315-28270-revercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28316-28340-rohaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28316-28340-rohaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28316-28340-rohaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28316-28340-rohaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28317-28700-roinville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28317-28700-roinville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28317-28700-roinville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28317-28700-roinville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28319-28310-rouvray_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28319-28310-rouvray_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28319-28310-rouvray_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28319-28310-rouvray_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28321-28260-rouvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28321-28260-rouvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28321-28260-rouvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28321-28260-rouvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28322-28270-rueil_la_gadeliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28322-28270-rueil_la_gadeliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28322-28270-rueil_la_gadeliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28322-28270-rueil_la_gadeliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28323-28170-saint_ange_et_torcay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28323-28170-saint_ange_et_torcay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28323-28170-saint_ange_et_torcay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28323-28170-saint_ange_et_torcay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28324-28190-saint_arnoult_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28324-28190-saint_arnoult_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28324-28190-saint_arnoult_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28324-28190-saint_arnoult_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28325-28300-saint_aubin_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28325-28300-saint_aubin_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28325-28300-saint_aubin_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28325-28300-saint_aubin_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28326-28120-saint_avit_les_guespieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28326-28120-saint_avit_les_guespieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28326-28120-saint_avit_les_guespieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28326-28120-saint_avit_les_guespieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28327-28330-saint_bomer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28327-28330-saint_bomer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28327-28330-saint_bomer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28327-28330-saint_bomer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28329-28200-saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28329-28200-saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28329-28200-saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28329-28200-saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28330-28200-villemaury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28330-28200-villemaury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28330-28200-villemaury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28330-28200-villemaury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28331-28480-saintigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28331-28480-saintigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28331-28480-saintigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28331-28480-saintigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28332-28500-sainte_gemme_moronval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28332-28500-sainte_gemme_moronval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28332-28500-sainte_gemme_moronval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28332-28500-sainte_gemme_moronval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28333-28240-saint_denis_des_puits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28333-28240-saint_denis_des_puits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28333-28240-saint_denis_des_puits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28333-28240-saint_denis_des_puits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28334-28200-saint_denis_lanneray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28334-28200-saint_denis_lanneray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28334-28200-saint_denis_lanneray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28334-28200-saint_denis_lanneray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28335-28240-saint_eliph/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28335-28240-saint_eliph/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28335-28240-saint_eliph/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28335-28240-saint_eliph/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28336-28120-saint_eman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28336-28120-saint_eman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28336-28120-saint_eman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28336-28120-saint_eman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28337-28190-saint_georges_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28337-28190-saint_georges_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28337-28190-saint_georges_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28337-28190-saint_georges_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28339-28190-saint_germain_le_gaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28339-28190-saint_germain_le_gaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28339-28190-saint_germain_le_gaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28339-28190-saint_germain_le_gaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28341-28170-saint_jean_de_rebervilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28341-28170-saint_jean_de_rebervilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28341-28170-saint_jean_de_rebervilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28341-28170-saint_jean_de_rebervilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28342-28400-saint_jean_pierre_fixte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28342-28400-saint_jean_pierre_fixte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28342-28400-saint_jean_pierre_fixte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28342-28400-saint_jean_pierre_fixte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28343-28210-saint_laurent_la_gatine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28343-28210-saint_laurent_la_gatine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28343-28210-saint_laurent_la_gatine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28343-28210-saint_laurent_la_gatine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28344-28700-saint_leger_des_aubees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28344-28700-saint_leger_des_aubees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28344-28700-saint_leger_des_aubees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28344-28700-saint_leger_des_aubees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28346-28270-saint_lubin_de_cravant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28346-28270-saint_lubin_de_cravant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28346-28270-saint_lubin_de_cravant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28346-28270-saint_lubin_de_cravant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28347-28410-saint_lubin_de_la_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28347-28410-saint_lubin_de_la_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28347-28410-saint_lubin_de_la_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28347-28410-saint_lubin_de_la_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28348-28350-saint_lubin_des_joncherets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28348-28350-saint_lubin_des_joncherets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28348-28350-saint_lubin_des_joncherets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28348-28350-saint_lubin_des_joncherets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28349-28210-saint_lucien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28349-28210-saint_lucien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28349-28210-saint_lucien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28349-28210-saint_lucien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28350-28190-saint_luperce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28350-28190-saint_luperce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28350-28190-saint_luperce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28350-28190-saint_luperce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28351-28170-saint_maixme_hauterive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28351-28170-saint_maixme_hauterive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28351-28170-saint_maixme_hauterive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28351-28170-saint_maixme_hauterive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28352-28130-saint_martin_de_nigelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28352-28130-saint_martin_de_nigelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28352-28130-saint_martin_de_nigelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28352-28130-saint_martin_de_nigelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28353-28800-saint_maur_sur_le_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28353-28800-saint_maur_sur_le_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28353-28800-saint_maur_sur_le_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28353-28800-saint_maur_sur_le_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28354-28240-saint_maurice_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28354-28240-saint_maurice_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28354-28240-saint_maurice_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28354-28240-saint_maurice_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28355-28260-saint_ouen_marchefroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28355-28260-saint_ouen_marchefroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28355-28260-saint_ouen_marchefroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28355-28260-saint_ouen_marchefroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28357-28130-saint_piat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28357-28130-saint_piat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28357-28130-saint_piat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28357-28130-saint_piat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28358-28300-saint_prest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28358-28300-saint_prest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28358-28300-saint_prest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28358-28300-saint_prest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28359-28380-saint_remy_sur_avre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28359-28380-saint_remy_sur_avre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28359-28380-saint_remy_sur_avre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28359-28380-saint_remy_sur_avre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28360-28170-saint_sauveur_marville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28360-28170-saint_sauveur_marville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28360-28170-saint_sauveur_marville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28360-28170-saint_sauveur_marville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28362-28240-saint_victor_de_buthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28362-28240-saint_victor_de_buthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28362-28240-saint_victor_de_buthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28362-28240-saint_victor_de_buthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28363-28700-sainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28363-28700-sainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28363-28700-sainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28363-28700-sainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28364-28800-sancheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28364-28800-sancheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28364-28800-sancheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28364-28800-sancheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28365-28120-sandarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28365-28120-sandarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28365-28120-sandarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28365-28120-sandarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28366-28700-santeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28366-28700-santeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28366-28700-santeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28366-28700-santeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28367-28310-santilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28367-28310-santilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28367-28310-santilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28367-28310-santilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28368-28250-la_saucelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28368-28250-la_saucelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28368-28250-la_saucelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28368-28250-la_saucelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28369-28500-saulnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28369-28500-saulnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28369-28500-saulnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28369-28500-saulnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28370-28800-saumeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28370-28800-saumeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28370-28800-saumeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28370-28800-saumeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28371-28260-saussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28371-28260-saussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28371-28260-saussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28371-28260-saussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28372-28210-senantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28372-28210-senantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28372-28210-senantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28372-28210-senantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28373-28250-senonches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28373-28250-senonches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28373-28250-senonches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28373-28250-senonches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28374-28170-serazereux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28374-28170-serazereux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28374-28170-serazereux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28374-28170-serazereux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28375-28410-serville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28375-28410-serville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28375-28410-serville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28375-28410-serville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28377-28260-sorel_moussel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28377-28260-sorel_moussel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28377-28260-sorel_moussel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28377-28260-sorel_moussel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28378-28400-souance_au_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28378-28400-souance_au_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28378-28400-souance_au_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28378-28400-souance_au_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28379-28130-soulaires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28379-28130-soulaires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28379-28130-soulaires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28379-28130-soulaires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28380-28630-sours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28380-28630-sours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28380-28630-sours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28380-28630-sours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28382-28140-terminiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28382-28140-terminiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28382-28140-terminiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28382-28140-terminiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28383-28360-theuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28383-28360-theuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28383-28360-theuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28383-28360-theuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28383-28150-theuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28383-28150-theuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28383-28150-theuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28383-28150-theuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28385-28240-le_thieulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28385-28240-le_thieulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28385-28240-le_thieulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28385-28240-le_thieulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28386-28170-thimert_gatelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28386-28170-thimert_gatelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28386-28170-thimert_gatelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28386-28170-thimert_gatelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28387-28480-thiron_gardais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28387-28480-thiron_gardais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28387-28480-thiron_gardais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28387-28480-thiron_gardais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28388-28630-thivars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28388-28630-thivars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28388-28630-thivars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28388-28630-thivars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28389-28200-thiville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28389-28200-thiville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28389-28200-thiville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28389-28200-thiville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28390-28140-tillay_le_peneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28390-28140-tillay_le_peneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28390-28140-tillay_le_peneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28390-28140-tillay_le_peneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28391-28310-toury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28391-28310-toury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28391-28310-toury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28391-28310-toury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28392-28310-trancrainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28392-28310-trancrainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28392-28310-trancrainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28392-28310-trancrainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28393-28170-tremblay_les_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28393-28170-tremblay_les_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28393-28170-tremblay_les_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28393-28170-tremblay_les_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28394-28500-treon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28394-28500-treon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28394-28500-treon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28394-28500-treon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28395-28400-trizay_coutretot_saint_serge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28395-28400-trizay_coutretot_saint_serge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28395-28400-trizay_coutretot_saint_serge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28395-28400-trizay_coutretot_saint_serge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28396-28800-trizay_les_bonneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28396-28800-trizay_les_bonneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28396-28800-trizay_les_bonneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28396-28800-trizay_les_bonneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28397-28700-umpeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28397-28700-umpeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28397-28700-umpeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28397-28700-umpeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28398-28160-unverre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28398-28160-unverre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28398-28160-unverre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28398-28160-unverre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28400-28140-varize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28400-28140-varize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28400-28140-varize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28400-28140-varize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28401-28240-vaupillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28401-28240-vaupillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28401-28240-vaupillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28401-28240-vaupillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28403-28630-ver_les_chartres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28403-28630-ver_les_chartres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28403-28630-ver_les_chartres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28403-28630-ver_les_chartres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28404-28500-vernouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28404-28500-vernouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28404-28500-vernouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28404-28500-vernouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28405-28500-vert_en_drouais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28405-28500-vert_en_drouais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28405-28500-vert_en_drouais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28405-28500-vert_en_drouais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28406-28150-eole_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28406-28150-eole_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28406-28150-eole_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28406-28150-eole_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28406-28140-eole_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28406-28140-eole_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28406-28140-eole_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28406-28140-eole_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28407-28480-vicheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28407-28480-vicheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28407-28480-vicheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28407-28480-vicheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28408-28700-vierville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28408-28700-vierville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28408-28700-vierville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28408-28700-vierville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28409-28120-vieuvicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28409-28120-vieuvicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28409-28120-vieuvicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28409-28120-vieuvicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28410-28200-villampuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28410-28200-villampuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28410-28200-villampuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28410-28200-villampuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28411-28150-villars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28411-28150-villars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28411-28150-villars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28411-28150-villars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28414-28190-villebon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28414-28190-villebon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28414-28190-villebon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28414-28190-villebon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28415-28210-villemeux_sur_eure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28415-28210-villemeux_sur_eure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28415-28210-villemeux_sur_eure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28415-28210-villemeux_sur_eure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28417-28130-villiers_le_morhier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28417-28130-villiers_le_morhier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28417-28130-villiers_le_morhier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28417-28130-villiers_le_morhier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28418-28800-villiers_saint_orien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28418-28800-villiers_saint_orien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28418-28800-villiers_saint_orien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28418-28800-villiers_saint_orien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28419-28360-vitray_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28419-28360-vitray_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28419-28360-vitray_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28419-28360-vitray_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28421-28700-voise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28421-28700-voise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28421-28700-voise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28421-28700-voise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28422-28150-les_villages_voveens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28422-28150-les_villages_voveens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28422-28150-les_villages_voveens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28422-28150-les_villages_voveens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28423-28130-yermenonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28423-28130-yermenonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28423-28130-yermenonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28423-28130-yermenonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28424-28160-yevres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28424-28160-yevres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28424-28160-yevres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28424-28160-yevres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28425-28320-ymeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28425-28320-ymeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28425-28320-ymeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28425-28320-ymeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28426-28150-ymonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28426-28150-ymonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28426-28150-ymonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt28-eure_et_loir/commune28426-28150-ymonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-29.xml
+++ b/public/sitemaps/sitemap-29.xml
@@ -5,568 +5,1132 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29001-29560-argol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29001-29560-argol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29001-29560-argol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29001-29560-argol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29002-29300-arzano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29002-29300-arzano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29002-29300-arzano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29002-29300-arzano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29003-29770-audierne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29003-29770-audierne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29003-29770-audierne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29003-29770-audierne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29004-29380-bannalec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29004-29380-bannalec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29004-29380-bannalec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29004-29380-bannalec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29005-29300-baye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29005-29300-baye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29005-29300-baye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29005-29300-baye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29006-29950-benodet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29006-29950-benodet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29006-29950-benodet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29006-29950-benodet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29007-29690-berrien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29007-29690-berrien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29007-29690-berrien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29007-29690-berrien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29008-29790-beuzec_cap_sizun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29008-29790-beuzec_cap_sizun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29008-29790-beuzec_cap_sizun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29008-29790-beuzec_cap_sizun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29010-29400-bodilis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29010-29400-bodilis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29010-29400-bodilis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29010-29400-bodilis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29011-29820-bohars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29011-29820-bohars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29011-29820-bohars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29011-29820-bohars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29012-29640-bolazec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29012-29640-bolazec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29012-29640-bolazec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29012-29640-bolazec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29013-29690-botmeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29013-29690-botmeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29013-29690-botmeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29013-29690-botmeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29014-29650-botsorhel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29014-29650-botsorhel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29014-29650-botsorhel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29014-29650-botsorhel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29015-29860-bourg_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29015-29860-bourg_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29015-29860-bourg_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29015-29860-bourg_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29016-29190-brasparts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29016-29190-brasparts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29016-29190-brasparts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29016-29190-brasparts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29017-29810-breles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29017-29810-breles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29017-29810-breles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29017-29810-breles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29018-29690-brennilis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29018-29690-brennilis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29018-29690-brennilis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29018-29690-brennilis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29200-brest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29200-brest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29200-brest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29200-brest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29000-brest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29000-brest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29000-brest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29000-brest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29240-brest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29240-brest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29240-brest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29019-29240-brest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29020-29510-briec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29020-29510-briec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29020-29510-briec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29020-29510-briec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29021-29890-plouneour_brignogan_plages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29021-29890-plouneour_brignogan_plages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29021-29890-plouneour_brignogan_plages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29021-29890-plouneour_brignogan_plages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29022-29570-camaret_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29022-29570-camaret_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29022-29570-camaret_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29022-29570-camaret_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29023-29660-carantec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29023-29660-carantec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29023-29660-carantec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29023-29660-carantec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29024-29270-carhaix_plouguer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29024-29270-carhaix_plouguer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29024-29270-carhaix_plouguer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29024-29270-carhaix_plouguer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29025-29150-cast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29025-29150-cast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29025-29150-cast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29025-29150-cast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29026-29150-chateaulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29026-29150-chateaulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29026-29150-chateaulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29026-29150-chateaulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29027-29520-chateauneuf_du_faou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29027-29520-chateauneuf_du_faou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29027-29520-chateauneuf_du_faou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29027-29520-chateauneuf_du_faou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29028-29770-cleden_cap_sizun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29028-29770-cleden_cap_sizun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29028-29770-cleden_cap_sizun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29028-29770-cleden_cap_sizun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29029-29270-cleden_poher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29029-29270-cleden_poher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29029-29270-cleden_poher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29029-29270-cleden_poher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29030-29233-cleder/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29030-29233-cleder/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29030-29233-cleder/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29030-29233-cleder/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29031-29360-clohars_carnoet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29031-29360-clohars_carnoet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29031-29360-clohars_carnoet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29031-29360-clohars_carnoet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29032-29950-clohars_fouesnant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29032-29950-clohars_fouesnant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29032-29950-clohars_fouesnant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29032-29950-clohars_fouesnant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29033-29190-le_cloitre_pleyben/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29033-29190-le_cloitre_pleyben/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29033-29190-le_cloitre_pleyben/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29033-29190-le_cloitre_pleyben/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29034-29410-le_cloitre_saint_thegonnec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29034-29410-le_cloitre_saint_thegonnec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29034-29410-le_cloitre_saint_thegonnec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29034-29410-le_cloitre_saint_thegonnec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29035-29870-coat_meal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29035-29870-coat_meal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29035-29870-coat_meal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29035-29870-coat_meal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29036-29530-collorec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29036-29530-collorec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29036-29530-collorec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29036-29530-collorec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29037-29120-combrit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29037-29120-combrit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29037-29120-combrit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29037-29120-combrit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29038-29450-commana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29038-29450-commana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29038-29450-commana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29038-29450-commana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29039-29900-concarneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29039-29900-concarneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29039-29900-concarneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29039-29900-concarneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29040-29217-le_conquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29040-29217-le_conquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29040-29217-le_conquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29040-29217-le_conquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29041-29370-coray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29041-29370-coray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29041-29370-coray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29041-29370-coray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29042-29160-crozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29042-29160-crozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29042-29160-crozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29042-29160-crozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29043-29460-daoulas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29043-29460-daoulas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29043-29460-daoulas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29043-29460-daoulas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29044-29150-dineault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29044-29150-dineault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29044-29150-dineault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29044-29150-dineault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29045-29460-dirinon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29045-29460-dirinon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29045-29460-dirinon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29045-29460-dirinon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29046-29100-douarnenez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29046-29100-douarnenez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29046-29100-douarnenez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29046-29100-douarnenez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29047-29860-le_drennec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29047-29860-le_drennec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29047-29860-le_drennec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29047-29860-le_drennec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29048-29510-edern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29048-29510-edern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29048-29510-edern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29048-29510-edern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29049-29370-elliant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29049-29370-elliant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29049-29370-elliant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29049-29370-elliant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29051-29500-ergue_gaberic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29051-29500-ergue_gaberic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29051-29500-ergue_gaberic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29051-29500-ergue_gaberic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29053-29590-le_faou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29053-29590-le_faou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29053-29590-le_faou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29053-29590-le_faou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29054-29690-la_feuillee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29054-29690-la_feuillee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29054-29690-la_feuillee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29054-29690-la_feuillee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29055-29260-le_folgoet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29055-29260-le_folgoet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29055-29260-le_folgoet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29055-29260-le_folgoet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29056-29800-la_forest_landerneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29056-29800-la_forest_landerneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29056-29800-la_forest_landerneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29056-29800-la_forest_landerneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29057-29940-la_foret_fouesnant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29057-29940-la_foret_fouesnant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29057-29940-la_foret_fouesnant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29057-29940-la_foret_fouesnant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29058-29170-fouesnant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29058-29170-fouesnant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29058-29170-fouesnant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29058-29170-fouesnant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29059-29610-garlan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29059-29610-garlan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29059-29610-garlan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29059-29610-garlan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29060-29950-gouesnach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29060-29950-gouesnach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29060-29950-gouesnach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29060-29950-gouesnach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29061-29850-gouesnou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29061-29850-gouesnou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29061-29850-gouesnou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29061-29850-gouesnou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29062-29190-gouezec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29062-29190-gouezec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29062-29190-gouezec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29062-29190-gouezec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29063-29770-goulien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29063-29770-goulien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29063-29770-goulien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29063-29770-goulien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29064-29890-goulven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29064-29890-goulven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29064-29890-goulven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29064-29890-goulven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29065-29710-gourlizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29065-29710-gourlizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29065-29710-gourlizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29065-29710-gourlizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29066-29180-guengat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29066-29180-guengat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29066-29180-guengat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29066-29180-guengat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29067-29650-guerlesquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29067-29650-guerlesquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29067-29650-guerlesquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29067-29650-guerlesquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29068-29410-guiclan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29068-29410-guiclan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29068-29410-guiclan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29068-29410-guiclan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29069-29820-guilers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29069-29820-guilers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29069-29820-guilers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29069-29820-guilers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29070-29710-guiler_sur_goyen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29070-29710-guiler_sur_goyen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29070-29710-guiler_sur_goyen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29070-29710-guiler_sur_goyen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29071-29300-guilligomarc_h/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29071-29300-guilligomarc_h/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29071-29300-guilligomarc_h/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29071-29300-guilligomarc_h/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29072-29730-guilvinec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29072-29730-guilvinec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29072-29730-guilvinec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29072-29730-guilvinec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29073-29620-guimaec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29073-29620-guimaec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29073-29620-guimaec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29073-29620-guimaec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29074-29400-guimiliau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29074-29400-guimiliau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29074-29400-guimiliau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29074-29400-guimiliau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29075-29490-guipavas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29075-29490-guipavas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29075-29490-guipavas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29075-29490-guipavas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29076-29290-milizac_guipronvel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29076-29290-milizac_guipronvel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29076-29290-milizac_guipronvel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29076-29290-milizac_guipronvel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29077-29880-guisseny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29077-29880-guisseny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29077-29880-guisseny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29077-29880-guisseny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29078-29460-hanvec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29078-29460-hanvec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29078-29460-hanvec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29078-29460-hanvec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29079-29670-henvic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29079-29670-henvic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29079-29670-henvic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29079-29670-henvic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29080-29460-hopital_camfrout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29080-29460-hopital_camfrout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29080-29460-hopital_camfrout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29080-29460-hopital_camfrout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29081-29690-huelgoat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29081-29690-huelgoat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29081-29690-huelgoat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29081-29690-huelgoat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29082-29253-ile_de_batz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29082-29253-ile_de_batz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29082-29253-ile_de_batz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29082-29253-ile_de_batz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29083-29990-ile_de_sein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29083-29990-ile_de_sein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29083-29990-ile_de_sein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29083-29990-ile_de_sein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29084-29259-ile_molene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29084-29259-ile_molene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29084-29259-ile_molene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29084-29259-ile_molene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29085-29980-ile_tudy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29085-29980-ile_tudy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29085-29980-ile_tudy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29085-29980-ile_tudy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29086-29460-irvillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29086-29460-irvillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29086-29460-irvillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29086-29460-irvillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29087-29100-le_juch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29087-29100-le_juch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29087-29100-le_juch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29087-29100-le_juch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29089-29270-kergloff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29089-29270-kergloff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29089-29270-kergloff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29089-29270-kergloff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29090-29100-kerlaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29090-29100-kerlaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29090-29100-kerlaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29090-29100-kerlaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29091-29890-kerlouan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29091-29890-kerlouan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29091-29890-kerlouan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29091-29890-kerlouan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29093-29260-kernilis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29093-29260-kernilis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29093-29260-kernilis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29093-29260-kernilis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29094-29260-kernoues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29094-29260-kernoues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29094-29260-kernoues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29094-29260-kernoues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29095-29860-kersaint_plabennec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29095-29860-kersaint_plabennec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29095-29860-kersaint_plabennec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29095-29860-kersaint_plabennec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29097-29400-lampaul_guimiliau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29097-29400-lampaul_guimiliau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29097-29400-lampaul_guimiliau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29097-29400-lampaul_guimiliau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29098-29810-lampaul_plouarzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29098-29810-lampaul_plouarzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29098-29810-lampaul_plouarzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29098-29810-lampaul_plouarzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29099-29830-lampaul_ploudalmezeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29099-29830-lampaul_ploudalmezeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29099-29830-lampaul_ploudalmezeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29099-29830-lampaul_ploudalmezeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29100-29260-lanarvily/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29100-29260-lanarvily/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29100-29260-lanarvily/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29100-29260-lanarvily/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29101-29870-landeda/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29101-29870-landeda/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29101-29870-landeda/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29101-29870-landeda/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29102-29530-landeleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29102-29530-landeleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29102-29530-landeleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29102-29530-landeleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29103-29800-landerneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29103-29800-landerneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29103-29800-landerneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29103-29800-landerneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29104-29560-landevennec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29104-29560-landevennec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29104-29560-landevennec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29104-29560-landevennec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29105-29400-landivisiau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29105-29400-landivisiau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29105-29400-landivisiau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29105-29400-landivisiau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29106-29510-landrevarzec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29106-29510-landrevarzec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29106-29510-landrevarzec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29106-29510-landrevarzec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29107-29510-landudal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29107-29510-landudal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29107-29510-landudal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29107-29510-landudal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29108-29710-landudec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29108-29710-landudec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29108-29710-landudec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29108-29710-landudec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29109-29840-landunvez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29109-29840-landunvez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29109-29840-landunvez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29109-29840-landunvez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29110-29510-langolen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29110-29510-langolen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29110-29510-langolen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29110-29510-langolen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29111-29430-lanhouarneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29111-29430-lanhouarneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29111-29430-lanhouarneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29111-29430-lanhouarneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29112-29840-lanildut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29112-29840-lanildut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29112-29840-lanildut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29112-29840-lanildut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29113-29620-lanmeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29113-29620-lanmeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29113-29620-lanmeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29113-29620-lanmeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29114-29640-lanneanou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29114-29640-lanneanou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29114-29640-lanneanou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29114-29640-lanneanou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29115-29190-lannedern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29115-29190-lannedern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29115-29190-lannedern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29115-29190-lannedern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29116-29400-lanneuffret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29116-29400-lanneuffret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29116-29400-lanneuffret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29116-29400-lanneuffret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29117-29870-lannilis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29117-29870-lannilis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29117-29870-lannilis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29117-29870-lannilis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29119-29290-lanrivoare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29119-29290-lanrivoare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29119-29290-lanrivoare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29119-29290-lanrivoare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29120-29160-lanveoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29120-29160-lanveoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29120-29160-lanveoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29120-29160-lanveoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29122-29520-laz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29122-29520-laz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29122-29520-laz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29122-29520-laz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29123-29190-lennon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29123-29190-lennon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29123-29190-lennon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29123-29190-lennon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29124-29260-lesneven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29124-29260-lesneven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29124-29260-lesneven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29124-29260-lesneven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29125-29390-leuhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29125-29390-leuhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29125-29390-leuhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29125-29390-leuhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29126-29260-loc_brevalaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29126-29260-loc_brevalaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29126-29260-loc_brevalaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29126-29260-loc_brevalaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29128-29400-loc_eguiner/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29128-29400-loc_eguiner/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29128-29400-loc_eguiner/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29128-29400-loc_eguiner/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29130-29280-locmaria_plouzane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29130-29280-locmaria_plouzane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29130-29280-locmaria_plouzane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29130-29280-locmaria_plouzane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29131-29400-locmelar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29131-29400-locmelar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29131-29400-locmelar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29131-29400-locmelar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29132-29670-locquenole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29132-29670-locquenole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29132-29670-locquenole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29132-29670-locquenole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29133-29241-locquirec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29133-29241-locquirec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29133-29241-locquirec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29133-29241-locquirec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29134-29180-locronan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29134-29180-locronan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29134-29180-locronan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29134-29180-locronan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29135-29750-loctudy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29135-29750-loctudy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29135-29750-loctudy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29135-29750-loctudy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29136-29310-locunole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29136-29310-locunole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29136-29310-locunole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29136-29310-locunole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29137-29460-logonna_daoulas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29137-29460-logonna_daoulas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29137-29460-logonna_daoulas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29137-29460-logonna_daoulas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29139-29590-loperec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29139-29590-loperec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29139-29590-loperec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29139-29590-loperec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29140-29470-loperhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29140-29470-loperhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29140-29470-loperhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29140-29470-loperhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29141-29530-loqueffret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29141-29530-loqueffret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29141-29530-loqueffret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29141-29530-loqueffret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29142-29190-lothey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29142-29190-lothey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29142-29190-lothey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29142-29190-lothey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29143-29790-mahalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29143-29790-mahalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29143-29790-mahalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29143-29790-mahalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29144-29800-la_martyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29144-29800-la_martyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29144-29800-la_martyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29144-29800-la_martyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29145-29790-confort_meilars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29145-29790-confort_meilars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29145-29790-confort_meilars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29145-29790-confort_meilars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29146-29140-melgven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29146-29140-melgven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29146-29140-melgven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29146-29140-melgven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29147-29300-mellac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29147-29300-mellac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29147-29300-mellac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29147-29300-mellac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29148-29420-mespaul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29148-29420-mespaul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29148-29420-mespaul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29148-29420-mespaul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29150-29350-moelan_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29150-29350-moelan_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29150-29350-moelan_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29150-29350-moelan_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29151-29600-morlaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29151-29600-morlaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29151-29600-morlaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29151-29600-morlaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29152-29270-motreff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29152-29270-motreff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29152-29270-motreff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29152-29270-motreff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29153-29920-nevez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29153-29920-nevez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29153-29920-nevez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29153-29920-nevez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29155-29242-ouessant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29155-29242-ouessant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29155-29242-ouessant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29155-29242-ouessant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29156-29800-pencran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29156-29800-pencran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29156-29800-pencran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29156-29800-pencran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29158-29760-penmarch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29158-29760-penmarch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29158-29760-penmarch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29158-29760-penmarch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29159-29710-peumerit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29159-29710-peumerit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29159-29710-peumerit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29159-29710-peumerit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29160-29860-plabennec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29160-29860-plabennec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29160-29860-plabennec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29160-29860-plabennec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29161-29170-pleuven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29161-29170-pleuven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29161-29170-pleuven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29161-29170-pleuven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29162-29190-pleyben/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29162-29190-pleyben/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29162-29190-pleyben/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29162-29190-pleyben/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29163-29410-pleyber_christ/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29163-29410-pleyber_christ/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29163-29410-pleyber_christ/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29163-29410-pleyber_christ/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29165-29740-plobannalec_lesconil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29165-29740-plobannalec_lesconil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29165-29740-plobannalec_lesconil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29165-29740-plobannalec_lesconil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29166-29550-ploeven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29166-29550-ploeven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29166-29550-ploeven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29166-29550-ploeven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29167-29710-plogastel_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29167-29710-plogastel_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29167-29710-plogastel_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29167-29710-plogastel_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29168-29770-plogoff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29168-29770-plogoff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29168-29770-plogoff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29168-29770-plogoff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29169-29180-plogonnec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29169-29180-plogonnec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29169-29180-plogonnec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29169-29180-plogonnec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29170-29700-plomelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29170-29700-plomelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29170-29700-plomelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29170-29700-plomelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29171-29120-plomeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29171-29120-plomeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29171-29120-plomeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29171-29120-plomeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29172-29550-plomodiern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29172-29550-plomodiern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29172-29550-plomodiern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29172-29550-plomodiern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29173-29710-ploneis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29173-29710-ploneis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29173-29710-ploneis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29173-29710-ploneis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29174-29720-ploneour_lanvern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29174-29720-ploneour_lanvern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29174-29720-ploneour_lanvern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29174-29720-ploneour_lanvern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29175-29530-plonevez_du_faou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29175-29530-plonevez_du_faou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29175-29530-plonevez_du_faou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29175-29530-plonevez_du_faou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29176-29550-plonevez_porzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29176-29550-plonevez_porzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29176-29550-plonevez_porzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29176-29550-plonevez_porzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29177-29810-plouarzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29177-29810-plouarzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29177-29810-plouarzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29177-29810-plouarzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29178-29830-ploudalmezeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29178-29830-ploudalmezeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29178-29830-ploudalmezeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29178-29830-ploudalmezeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29179-29260-ploudaniel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29179-29260-ploudaniel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29179-29260-ploudaniel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29179-29260-ploudaniel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29180-29800-ploudiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29180-29800-ploudiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29180-29800-ploudiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29180-29800-ploudiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29181-29800-plouedern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29181-29800-plouedern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29181-29800-plouedern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29181-29800-plouedern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29182-29620-plouegat_guerand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29182-29620-plouegat_guerand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29182-29620-plouegat_guerand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29182-29620-plouegat_guerand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29183-29650-plouegat_moysan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29183-29650-plouegat_moysan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29183-29650-plouegat_moysan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29183-29650-plouegat_moysan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29184-29420-plouenan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29184-29420-plouenan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29184-29420-plouenan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29184-29420-plouenan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29185-29430-plouescat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29185-29430-plouescat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29185-29430-plouescat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29185-29430-plouescat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29186-29252-plouezoc_h/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29186-29252-plouezoc_h/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29186-29252-plouezoc_h/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29186-29252-plouezoc_h/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29187-29440-plougar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29187-29440-plougar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29187-29440-plougar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29187-29440-plougar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29188-29630-plougasnou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29188-29630-plougasnou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29188-29630-plougasnou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29188-29630-plougasnou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29189-29470-plougastel_daoulas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29189-29470-plougastel_daoulas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29189-29470-plougastel_daoulas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29189-29470-plougastel_daoulas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29190-29217-plougonvelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29190-29217-plougonvelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29190-29217-plougonvelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29190-29217-plougonvelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29191-29640-plougonven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29191-29640-plougonven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29191-29640-plougonven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29191-29640-plougonven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29192-29250-plougoulm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29192-29250-plougoulm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29192-29250-plougoulm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29192-29250-plougoulm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29193-29400-plougourvest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29193-29400-plougourvest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29193-29400-plougourvest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29193-29400-plougourvest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29195-29880-plouguerneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29195-29880-plouguerneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29195-29880-plouguerneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29195-29880-plouguerneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29196-29830-plouguin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29196-29830-plouguin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29196-29830-plouguin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29196-29830-plouguin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29197-29780-plouhinec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29197-29780-plouhinec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29197-29780-plouhinec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29197-29780-plouhinec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29198-29260-plouider/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29198-29260-plouider/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29198-29260-plouider/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29198-29260-plouider/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29199-29610-plouigneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29199-29610-plouigneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29199-29610-plouigneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29199-29610-plouigneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29199-29650-plouigneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29199-29650-plouigneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29199-29650-plouigneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29199-29650-plouigneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29201-29810-ploumoguer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29201-29810-ploumoguer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29201-29810-ploumoguer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29201-29810-ploumoguer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29202-29410-plouneour_menez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29202-29410-plouneour_menez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29202-29410-plouneour_menez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29202-29410-plouneour_menez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29204-29400-plouneventer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29204-29400-plouneventer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29204-29400-plouneventer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29204-29400-plouneventer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29205-29270-plounevezel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29205-29270-plounevezel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29205-29270-plounevezel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29205-29270-plounevezel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29206-29430-plounevez_lochrist/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29206-29430-plounevez_lochrist/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29206-29430-plounevez_lochrist/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29206-29430-plounevez_lochrist/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29207-29600-plourin_les_morlaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29207-29600-plourin_les_morlaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29207-29600-plourin_les_morlaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29207-29600-plourin_les_morlaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29208-29830-plourin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29208-29830-plourin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29208-29830-plourin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29208-29830-plourin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29209-29860-plouvien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29209-29860-plouvien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29209-29860-plouvien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29209-29860-plouvien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29210-29420-plouvorn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29210-29420-plouvorn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29210-29420-plouvorn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29210-29420-plouvorn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29211-29690-plouye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29211-29690-plouye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29211-29690-plouye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29211-29690-plouye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29212-29280-plouzane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29212-29280-plouzane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29212-29280-plouzane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29212-29280-plouzane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29213-29440-plouzevede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29213-29440-plouzevede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29213-29440-plouzevede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29213-29440-plouzevede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29214-29720-plovan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29214-29720-plovan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29214-29720-plovan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29214-29720-plovan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29215-29710-plozevet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29215-29710-plozevet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29215-29710-plozevet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29215-29710-plozevet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29216-29700-pluguffan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29216-29700-pluguffan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29216-29700-pluguffan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29216-29700-pluguffan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29217-29930-pont_aven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29217-29930-pont_aven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29217-29930-pont_aven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29217-29930-pont_aven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29218-29790-pont_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29218-29790-pont_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29218-29790-pont_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29218-29790-pont_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29220-29120-pont_l_abbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29220-29120-pont_l_abbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29220-29120-pont_l_abbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29220-29120-pont_l_abbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29221-29840-porspoder/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29221-29840-porspoder/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29221-29840-porspoder/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29221-29840-porspoder/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29222-29150-port_launay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29222-29150-port_launay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29222-29150-port_launay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29222-29150-port_launay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29224-29100-pouldergat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29224-29100-pouldergat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29224-29100-pouldergat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29224-29100-pouldergat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29225-29710-pouldreuzic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29225-29710-pouldreuzic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29225-29710-pouldreuzic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29225-29710-pouldreuzic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29226-29100-poullan_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29226-29100-poullan_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29226-29100-poullan_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29226-29100-poullan_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29227-29246-poullaouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29227-29246-poullaouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29227-29246-poullaouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29227-29246-poullaouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29227-29690-poullaouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29227-29690-poullaouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29227-29690-poullaouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29227-29690-poullaouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29228-29770-primelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29228-29770-primelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29228-29770-primelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29228-29770-primelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29229-29180-quemeneven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29229-29180-quemeneven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29229-29180-quemeneven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29229-29180-quemeneven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29230-29310-querrien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29230-29310-querrien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29230-29310-querrien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29230-29310-querrien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29232-29000-quimper/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29232-29000-quimper/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29232-29000-quimper/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29232-29000-quimper/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29233-29300-quimperle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29233-29300-quimperle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29233-29300-quimperle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29233-29300-quimperle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29234-29300-redene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29234-29300-redene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29234-29300-redene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29234-29300-redene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29235-29480-le_relecq_kerhuon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29235-29480-le_relecq_kerhuon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29235-29480-le_relecq_kerhuon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29235-29480-le_relecq_kerhuon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29236-29340-riec_sur_belon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29236-29340-riec_sur_belon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29236-29340-riec_sur_belon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29236-29340-riec_sur_belon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29237-29800-la_roche_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29237-29800-la_roche_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29237-29800-la_roche_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29237-29800-la_roche_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29238-29570-roscanvel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29238-29570-roscanvel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29238-29570-roscanvel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29238-29570-roscanvel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29239-29680-roscoff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29239-29680-roscoff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29239-29680-roscoff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29239-29680-roscoff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29240-29590-rosnoen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29240-29590-rosnoen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29240-29590-rosnoen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29240-29590-rosnoen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29241-29140-rosporden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29241-29140-rosporden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29241-29140-rosporden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29241-29140-rosporden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29243-29150-saint_coulitz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29243-29150-saint_coulitz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29243-29150-saint_coulitz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29243-29150-saint_coulitz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29244-29440-saint_derrien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29244-29440-saint_derrien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29244-29440-saint_derrien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29244-29440-saint_derrien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29245-29800-saint_divy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29245-29800-saint_divy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29245-29800-saint_divy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29245-29800-saint_divy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29246-29460-saint_eloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29246-29460-saint_eloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29246-29460-saint_eloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29246-29460-saint_eloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29247-29170-saint_evarzec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29247-29170-saint_evarzec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29247-29170-saint_evarzec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29247-29170-saint_evarzec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29248-29260-saint_fregant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29248-29260-saint_fregant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29248-29260-saint_fregant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29248-29260-saint_fregant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29249-29520-saint_goazec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29249-29520-saint_goazec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29249-29520-saint_goazec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29249-29520-saint_goazec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29250-29270-saint_hernin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29250-29270-saint_hernin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29250-29270-saint_hernin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29250-29270-saint_hernin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29251-29630-saint_jean_du_doigt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29251-29630-saint_jean_du_doigt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29251-29630-saint_jean_du_doigt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29251-29630-saint_jean_du_doigt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29252-29120-saint_jean_trolimon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29252-29120-saint_jean_trolimon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29252-29120-saint_jean_trolimon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29252-29120-saint_jean_trolimon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29254-29600-saint_martin_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29254-29600-saint_martin_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29254-29600-saint_martin_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29254-29600-saint_martin_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29255-29260-saint_meen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29255-29260-saint_meen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29255-29260-saint_meen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29255-29260-saint_meen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29256-29550-saint_nic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29256-29550-saint_nic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29256-29550-saint_nic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29256-29550-saint_nic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29257-29830-saint_pabu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29257-29830-saint_pabu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29257-29830-saint_pabu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29257-29830-saint_pabu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29259-29250-saint_pol_de_leon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29259-29250-saint_pol_de_leon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29259-29250-saint_pol_de_leon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29259-29250-saint_pol_de_leon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29260-29290-saint_renan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29260-29290-saint_renan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29260-29290-saint_renan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29260-29290-saint_renan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29261-29190-saint_rivoal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29261-29190-saint_rivoal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29261-29190-saint_rivoal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29261-29190-saint_rivoal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29262-29400-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29262-29400-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29262-29400-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29262-29400-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29263-29590-saint_segal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29263-29590-saint_segal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29263-29590-saint_segal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29263-29590-saint_segal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29264-29400-saint_servais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29264-29400-saint_servais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29264-29400-saint_servais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29264-29400-saint_servais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29265-29600-sainte_seve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29265-29600-sainte_seve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29265-29600-sainte_seve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29265-29600-sainte_seve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29266-29410-saint_thegonnec_loc_eguiner/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29266-29410-saint_thegonnec_loc_eguiner/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29266-29410-saint_thegonnec_loc_eguiner/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29266-29410-saint_thegonnec_loc_eguiner/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29267-29520-saint_thois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29267-29520-saint_thois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29267-29520-saint_thois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29267-29520-saint_thois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29268-29800-saint_thonan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29268-29800-saint_thonan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29268-29800-saint_thonan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29268-29800-saint_thonan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29269-29380-saint_thurien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29269-29380-saint_thurien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29269-29380-saint_thurien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29269-29380-saint_thurien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29270-29800-saint_urbain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29270-29800-saint_urbain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29270-29800-saint_urbain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29270-29800-saint_urbain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29271-29440-saint_vougay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29271-29440-saint_vougay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29271-29440-saint_vougay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29271-29440-saint_vougay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29272-29140-saint_yvi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29272-29140-saint_yvi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29272-29140-saint_yvi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29272-29140-saint_yvi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29273-29250-santec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29273-29250-santec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29273-29250-santec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29273-29250-santec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29274-29390-scaer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29274-29390-scaer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29274-29390-scaer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29274-29390-scaer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29275-29640-scrignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29275-29640-scrignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29275-29640-scrignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29275-29640-scrignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29276-29250-sibiril/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29276-29250-sibiril/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29276-29250-sibiril/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29276-29250-sibiril/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29277-29450-sizun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29277-29450-sizun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29277-29450-sizun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29277-29450-sizun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29278-29540-spezet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29278-29540-spezet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29278-29540-spezet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29278-29540-spezet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29279-29670-taule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29279-29670-taule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29279-29670-taule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29279-29670-taule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29280-29560-telgruc_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29280-29560-telgruc_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29280-29560-telgruc_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29280-29560-telgruc_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29281-29140-tourch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29281-29140-tourch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29281-29140-tourch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29281-29140-tourch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29282-29217-trebabu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29282-29217-trebabu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29282-29217-trebabu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29282-29217-trebabu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29284-29730-treffiagat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29284-29730-treffiagat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29284-29730-treffiagat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29284-29730-treffiagat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29285-29440-treflaouenan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29285-29440-treflaouenan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29285-29440-treflaouenan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29285-29440-treflaouenan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29286-29800-treflevenez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29286-29800-treflevenez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29286-29800-treflevenez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29286-29800-treflevenez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29287-29430-treflez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29287-29430-treflez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29287-29430-treflez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29287-29430-treflez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29288-29260-tregarantec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29288-29260-tregarantec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29288-29260-tregarantec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29288-29260-tregarantec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29289-29560-tregarvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29289-29560-tregarvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29289-29560-tregarvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29289-29560-tregarvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29290-29870-treglonou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29290-29870-treglonou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29290-29870-treglonou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29290-29870-treglonou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29291-29970-tregourez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29291-29970-tregourez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29291-29970-tregourez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29291-29970-tregourez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29292-29720-treguennec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29292-29720-treguennec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29292-29720-treguennec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29292-29720-treguennec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29293-29910-tregunc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29293-29910-tregunc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29293-29910-tregunc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29293-29910-tregunc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29294-29450-le_trehou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29294-29450-le_trehou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29294-29450-le_trehou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29294-29450-le_trehou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29295-29800-tremaouezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29295-29800-tremaouezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29295-29800-tremaouezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29295-29800-tremaouezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29296-29120-tremeoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29296-29120-tremeoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29296-29120-tremeoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29296-29120-tremeoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29297-29300-tremeven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29297-29300-tremeven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29297-29300-tremeven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29297-29300-tremeven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29298-29720-treogat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29298-29720-treogat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29298-29720-treogat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29298-29720-treogat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29299-29290-treouergat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29299-29290-treouergat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29299-29290-treouergat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29299-29290-treouergat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29300-29380-le_trevoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29300-29380-le_trevoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29300-29380-le_trevoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29300-29380-le_trevoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29301-29440-trezilide/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29301-29440-trezilide/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29301-29440-trezilide/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29301-29440-trezilide/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29302-29590-pont_de_buis_les_quimerch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29302-29590-pont_de_buis_les_quimerch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29302-29590-pont_de_buis_les_quimerch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt29-finistere/commune29302-29590-pont_de_buis_les_quimerch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-2A.xml
+++ b/public/sitemaps/sitemap-2A.xml
@@ -5,304 +5,604 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A001-20167-afa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A001-20167-afa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A001-20167-afa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A001-20167-afa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20167-ajaccio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20167-ajaccio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20167-ajaccio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20167-ajaccio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20000-ajaccio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20000-ajaccio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20000-ajaccio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20000-ajaccio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20090-ajaccio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20090-ajaccio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20090-ajaccio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20090-ajaccio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20129-ajaccio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20129-ajaccio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20129-ajaccio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20129-ajaccio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20166-ajaccio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20166-ajaccio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20166-ajaccio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A004-20166-ajaccio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A006-20167-alata/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A006-20167-alata/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A006-20167-alata/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A006-20167-alata/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A008-20166-albitreccia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A008-20166-albitreccia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A008-20166-albitreccia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A008-20166-albitreccia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A008-20128-albitreccia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A008-20128-albitreccia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A008-20128-albitreccia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A008-20128-albitreccia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A011-20112-altagene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A011-20112-altagene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A011-20112-altagene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A011-20112-altagene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A014-20151-ambiegna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A014-20151-ambiegna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A014-20151-ambiegna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A014-20151-ambiegna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A017-20167-appietto/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A017-20167-appietto/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A017-20167-appietto/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A017-20167-appietto/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A018-20110-arbellara/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A018-20110-arbellara/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A018-20110-arbellara/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A018-20110-arbellara/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A019-20160-arbori/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A019-20160-arbori/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A019-20160-arbori/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A019-20160-arbori/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A021-20140-argiusta_moriccio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A021-20140-argiusta_moriccio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A021-20140-argiusta_moriccio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A021-20140-argiusta_moriccio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A022-20151-arro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A022-20151-arro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A022-20151-arro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A022-20151-arro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A024-20116-aullene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A024-20116-aullene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A024-20116-aullene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A024-20116-aullene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A026-20190-azilone_ampaza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A026-20190-azilone_ampaza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A026-20190-azilone_ampaza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A026-20190-azilone_ampaza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A027-20121-azzana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A027-20121-azzana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A027-20121-azzana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A027-20121-azzana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A028-20160-balogna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A028-20160-balogna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A028-20160-balogna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A028-20160-balogna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A031-20119-bastelica/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A031-20119-bastelica/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A031-20119-bastelica/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A031-20119-bastelica/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A032-20129-bastelicaccia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A032-20129-bastelicaccia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A032-20129-bastelicaccia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A032-20129-bastelicaccia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A035-20110-belvedere_campomoro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A035-20110-belvedere_campomoro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A035-20110-belvedere_campomoro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A035-20110-belvedere_campomoro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A038-20100-bilia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A038-20100-bilia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A038-20100-bilia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A038-20100-bilia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A040-20136-bocognano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A040-20136-bocognano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A040-20136-bocognano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A040-20136-bocognano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A041-20169-bonifacio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A041-20169-bonifacio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A041-20169-bonifacio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A041-20169-bonifacio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A041-20146-bonifacio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A041-20146-bonifacio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A041-20146-bonifacio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A041-20146-bonifacio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A048-20111-calcatoggio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A048-20111-calcatoggio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A048-20111-calcatoggio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A048-20111-calcatoggio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A056-20142-campo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A056-20142-campo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A056-20142-campo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A056-20142-campo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A060-20151-cannelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A060-20151-cannelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A060-20151-cannelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A060-20151-cannelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A061-20170-carbini/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A061-20170-carbini/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A061-20170-carbini/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A061-20170-carbini/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A062-20133-carbuccia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A062-20133-carbuccia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A062-20133-carbuccia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A062-20133-carbuccia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A064-20190-cardo_torgia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A064-20190-cardo_torgia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A064-20190-cardo_torgia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A064-20190-cardo_torgia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A065-20130-cargese/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A065-20130-cargese/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A065-20130-cargese/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A065-20130-cargese/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A066-20164-cargiaca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A066-20164-cargiaca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A066-20164-cargiaca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A066-20164-cargiaca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A070-20111-casaglione/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A070-20111-casaglione/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A070-20111-casaglione/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A070-20111-casaglione/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A071-20140-casalabriva/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A071-20140-casalabriva/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A071-20140-casalabriva/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A071-20140-casalabriva/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A085-20166-cauro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A085-20166-cauro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A085-20166-cauro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A085-20166-cauro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A085-20117-cauro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A085-20117-cauro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A085-20117-cauro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A085-20117-cauro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A089-20134-ciamannacce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A089-20134-ciamannacce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A089-20134-ciamannacce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A089-20134-ciamannacce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A090-20118-coggia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A090-20118-coggia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A090-20118-coggia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A090-20118-coggia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A090-20160-coggia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A090-20160-coggia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A090-20160-coggia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A090-20160-coggia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A091-20123-cognocoli_monticchi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A091-20123-cognocoli_monticchi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A091-20123-cognocoli_monticchi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A091-20123-cognocoli_monticchi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A091-20166-cognocoli_monticchi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A091-20166-cognocoli_monticchi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A091-20166-cognocoli_monticchi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A091-20166-cognocoli_monticchi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A092-20144-conca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A092-20144-conca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A092-20144-conca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A092-20144-conca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A092-20135-conca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A092-20135-conca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A092-20135-conca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A092-20135-conca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A094-20168-corrano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A094-20168-corrano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A094-20168-corrano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A094-20168-corrano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A098-20138-coti_chiavari/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A098-20138-coti_chiavari/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A098-20138-coti_chiavari/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A098-20138-coti_chiavari/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A099-20148-cozzano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A099-20148-cozzano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A099-20148-cozzano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A099-20148-cozzano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A100-20126-cristinacce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A100-20126-cristinacce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A100-20126-cristinacce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A100-20126-cristinacce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A103-20167-cuttoli_corticchiato/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A103-20167-cuttoli_corticchiato/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A103-20167-cuttoli_corticchiato/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A103-20167-cuttoli_corticchiato/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A104-20117-eccica_suarella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A104-20117-eccica_suarella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A104-20117-eccica_suarella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A104-20117-eccica_suarella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A104-20166-eccica_suarella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A104-20166-eccica_suarella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A104-20166-eccica_suarella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A104-20166-eccica_suarella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A108-20126-evisa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A108-20126-evisa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A108-20126-evisa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A108-20126-evisa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20114-figari/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20114-figari/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20114-figari/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20114-figari/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20146-figari/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20146-figari/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20146-figari/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20146-figari/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20131-figari/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20131-figari/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20131-figari/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A114-20131-figari/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A115-20100-foce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A115-20100-foce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A115-20100-foce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A115-20100-foce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A117-20190-forciolo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A117-20190-forciolo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A117-20190-forciolo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A117-20190-forciolo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A118-20143-fozzano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A118-20143-fozzano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A118-20143-fozzano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A118-20143-fozzano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A119-20157-frasseto/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A119-20157-frasseto/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A119-20157-frasseto/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A119-20157-frasseto/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A127-20100-giuncheto/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A127-20100-giuncheto/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A127-20100-giuncheto/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A127-20100-giuncheto/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A128-20100-granace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A128-20100-granace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A128-20100-granace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A128-20100-granace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A129-20100-grossa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A129-20100-grossa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A129-20100-grossa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A129-20100-grossa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20166-grosseto_prugna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20166-grosseto_prugna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20166-grosseto_prugna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20166-grosseto_prugna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20117-grosseto_prugna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20117-grosseto_prugna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20117-grosseto_prugna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20117-grosseto_prugna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20128-grosseto_prugna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20128-grosseto_prugna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20128-grosseto_prugna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A130-20128-grosseto_prugna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A131-20160-guagno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A131-20160-guagno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A131-20160-guagno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A131-20160-guagno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A132-20128-guarguale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A132-20128-guarguale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A132-20128-guarguale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A132-20128-guarguale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A133-20153-guitera_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A133-20153-guitera_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A133-20153-guitera_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A133-20153-guitera_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20137-lecci/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20137-lecci/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20137-lecci/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20137-lecci/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20000-lecci/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20000-lecci/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20000-lecci/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20000-lecci/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20144-lecci/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20144-lecci/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20144-lecci/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A139-20144-lecci/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A141-20160-letia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A141-20160-letia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A141-20160-letia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A141-20160-letia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A142-20170-levie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A142-20170-levie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A142-20170-levie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A142-20170-levie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A142-20100-levie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A142-20100-levie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A142-20100-levie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A142-20100-levie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A144-20139-lopigna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A144-20139-lopigna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A144-20139-lopigna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A144-20139-lopigna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A146-20165-loreto_di_tallano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A146-20165-loreto_di_tallano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A146-20165-loreto_di_tallano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A146-20165-loreto_di_tallano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A154-20141-marignana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A154-20141-marignana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A154-20141-marignana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A154-20141-marignana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A158-20112-mela/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A158-20112-mela/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A158-20112-mela/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A158-20112-mela/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A160-20140-moca_croce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A160-20140-moca_croce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A160-20140-moca_croce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A160-20140-moca_croce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A163-20171-monacia_d_aullene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A163-20171-monacia_d_aullene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A163-20171-monacia_d_aullene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A163-20171-monacia_d_aullene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A174-20160-murzo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A174-20160-murzo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A174-20160-murzo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A174-20160-murzo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A181-20117-ocana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A181-20117-ocana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A181-20117-ocana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A181-20117-ocana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A186-20140-olivese/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A186-20140-olivese/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A186-20140-olivese/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A186-20140-olivese/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A189-20113-olmeto/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A189-20113-olmeto/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A189-20113-olmeto/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A189-20113-olmeto/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A191-20112-olmiccia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A191-20112-olmiccia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A191-20112-olmiccia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A191-20112-olmiccia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A196-20125-orto/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A196-20125-orto/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A196-20125-orto/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A196-20125-orto/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A197-20147-osani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A197-20147-osani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A197-20147-osani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A197-20147-osani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A198-20150-ota/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A198-20150-ota/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A198-20150-ota/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A198-20150-ota/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A200-20134-palneca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A200-20134-palneca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A200-20134-palneca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A200-20134-palneca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A203-20147-partinello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A203-20147-partinello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A203-20147-partinello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A203-20147-partinello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A204-20121-pastricciola/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A204-20121-pastricciola/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A204-20121-pastricciola/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A204-20121-pastricciola/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A209-20167-peri/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A209-20167-peri/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A209-20167-peri/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A209-20167-peri/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A211-20140-petreto_bicchisano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A211-20140-petreto_bicchisano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A211-20140-petreto_bicchisano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A211-20140-petreto_bicchisano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A212-20115-piana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A212-20115-piana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A212-20115-piana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A212-20115-piana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A215-20131-pianottoli_caldarello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A215-20131-pianottoli_caldarello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A215-20131-pianottoli_caldarello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A215-20131-pianottoli_caldarello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A228-20166-pietrosella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A228-20166-pietrosella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A228-20166-pietrosella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A228-20166-pietrosella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A232-20123-pila_canale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A232-20123-pila_canale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A232-20123-pila_canale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A232-20123-pila_canale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A240-20125-poggiolo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A240-20125-poggiolo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A240-20125-poggiolo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A240-20125-poggiolo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A247-20137-porto_vecchio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A247-20137-porto_vecchio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A247-20137-porto_vecchio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A247-20137-porto_vecchio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A249-20110-propriano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A249-20110-propriano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A249-20110-propriano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A249-20110-propriano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A249-20100-propriano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A249-20100-propriano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A249-20100-propriano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A249-20100-propriano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A253-20142-quasquara/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A253-20142-quasquara/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A253-20142-quasquara/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A253-20142-quasquara/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A254-20122-quenza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A254-20122-quenza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A254-20122-quenza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A254-20122-quenza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A258-20160-renno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A258-20160-renno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A258-20160-renno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A258-20160-renno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A259-20121-rezza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A259-20121-rezza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A259-20121-rezza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A259-20121-rezza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A262-20121-rosazia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A262-20121-rosazia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A262-20121-rosazia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A262-20121-rosazia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A266-20121-salice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A266-20121-salice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A266-20121-salice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A266-20121-salice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A268-20134-sampolo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A268-20134-sampolo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A268-20134-sampolo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A268-20134-sampolo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A269-20145-sari_solenzara/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A269-20145-sari_solenzara/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A269-20145-sari_solenzara/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A269-20145-sari_solenzara/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A269-20144-sari_solenzara/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A269-20144-sari_solenzara/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A269-20144-sari_solenzara/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A269-20144-sari_solenzara/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A270-20151-sari_d_orcino/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A270-20151-sari_d_orcino/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A270-20151-sari_d_orcino/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A270-20151-sari_d_orcino/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A271-20167-sarrola_carcopino/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A271-20167-sarrola_carcopino/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A271-20167-sarrola_carcopino/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A271-20167-sarrola_carcopino/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A272-20100-sartene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A272-20100-sartene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A272-20100-sartene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A272-20100-sartene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A276-20140-serra_di_ferro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A276-20140-serra_di_ferro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A276-20140-serra_di_ferro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A276-20140-serra_di_ferro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A278-20127-serra_di_scopamene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A278-20127-serra_di_scopamene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A278-20127-serra_di_scopamene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A278-20127-serra_di_scopamene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A279-20147-serriera/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A279-20147-serriera/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A279-20147-serriera/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A279-20147-serriera/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A282-20125-soccia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A282-20125-soccia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A282-20125-soccia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A282-20125-soccia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A284-20140-sollacaro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A284-20140-sollacaro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A284-20140-sollacaro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A284-20140-sollacaro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A285-20152-sorbollano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A285-20152-sorbollano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A285-20152-sorbollano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A285-20152-sorbollano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A288-20146-sotta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A288-20146-sotta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A288-20146-sotta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A288-20146-sotta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A295-20151-sant_andrea_d_orcino/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A295-20151-sant_andrea_d_orcino/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A295-20151-sant_andrea_d_orcino/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A295-20151-sant_andrea_d_orcino/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A300-20137-san_gavino_di_carbini/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A300-20137-san_gavino_di_carbini/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A300-20137-san_gavino_di_carbini/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A300-20137-san_gavino_di_carbini/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A300-20170-san_gavino_di_carbini/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A300-20170-san_gavino_di_carbini/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A300-20170-san_gavino_di_carbini/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A300-20170-san_gavino_di_carbini/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A308-20112-sainte_lucie_de_tallano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A308-20112-sainte_lucie_de_tallano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A308-20112-sainte_lucie_de_tallano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A308-20112-sainte_lucie_de_tallano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A310-20143-santa_maria_figaniella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A310-20143-santa_maria_figaniella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A310-20143-santa_maria_figaniella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A310-20143-santa_maria_figaniella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A312-20190-santa_maria_siche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A312-20190-santa_maria_siche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A312-20190-santa_maria_siche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A312-20190-santa_maria_siche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A322-20134-tasso/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A322-20134-tasso/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A322-20134-tasso/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A322-20134-tasso/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A323-20167-tavaco/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A323-20167-tavaco/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A323-20167-tavaco/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A323-20167-tavaco/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A324-20163-tavera/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A324-20163-tavera/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A324-20163-tavera/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A324-20163-tavera/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A326-20117-tolla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A326-20117-tolla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A326-20117-tolla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A326-20117-tolla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A330-20133-ucciani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A330-20133-ucciani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A330-20133-ucciani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A330-20133-ucciani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A331-20128-urbalacone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A331-20128-urbalacone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A331-20128-urbalacone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A331-20128-urbalacone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A336-20167-valle_di_mezzana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A336-20167-valle_di_mezzana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A336-20167-valle_di_mezzana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A336-20167-valle_di_mezzana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A345-20172-vero/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A345-20172-vero/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A345-20172-vero/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A345-20172-vero/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A345-20133-vero/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A345-20133-vero/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A345-20133-vero/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A345-20133-vero/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A348-20118-vico/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A348-20118-vico/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A348-20118-vico/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A348-20118-vico/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A348-20160-vico/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A348-20160-vico/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A348-20160-vico/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A348-20160-vico/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A349-20110-viggianello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A349-20110-viggianello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A349-20110-viggianello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A349-20110-viggianello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A351-20167-villanova/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A351-20167-villanova/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A351-20167-villanova/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A351-20167-villanova/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A357-20116-zerubia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A357-20116-zerubia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A357-20116-zerubia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A357-20116-zerubia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A358-20173-zevaco/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A358-20173-zevaco/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A358-20173-zevaco/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A358-20173-zevaco/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A359-20132-zicavo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A359-20132-zicavo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A359-20132-zicavo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A359-20132-zicavo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A360-20190-zigliara/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A360-20190-zigliara/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A360-20190-zigliara/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A360-20190-zigliara/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20144-zonza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20144-zonza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20144-zonza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20144-zonza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20124-zonza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20124-zonza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20124-zonza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20124-zonza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20170-zonza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20170-zonza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20170-zonza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A362-20170-zonza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A363-20112-zoza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A363-20112-zoza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A363-20112-zoza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2A-corse_du_sud/commune2A363-20112-zoza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-2B.xml
+++ b/public/sitemaps/sitemap-2B.xml
@@ -5,490 +5,976 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B002-20270-aghione/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B002-20270-aghione/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B002-20270-aghione/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B002-20270-aghione/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B003-20244-aiti/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B003-20244-aiti/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B003-20244-aiti/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B003-20244-aiti/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B005-20212-alando/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B005-20212-alando/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B005-20212-alando/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B005-20212-alando/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B007-20224-albertacce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B007-20224-albertacce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B007-20224-albertacce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B007-20224-albertacce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B009-20270-aleria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B009-20270-aleria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B009-20270-aleria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B009-20270-aleria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B010-20220-algajola/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B010-20220-algajola/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B010-20220-algajola/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B010-20220-algajola/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B012-20251-altiani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B012-20251-altiani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B012-20251-altiani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B012-20251-altiani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B013-20212-alzi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B013-20212-alzi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B013-20212-alzi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B013-20212-alzi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B015-20272-ampriani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B015-20272-ampriani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B015-20272-ampriani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B015-20272-ampriani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B016-20270-antisanti/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B016-20270-antisanti/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B016-20270-antisanti/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B016-20270-antisanti/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B020-20220-aregno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B020-20220-aregno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B020-20220-aregno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B020-20220-aregno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B023-20276-asco/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B023-20276-asco/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B023-20276-asco/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B023-20276-asco/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B025-20225-avapessa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B025-20225-avapessa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B025-20225-avapessa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B025-20225-avapessa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B029-20253-barbaggio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B029-20253-barbaggio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B029-20253-barbaggio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B029-20253-barbaggio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B030-20228-barrettali/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B030-20228-barrettali/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B030-20228-barrettali/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B030-20228-barrettali/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B033-20200-bastia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B033-20200-bastia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B033-20200-bastia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B033-20200-bastia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B033-20600-bastia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B033-20600-bastia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B033-20600-bastia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B033-20600-bastia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B034-20226-belgodere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B034-20226-belgodere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B034-20226-belgodere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B034-20226-belgodere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B036-20252-bigorno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B036-20252-bigorno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B036-20252-bigorno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B036-20252-bigorno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B037-20620-biguglia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B037-20620-biguglia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B037-20620-biguglia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B037-20620-biguglia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B039-20235-bisinchi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B039-20235-bisinchi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B039-20235-bisinchi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B039-20235-bisinchi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B042-20290-borgo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B042-20290-borgo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B042-20290-borgo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B042-20290-borgo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B043-20222-brando/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B043-20222-brando/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B043-20222-brando/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B043-20222-brando/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B045-20212-bustanico/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B045-20212-bustanico/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B045-20212-bustanico/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B045-20212-bustanico/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B046-20228-cagnano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B046-20228-cagnano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B046-20228-cagnano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B046-20228-cagnano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B047-20224-calacuccia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B047-20224-calacuccia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B047-20224-calacuccia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B047-20224-calacuccia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B049-20214-calenzana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B049-20214-calenzana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B049-20214-calenzana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B049-20214-calenzana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B050-20260-calvi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B050-20260-calvi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B050-20260-calvi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B050-20260-calvi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B051-20244-cambia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B051-20244-cambia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B051-20244-cambia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B051-20244-cambia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B052-20229-campana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B052-20229-campana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B052-20229-campana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B052-20229-campana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B053-20270-campi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B053-20270-campi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B053-20270-campi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B053-20270-campi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B054-20290-campile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B054-20290-campile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B054-20290-campile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B054-20290-campile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B055-20252-campitello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B055-20252-campitello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B055-20252-campitello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B055-20252-campitello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B057-20230-canale_di_verde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B057-20230-canale_di_verde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B057-20230-canale_di_verde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B057-20230-canale_di_verde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B058-20217-canari/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B058-20217-canari/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B058-20217-canari/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B058-20217-canari/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B059-20235-canavaggia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B059-20235-canavaggia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B059-20235-canavaggia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B059-20235-canavaggia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B063-20229-carcheto_brustico/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B063-20229-carcheto_brustico/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B063-20229-carcheto_brustico/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B063-20229-carcheto_brustico/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B067-20229-carpineto/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B067-20229-carpineto/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B067-20229-carpineto/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B067-20229-carpineto/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B068-20244-carticasi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B068-20244-carticasi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B068-20244-carticasi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B068-20244-carticasi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B069-20237-casabianca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B069-20237-casabianca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B069-20237-casabianca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B069-20237-casabianca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B072-20215-casalta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B072-20215-casalta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B072-20215-casalta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B072-20215-casalta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B073-20224-casamaccioli/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B073-20224-casamaccioli/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B073-20224-casamaccioli/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B073-20224-casamaccioli/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B074-20250-casanova/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B074-20250-casanova/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B074-20250-casanova/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B074-20250-casanova/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B075-20270-casevecchie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B075-20270-casevecchie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B075-20270-casevecchie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B075-20270-casevecchie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B077-20213-castellare_di_casinca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B077-20213-castellare_di_casinca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B077-20213-castellare_di_casinca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B077-20213-castellare_di_casinca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B078-20212-castellare_di_mercurio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B078-20212-castellare_di_mercurio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B078-20212-castellare_di_mercurio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B078-20212-castellare_di_mercurio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B079-20235-castello_di_rostino/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B079-20235-castello_di_rostino/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B079-20235-castello_di_rostino/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B079-20235-castello_di_rostino/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B080-20218-castifao/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B080-20218-castifao/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B080-20218-castifao/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B080-20218-castifao/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B081-20218-castiglione/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B081-20218-castiglione/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B081-20218-castiglione/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B081-20218-castiglione/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B082-20218-castineta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B082-20218-castineta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B082-20218-castineta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B082-20218-castineta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B083-20218-castirla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B083-20218-castirla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B083-20218-castirla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B083-20218-castirla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B084-20225-cateri/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B084-20225-cateri/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B084-20225-cateri/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B084-20225-cateri/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B086-20238-centuri/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B086-20238-centuri/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B086-20238-centuri/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B086-20238-centuri/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B087-20221-cervione/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B087-20221-cervione/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B087-20221-cervione/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B087-20221-cervione/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B088-20230-chiatra/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B088-20230-chiatra/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B088-20230-chiatra/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B088-20230-chiatra/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B093-20220-corbara/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B093-20220-corbara/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B093-20220-corbara/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B093-20220-corbara/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B093-20256-corbara/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B093-20256-corbara/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B093-20256-corbara/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B093-20256-corbara/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B095-20224-corscia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B095-20224-corscia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B095-20224-corscia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B095-20224-corscia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B096-20250-corte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B096-20250-corte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B096-20250-corte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B096-20250-corte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B097-20226-costa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B097-20226-costa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B097-20226-costa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B097-20226-costa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B101-20237-croce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B101-20237-croce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B101-20237-croce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B101-20237-croce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B102-20290-crocicchia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B102-20290-crocicchia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B102-20290-crocicchia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B102-20290-crocicchia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B105-20212-erbajolo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B105-20212-erbajolo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B105-20212-erbajolo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B105-20212-erbajolo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B106-20244-erone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B106-20244-erone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B106-20244-erone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B106-20244-erone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B107-20275-ersa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B107-20275-ersa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B107-20275-ersa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B107-20275-ersa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B109-20253-farinole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B109-20253-farinole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B109-20253-farinole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B109-20253-farinole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B110-20212-favalello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B110-20212-favalello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B110-20212-favalello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B110-20212-favalello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B111-20234-felce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B111-20234-felce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B111-20234-felce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B111-20234-felce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B112-20225-feliceto/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B112-20225-feliceto/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B112-20225-feliceto/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B112-20225-feliceto/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B113-20237-ficaja/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B113-20237-ficaja/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B113-20237-ficaja/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B113-20237-ficaja/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B116-20212-focicchia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B116-20212-focicchia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B116-20212-focicchia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B116-20212-focicchia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B120-20600-furiani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B120-20600-furiani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B120-20600-furiani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B120-20600-furiani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B121-20245-galeria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B121-20245-galeria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B121-20245-galeria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B121-20245-galeria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B121-20260-galeria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B121-20260-galeria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B121-20260-galeria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B121-20260-galeria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B122-20218-gavignano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B122-20218-gavignano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B122-20218-gavignano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B122-20218-gavignano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B123-20240-ghisonaccia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B123-20240-ghisonaccia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B123-20240-ghisonaccia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B123-20240-ghisonaccia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B124-20227-ghisoni/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B124-20227-ghisoni/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B124-20227-ghisoni/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B124-20227-ghisoni/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B125-20237-giocatojo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B125-20237-giocatojo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B125-20237-giocatojo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B125-20237-giocatojo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B126-20251-giuncaggio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B126-20251-giuncaggio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B126-20251-giuncaggio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B126-20251-giuncaggio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B126-20270-giuncaggio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B126-20270-giuncaggio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B126-20270-giuncaggio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B126-20270-giuncaggio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B134-20220-l_ile_rousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B134-20220-l_ile_rousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B134-20220-l_ile_rousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B134-20220-l_ile_rousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B135-20243-isolaccio_di_fiumorbo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B135-20243-isolaccio_di_fiumorbo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B135-20243-isolaccio_di_fiumorbo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B135-20243-isolaccio_di_fiumorbo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B136-20218-lama/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B136-20218-lama/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B136-20218-lama/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B136-20218-lama/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B137-20244-lano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B137-20244-lano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B137-20244-lano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B137-20244-lano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B138-20225-lavatoggio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B138-20225-lavatoggio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B138-20225-lavatoggio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B138-20225-lavatoggio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B140-20252-lento/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B140-20252-lento/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B140-20252-lento/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B140-20252-lento/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B143-20230-linguizzetta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B143-20230-linguizzetta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B143-20230-linguizzetta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B143-20230-linguizzetta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B145-20215-loreto_di_casinca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B145-20215-loreto_di_casinca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B145-20215-loreto_di_casinca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B145-20215-loreto_di_casinca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B147-20224-lozzi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B147-20224-lozzi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B147-20224-lozzi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B147-20224-lozzi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B148-20290-lucciana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B148-20290-lucciana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B148-20290-lucciana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B148-20290-lucciana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B149-20240-lugo_di_nazza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B149-20240-lugo_di_nazza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B149-20240-lugo_di_nazza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B149-20240-lugo_di_nazza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B150-20260-lumio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B150-20260-lumio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B150-20260-lumio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B150-20260-lumio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B152-20228-luri/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B152-20228-luri/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B152-20228-luri/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B152-20228-luri/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B153-20245-manso/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B153-20245-manso/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B153-20245-manso/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B153-20245-manso/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B155-20270-matra/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B155-20270-matra/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B155-20270-matra/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B155-20270-matra/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B156-20259-mausoleo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B156-20259-mausoleo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B156-20259-mausoleo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B156-20259-mausoleo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B157-20212-mazzola/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B157-20212-mazzola/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B157-20212-mazzola/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B157-20212-mazzola/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B159-20287-meria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B159-20287-meria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B159-20287-meria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B159-20287-meria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B161-20270-moita/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B161-20270-moita/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B161-20270-moita/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B161-20270-moita/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B162-20218-moltifao/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B162-20218-moltifao/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B162-20218-moltifao/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B162-20218-moltifao/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B164-20229-monacia_d_orezza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B164-20229-monacia_d_orezza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B164-20229-monacia_d_orezza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B164-20229-monacia_d_orezza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B165-20214-moncale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B165-20214-moncale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B165-20214-moncale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B165-20214-moncale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B166-20290-monte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B166-20290-monte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B166-20290-monte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B166-20290-monte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B167-20214-montegrosso/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B167-20214-montegrosso/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B167-20214-montegrosso/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B167-20214-montegrosso/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B168-20220-monticello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B168-20220-monticello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B168-20220-monticello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B168-20220-monticello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B169-20218-morosaglia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B169-20218-morosaglia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B169-20218-morosaglia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B169-20218-morosaglia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B170-20238-morsiglia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B170-20238-morsiglia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B170-20238-morsiglia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B170-20238-morsiglia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B171-20219-muracciole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B171-20219-muracciole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B171-20219-muracciole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B171-20219-muracciole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B172-20239-murato/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B172-20239-murato/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B172-20239-murato/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B172-20239-murato/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B173-20225-muro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B173-20225-muro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B173-20225-muro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B173-20225-muro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B175-20225-nessa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B175-20225-nessa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B175-20225-nessa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B175-20225-nessa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B176-20229-nocario/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B176-20229-nocario/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B176-20229-nocario/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B176-20229-nocario/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B177-20219-noceta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B177-20219-noceta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B177-20219-noceta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B177-20219-noceta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B178-20217-nonza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B178-20217-nonza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B178-20217-nonza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B178-20217-nonza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B179-20234-novale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B179-20234-novale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B179-20234-novale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B179-20234-novale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B180-20211-novella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B180-20211-novella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B180-20211-novella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B180-20211-novella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B182-20226-occhiatana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B182-20226-occhiatana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B182-20226-occhiatana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B182-20226-occhiatana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B183-20217-ogliastro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B183-20217-ogliastro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B183-20217-ogliastro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B183-20217-ogliastro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B184-20217-olcani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B184-20217-olcani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B184-20217-olcani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B184-20217-olcani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B185-20232-oletta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B185-20232-oletta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B185-20232-oletta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B185-20232-oletta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B187-20217-olmeta_di_capocorso/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B187-20217-olmeta_di_capocorso/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B187-20217-olmeta_di_capocorso/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B187-20217-olmeta_di_capocorso/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B188-20232-olmeta_di_tuda/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B188-20232-olmeta_di_tuda/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B188-20232-olmeta_di_tuda/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B188-20232-olmeta_di_tuda/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B190-20259-olmi_cappella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B190-20259-olmi_cappella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B190-20259-olmi_cappella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B190-20259-olmi_cappella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B192-20290-olmo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B192-20290-olmo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B192-20290-olmo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B192-20290-olmo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B193-20236-omessa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B193-20236-omessa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B193-20236-omessa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B193-20236-omessa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B194-20234-ortale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B194-20234-ortale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B194-20234-ortale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B194-20234-ortale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B195-20290-ortiporio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B195-20290-ortiporio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B195-20290-ortiporio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B195-20290-ortiporio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B199-20226-palasca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B199-20226-palasca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B199-20226-palasca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B199-20226-palasca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B201-20251-pancheraccia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B201-20251-pancheraccia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B201-20251-pancheraccia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B201-20251-pancheraccia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B201-20270-pancheraccia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B201-20270-pancheraccia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B201-20270-pancheraccia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B201-20270-pancheraccia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B202-20229-parata/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B202-20229-parata/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B202-20229-parata/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B202-20229-parata/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B205-20253-patrimonio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B205-20253-patrimonio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B205-20253-patrimonio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B205-20253-patrimonio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B206-20290-penta_acquatella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B206-20290-penta_acquatella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B206-20290-penta_acquatella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B206-20290-penta_acquatella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B207-20213-penta_di_casinca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B207-20213-penta_di_casinca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B207-20213-penta_di_casinca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B207-20213-penta_di_casinca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B208-20234-perelli/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B208-20234-perelli/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B208-20234-perelli/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B208-20234-perelli/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B210-20230-pero_casevecchie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B210-20230-pero_casevecchie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B210-20230-pero_casevecchie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B210-20230-pero_casevecchie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B213-20272-pianello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B213-20272-pianello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B213-20272-pianello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B213-20272-pianello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B214-20215-piano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B214-20215-piano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B214-20215-piano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B214-20215-piano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B216-20234-piazzali/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B216-20234-piazzali/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B216-20234-piazzali/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B216-20234-piazzali/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B217-20229-piazzole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B217-20229-piazzole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B217-20229-piazzole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B217-20229-piazzole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B218-20251-piedicorte_di_gaggio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B218-20251-piedicorte_di_gaggio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B218-20251-piedicorte_di_gaggio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B218-20251-piedicorte_di_gaggio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B219-20229-piedicroce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B219-20229-piedicroce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B219-20229-piedicroce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B219-20229-piedicroce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B220-20218-piedigriggio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B220-20218-piedigriggio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B220-20218-piedigriggio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B220-20218-piedigriggio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B221-20229-piedipartino/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B221-20229-piedipartino/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B221-20229-piedipartino/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B221-20229-piedipartino/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B222-20229-pie_d_orezza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B222-20229-pie_d_orezza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B222-20229-pie_d_orezza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B222-20229-pie_d_orezza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B223-20218-pietralba/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B223-20218-pietralba/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B223-20218-pietralba/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B223-20218-pietralba/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B224-20233-pietracorbara/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B224-20233-pietracorbara/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B224-20233-pietracorbara/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B224-20233-pietracorbara/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B225-20230-pietra_di_verde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B225-20230-pietra_di_verde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B225-20230-pietra_di_verde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B225-20230-pietra_di_verde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B226-20251-pietraserena/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B226-20251-pietraserena/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B226-20251-pietraserena/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B226-20251-pietraserena/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B227-20234-pietricaggio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B227-20234-pietricaggio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B227-20234-pietricaggio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B227-20234-pietricaggio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B229-20242-pietroso/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B229-20242-pietroso/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B229-20242-pietroso/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B229-20242-pietroso/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B229-20240-pietroso/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B229-20240-pietroso/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B229-20240-pietroso/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B229-20240-pietroso/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B230-20246-pieve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B230-20246-pieve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B230-20246-pieve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B230-20246-pieve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B231-20220-pigna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B231-20220-pigna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B231-20220-pigna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B231-20220-pigna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B233-20228-pino/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B233-20228-pino/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B233-20228-pino/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B233-20228-pino/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B234-20234-piobetta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B234-20234-piobetta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B234-20234-piobetta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B234-20234-piobetta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B235-20259-pioggiola/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B235-20259-pioggiola/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B235-20259-pioggiola/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B235-20259-pioggiola/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B236-20240-poggio_di_nazza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B236-20240-poggio_di_nazza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B236-20240-poggio_di_nazza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B236-20240-poggio_di_nazza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B238-20250-poggio_di_venaco/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B238-20250-poggio_di_venaco/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B238-20250-poggio_di_venaco/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B238-20250-poggio_di_venaco/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B239-20232-poggio_d_oletta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B239-20232-poggio_d_oletta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B239-20232-poggio_d_oletta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B239-20232-poggio_d_oletta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B241-20237-poggio_marinaccio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B241-20237-poggio_marinaccio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B241-20237-poggio_marinaccio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B241-20237-poggio_marinaccio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B242-20230-poggio_mezzana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B242-20230-poggio_mezzana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B242-20230-poggio_mezzana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B242-20230-poggio_mezzana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B243-20229-polveroso/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B243-20229-polveroso/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B243-20229-polveroso/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B243-20229-polveroso/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B244-20218-popolasca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B244-20218-popolasca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B244-20218-popolasca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B244-20218-popolasca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B245-20215-porri/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B245-20215-porri/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B245-20215-porri/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B245-20215-porri/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B246-20237-la_porta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B246-20237-la_porta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B246-20237-la_porta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B246-20237-la_porta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B248-20218-prato_di_giovellina/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B248-20218-prato_di_giovellina/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B248-20218-prato_di_giovellina/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B248-20218-prato_di_giovellina/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B250-20290-prunelli_di_casacconi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B250-20290-prunelli_di_casacconi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B250-20290-prunelli_di_casacconi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B250-20290-prunelli_di_casacconi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B251-20243-prunelli_di_fiumorbo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B251-20243-prunelli_di_fiumorbo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B251-20243-prunelli_di_fiumorbo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B251-20243-prunelli_di_fiumorbo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B252-20213-pruno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B252-20213-pruno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B252-20213-pruno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B252-20213-pruno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B255-20237-quercitello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B255-20237-quercitello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B255-20237-quercitello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B255-20237-quercitello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B256-20229-rapaggio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B256-20229-rapaggio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B256-20229-rapaggio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B256-20229-rapaggio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B257-20246-rapale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B257-20246-rapale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B257-20246-rapale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B257-20246-rapale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B260-20250-riventosa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B260-20250-riventosa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B260-20250-riventosa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B260-20250-riventosa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B261-20247-rogliano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B261-20247-rogliano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B261-20247-rogliano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B261-20247-rogliano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B263-20219-rospigliani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B263-20219-rospigliani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B263-20219-rospigliani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B263-20219-rospigliani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B264-20244-rusio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B264-20244-rusio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B264-20244-rusio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B264-20244-rusio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B265-20239-rutali/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B265-20239-rutali/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B265-20239-rutali/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B265-20239-rutali/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B267-20218-saliceto/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B267-20218-saliceto/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B267-20218-saliceto/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B267-20218-saliceto/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B273-20264-scata/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B273-20264-scata/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B273-20264-scata/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B273-20264-scata/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B274-20290-scolca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B274-20290-scolca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B274-20290-scolca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B274-20290-scolca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B275-20212-sermano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B275-20212-sermano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B275-20212-sermano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B275-20212-sermano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B277-20243-serra_di_fiumorbo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B277-20243-serra_di_fiumorbo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B277-20243-serra_di_fiumorbo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B277-20243-serra_di_fiumorbo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B280-20215-silvareccio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B280-20215-silvareccio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B280-20215-silvareccio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B280-20215-silvareccio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B281-20233-sisco/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B281-20233-sisco/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B281-20233-sisco/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B281-20233-sisco/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B283-20240-solaro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B283-20240-solaro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B283-20240-solaro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B283-20240-solaro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B286-20213-sorbo_ocagnano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B286-20213-sorbo_ocagnano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B286-20213-sorbo_ocagnano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B286-20213-sorbo_ocagnano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B287-20246-sorio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B287-20246-sorio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B287-20246-sorio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B287-20246-sorio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B289-20250-soveria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B289-20250-soveria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B289-20250-soveria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B289-20250-soveria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B290-20226-speloncato/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B290-20226-speloncato/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B290-20226-speloncato/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B290-20226-speloncato/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B291-20229-stazzona/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B291-20229-stazzona/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B291-20229-stazzona/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B291-20229-stazzona/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B292-20212-sant_andrea_di_bozio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B292-20212-sant_andrea_di_bozio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B292-20212-sant_andrea_di_bozio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B292-20212-sant_andrea_di_bozio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B293-20221-sant_andrea_di_cotone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B293-20221-sant_andrea_di_cotone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B293-20221-sant_andrea_di_cotone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B293-20221-sant_andrea_di_cotone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B296-20220-sant_antonino/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B296-20220-sant_antonino/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B296-20220-sant_antonino/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B296-20220-sant_antonino/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B297-20264-san_damiano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B297-20264-san_damiano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B297-20264-san_damiano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B297-20264-san_damiano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B298-20217-saint_florent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B298-20217-saint_florent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B298-20217-saint_florent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B298-20217-saint_florent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B299-20264-san_gavino_d_ampugnani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B299-20264-san_gavino_d_ampugnani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B299-20264-san_gavino_d_ampugnani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B299-20264-san_gavino_d_ampugnani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B301-20246-san_gavino_di_tenda/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B301-20246-san_gavino_di_tenda/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B301-20246-san_gavino_di_tenda/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B301-20246-san_gavino_di_tenda/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B302-20230-san_giovanni_di_moriani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B302-20230-san_giovanni_di_moriani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B302-20230-san_giovanni_di_moriani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B302-20230-san_giovanni_di_moriani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B303-20230-san_giuliano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B303-20230-san_giuliano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B303-20230-san_giuliano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B303-20230-san_giuliano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B304-20244-san_lorenzo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B304-20244-san_lorenzo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B304-20244-san_lorenzo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B304-20244-san_lorenzo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B305-20200-san_martino_di_lota/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B305-20200-san_martino_di_lota/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B305-20200-san_martino_di_lota/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B305-20200-san_martino_di_lota/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B306-20250-santa_lucia_di_mercurio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B306-20250-santa_lucia_di_mercurio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B306-20250-santa_lucia_di_mercurio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B306-20250-santa_lucia_di_mercurio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B307-20230-santa_lucia_di_moriani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B307-20230-santa_lucia_di_moriani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B307-20230-santa_lucia_di_moriani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B307-20230-santa_lucia_di_moriani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B309-20200-santa_maria_di_lota/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B309-20200-santa_maria_di_lota/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B309-20200-santa_maria_di_lota/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B309-20200-santa_maria_di_lota/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B311-20221-santa_maria_poggio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B311-20221-santa_maria_poggio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B311-20221-santa_maria_poggio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B311-20221-santa_maria_poggio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B313-20230-san_nicolao/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B313-20230-san_nicolao/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B313-20230-san_nicolao/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B313-20230-san_nicolao/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B314-20246-santo_pietro_di_tenda/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B314-20246-santo_pietro_di_tenda/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B314-20246-santo_pietro_di_tenda/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B314-20246-santo_pietro_di_tenda/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B315-20250-santo_pietro_di_venaco/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B315-20250-santo_pietro_di_venaco/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B315-20250-santo_pietro_di_venaco/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B315-20250-santo_pietro_di_venaco/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B316-20220-santa_reparata_di_balagna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B316-20220-santa_reparata_di_balagna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B316-20220-santa_reparata_di_balagna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B316-20220-santa_reparata_di_balagna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B317-20230-santa_reparata_di_moriani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B317-20230-santa_reparata_di_moriani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B317-20230-santa_reparata_di_moriani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B317-20230-santa_reparata_di_moriani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B318-20230-taglio_isolaccio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B318-20230-taglio_isolaccio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B318-20230-taglio_isolaccio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B318-20230-taglio_isolaccio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B319-20230-talasani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B319-20230-talasani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B319-20230-talasani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B319-20230-talasani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B320-20270-tallone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B320-20270-tallone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B320-20270-tallone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B320-20270-tallone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B321-20234-tarrano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B321-20234-tarrano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B321-20234-tarrano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B321-20234-tarrano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B327-20248-tomino/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B327-20248-tomino/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B327-20248-tomino/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B327-20248-tomino/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B328-20270-tox/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B328-20270-tox/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B328-20270-tox/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B328-20270-tox/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B329-20250-tralonca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B329-20250-tralonca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B329-20250-tralonca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B329-20250-tralonca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B332-20218-urtaca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B332-20218-urtaca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B332-20218-urtaca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B332-20218-urtaca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B333-20232-vallecalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B333-20232-vallecalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B333-20232-vallecalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B333-20232-vallecalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B334-20234-valle_d_alesani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B334-20234-valle_d_alesani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B334-20234-valle_d_alesani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B334-20234-valle_d_alesani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B335-20221-valle_di_campoloro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B335-20221-valle_di_campoloro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B335-20221-valle_di_campoloro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B335-20221-valle_di_campoloro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B337-20235-valle_di_rostino/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B337-20235-valle_di_rostino/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B337-20235-valle_di_rostino/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B337-20235-valle_di_rostino/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B338-20229-valle_d_orezza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B338-20229-valle_d_orezza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B338-20229-valle_d_orezza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B338-20229-valle_d_orezza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B339-20259-vallica/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B339-20259-vallica/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B339-20259-vallica/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B339-20259-vallica/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B340-20230-velone_orneto/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B340-20230-velone_orneto/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B340-20230-velone_orneto/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B340-20230-velone_orneto/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B341-20231-venaco/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B341-20231-venaco/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B341-20231-venaco/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B341-20231-venaco/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B342-20240-ventiseri/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B342-20240-ventiseri/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B342-20240-ventiseri/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B342-20240-ventiseri/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B343-20215-venzolasca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B343-20215-venzolasca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B343-20215-venzolasca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B343-20215-venzolasca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B344-20229-verdese/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B344-20229-verdese/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B344-20229-verdese/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B344-20229-verdese/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B346-20215-vescovato/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B346-20215-vescovato/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B346-20215-vescovato/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B346-20215-vescovato/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B347-20242-vezzani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B347-20242-vezzani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B347-20242-vezzani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B347-20242-vezzani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B350-20290-vignale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B350-20290-vignale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B350-20290-vignale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B350-20290-vignale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B352-20279-ville_di_paraso/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B352-20279-ville_di_paraso/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B352-20279-ville_di_paraso/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B352-20279-ville_di_paraso/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B353-20200-ville_di_pietrabugno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B353-20200-ville_di_pietrabugno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B353-20200-ville_di_pietrabugno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B353-20200-ville_di_pietrabugno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B354-20219-vivario/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B354-20219-vivario/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B354-20219-vivario/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B354-20219-vivario/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B355-20290-volpajola/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B355-20290-volpajola/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B355-20290-volpajola/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B355-20290-volpajola/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B356-20272-zalana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B356-20272-zalana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B356-20272-zalana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B356-20272-zalana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B361-20214-zilia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B361-20214-zilia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B361-20214-zilia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B361-20214-zilia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B364-20272-zuani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B364-20272-zuani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B364-20272-zuani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B364-20272-zuani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B365-20243-san_gavino_di_fiumorbo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B365-20243-san_gavino_di_fiumorbo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B365-20243-san_gavino_di_fiumorbo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B365-20243-san_gavino_di_fiumorbo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B366-20240-chisa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B366-20240-chisa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B366-20240-chisa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt2B-haute_corse/commune2B366-20240-chisa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-30.xml
+++ b/public/sitemaps/sitemap-30.xml
@@ -5,724 +5,1444 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30001-30700-aigaliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30001-30700-aigaliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30001-30700-aigaliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30001-30700-aigaliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30002-30350-aigremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30002-30350-aigremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30002-30350-aigremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30002-30350-aigremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30003-30220-aigues_mortes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30003-30220-aigues_mortes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30003-30220-aigues_mortes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30003-30220-aigues_mortes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30004-30670-aigues_vives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30004-30670-aigues_vives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30004-30670-aigues_vives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30004-30670-aigues_vives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30005-30760-aigueze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30005-30760-aigueze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30005-30760-aigueze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30005-30760-aigueze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30006-30470-aimargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30006-30470-aimargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30006-30470-aimargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30006-30470-aimargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30006-30220-aimargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30006-30220-aimargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30006-30220-aimargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30006-30220-aimargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30007-30100-ales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30007-30100-ales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30007-30100-ales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30007-30100-ales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30008-30500-allegre_les_fumades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30008-30500-allegre_les_fumades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30008-30500-allegre_les_fumades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30008-30500-allegre_les_fumades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30008-30340-allegre_les_fumades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30008-30340-allegre_les_fumades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30008-30340-allegre_les_fumades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30008-30340-allegre_les_fumades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30009-30770-alzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30009-30770-alzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30009-30770-alzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30009-30770-alzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30010-30140-anduze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30010-30140-anduze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30010-30140-anduze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30010-30140-anduze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30011-30133-les_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30011-30133-les_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30011-30133-les_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30011-30133-les_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30012-30390-aramon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30012-30390-aramon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30012-30390-aramon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30012-30390-aramon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30013-30210-argilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30013-30210-argilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30013-30210-argilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30013-30210-argilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30014-30700-arpaillargues_et_aureillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30014-30700-arpaillargues_et_aureillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30014-30700-arpaillargues_et_aureillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30014-30700-arpaillargues_et_aureillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30015-30120-arphy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30015-30120-arphy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30015-30120-arphy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30015-30120-arphy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30016-30120-arre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30016-30120-arre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30016-30120-arre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30016-30120-arre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30017-30770-arrigas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30017-30770-arrigas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30017-30770-arrigas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30017-30770-arrigas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30018-30250-asperes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30018-30250-asperes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30018-30250-asperes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30018-30250-asperes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30019-30250-aubais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30019-30250-aubais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30019-30250-aubais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30019-30250-aubais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30020-30620-aubord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30020-30620-aubord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30020-30620-aubord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30020-30620-aubord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30021-30190-aubussargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30021-30190-aubussargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30021-30190-aubussargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30021-30190-aubussargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30022-30450-aujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30022-30450-aujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30022-30450-aujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30022-30450-aujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30023-30250-aujargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30023-30250-aujargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30023-30250-aujargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30023-30250-aujargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30024-30120-aulas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30024-30120-aulas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30024-30120-aulas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30024-30120-aulas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30025-30770-aumessas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30025-30770-aumessas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30025-30770-aumessas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30025-30770-aumessas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30026-30120-aveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30026-30120-aveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30026-30120-aveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30026-30120-aveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30027-30140-bagard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30027-30140-bagard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30027-30140-bagard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30027-30140-bagard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30028-30200-bagnols_sur_ceze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30028-30200-bagnols_sur_ceze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30028-30200-bagnols_sur_ceze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30028-30200-bagnols_sur_ceze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30029-30430-barjac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30029-30430-barjac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30029-30430-barjac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30029-30430-barjac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30030-30700-baron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30030-30700-baron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30030-30700-baron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30030-30700-baron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30031-30330-la_bastide_d_engras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30031-30330-la_bastide_d_engras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30031-30330-la_bastide_d_engras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30031-30330-la_bastide_d_engras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30032-30300-beaucaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30032-30300-beaucaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30032-30300-beaucaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30032-30300-beaucaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30033-30640-beauvoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30033-30640-beauvoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30033-30640-beauvoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30033-30640-beauvoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30034-30127-bellegarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30034-30127-bellegarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30034-30127-bellegarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30034-30127-bellegarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30035-30580-belvezet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30035-30580-belvezet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30035-30580-belvezet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30035-30580-belvezet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30036-30620-bernis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30036-30620-bernis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30036-30620-bernis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30036-30620-bernis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30037-30160-besseges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30037-30160-besseges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30037-30160-besseges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30037-30160-besseges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30038-30120-bez_et_esparon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30038-30120-bez_et_esparon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30038-30120-bez_et_esparon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30038-30120-bez_et_esparon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30039-30320-bezouce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30039-30320-bezouce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30039-30320-bezouce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30039-30320-bezouce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30040-30770-blandas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30040-30770-blandas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30040-30770-blandas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30040-30770-blandas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30041-30700-blauzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30041-30700-blauzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30041-30700-blauzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30041-30700-blauzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30042-30140-boisset_et_gaujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30042-30140-boisset_et_gaujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30042-30140-boisset_et_gaujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30042-30140-boisset_et_gaujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30043-30114-boissieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30043-30114-boissieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30043-30114-boissieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30043-30114-boissieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30044-30450-bonnevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30044-30450-bonnevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30044-30450-bonnevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30044-30450-bonnevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30045-30160-bordezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30045-30160-bordezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30045-30160-bordezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30045-30160-bordezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30046-30190-boucoiran_et_nozieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30046-30190-boucoiran_et_nozieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30046-30190-boucoiran_et_nozieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30046-30190-boucoiran_et_nozieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30047-30230-bouillargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30047-30230-bouillargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30047-30230-bouillargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30047-30230-bouillargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30048-30580-bouquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30048-30580-bouquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30048-30580-bouquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30048-30580-bouquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30049-30190-bourdic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30049-30190-bourdic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30049-30190-bourdic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30049-30190-bourdic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30050-30260-bragassargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30050-30260-bragassargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30050-30260-bragassargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30050-30260-bragassargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30051-30110-branoux_les_taillades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30051-30110-branoux_les_taillades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30051-30110-branoux_les_taillades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30051-30110-branoux_les_taillades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30052-30120-breau_mars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30052-30120-breau_mars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30052-30120-breau_mars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30052-30120-breau_mars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30053-30190-brignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30053-30190-brignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30053-30190-brignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30053-30190-brignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30054-30260-brouzet_les_quissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30054-30260-brouzet_les_quissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30054-30260-brouzet_les_quissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30054-30260-brouzet_les_quissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30055-30580-brouzet_les_ales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30055-30580-brouzet_les_ales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30055-30580-brouzet_les_ales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30055-30580-brouzet_les_ales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30056-30580-la_bruguiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30056-30580-la_bruguiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30056-30580-la_bruguiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30056-30580-la_bruguiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30057-30210-cabrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30057-30210-cabrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30057-30210-cabrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30057-30210-cabrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30058-30170-la_cadiere_et_cambo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30058-30170-la_cadiere_et_cambo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30058-30170-la_cadiere_et_cambo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30058-30170-la_cadiere_et_cambo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30059-30740-le_cailar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30059-30740-le_cailar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30059-30740-le_cailar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30059-30740-le_cailar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30060-30132-caissargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30060-30132-caissargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30060-30132-caissargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30060-30132-caissargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30061-30190-la_calmette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30061-30190-la_calmette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30061-30190-la_calmette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30061-30190-la_calmette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30062-30420-calvisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30062-30420-calvisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30062-30420-calvisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30062-30420-calvisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30064-30770-campestre_et_luc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30064-30770-campestre_et_luc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30064-30770-campestre_et_luc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30064-30770-campestre_et_luc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30065-30350-canaules_et_argentieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30065-30350-canaules_et_argentieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30065-30350-canaules_et_argentieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30065-30350-canaules_et_argentieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30066-30260-cannes_et_clairan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30066-30260-cannes_et_clairan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30066-30260-cannes_et_clairan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30066-30260-cannes_et_clairan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30067-30700-la_capelle_et_masmolene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30067-30700-la_capelle_et_masmolene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30067-30700-la_capelle_et_masmolene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30067-30700-la_capelle_et_masmolene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30068-30350-cardet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30068-30350-cardet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30068-30350-cardet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30068-30350-cardet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30069-30260-carnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30069-30260-carnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30069-30260-carnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30069-30260-carnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30070-30130-carsan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30070-30130-carsan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30070-30130-carsan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30070-30130-carsan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30071-30350-cassagnoles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30071-30350-cassagnoles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30071-30350-cassagnoles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30071-30350-cassagnoles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30072-30190-castelnau_valence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30072-30190-castelnau_valence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30072-30190-castelnau_valence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30072-30190-castelnau_valence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30073-30210-castillon_du_gard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30073-30210-castillon_du_gard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30073-30210-castillon_du_gard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30073-30210-castillon_du_gard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30074-30750-causse_begon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30074-30750-causse_begon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30074-30750-causse_begon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30074-30750-causse_begon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30075-30820-caveirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30075-30820-caveirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30075-30820-caveirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30075-30820-caveirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30075-30900-caveirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30075-30900-caveirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30075-30900-caveirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30075-30900-caveirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30076-30330-cavillargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30076-30330-cavillargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30076-30330-cavillargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30076-30330-cavillargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30077-30480-cendras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30077-30480-cendras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30077-30480-cendras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30077-30480-cendras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30079-30450-chambon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30079-30450-chambon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30079-30450-chambon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30079-30450-chambon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30080-30530-chamborigaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30080-30530-chamborigaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30080-30530-chamborigaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30080-30530-chamborigaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30081-30200-chusclan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30081-30200-chusclan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30081-30200-chusclan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30081-30200-chusclan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30082-30870-clarensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30082-30870-clarensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30082-30870-clarensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30082-30870-clarensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30083-30920-codognan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30083-30920-codognan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30083-30920-codognan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30083-30920-codognan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30084-30200-codolet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30084-30200-codolet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30084-30200-codolet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30084-30200-codolet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30085-30210-collias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30085-30210-collias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30085-30210-collias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30085-30210-collias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30086-30190-collorgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30086-30190-collorgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30086-30190-collorgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30086-30190-collorgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30087-30460-colognac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30087-30460-colognac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30087-30460-colognac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30087-30460-colognac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30088-30250-combas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30088-30250-combas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30088-30250-combas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30088-30250-combas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30089-30300-comps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30089-30300-comps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30089-30300-comps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30089-30300-comps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30090-30450-concoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30090-30450-concoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30090-30450-concoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30090-30450-concoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30091-30111-congenies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30091-30111-congenies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30091-30111-congenies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30091-30111-congenies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30092-30330-connaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30092-30330-connaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30092-30330-connaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30092-30330-connaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30093-30170-conqueyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30093-30170-conqueyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30093-30170-conqueyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30093-30170-conqueyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30094-30140-corbes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30094-30140-corbes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30094-30140-corbes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30094-30140-corbes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30095-30260-corconne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30095-30260-corconne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30095-30260-corconne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30095-30260-corconne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30096-30630-cornillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30096-30630-cornillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30096-30630-cornillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30096-30630-cornillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30097-30500-courry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30097-30500-courry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30097-30500-courry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30097-30500-courry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30098-30260-crespian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30098-30260-crespian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30098-30260-crespian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30098-30260-crespian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30099-30170-cros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30099-30170-cros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30099-30170-cros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30099-30170-cros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30100-30360-cruviers_lascours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30100-30360-cruviers_lascours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30100-30360-cruviers_lascours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30100-30360-cruviers_lascours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30101-30360-deaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30101-30360-deaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30101-30360-deaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30101-30360-deaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30102-30190-dions/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30102-30190-dions/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30102-30190-dions/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30102-30190-dions/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30103-30390-domazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30103-30390-domazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30103-30390-domazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30103-30390-domazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30104-30350-domessargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30104-30350-domessargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30104-30350-domessargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30104-30350-domessargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30105-30750-dourbies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30105-30750-dourbies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30105-30750-dourbies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30105-30750-dourbies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30106-30170-durfort_et_saint_martin_de_sossenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30106-30170-durfort_et_saint_martin_de_sossenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30106-30170-durfort_et_saint_martin_de_sossenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30106-30170-durfort_et_saint_martin_de_sossenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30107-30390-estezargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30107-30390-estezargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30107-30390-estezargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30107-30390-estezargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30108-30124-l_estrechure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30108-30124-l_estrechure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30108-30124-l_estrechure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30108-30124-l_estrechure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30109-30360-euzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30109-30360-euzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30109-30360-euzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30109-30360-euzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30110-30700-flaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30110-30700-flaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30110-30700-flaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30110-30700-flaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30111-30700-foissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30111-30700-foissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30111-30700-foissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30111-30700-foissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30112-30730-fons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30112-30730-fons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30112-30730-fons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30112-30730-fons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30113-30580-fons_sur_lussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30113-30580-fons_sur_lussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30113-30580-fons_sur_lussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30113-30580-fons_sur_lussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30114-30250-fontanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30114-30250-fontanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30114-30250-fontanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30114-30250-fontanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30115-30580-fontareches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30115-30580-fontareches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30115-30580-fontareches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30115-30580-fontareches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30116-30210-fournes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30116-30210-fournes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30116-30210-fournes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30116-30210-fournes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30117-30300-fourques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30117-30300-fourques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30117-30300-fourques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30117-30300-fourques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30119-30170-fressac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30119-30170-fressac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30119-30170-fressac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30119-30170-fressac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30120-30160-gagnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30120-30160-gagnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30120-30160-gagnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30120-30160-gagnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30121-30260-gailhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30121-30260-gailhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30121-30260-gailhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30121-30260-gailhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30122-30730-gajan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30122-30730-gajan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30122-30730-gajan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30122-30730-gajan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30123-30660-gallargues_le_montueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30123-30660-gallargues_le_montueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30123-30660-gallargues_le_montueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30123-30660-gallargues_le_montueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30124-30760-le_garn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30124-30760-le_garn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30124-30760-le_garn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30124-30760-le_garn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30125-30128-garons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30125-30128-garons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30125-30128-garons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30125-30128-garons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30126-30190-garrigues_sainte_eulalie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30126-30190-garrigues_sainte_eulalie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30126-30190-garrigues_sainte_eulalie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30126-30190-garrigues_sainte_eulalie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30127-30330-gaujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30127-30330-gaujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30127-30330-gaujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30127-30330-gaujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30128-30510-generac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30128-30510-generac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30128-30510-generac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30128-30510-generac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30129-30140-generargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30129-30140-generargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30129-30140-generargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30129-30140-generargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30130-30450-genolhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30130-30450-genolhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30130-30450-genolhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30130-30450-genolhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30131-30630-goudargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30131-30630-goudargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30131-30630-goudargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30131-30630-goudargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30132-30110-la_grand_combe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30132-30110-la_grand_combe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30132-30110-la_grand_combe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30132-30110-la_grand_combe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30133-30240-le_grau_du_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30133-30240-le_grau_du_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30133-30240-le_grau_du_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30133-30240-le_grau_du_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30134-30760-issirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30134-30760-issirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30134-30760-issirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30134-30760-issirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30135-30300-jonquieres_saint_vincent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30135-30300-jonquieres_saint_vincent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30135-30300-jonquieres_saint_vincent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30135-30300-jonquieres_saint_vincent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30136-30250-junas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30136-30250-junas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30136-30250-junas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30136-30250-junas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30137-30110-lamelouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30137-30110-lamelouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30137-30110-lamelouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30137-30110-lamelouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30138-30980-langlade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30138-30980-langlade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30138-30980-langlade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30138-30980-langlade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30139-30750-lanuejols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30139-30750-lanuejols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30139-30750-lanuejols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30139-30750-lanuejols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30140-30460-lasalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30140-30460-lasalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30140-30460-lasalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30140-30460-lasalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30141-30290-laudun_l_ardoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30141-30290-laudun_l_ardoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30141-30290-laudun_l_ardoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30141-30290-laudun_l_ardoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30142-30110-laval_pradel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30142-30110-laval_pradel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30142-30110-laval_pradel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30142-30110-laval_pradel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30143-30760-laval_saint_roman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30143-30760-laval_saint_roman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30143-30760-laval_saint_roman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30143-30760-laval_saint_roman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30144-30250-lecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30144-30250-lecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30144-30250-lecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30144-30250-lecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30145-30210-ledenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30145-30210-ledenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30145-30210-ledenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30145-30210-ledenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30146-30350-ledignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30146-30350-ledignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30146-30350-ledignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30146-30350-ledignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30147-30350-lezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30147-30350-lezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30147-30350-lezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30147-30350-lezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30148-30260-liouc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30148-30260-liouc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30148-30260-liouc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30148-30260-liouc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30149-30126-lirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30149-30126-lirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30149-30126-lirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30149-30126-lirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30150-30610-logrian_florian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30150-30610-logrian_florian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30150-30610-logrian_florian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30150-30610-logrian_florian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30151-30580-lussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30151-30580-lussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30151-30580-lussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30151-30580-lussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30152-30960-les_mages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30152-30960-les_mages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30152-30960-les_mages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30152-30960-les_mages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30153-30450-malons_et_elze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30153-30450-malons_et_elze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30153-30450-malons_et_elze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30153-30450-malons_et_elze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30154-30120-mandagout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30154-30120-mandagout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30154-30120-mandagout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30154-30120-mandagout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30155-30129-manduel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30155-30129-manduel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30155-30129-manduel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30155-30129-manduel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30156-30320-marguerittes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30156-30320-marguerittes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30156-30320-marguerittes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30156-30320-marguerittes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30158-30360-martignargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30158-30360-martignargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30158-30360-martignargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30158-30360-martignargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30159-30960-le_martinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30159-30960-le_martinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30159-30960-le_martinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30159-30960-le_martinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30160-30350-maruejols_les_gardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30160-30350-maruejols_les_gardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30160-30350-maruejols_les_gardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30160-30350-maruejols_les_gardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30161-30350-massanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30161-30350-massanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30161-30350-massanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30161-30350-massanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30162-30140-massillargues_attuech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30162-30140-massillargues_attuech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30162-30140-massillargues_attuech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30162-30140-massillargues_attuech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30163-30350-mauressargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30163-30350-mauressargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30163-30350-mauressargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30163-30350-mauressargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30164-30430-mejannes_le_clap/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30164-30430-mejannes_le_clap/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30164-30430-mejannes_le_clap/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30164-30430-mejannes_le_clap/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30165-30340-mejannes_les_ales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30165-30340-mejannes_les_ales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30165-30340-mejannes_les_ales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30165-30340-mejannes_les_ales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30166-30840-meynes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30166-30840-meynes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30166-30840-meynes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30166-30840-meynes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30167-30410-meyrannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30167-30410-meyrannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30167-30410-meyrannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30167-30410-meyrannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30168-30140-mialet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30168-30140-mialet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30168-30140-mialet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30168-30140-mialet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30169-30540-milhaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30169-30540-milhaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30169-30540-milhaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30169-30540-milhaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30170-30120-molieres_cavaillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30170-30120-molieres_cavaillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30170-30120-molieres_cavaillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30170-30120-molieres_cavaillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30171-30410-molieres_sur_ceze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30171-30410-molieres_sur_ceze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30171-30410-molieres_sur_ceze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30171-30410-molieres_sur_ceze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30172-30170-monoblet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30172-30170-monoblet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30172-30170-monoblet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30172-30170-monoblet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30173-30340-mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30173-30340-mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30173-30340-mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30173-30340-mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30174-30700-montaren_et_saint_mediers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30174-30700-montaren_et_saint_mediers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30174-30700-montaren_et_saint_mediers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30174-30700-montaren_et_saint_mediers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30175-30630-montclus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30175-30630-montclus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30175-30630-montclus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30175-30630-montclus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30176-30120-montdardier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30176-30120-montdardier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30176-30120-montdardier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30176-30120-montdardier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30177-30360-monteils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30177-30360-monteils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30177-30360-monteils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30177-30360-monteils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30178-30150-montfaucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30178-30150-montfaucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30178-30150-montfaucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30178-30150-montfaucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30179-30490-montfrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30179-30490-montfrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30179-30490-montfrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30179-30490-montfrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30180-30190-montignargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30180-30190-montignargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30180-30190-montignargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30180-30190-montignargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30181-30260-montmirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30181-30260-montmirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30181-30260-montmirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30181-30260-montmirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30182-30730-montpezat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30182-30730-montpezat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30182-30730-montpezat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30182-30730-montpezat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30183-30350-moulezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30183-30350-moulezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30183-30350-moulezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30183-30350-moulezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30184-30190-moussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30184-30190-moussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30184-30190-moussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30184-30190-moussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30185-30121-mus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30185-30121-mus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30185-30121-mus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30185-30121-mus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30186-30114-nages_et_solorgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30186-30114-nages_et_solorgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30186-30114-nages_et_solorgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30186-30114-nages_et_solorgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30187-30580-navacelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30187-30580-navacelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30187-30580-navacelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30187-30580-navacelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30188-30360-ners/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30188-30360-ners/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30188-30360-ners/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30188-30360-ners/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30000-nimes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30000-nimes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30000-nimes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30000-nimes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30998-nimes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30998-nimes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30998-nimes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30998-nimes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30900-nimes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30900-nimes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30900-nimes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30189-30900-nimes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30191-30200-orsan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30191-30200-orsan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30191-30200-orsan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30191-30200-orsan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30192-30260-orthoux_serignac_quilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30192-30260-orthoux_serignac_quilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30192-30260-orthoux_serignac_quilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30192-30260-orthoux_serignac_quilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30193-30730-parignargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30193-30730-parignargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30193-30730-parignargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30193-30730-parignargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30194-30160-peyremale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30194-30160-peyremale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30194-30160-peyremale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30194-30160-peyremale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30195-30124-peyrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30195-30124-peyrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30195-30124-peyrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30195-30124-peyrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30196-30330-le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30196-30330-le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30196-30330-le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30196-30330-le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30197-30340-les_plans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30197-30340-les_plans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30197-30340-les_plans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30197-30340-les_plans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30198-30122-les_plantiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30198-30122-les_plantiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30198-30122-les_plantiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30198-30122-les_plantiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30199-30120-pommiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30199-30120-pommiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30199-30120-pommiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30199-30120-pommiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30200-30170-pompignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30200-30170-pompignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30200-30170-pompignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30200-30170-pompignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30201-30450-ponteils_et_bresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30201-30450-ponteils_et_bresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30201-30450-ponteils_et_bresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30201-30450-ponteils_et_bresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30202-30130-pont_saint_esprit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30202-30130-pont_saint_esprit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30202-30130-pont_saint_esprit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30202-30130-pont_saint_esprit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30203-30530-portes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30203-30530-portes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30203-30530-portes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30203-30530-portes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30204-30500-potelieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30204-30500-potelieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30204-30500-potelieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30204-30500-potelieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30205-30330-pougnadoresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30205-30330-pougnadoresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30205-30330-pougnadoresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30205-30330-pougnadoresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30206-30320-poulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30206-30320-poulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30206-30320-poulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30206-30320-poulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30207-30210-pouzilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30207-30210-pouzilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30207-30210-pouzilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30207-30210-pouzilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30208-30610-puechredon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30208-30610-puechredon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30208-30610-puechredon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30208-30610-puechredon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30209-30131-pujaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30209-30131-pujaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30209-30131-pujaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30209-30131-pujaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30210-30260-quissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30210-30260-quissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30210-30260-quissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30210-30260-quissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30211-30129-redessan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30211-30129-redessan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30211-30129-redessan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30211-30129-redessan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30212-30210-remoulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30212-30210-remoulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30212-30210-remoulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30212-30210-remoulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30213-30750-revens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30213-30750-revens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30213-30750-revens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30213-30750-revens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30214-30720-ribaute_les_tavernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30214-30720-ribaute_les_tavernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30214-30720-ribaute_les_tavernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30214-30720-ribaute_les_tavernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30215-30430-rivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30215-30430-rivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30215-30430-rivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30215-30430-rivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30216-30160-robiac_rochessadoule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30216-30160-robiac_rochessadoule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30216-30160-robiac_rochessadoule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30216-30160-robiac_rochessadoule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30217-30650-rochefort_du_gard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30217-30650-rochefort_du_gard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30217-30650-rochefort_du_gard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30217-30650-rochefort_du_gard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30218-30430-rochegude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30218-30430-rochegude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30218-30430-rochegude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30218-30430-rochegude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30219-30120-rogues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30219-30120-rogues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30219-30120-rogues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30219-30120-rogues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30220-30440-roquedur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30220-30440-roquedur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30220-30440-roquedur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30220-30440-roquedur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30221-30150-roquemaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30221-30150-roquemaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30221-30150-roquemaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30221-30150-roquemaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30222-30200-la_roque_sur_ceze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30222-30200-la_roque_sur_ceze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30222-30200-la_roque_sur_ceze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30222-30200-la_roque_sur_ceze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30223-30340-rousson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30223-30340-rousson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30223-30340-rousson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30223-30340-rousson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30224-30190-la_rouviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30224-30190-la_rouviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30224-30190-la_rouviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30224-30190-la_rouviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30225-30200-sabran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30225-30200-sabran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30225-30200-sabran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30225-30200-sabran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30226-30130-saint_alexandre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30226-30130-saint_alexandre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30226-30130-saint_alexandre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30226-30130-saint_alexandre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30227-30500-saint_ambroix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30227-30500-saint_ambroix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30227-30500-saint_ambroix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30227-30500-saint_ambroix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30228-30190-sainte_anastasie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30228-30190-sainte_anastasie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30228-30190-sainte_anastasie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30228-30190-sainte_anastasie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30229-30570-saint_andre_de_majencoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30229-30570-saint_andre_de_majencoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30229-30570-saint_andre_de_majencoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30229-30570-saint_andre_de_majencoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30230-30630-saint_andre_de_roquepertuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30230-30630-saint_andre_de_roquepertuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30230-30630-saint_andre_de_roquepertuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30230-30630-saint_andre_de_roquepertuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30231-30940-saint_andre_de_valborgne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30231-30940-saint_andre_de_valborgne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30231-30940-saint_andre_de_valborgne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30231-30940-saint_andre_de_valborgne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30232-30330-saint_andre_d_olerargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30232-30330-saint_andre_d_olerargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30232-30330-saint_andre_d_olerargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30232-30330-saint_andre_d_olerargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30233-30730-saint_bauzely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30233-30730-saint_bauzely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30233-30730-saint_bauzely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30233-30730-saint_bauzely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30234-30350-saint_benezet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30234-30350-saint_benezet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30234-30350-saint_benezet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30234-30350-saint_benezet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30235-30210-saint_bonnet_du_gard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30235-30210-saint_bonnet_du_gard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30235-30210-saint_bonnet_du_gard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30235-30210-saint_bonnet_du_gard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30236-30460-saint_bonnet_de_salendrinque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30236-30460-saint_bonnet_de_salendrinque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30236-30460-saint_bonnet_de_salendrinque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30236-30460-saint_bonnet_de_salendrinque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30237-30500-saint_bres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30237-30500-saint_bres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30237-30500-saint_bres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30237-30500-saint_bres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30238-30440-saint_bresson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30238-30440-saint_bresson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30238-30440-saint_bresson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30238-30440-saint_bresson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30239-30110-sainte_cecile_d_andorge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30239-30110-sainte_cecile_d_andorge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30239-30110-sainte_cecile_d_andorge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30239-30110-sainte_cecile_d_andorge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30240-30360-saint_cesaire_de_gauzignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30240-30360-saint_cesaire_de_gauzignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30240-30360-saint_cesaire_de_gauzignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30240-30360-saint_cesaire_de_gauzignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30241-30190-saint_chaptes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30241-30190-saint_chaptes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30241-30190-saint_chaptes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30241-30190-saint_chaptes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30242-30760-saint_christol_de_rodieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30242-30760-saint_christol_de_rodieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30242-30760-saint_christol_de_rodieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30242-30760-saint_christol_de_rodieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30243-30380-saint_christol_les_ales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30243-30380-saint_christol_les_ales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30243-30380-saint_christol_les_ales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30243-30380-saint_christol_les_ales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30244-30260-saint_clement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30244-30260-saint_clement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30244-30260-saint_clement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30244-30260-saint_clement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30245-30870-saint_come_et_maruejols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30245-30870-saint_come_et_maruejols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30245-30870-saint_come_et_maruejols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30245-30870-saint_come_et_maruejols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30246-30460-sainte_croix_de_caderle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30246-30460-sainte_croix_de_caderle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30246-30460-sainte_croix_de_caderle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30246-30460-sainte_croix_de_caderle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30247-30500-saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30247-30500-saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30247-30500-saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30247-30500-saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30248-30190-saint_dezery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30248-30190-saint_dezery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30248-30190-saint_dezery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30248-30190-saint_dezery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30249-30980-saint_dionisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30249-30980-saint_dionisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30249-30980-saint_dionisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30249-30980-saint_dionisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30250-30360-saint_etienne_de_l_olm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30250-30360-saint_etienne_de_l_olm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30250-30360-saint_etienne_de_l_olm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30250-30360-saint_etienne_de_l_olm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30251-30200-saint_etienne_des_sorts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30251-30200-saint_etienne_des_sorts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30251-30200-saint_etienne_des_sorts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30251-30200-saint_etienne_des_sorts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30252-30140-saint_felix_de_pallieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30252-30140-saint_felix_de_pallieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30252-30140-saint_felix_de_pallieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30252-30140-saint_felix_de_pallieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30253-30960-saint_florent_sur_auzonnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30253-30960-saint_florent_sur_auzonnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30253-30960-saint_florent_sur_auzonnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30253-30960-saint_florent_sur_auzonnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30254-30150-saint_genies_de_comolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30254-30150-saint_genies_de_comolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30254-30150-saint_genies_de_comolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30254-30150-saint_genies_de_comolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30255-30190-saint_genies_de_malgoires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30255-30190-saint_genies_de_malgoires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30255-30190-saint_genies_de_malgoires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30255-30190-saint_genies_de_malgoires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30256-30200-saint_gervais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30256-30200-saint_gervais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30256-30200-saint_gervais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30256-30200-saint_gervais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30257-30320-saint_gervasy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30257-30320-saint_gervasy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30257-30320-saint_gervasy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30257-30320-saint_gervasy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30258-30800-saint_gilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30258-30800-saint_gilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30258-30800-saint_gilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30258-30800-saint_gilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30258-30998-saint_gilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30258-30998-saint_gilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30258-30998-saint_gilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30258-30998-saint_gilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30259-30560-saint_hilaire_de_brethmas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30259-30560-saint_hilaire_de_brethmas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30259-30560-saint_hilaire_de_brethmas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30259-30560-saint_hilaire_de_brethmas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30260-30210-saint_hilaire_d_ozilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30260-30210-saint_hilaire_d_ozilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30260-30210-saint_hilaire_d_ozilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30260-30210-saint_hilaire_d_ozilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30261-30360-saint_hippolyte_de_caton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30261-30360-saint_hippolyte_de_caton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30261-30360-saint_hippolyte_de_caton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30261-30360-saint_hippolyte_de_caton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30262-30700-saint_hippolyte_de_montaigu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30262-30700-saint_hippolyte_de_montaigu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30262-30700-saint_hippolyte_de_montaigu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30262-30700-saint_hippolyte_de_montaigu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30263-30170-saint_hippolyte_du_fort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30263-30170-saint_hippolyte_du_fort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30263-30170-saint_hippolyte_du_fort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30263-30170-saint_hippolyte_du_fort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30264-30360-saint_jean_de_ceyrargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30264-30360-saint_jean_de_ceyrargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30264-30360-saint_jean_de_ceyrargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30264-30360-saint_jean_de_ceyrargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30265-30610-saint_jean_de_crieulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30265-30610-saint_jean_de_crieulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30265-30610-saint_jean_de_crieulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30265-30610-saint_jean_de_crieulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30266-30430-saint_jean_de_maruejols_et_avejan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30266-30430-saint_jean_de_maruejols_et_avejan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30266-30430-saint_jean_de_maruejols_et_avejan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30266-30430-saint_jean_de_maruejols_et_avejan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30267-30350-saint_jean_de_serres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30267-30350-saint_jean_de_serres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30267-30350-saint_jean_de_serres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30267-30350-saint_jean_de_serres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30268-30960-saint_jean_de_valeriscle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30268-30960-saint_jean_de_valeriscle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30268-30960-saint_jean_de_valeriscle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30268-30960-saint_jean_de_valeriscle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30269-30270-saint_jean_du_gard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30269-30270-saint_jean_du_gard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30269-30270-saint_jean_du_gard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30269-30270-saint_jean_du_gard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30270-30140-saint_jean_du_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30270-30140-saint_jean_du_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30270-30140-saint_jean_du_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30270-30140-saint_jean_du_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30271-30500-saint_julien_de_cassagnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30271-30500-saint_julien_de_cassagnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30271-30500-saint_julien_de_cassagnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30271-30500-saint_julien_de_cassagnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30272-30440-saint_julien_de_la_nef/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30272-30440-saint_julien_de_la_nef/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30272-30440-saint_julien_de_la_nef/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30272-30440-saint_julien_de_la_nef/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30273-30760-saint_julien_de_peyrolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30273-30760-saint_julien_de_peyrolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30273-30760-saint_julien_de_peyrolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30273-30760-saint_julien_de_peyrolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30274-30340-saint_julien_les_rosiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30274-30340-saint_julien_les_rosiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30274-30340-saint_julien_les_rosiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30274-30340-saint_julien_les_rosiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30275-30580-saint_just_et_vacquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30275-30580-saint_just_et_vacquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30275-30580-saint_just_et_vacquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30275-30580-saint_just_et_vacquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30276-30220-saint_laurent_d_aigouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30276-30220-saint_laurent_d_aigouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30276-30220-saint_laurent_d_aigouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30276-30220-saint_laurent_d_aigouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30277-30200-saint_laurent_de_carnols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30277-30200-saint_laurent_de_carnols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30277-30200-saint_laurent_de_carnols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30277-30200-saint_laurent_de_carnols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30278-30126-saint_laurent_des_arbres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30278-30126-saint_laurent_des_arbres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30278-30126-saint_laurent_des_arbres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30278-30126-saint_laurent_des_arbres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30279-30330-saint_laurent_la_vernede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30279-30330-saint_laurent_la_vernede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30279-30330-saint_laurent_la_vernede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30279-30330-saint_laurent_la_vernede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30280-30440-saint_laurent_le_minier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30280-30440-saint_laurent_le_minier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30280-30440-saint_laurent_le_minier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30280-30440-saint_laurent_le_minier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30281-30730-saint_mamert_du_gard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30281-30730-saint_mamert_du_gard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30281-30730-saint_mamert_du_gard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30281-30730-saint_mamert_du_gard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30282-30330-saint_marcel_de_careiret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30282-30330-saint_marcel_de_careiret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30282-30330-saint_marcel_de_careiret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30282-30330-saint_marcel_de_careiret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30283-30440-saint_martial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30283-30440-saint_martial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30283-30440-saint_martial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30283-30440-saint_martial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30284-30520-saint_martin_de_valgalgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30284-30520-saint_martin_de_valgalgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30284-30520-saint_martin_de_valgalgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30284-30520-saint_martin_de_valgalgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30284-30100-saint_martin_de_valgalgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30284-30100-saint_martin_de_valgalgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30284-30100-saint_martin_de_valgalgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30284-30100-saint_martin_de_valgalgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30285-30360-saint_maurice_de_cazevieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30285-30360-saint_maurice_de_cazevieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30285-30360-saint_maurice_de_cazevieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30285-30360-saint_maurice_de_cazevieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30286-30700-saint_maximin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30286-30700-saint_maximin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30286-30700-saint_maximin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30286-30700-saint_maximin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30287-30200-saint_michel_d_euzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30287-30200-saint_michel_d_euzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30287-30200-saint_michel_d_euzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30287-30200-saint_michel_d_euzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30288-30200-saint_nazaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30288-30200-saint_nazaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30288-30200-saint_nazaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30288-30200-saint_nazaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30289-30610-saint_nazaire_des_gardies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30289-30610-saint_nazaire_des_gardies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30289-30610-saint_nazaire_des_gardies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30289-30610-saint_nazaire_des_gardies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30290-30130-saint_paulet_de_caisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30290-30130-saint_paulet_de_caisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30290-30130-saint_paulet_de_caisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30290-30130-saint_paulet_de_caisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30291-30480-saint_paul_la_coste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30291-30480-saint_paul_la_coste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30291-30480-saint_paul_la_coste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30291-30480-saint_paul_la_coste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30292-30330-saint_pons_la_calm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30292-30330-saint_pons_la_calm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30292-30330-saint_pons_la_calm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30292-30330-saint_pons_la_calm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30293-30430-saint_privat_de_champclos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30293-30430-saint_privat_de_champclos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30293-30430-saint_privat_de_champclos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30293-30430-saint_privat_de_champclos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30294-30340-saint_privat_des_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30294-30340-saint_privat_des_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30294-30340-saint_privat_des_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30294-30340-saint_privat_des_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30295-30700-saint_quentin_la_poterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30295-30700-saint_quentin_la_poterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30295-30700-saint_quentin_la_poterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30295-30700-saint_quentin_la_poterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30296-30440-saint_roman_de_codieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30296-30440-saint_roman_de_codieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30296-30440-saint_roman_de_codieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30296-30440-saint_roman_de_codieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30297-30750-saint_sauveur_camprieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30297-30750-saint_sauveur_camprieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30297-30750-saint_sauveur_camprieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30297-30750-saint_sauveur_camprieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30298-30140-saint_sebastien_d_aigrefeuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30298-30140-saint_sebastien_d_aigrefeuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30298-30140-saint_sebastien_d_aigrefeuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30298-30140-saint_sebastien_d_aigrefeuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30299-30700-saint_siffret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30299-30700-saint_siffret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30299-30700-saint_siffret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30299-30700-saint_siffret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30300-30260-saint_theodorit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30300-30260-saint_theodorit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30300-30260-saint_theodorit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30300-30260-saint_theodorit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30301-30700-saint_victor_des_oules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30301-30700-saint_victor_des_oules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30301-30700-saint_victor_des_oules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30301-30700-saint_victor_des_oules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30302-30290-saint_victor_la_coste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30302-30290-saint_victor_la_coste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30302-30290-saint_victor_la_coste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30302-30290-saint_victor_la_coste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30303-30500-saint_victor_de_malcap/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30303-30500-saint_victor_de_malcap/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30303-30500-saint_victor_de_malcap/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30303-30500-saint_victor_de_malcap/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30304-30760-salazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30304-30760-salazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30304-30760-salazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30304-30760-salazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30305-30340-salindres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30305-30340-salindres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30305-30340-salindres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30305-30340-salindres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30306-30250-salinelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30306-30250-salinelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30306-30250-salinelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30306-30250-salinelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30307-30110-les_salles_du_gardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30307-30110-les_salles_du_gardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30307-30110-les_salles_du_gardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30307-30110-les_salles_du_gardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30308-30700-sanilhac_sagries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30308-30700-sanilhac_sagries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30308-30700-sanilhac_sagries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30308-30700-sanilhac_sagries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30309-30260-sardan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30309-30260-sardan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30309-30260-sardan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30309-30260-sardan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30310-30125-saumane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30310-30125-saumane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30310-30125-saumane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30310-30125-saumane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30311-30610-sauve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30311-30610-sauve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30311-30610-sauve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30311-30610-sauve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30312-30150-sauveterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30312-30150-sauveterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30312-30150-sauveterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30312-30150-sauveterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30313-30190-sauzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30313-30190-sauzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30313-30190-sauzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30313-30190-sauzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30314-30350-savignargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30314-30350-savignargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30314-30350-savignargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30314-30350-savignargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30315-30650-saze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30315-30650-saze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30315-30650-saze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30315-30650-saze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30316-30450-senechas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30316-30450-senechas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30316-30450-senechas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30316-30450-senechas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30317-30210-sernhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30317-30210-sernhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30317-30210-sernhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30317-30210-sernhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30318-30340-servas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30318-30340-servas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30318-30340-servas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30318-30340-servas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30319-30700-serviers_et_labaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30319-30700-serviers_et_labaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30319-30700-serviers_et_labaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30319-30700-serviers_et_labaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30320-30580-seynes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30320-30580-seynes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30320-30580-seynes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30320-30580-seynes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30321-30250-sommieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30321-30250-sommieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30321-30250-sommieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30321-30250-sommieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30322-30460-soudorgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30322-30460-soudorgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30322-30460-soudorgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30322-30460-soudorgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30323-30110-soustelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30323-30110-soustelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30323-30110-soustelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30323-30110-soustelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30324-30250-souvignargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30324-30250-souvignargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30324-30250-souvignargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30324-30250-souvignargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30325-30440-sumene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30325-30440-sumene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30325-30440-sumene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30325-30440-sumene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30326-30126-tavel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30326-30126-tavel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30326-30126-tavel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30326-30126-tavel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30327-30430-tharaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30327-30430-tharaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30327-30430-tharaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30327-30430-tharaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30328-30390-theziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30328-30390-theziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30328-30390-theziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30328-30390-theziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30329-30140-thoiras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30329-30140-thoiras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30329-30140-thoiras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30329-30140-thoiras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30330-30140-tornac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30330-30140-tornac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30330-30140-tornac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30330-30140-tornac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30331-30330-tresques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30331-30330-tresques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30331-30330-tresques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30331-30330-tresques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30332-30750-treves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30332-30750-treves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30332-30750-treves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30332-30750-treves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30333-30620-uchaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30333-30620-uchaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30333-30620-uchaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30333-30620-uchaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30334-30700-uzes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30334-30700-uzes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30334-30700-uzes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30334-30700-uzes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30335-30460-vabres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30335-30460-vabres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30335-30460-vabres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30335-30460-vabres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30336-30300-vallabregues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30336-30300-vallabregues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30336-30300-vallabregues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30336-30300-vallabregues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30337-30700-vallabrix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30337-30700-vallabrix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30337-30700-vallabrix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30337-30700-vallabrix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30338-30580-vallerargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30338-30580-vallerargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30338-30580-vallerargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30338-30580-vallerargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30339-30570-val_d’aigoual/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30339-30570-val_d’aigoual/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30339-30570-val_d’aigoual/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30339-30570-val_d’aigoual/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30340-30210-valliguieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30340-30210-valliguieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30340-30210-valliguieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30340-30210-valliguieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30341-30600-vauvert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30341-30600-vauvert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30341-30600-vauvert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30341-30600-vauvert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30341-30640-vauvert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30341-30640-vauvert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30341-30640-vauvert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30341-30640-vauvert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30342-30200-venejan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30342-30200-venejan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30342-30200-venejan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30342-30200-venejan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30343-30630-verfeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30343-30630-verfeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30343-30630-verfeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30343-30630-verfeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30344-30310-vergeze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30344-30310-vergeze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30344-30310-vergeze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30344-30310-vergeze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30345-30530-la_vernarede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30345-30530-la_vernarede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30345-30530-la_vernarede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30345-30530-la_vernarede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30346-30210-vers_pont_du_gard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30346-30210-vers_pont_du_gard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30346-30210-vers_pont_du_gard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30346-30210-vers_pont_du_gard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30347-30600-vestric_et_candiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30347-30600-vestric_et_candiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30347-30600-vestric_et_candiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30347-30600-vestric_et_candiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30348-30360-vezenobres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30348-30360-vezenobres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30348-30360-vezenobres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30348-30360-vezenobres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30349-30260-vic_le_fesq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30349-30260-vic_le_fesq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30349-30260-vic_le_fesq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30349-30260-vic_le_fesq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30350-30120-le_vigan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30350-30120-le_vigan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30350-30120-le_vigan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30350-30120-le_vigan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30351-30400-villeneuve_les_avignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30351-30400-villeneuve_les_avignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30351-30400-villeneuve_les_avignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30351-30400-villeneuve_les_avignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30352-30250-villevieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30352-30250-villevieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30352-30250-villevieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30352-30250-villevieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30353-30770-vissec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30353-30770-vissec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30353-30770-vissec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30353-30770-vissec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30354-30350-montagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30354-30350-montagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30354-30350-montagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30354-30350-montagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30355-30330-saint_paul_les_fonts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30355-30330-saint_paul_les_fonts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30355-30330-saint_paul_les_fonts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30355-30330-saint_paul_les_fonts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30356-30230-rodilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30356-30230-rodilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30356-30230-rodilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt30-gard/commune30356-30230-rodilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-31.xml
+++ b/public/sitemaps/sitemap-31.xml
@@ -5,1192 +5,2380 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31001-31230-agassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31001-31230-agassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31001-31230-agassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31001-31230-agassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31002-31550-aignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31002-31550-aignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31002-31550-aignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31002-31550-aignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31003-31280-aigrefeuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31003-31280-aigrefeuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31003-31280-aigrefeuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31003-31280-aigrefeuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31004-31450-ayguesvives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31004-31450-ayguesvives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31004-31450-ayguesvives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31004-31450-ayguesvives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31005-31420-alan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31005-31420-alan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31005-31420-alan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31005-31420-alan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31006-31460-albiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31006-31460-albiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31006-31460-albiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31006-31460-albiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31007-31230-ambax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31007-31230-ambax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31007-31230-ambax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31007-31230-ambax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31008-31230-anan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31008-31230-anan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31008-31230-anan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31008-31230-anan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31009-31510-antichan_de_frontignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31009-31510-antichan_de_frontignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31009-31510-antichan_de_frontignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31009-31510-antichan_de_frontignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31010-31110-antignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31010-31110-antignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31010-31110-antignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31010-31110-antignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31011-31160-arbas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31011-31160-arbas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31011-31160-arbas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31011-31160-arbas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31012-31160-arbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31012-31160-arbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31012-31160-arbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31012-31160-arbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31013-31210-ardiege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31013-31210-ardiege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31013-31210-ardiege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31013-31210-ardiege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31014-31160-arguenos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31014-31160-arguenos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31014-31160-arguenos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31014-31160-arguenos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31015-31440-argut_dessous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31015-31440-argut_dessous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31015-31440-argut_dessous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31015-31440-argut_dessous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31017-31440-arlos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31017-31440-arlos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31017-31440-arlos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31017-31440-arlos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31018-31360-arnaud_guilhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31018-31360-arnaud_guilhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31018-31360-arnaud_guilhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31018-31360-arnaud_guilhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31019-31110-artigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31019-31110-artigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31019-31110-artigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31019-31110-artigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31020-31160-aspet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31020-31160-aspet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31020-31160-aspet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31020-31160-aspet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31021-31800-aspret_sarrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31021-31800-aspret_sarrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31021-31800-aspret_sarrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31021-31800-aspret_sarrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31022-31140-aucamville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31022-31140-aucamville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31022-31140-aucamville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31022-31140-aucamville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31023-31420-aulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31023-31420-aulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31023-31420-aulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31023-31420-aulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31024-31190-auragne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31024-31190-auragne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31024-31190-auragne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31024-31190-auragne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31025-31320-aureville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31025-31320-aureville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31025-31320-aureville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31025-31320-aureville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31026-31460-auriac_sur_vendinelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31026-31460-auriac_sur_vendinelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31026-31460-auriac_sur_vendinelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31026-31460-auriac_sur_vendinelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31027-31190-auribail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31027-31190-auribail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31027-31190-auribail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31027-31190-auribail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31028-31420-aurignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31028-31420-aurignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31028-31420-aurignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31028-31420-aurignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31029-31570-aurin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31029-31570-aurin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31029-31570-aurin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31029-31570-aurin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31030-31260-ausseing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31030-31260-ausseing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31030-31260-ausseing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31030-31260-ausseing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31031-31210-ausson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31031-31210-ausson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31031-31210-ausson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31031-31210-ausson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31032-31840-aussonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31032-31840-aussonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31032-31840-aussonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31032-31840-aussonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31033-31190-auterive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31033-31190-auterive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31033-31190-auterive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31033-31190-auterive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31034-31360-auzas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31034-31360-auzas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31034-31360-auzas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31034-31360-auzas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31035-31320-auzeville_tolosane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31035-31320-auzeville_tolosane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31035-31320-auzeville_tolosane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31035-31320-auzeville_tolosane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31036-31650-auzielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31036-31650-auzielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31036-31650-auzielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31036-31650-auzielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31037-31290-avignonet_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31037-31290-avignonet_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31037-31290-avignonet_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31037-31290-avignonet_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31038-31380-azas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31038-31380-azas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31038-31380-azas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31038-31380-azas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31039-31420-bachas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31039-31420-bachas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31039-31420-bachas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31039-31420-bachas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31040-31440-bachos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31040-31440-bachos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31040-31440-bachos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31040-31440-bachos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31041-31510-bagiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31041-31510-bagiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31041-31510-bagiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31041-31510-bagiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31042-31110-bagneres_de_luchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31042-31110-bagneres_de_luchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31042-31110-bagneres_de_luchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31042-31110-bagneres_de_luchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31043-31580-balesta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31043-31580-balesta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31043-31580-balesta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31043-31580-balesta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31044-31130-balma/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31044-31130-balma/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31044-31130-balma/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31044-31130-balma/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31045-31510-barbazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31045-31510-barbazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31045-31510-barbazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31045-31510-barbazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31046-31440-baren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31046-31440-baren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31046-31440-baren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31046-31440-baren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31047-31310-bax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31047-31310-bax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31047-31310-bax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31047-31310-bax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31048-31450-baziege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31048-31450-baziege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31048-31450-baziege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31048-31450-baziege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31049-31380-bazus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31049-31380-bazus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31049-31380-bazus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31049-31380-bazus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31050-31360-beauchalot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31050-31360-beauchalot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31050-31360-beauchalot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31050-31360-beauchalot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31051-31370-beaufort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31051-31370-beaufort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31051-31370-beaufort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31051-31370-beaufort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31052-31870-beaumont_sur_leze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31052-31870-beaumont_sur_leze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31052-31870-beaumont_sur_leze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31052-31870-beaumont_sur_leze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31053-31850-beaupuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31053-31850-beaupuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31053-31850-beaupuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31053-31850-beaupuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31054-31290-beauteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31054-31290-beauteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31054-31290-beauteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31054-31290-beauteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31055-31460-beauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31055-31460-beauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31055-31460-beauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31055-31460-beauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31056-31700-beauzelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31056-31700-beauzelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31056-31700-beauzelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31056-31700-beauzelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31057-31450-belberaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31057-31450-belberaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31057-31450-belberaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31057-31450-belberaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31058-31450-belbeze_de_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31058-31450-belbeze_de_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31058-31450-belbeze_de_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31058-31450-belbeze_de_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31059-31260-belbeze_en_comminges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31059-31260-belbeze_en_comminges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31059-31260-belbeze_en_comminges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31059-31260-belbeze_en_comminges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31060-31540-belesta_en_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31060-31540-belesta_en_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31060-31540-belesta_en_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31060-31540-belesta_en_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31061-31530-bellegarde_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31061-31530-bellegarde_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31061-31530-bellegarde_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31061-31530-bellegarde_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31062-31480-bellesserre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31062-31480-bellesserre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31062-31480-bellesserre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31062-31480-bellesserre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31063-31420-benque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31063-31420-benque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31063-31420-benque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31063-31420-benque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31064-31110-benque_dessous_et_dessus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31064-31110-benque_dessous_et_dessus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31064-31110-benque_dessous_et_dessus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31064-31110-benque_dessous_et_dessus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31065-31370-berat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31065-31370-berat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31065-31370-berat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31065-31370-berat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31066-31660-bessieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31066-31660-bessieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31066-31660-bessieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31066-31660-bessieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31067-31440-bezins_garraux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31067-31440-bezins_garraux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31067-31440-bezins_garraux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31067-31440-bezins_garraux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31068-31110-billiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31068-31110-billiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31068-31110-billiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31068-31110-billiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31069-31700-blagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31069-31700-blagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31069-31700-blagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31069-31700-blagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31070-31350-blajan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31070-31350-blajan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31070-31350-blajan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31070-31350-blajan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31071-31390-bois_de_la_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31071-31390-bois_de_la_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31071-31390-bois_de_la_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31071-31390-bois_de_la_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31072-31230-boissede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31072-31230-boissede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31072-31230-boissede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31072-31230-boissede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31073-31340-bondigoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31073-31340-bondigoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31073-31340-bondigoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31073-31340-bondigoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31074-31590-bonrepos_riquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31074-31590-bonrepos_riquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31074-31590-bonrepos_riquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31074-31590-bonrepos_riquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31075-31470-bonrepos_sur_aussonnelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31075-31470-bonrepos_sur_aussonnelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31075-31470-bonrepos_sur_aussonnelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31075-31470-bonrepos_sur_aussonnelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31076-31210-bordes_de_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31076-31210-bordes_de_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31076-31210-bordes_de_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31076-31210-bordes_de_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31077-31340-le_born/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31077-31340-le_born/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31077-31340-le_born/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31077-31340-le_born/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31078-31580-boudrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31078-31580-boudrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31078-31580-boudrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31078-31580-boudrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31079-31620-bouloc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31079-31620-bouloc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31079-31620-bouloc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31079-31620-bouloc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31080-31350-boulogne_sur_gesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31080-31350-boulogne_sur_gesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31080-31350-boulogne_sur_gesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31080-31350-boulogne_sur_gesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31081-31110-bourg_d_oueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31081-31110-bourg_d_oueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31081-31110-bourg_d_oueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31081-31110-bourg_d_oueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31082-31570-bourg_saint_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31082-31570-bourg_saint_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31082-31570-bourg_saint_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31082-31570-bourg_saint_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31083-31420-boussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31083-31420-boussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31083-31420-boussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31083-31420-boussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31084-31360-boussens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31084-31360-boussens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31084-31360-boussens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31084-31360-boussens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31085-31160-boutx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31085-31160-boutx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31085-31160-boutx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31085-31160-boutx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31085-31440-boutx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31085-31440-boutx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31085-31440-boutx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31085-31440-boutx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31086-31420-bouzin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31086-31420-bouzin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31086-31420-bouzin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31086-31420-bouzin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31087-31470-bragayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31087-31470-bragayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31087-31470-bragayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31087-31470-bragayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31088-31490-brax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31088-31490-brax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31088-31490-brax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31088-31490-brax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31089-31530-bretx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31089-31530-bretx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31089-31530-bretx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31089-31530-bretx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31090-31480-brignemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31090-31480-brignemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31090-31480-brignemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31090-31480-brignemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31091-31150-bruguieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31091-31150-bruguieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31091-31150-bruguieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31091-31150-bruguieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31092-31440-burgalays/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31092-31440-burgalays/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31092-31440-burgalays/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31092-31440-burgalays/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31093-31330-le_burgaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31093-31330-le_burgaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31093-31330-le_burgaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31093-31330-le_burgaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31094-31660-buzet_sur_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31094-31660-buzet_sur_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31094-31660-buzet_sur_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31094-31660-buzet_sur_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31095-31160-cabanac_cazaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31095-31160-cabanac_cazaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31095-31160-cabanac_cazaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31095-31160-cabanac_cazaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31096-31480-cabanac_seguenville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31096-31480-cabanac_seguenville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31096-31480-cabanac_seguenville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31096-31480-cabanac_seguenville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31097-31460-le_cabanial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31097-31460-le_cabanial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31097-31460-le_cabanial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31097-31460-le_cabanial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31098-31480-cadours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31098-31480-cadours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31098-31480-cadours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31098-31480-cadours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31099-31560-caignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31099-31560-caignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31099-31560-caignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31099-31560-caignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31100-31560-calmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31100-31560-calmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31100-31560-calmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31100-31560-calmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31101-31470-cambernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31101-31470-cambernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31101-31470-cambernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31101-31470-cambernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31102-31460-cambiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31102-31460-cambiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31102-31460-cambiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31102-31460-cambiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31103-31310-canens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31103-31310-canens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31103-31310-canens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31103-31310-canens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31104-31410-capens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31104-31410-capens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31104-31410-capens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31104-31410-capens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31105-31460-caragoudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31105-31460-caragoudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31105-31460-caragoudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31105-31460-caragoudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31106-31460-caraman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31106-31460-caraman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31106-31460-caraman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31106-31460-caraman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31107-31390-carbonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31107-31390-carbonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31107-31390-carbonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31107-31390-carbonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31108-31350-cardeilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31108-31350-cardeilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31108-31350-cardeilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31108-31350-cardeilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31109-31420-cassagnabere_tournas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31109-31420-cassagnabere_tournas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31109-31420-cassagnabere_tournas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31109-31420-cassagnabere_tournas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31110-31260-cassagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31110-31260-cassagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31110-31260-cassagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31110-31260-cassagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31111-31310-castagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31111-31310-castagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31111-31310-castagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31111-31310-castagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31112-31260-castagnede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31112-31260-castagnede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31112-31260-castagnede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31112-31260-castagnede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31113-31320-castanet_tolosan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31113-31320-castanet_tolosan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31113-31320-castanet_tolosan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31113-31320-castanet_tolosan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31114-31160-castelbiague/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31114-31160-castelbiague/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31114-31160-castelbiague/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31114-31160-castelbiague/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31115-31230-castelgaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31115-31230-castelgaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31115-31230-castelgaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31115-31230-castelgaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31116-31780-castelginest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31116-31780-castelginest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31116-31780-castelginest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31116-31780-castelginest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31117-31180-castelmaurou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31117-31180-castelmaurou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31117-31180-castelmaurou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31117-31180-castelmaurou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31118-31620-castelnau_d_estretefonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31118-31620-castelnau_d_estretefonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31118-31620-castelnau_d_estretefonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31118-31620-castelnau_d_estretefonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31119-31430-castelnau_picampeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31119-31430-castelnau_picampeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31119-31430-castelnau_picampeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31119-31430-castelnau_picampeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31120-31530-le_castera/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31120-31530-le_castera/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31120-31530-le_castera/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31120-31530-le_castera/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31121-31350-castera_vignoles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31121-31350-castera_vignoles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31121-31350-castera_vignoles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31121-31350-castera_vignoles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31122-31430-casties_labrande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31122-31430-casties_labrande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31122-31430-casties_labrande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31122-31430-casties_labrande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31123-31110-castillon_de_larboust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31123-31110-castillon_de_larboust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31123-31110-castillon_de_larboust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31123-31110-castillon_de_larboust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31124-31360-castillon_de_saint_martory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31124-31360-castillon_de_saint_martory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31124-31360-castillon_de_saint_martory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31124-31360-castillon_de_saint_martory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31125-31110-cathervielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31125-31110-cathervielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31125-31110-cathervielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31125-31110-cathervielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31126-31480-caubiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31126-31480-caubiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31126-31480-caubiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31126-31480-caubiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31127-31110-caubous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31127-31110-caubous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31127-31110-caubous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31127-31110-caubous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31128-31190-caujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31128-31190-caujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31128-31190-caujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31128-31190-caujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31129-31110-cazarilh_laspenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31129-31110-cazarilh_laspenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31129-31110-cazarilh_laspenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31129-31110-cazarilh_laspenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31130-31580-cazaril_tamboures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31130-31580-cazaril_tamboures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31130-31580-cazaril_tamboures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31130-31580-cazaril_tamboures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31131-31160-cazaunous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31131-31160-cazaunous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31131-31160-cazaunous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31131-31160-cazaunous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31132-31440-cazaux_layrisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31132-31440-cazaux_layrisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31132-31440-cazaux_layrisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31132-31440-cazaux_layrisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31133-31110-cazeaux_de_larboust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31133-31110-cazeaux_de_larboust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31133-31110-cazeaux_de_larboust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31133-31110-cazeaux_de_larboust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31134-31420-cazeneuve_montaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31134-31420-cazeneuve_montaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31134-31420-cazeneuve_montaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31134-31420-cazeneuve_montaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31135-31220-cazeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31135-31220-cazeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31135-31220-cazeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31135-31220-cazeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31136-31620-cepet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31136-31620-cepet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31136-31620-cepet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31136-31620-cepet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31137-31290-cessales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31137-31290-cessales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31137-31290-cessales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31137-31290-cessales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31138-31350-charlas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31138-31350-charlas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31138-31350-charlas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31138-31350-charlas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31139-31440-chaum/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31139-31440-chaum/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31139-31440-chaum/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31139-31440-chaum/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31140-31160-chein_dessus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31140-31160-chein_dessus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31140-31160-chein_dessus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31140-31160-chein_dessus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31141-31350-ciadoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31141-31350-ciadoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31141-31350-ciadoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31141-31350-ciadoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31142-31110-cier_de_luchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31142-31110-cier_de_luchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31142-31110-cier_de_luchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31142-31110-cier_de_luchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31143-31510-cier_de_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31143-31510-cier_de_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31143-31510-cier_de_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31143-31510-cier_de_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31144-31440-cierp_gaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31144-31440-cierp_gaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31144-31440-cierp_gaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31144-31440-cierp_gaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31145-31550-cintegabelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31145-31550-cintegabelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31145-31550-cintegabelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31145-31550-cintegabelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31146-31110-cires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31146-31110-cires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31146-31110-cires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31146-31110-cires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31147-31210-clarac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31147-31210-clarac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31147-31210-clarac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31147-31210-clarac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31148-31810-clermont_le_fort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31148-31810-clermont_le_fort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31148-31810-clermont_le_fort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31148-31810-clermont_le_fort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31149-31770-colomiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31149-31770-colomiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31149-31770-colomiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31149-31770-colomiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31150-31700-cornebarrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31150-31700-cornebarrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31150-31700-cornebarrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31150-31700-cornebarrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31151-31450-corronsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31151-31450-corronsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31151-31450-corronsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31151-31450-corronsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31152-31230-coueilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31152-31230-coueilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31152-31230-coueilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31152-31230-coueilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31153-31220-couladere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31153-31220-couladere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31153-31220-couladere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31153-31220-couladere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31155-31160-couret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31155-31160-couret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31155-31160-couret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31155-31160-couret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31156-31480-cox/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31156-31480-cox/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31156-31480-cox/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31156-31480-cox/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31157-31270-cugnaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31157-31270-cugnaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31157-31270-cugnaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31157-31270-cugnaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31158-31210-cuguron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31158-31210-cuguron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31158-31210-cuguron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31158-31210-cuguron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31159-31210-le_cuing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31159-31210-le_cuing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31159-31210-le_cuing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31159-31210-le_cuing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31160-31700-daux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31160-31700-daux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31160-31700-daux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31160-31700-daux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31161-31450-deyme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31161-31450-deyme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31161-31450-deyme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31161-31450-deyme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31162-31450-donneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31162-31450-donneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31162-31450-donneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31162-31450-donneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31163-31280-dremil_lafage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31163-31280-dremil_lafage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31163-31280-dremil_lafage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31163-31280-dremil_lafage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31164-31480-drudas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31164-31480-drudas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31164-31480-drudas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31164-31480-drudas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31165-31600-eaunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31165-31600-eaunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31165-31600-eaunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31165-31600-eaunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31166-31470-empeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31166-31470-empeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31166-31470-empeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31166-31470-empeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31167-31160-encausse_les_thermes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31167-31160-encausse_les_thermes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31167-31160-encausse_les_thermes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31167-31160-encausse_les_thermes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31168-31420-eoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31168-31420-eoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31168-31420-eoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31168-31420-eoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31169-31750-escalquens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31169-31750-escalquens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31169-31750-escalquens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31169-31750-escalquens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31170-31350-escanecrabe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31170-31350-escanecrabe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31170-31350-escanecrabe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31170-31350-escanecrabe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31171-31450-espanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31171-31450-espanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31171-31450-espanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31171-31450-espanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31172-31420-esparron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31172-31420-esparron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31172-31420-esparron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31172-31420-esparron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31173-31190-esperce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31173-31190-esperce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31173-31190-esperce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31173-31190-esperce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31174-31160-estadens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31174-31160-estadens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31174-31160-estadens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31174-31160-estadens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31175-31800-estancarbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31175-31800-estancarbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31175-31800-estancarbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31175-31800-estancarbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31176-31440-estenos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31176-31440-estenos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31176-31440-estenos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31176-31440-estenos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31177-31440-eup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31177-31440-eup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31177-31440-eup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31177-31440-eup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31178-31230-fabas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31178-31230-fabas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31178-31230-fabas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31178-31230-fabas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31179-31460-le_faget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31179-31460-le_faget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31179-31460-le_faget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31179-31460-le_faget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31180-31540-falga/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31180-31540-falga/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31180-31540-falga/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31180-31540-falga/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31181-31410-le_fauga/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31181-31410-le_fauga/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31181-31410-le_fauga/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31181-31410-le_fauga/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31182-31150-fenouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31182-31150-fenouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31182-31150-fenouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31182-31150-fenouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31183-31260-figarol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31183-31260-figarol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31183-31260-figarol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31183-31260-figarol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31184-31130-flourens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31184-31130-flourens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31184-31130-flourens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31184-31130-flourens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31185-31290-folcarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31185-31290-folcarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31185-31290-folcarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31185-31290-folcarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31186-31140-fonbeauzard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31186-31140-fonbeauzard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31186-31140-fonbeauzard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31186-31140-fonbeauzard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31187-31470-fonsorbes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31187-31470-fonsorbes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31187-31470-fonsorbes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31187-31470-fonsorbes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31188-31470-fontenilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31188-31470-fontenilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31188-31470-fontenilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31188-31470-fontenilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31189-31370-forgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31189-31370-forgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31189-31370-forgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31189-31370-forgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31190-31440-fos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31190-31440-fos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31190-31440-fos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31190-31440-fos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31191-31160-fougaron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31191-31160-fougaron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31191-31160-fougaron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31191-31160-fougaron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31192-31450-fourquevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31192-31450-fourquevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31192-31450-fourquevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31192-31450-fourquevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31193-31430-le_fousseret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31193-31430-le_fousseret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31193-31430-le_fousseret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31193-31430-le_fousseret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31194-31460-francarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31194-31460-francarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31194-31460-francarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31194-31460-francarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31195-31260-francazal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31195-31260-francazal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31195-31260-francazal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31195-31260-francazal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31196-31420-francon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31196-31420-francon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31196-31420-francon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31196-31420-francon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31197-31210-franquevielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31197-31210-franquevielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31197-31210-franquevielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31197-31210-franquevielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31198-31360-le_frechet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31198-31360-le_frechet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31198-31360-le_frechet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31198-31360-le_frechet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31199-31440-fronsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31199-31440-fronsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31199-31440-fronsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31199-31440-fronsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31200-31510-frontignan_de_comminges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31200-31510-frontignan_de_comminges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31200-31510-frontignan_de_comminges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31200-31510-frontignan_de_comminges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31201-31230-frontignan_saves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31201-31230-frontignan_saves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31201-31230-frontignan_saves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31201-31230-frontignan_saves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31202-31620-fronton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31202-31620-fronton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31202-31620-fronton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31202-31620-fronton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31203-31270-frouzins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31203-31270-frouzins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31203-31270-frouzins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31203-31270-frouzins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31204-31430-fustignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31204-31430-fustignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31204-31430-fustignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31204-31430-fustignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31205-31150-gagnac_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31205-31150-gagnac_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31205-31150-gagnac_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31205-31150-gagnac_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31206-31550-gaillac_toulza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31206-31550-gaillac_toulza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31206-31550-gaillac_toulza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31206-31550-gaillac_toulza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31207-31510-galie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31207-31510-galie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31207-31510-galie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31207-31510-galie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31208-31160-ganties/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31208-31160-ganties/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31208-31160-ganties/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31208-31160-ganties/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31209-31480-garac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31209-31480-garac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31209-31480-garac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31209-31480-garac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31210-31290-gardouch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31210-31290-gardouch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31210-31290-gardouch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31210-31290-gardouch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31211-31620-gargas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31211-31620-gargas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31211-31620-gargas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31211-31620-gargas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31212-31380-garidech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31212-31380-garidech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31212-31380-garidech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31212-31380-garidech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31213-31110-garin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31213-31110-garin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31213-31110-garin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31213-31110-garin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31215-31590-gaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31215-31590-gaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31215-31590-gaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31215-31590-gaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31216-31380-gemil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31216-31380-gemil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31216-31380-gemil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31216-31380-gemil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31217-31510-genos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31217-31510-genos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31217-31510-genos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31217-31510-genos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31218-31350-gensac_de_boulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31218-31350-gensac_de_boulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31218-31350-gensac_de_boulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31218-31350-gensac_de_boulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31219-31310-gensac_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31219-31310-gensac_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31219-31310-gensac_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31219-31310-gensac_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31220-31560-gibel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31220-31560-gibel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31220-31560-gibel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31220-31560-gibel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31221-31110-gouaux_de_larboust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31221-31110-gouaux_de_larboust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31221-31110-gouaux_de_larboust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31221-31110-gouaux_de_larboust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31222-31110-gouaux_de_luchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31222-31110-gouaux_de_luchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31222-31110-gouaux_de_luchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31222-31110-gouaux_de_luchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31223-31230-goudex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31223-31230-goudex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31223-31230-goudex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31223-31230-goudex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31224-31210-gourdan_polignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31224-31210-gourdan_polignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31224-31210-gourdan_polignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31224-31210-gourdan_polignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31225-31310-goutevernisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31225-31310-goutevernisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31225-31310-goutevernisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31225-31310-goutevernisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31226-31310-gouzens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31226-31310-gouzens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31226-31310-gouzens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31226-31310-gouzens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31227-31120-goyrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31227-31120-goyrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31227-31120-goyrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31227-31120-goyrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31228-31380-gragnague/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31228-31380-gragnague/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31228-31380-gragnague/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31228-31380-gragnague/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31229-31430-gratens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31229-31430-gratens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31229-31430-gratens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31229-31430-gratens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31230-31150-gratentour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31230-31150-gratentour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31230-31150-gratentour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31230-31150-gratentour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31231-31190-grazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31231-31190-grazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31231-31190-grazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31231-31190-grazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31232-31330-grenade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31232-31330-grenade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31232-31330-grenade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31232-31330-grenade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31233-31190-grepiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31233-31190-grepiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31233-31190-grepiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31233-31190-grepiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31234-31480-le_gres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31234-31480-le_gres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31234-31480-le_gres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31234-31480-le_gres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31235-31440-guran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31235-31440-guran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31235-31440-guran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31235-31440-guran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31236-31160-herran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31236-31160-herran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31236-31160-herran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31236-31160-herran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31237-31260-his/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31237-31260-his/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31237-31260-his/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31237-31260-his/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31238-31210-huos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31238-31210-huos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31238-31210-huos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31238-31210-huos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31239-31230-l_isle_en_dodon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31239-31230-l_isle_en_dodon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31239-31230-l_isle_en_dodon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31239-31230-l_isle_en_dodon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31240-31450-issus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31240-31450-issus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31240-31450-issus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31240-31450-issus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31241-31160-izaut_de_l_hotel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31241-31160-izaut_de_l_hotel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31241-31160-izaut_de_l_hotel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31241-31160-izaut_de_l_hotel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31242-31110-jurvielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31242-31110-jurvielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31242-31110-jurvielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31242-31110-jurvielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31243-31540-juzes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31243-31540-juzes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31243-31540-juzes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31243-31540-juzes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31244-31110-juzet_de_luchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31244-31110-juzet_de_luchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31244-31110-juzet_de_luchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31244-31110-juzet_de_luchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31245-31160-juzet_d_izaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31245-31160-juzet_d_izaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31245-31160-juzet_d_izaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31245-31160-juzet_d_izaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31246-31800-labarthe_inard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31246-31800-labarthe_inard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31246-31800-labarthe_inard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31246-31800-labarthe_inard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31247-31800-labarthe_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31247-31800-labarthe_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31247-31800-labarthe_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31247-31800-labarthe_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31248-31860-labarthe_sur_leze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31248-31860-labarthe_sur_leze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31248-31860-labarthe_sur_leze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31248-31860-labarthe_sur_leze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31249-31450-labastide_beauvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31249-31450-labastide_beauvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31249-31450-labastide_beauvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31249-31450-labastide_beauvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31250-31370-labastide_clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31250-31370-labastide_clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31250-31370-labastide_clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31250-31370-labastide_clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31251-31230-labastide_paumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31251-31230-labastide_paumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31251-31230-labastide_paumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31251-31230-labastide_paumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31252-31620-labastide_saint_sernin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31252-31620-labastide_saint_sernin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31252-31620-labastide_saint_sernin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31252-31620-labastide_saint_sernin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31253-31600-labastidette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31253-31600-labastidette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31253-31600-labastidette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31253-31600-labastidette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31254-31670-labege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31254-31670-labege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31254-31670-labege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31254-31670-labege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31255-31510-labroquere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31255-31510-labroquere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31255-31510-labroquere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31255-31510-labroquere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31256-31190-labruyere_dorsa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31256-31190-labruyere_dorsa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31256-31190-labruyere_dorsa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31256-31190-labruyere_dorsa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31258-31390-lacaugne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31258-31390-lacaugne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31258-31390-lacaugne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31258-31390-lacaugne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31259-31120-lacroix_falgarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31259-31120-lacroix_falgarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31259-31120-lacroix_falgarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31259-31120-lacroix_falgarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31260-31360-laffite_toupiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31260-31360-laffite_toupiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31260-31360-laffite_toupiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31260-31360-laffite_toupiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31261-31390-lafitte_vigordane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31261-31390-lafitte_vigordane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31261-31390-lafitte_vigordane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31261-31390-lafitte_vigordane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31262-31290-lagarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31262-31290-lagarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31262-31290-lagarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31262-31290-lagarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31263-31870-lagardelle_sur_leze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31263-31870-lagardelle_sur_leze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31263-31870-lagardelle_sur_leze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31263-31870-lagardelle_sur_leze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31264-31190-lagrace_dieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31264-31190-lagrace_dieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31264-31190-lagrace_dieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31264-31190-lagrace_dieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31265-31480-lagraulet_saint_nicolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31265-31480-lagraulet_saint_nicolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31265-31480-lagraulet_saint_nicolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31265-31480-lagraulet_saint_nicolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31266-31370-lahage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31266-31370-lahage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31266-31370-lahage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31266-31370-lahage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31267-31310-lahitere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31267-31310-lahitere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31267-31310-lahitere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31267-31310-lahitere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31268-31800-lalouret_laffiteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31268-31800-lalouret_laffiteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31268-31800-lalouret_laffiteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31268-31800-lalouret_laffiteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31269-31600-lamasquere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31269-31600-lamasquere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31269-31600-lamasquere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31269-31600-lamasquere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31270-31800-landorthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31270-31800-landorthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31270-31800-landorthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31270-31800-landorthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31271-31570-lanta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31271-31570-lanta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31271-31570-lanta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31271-31570-lanta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31272-31310-lapeyrere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31272-31310-lapeyrere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31272-31310-lapeyrere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31272-31310-lapeyrere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31273-31180-lapeyrouse_fossat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31273-31180-lapeyrouse_fossat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31273-31180-lapeyrouse_fossat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31273-31180-lapeyrouse_fossat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31274-31800-larcan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31274-31800-larcan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31274-31800-larcan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31274-31800-larcan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31275-31480-lareole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31275-31480-lareole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31275-31480-lareole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31275-31480-lareole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31276-31580-larroque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31276-31580-larroque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31276-31580-larroque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31276-31580-larroque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31277-31530-lasserre_pradere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31277-31530-lasserre_pradere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31277-31530-lasserre_pradere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31277-31530-lasserre_pradere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31278-31800-latoue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31278-31800-latoue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31278-31800-latoue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31278-31800-latoue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31279-31310-latour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31279-31310-latour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31279-31310-latour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31279-31310-latour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31280-31310-latrape/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31280-31310-latrape/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31280-31310-latrape/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31280-31310-latrape/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31281-31330-launac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31281-31330-launac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31281-31330-launac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31281-31330-launac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31282-31140-launaguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31282-31140-launaguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31282-31140-launaguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31282-31140-launaguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31283-31370-lautignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31283-31370-lautignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31283-31370-lautignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31283-31370-lautignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31284-31650-lauzerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31284-31650-lauzerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31284-31650-lauzerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31284-31650-lauzerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31285-31590-lavalette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31285-31590-lavalette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31285-31590-lavalette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31285-31590-lavalette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31286-31220-lavelanet_de_comminges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31286-31220-lavelanet_de_comminges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31286-31220-lavelanet_de_comminges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31286-31220-lavelanet_de_comminges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31287-31410-lavernose_lacasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31287-31410-lavernose_lacasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31287-31410-lavernose_lacasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31287-31410-lavernose_lacasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31288-31340-layrac_sur_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31288-31340-layrac_sur_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31288-31340-layrac_sur_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31288-31340-layrac_sur_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31289-31580-lecussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31289-31580-lecussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31289-31580-lecussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31289-31580-lecussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31290-31440-lege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31290-31440-lege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31290-31440-lege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31290-31440-lege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31291-31490-leguevin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31291-31490-leguevin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31291-31490-leguevin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31291-31490-leguevin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31292-31220-lescuns/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31292-31220-lescuns/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31292-31220-lescuns/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31292-31220-lescuns/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31293-31150-lespinasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31293-31150-lespinasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31293-31150-lespinasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31293-31150-lespinasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31294-31160-lespiteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31294-31160-lespiteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31294-31160-lespiteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31294-31160-lespiteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31295-31350-lespugue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31295-31350-lespugue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31295-31350-lespugue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31295-31350-lespugue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31296-31360-lestelle_de_saint_martory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31296-31360-lestelle_de_saint_martory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31296-31360-lestelle_de_saint_martory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31296-31360-lestelle_de_saint_martory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31297-31530-levignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31297-31530-levignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31297-31530-levignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31297-31530-levignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31299-31600-lherm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31299-31600-lherm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31299-31600-lherm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31299-31600-lherm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31300-31800-lieoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31300-31800-lieoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31300-31800-lieoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31300-31800-lieoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31301-31230-lilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31301-31230-lilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31301-31230-lilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31301-31230-lilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31302-31800-lodes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31302-31800-lodes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31302-31800-lodes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31302-31800-lodes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31303-31410-longages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31303-31410-longages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31303-31410-longages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31303-31410-longages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31304-31460-loubens_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31304-31460-loubens_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31304-31460-loubens_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31304-31460-loubens_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31305-31580-loudet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31305-31580-loudet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31305-31580-loudet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31305-31580-loudet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31306-31510-lourde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31306-31510-lourde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31306-31510-lourde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31306-31510-lourde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31308-31510-luscan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31308-31510-luscan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31308-31510-luscan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31308-31510-luscan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31309-31430-lussan_adeilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31309-31430-lussan_adeilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31309-31430-lussan_adeilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31309-31430-lussan_adeilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31310-31290-lux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31310-31290-lux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31310-31290-lux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31310-31290-lux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31311-31340-la_magdelaine_sur_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31311-31340-la_magdelaine_sur_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31311-31340-la_magdelaine_sur_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31311-31340-la_magdelaine_sur_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31312-31310-mailholas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31312-31310-mailholas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31312-31310-mailholas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31312-31310-mailholas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31313-31510-malvezie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31313-31510-malvezie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31313-31510-malvezie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31313-31510-malvezie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31314-31360-mancioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31314-31360-mancioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31314-31360-mancioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31314-31360-mancioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31315-31260-mane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31315-31260-mane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31315-31260-mane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31315-31260-mane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31316-31440-marignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31316-31440-marignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31316-31440-marignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31316-31440-marignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31317-31430-marignac_lasclares/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31317-31430-marignac_lasclares/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31317-31430-marignac_lasclares/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31317-31430-marignac_lasclares/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31318-31220-marignac_laspeyres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31318-31220-marignac_laspeyres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31318-31220-marignac_laspeyres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31318-31220-marignac_laspeyres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31319-31550-marliac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31319-31550-marliac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31319-31550-marliac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31319-31550-marliac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31320-31390-marquefave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31320-31390-marquefave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31320-31390-marquefave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31320-31390-marquefave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31321-31260-marsoulas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31321-31260-marsoulas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31321-31260-marsoulas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31321-31260-marsoulas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31322-31230-martisserre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31322-31230-martisserre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31322-31230-martisserre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31322-31230-martisserre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31323-31210-martres_de_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31323-31210-martres_de_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31323-31210-martres_de_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31323-31210-martres_de_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31324-31220-martres_tolosane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31324-31220-martres_tolosane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31324-31220-martres_tolosane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31324-31220-martres_tolosane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31325-31460-mascarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31325-31460-mascarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31325-31460-mascarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31325-31460-mascarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31326-31310-massabrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31326-31310-massabrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31326-31310-massabrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31326-31310-massabrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31327-31220-mauran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31327-31220-mauran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31327-31220-mauran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31327-31220-mauran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31328-31290-mauremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31328-31290-mauremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31328-31290-mauremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31328-31290-mauremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31329-31540-maurens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31329-31540-maurens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31329-31540-maurens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31329-31540-maurens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31330-31190-mauressac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31330-31190-mauressac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31330-31190-mauressac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31330-31190-mauressac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31331-31460-maureville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31331-31460-maureville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31331-31460-maureville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31331-31460-maureville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31332-31190-mauvaisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31332-31190-mauvaisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31332-31190-mauvaisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31332-31190-mauvaisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31333-31230-mauvezin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31333-31230-mauvezin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31333-31230-mauvezin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31333-31230-mauvezin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31334-31410-mauzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31334-31410-mauzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31334-31410-mauzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31334-31410-mauzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31335-31110-mayregne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31335-31110-mayregne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31335-31110-mayregne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31335-31110-mayregne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31336-31260-mazeres_sur_salat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31336-31260-mazeres_sur_salat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31336-31260-mazeres_sur_salat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31336-31260-mazeres_sur_salat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31337-31440-melles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31337-31440-melles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31337-31440-melles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31337-31440-melles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31338-31530-menville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31338-31530-menville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31338-31530-menville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31338-31530-menville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31339-31530-merenvielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31339-31530-merenvielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31339-31530-merenvielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31339-31530-merenvielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31340-31320-mervilla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31340-31320-mervilla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31340-31320-mervilla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31340-31320-mervilla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31341-31330-merville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31341-31330-merville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31341-31330-merville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31341-31330-merville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31342-31160-milhas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31342-31160-milhas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31342-31160-milhas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31342-31160-milhas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31343-31230-mirambeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31343-31230-mirambeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31343-31230-mirambeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31343-31230-mirambeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31344-31800-miramont_de_comminges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31344-31800-miramont_de_comminges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31344-31800-miramont_de_comminges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31344-31800-miramont_de_comminges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31345-31190-miremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31345-31190-miremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31345-31190-miremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31345-31190-miremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31346-31340-mirepoix_sur_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31346-31340-mirepoix_sur_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31346-31340-mirepoix_sur_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31346-31340-mirepoix_sur_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31347-31230-molas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31347-31230-molas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31347-31230-molas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31347-31230-molas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31348-31160-moncaup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31348-31160-moncaup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31348-31160-moncaup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31348-31160-moncaup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31349-31220-mondavezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31349-31220-mondavezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31349-31220-mondavezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31349-31220-mondavezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31350-31350-mondilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31350-31350-mondilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31350-31350-mondilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31350-31350-mondilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31351-31700-mondonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31351-31700-mondonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31351-31700-mondonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31351-31700-mondonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31352-31850-mondouzil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31352-31850-mondouzil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31352-31850-mondouzil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31352-31850-mondouzil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31353-31370-mones/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31353-31370-mones/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31353-31370-mones/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31353-31370-mones/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31354-31560-monestrol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31354-31560-monestrol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31354-31560-monestrol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31354-31560-monestrol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31355-31280-mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31355-31280-mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31355-31280-mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31355-31280-mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31356-31530-montaigut_sur_save/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31356-31530-montaigut_sur_save/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31356-31530-montaigut_sur_save/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31356-31530-montaigut_sur_save/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31357-31160-montastruc_de_salies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31357-31160-montastruc_de_salies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31357-31160-montastruc_de_salies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31357-31160-montastruc_de_salies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31358-31380-montastruc_la_conseillere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31358-31380-montastruc_la_conseillere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31358-31380-montastruc_la_conseillere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31358-31380-montastruc_la_conseillere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31359-31370-montastruc_saves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31359-31370-montastruc_saves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31359-31370-montastruc_saves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31359-31370-montastruc_saves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31360-31110-montauban_de_luchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31360-31110-montauban_de_luchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31360-31110-montauban_de_luchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31360-31110-montauban_de_luchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31361-31410-montaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31361-31410-montaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31361-31410-montaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31361-31410-montaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31362-31220-montberaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31362-31220-montberaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31362-31220-montberaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31362-31220-montberaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31363-31230-montbernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31363-31230-montbernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31363-31230-montbernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31363-31230-montbernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31364-31140-montberon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31364-31140-montberon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31364-31140-montberon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31364-31140-montberon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31365-31310-montbrun_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31365-31310-montbrun_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31365-31310-montbrun_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31365-31310-montbrun_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31366-31450-montbrun_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31366-31450-montbrun_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31366-31450-montbrun_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31366-31450-montbrun_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31367-31220-montclar_de_comminges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31367-31220-montclar_de_comminges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31367-31220-montclar_de_comminges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31367-31220-montclar_de_comminges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31368-31290-montclar_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31368-31290-montclar_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31368-31290-montclar_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31368-31290-montclar_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31369-31510-mont_de_galie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31369-31510-mont_de_galie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31369-31510-mont_de_galie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31369-31510-mont_de_galie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31370-31430-montegut_bourjac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31370-31430-montegut_bourjac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31370-31430-montegut_bourjac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31370-31430-montegut_bourjac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31371-31540-montegut_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31371-31540-montegut_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31371-31540-montegut_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31371-31540-montegut_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31372-31260-montespan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31372-31260-montespan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31372-31260-montespan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31372-31260-montespan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31373-31230-montesquieu_guittaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31373-31230-montesquieu_guittaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31373-31230-montesquieu_guittaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31373-31230-montesquieu_guittaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31374-31450-montesquieu_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31374-31450-montesquieu_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31374-31450-montesquieu_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31374-31450-montesquieu_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31375-31310-montesquieu_volvestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31375-31310-montesquieu_volvestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31375-31310-montesquieu_volvestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31375-31310-montesquieu_volvestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31376-31260-montgaillard_de_salies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31376-31260-montgaillard_de_salies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31376-31260-montgaillard_de_salies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31376-31260-montgaillard_de_salies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31377-31290-montgaillard_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31377-31290-montgaillard_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31377-31290-montgaillard_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31377-31290-montgaillard_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31378-31350-montgaillard_sur_save/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31378-31350-montgaillard_sur_save/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31378-31350-montgaillard_sur_save/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31378-31350-montgaillard_sur_save/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31379-31410-montgazin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31379-31410-montgazin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31379-31410-montgazin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31379-31410-montgazin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31380-31560-montgeard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31380-31560-montgeard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31380-31560-montgeard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31380-31560-montgeard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31381-31450-montgiscard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31381-31450-montgiscard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31381-31450-montgiscard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31381-31450-montgiscard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31382-31370-montgras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31382-31370-montgras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31382-31370-montgras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31382-31370-montgras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31383-31380-montjoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31383-31380-montjoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31383-31380-montjoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31383-31380-montjoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31384-31450-montlaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31384-31450-montlaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31384-31450-montlaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31384-31450-montlaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31385-31350-montmaurin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31385-31350-montmaurin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31385-31350-montmaurin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31385-31350-montmaurin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31386-31420-montoulieu_saint_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31386-31420-montoulieu_saint_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31386-31420-montoulieu_saint_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31386-31420-montoulieu_saint_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31387-31430-montoussin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31387-31430-montoussin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31387-31430-montoussin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31387-31430-montoussin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31388-31380-montpitol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31388-31380-montpitol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31388-31380-montpitol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31388-31380-montpitol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31389-31850-montrabe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31389-31850-montrabe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31389-31850-montrabe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31389-31850-montrabe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31390-31210-montrejeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31390-31210-montrejeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31390-31210-montrejeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31390-31210-montrejeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31391-31260-montsaunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31391-31260-montsaunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31391-31260-montsaunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31391-31260-montsaunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31392-31460-mourvilles_basses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31392-31460-mourvilles_basses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31392-31460-mourvilles_basses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31392-31460-mourvilles_basses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31393-31540-mourvilles_hautes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31393-31540-mourvilles_hautes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31393-31540-mourvilles_hautes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31393-31540-mourvilles_hautes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31394-31110-moustajon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31394-31110-moustajon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31394-31110-moustajon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31394-31110-moustajon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31395-31600-muret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31395-31600-muret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31395-31600-muret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31395-31600-muret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31396-31560-nailloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31396-31560-nailloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31396-31560-nailloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31396-31560-nailloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31397-31350-nenigan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31397-31350-nenigan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31397-31350-nenigan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31397-31350-nenigan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31398-31350-nizan_gesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31398-31350-nizan_gesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31398-31350-nizan_gesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31398-31350-nizan_gesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31399-31410-noe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31399-31410-noe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31399-31410-noe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31399-31410-noe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31400-31540-nogaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31400-31540-nogaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31400-31540-nogaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31400-31540-nogaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31401-31450-noueilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31401-31450-noueilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31401-31450-noueilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31401-31450-noueilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31402-31450-odars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31402-31450-odars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31402-31450-odars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31402-31450-odars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31403-31330-ondes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31403-31330-ondes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31403-31330-ondes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31403-31330-ondes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31404-31110-oo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31404-31110-oo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31404-31110-oo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31404-31110-oo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31405-31510-ore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31405-31510-ore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31405-31510-ore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31405-31510-ore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31406-31220-palaminy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31406-31220-palaminy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31406-31220-palaminy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31406-31220-palaminy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31407-31380-paulhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31407-31380-paulhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31407-31380-paulhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31407-31380-paulhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31408-31510-payssous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31408-31510-payssous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31408-31510-payssous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31408-31510-payssous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31409-31320-pechabou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31409-31320-pechabou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31409-31320-pechabou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31409-31320-pechabou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31410-31140-pechbonnieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31410-31140-pechbonnieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31410-31140-pechbonnieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31410-31140-pechbonnieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31411-31320-pechbusque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31411-31320-pechbusque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31411-31320-pechbusque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31411-31320-pechbusque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31412-31350-peguilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31412-31350-peguilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31412-31350-peguilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31412-31350-peguilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31413-31480-pelleport/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31413-31480-pelleport/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31413-31480-pelleport/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31413-31480-pelleport/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31414-31420-peyrissas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31414-31420-peyrissas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31414-31420-peyrissas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31414-31420-peyrissas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31415-31420-peyrouzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31415-31420-peyrouzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31415-31420-peyrouzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31415-31420-peyrouzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31416-31390-peyssies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31416-31390-peyssies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31416-31390-peyssies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31416-31390-peyssies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31417-31820-pibrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31417-31820-pibrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31417-31820-pibrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31417-31820-pibrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31418-31130-pin_balma/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31418-31130-pin_balma/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31418-31130-pin_balma/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31418-31130-pin_balma/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31419-31370-le_pin_murelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31419-31370-le_pin_murelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31419-31370-le_pin_murelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31419-31370-le_pin_murelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31420-31120-pinsaguel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31420-31120-pinsaguel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31420-31120-pinsaguel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31420-31120-pinsaguel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31421-31860-pins_justaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31421-31860-pins_justaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31421-31860-pins_justaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31421-31860-pins_justaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31422-31220-plagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31422-31220-plagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31422-31220-plagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31422-31220-plagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31423-31370-plagnole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31423-31370-plagnole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31423-31370-plagnole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31423-31370-plagnole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31424-31830-plaisance_du_touch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31424-31830-plaisance_du_touch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31424-31830-plaisance_du_touch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31424-31830-plaisance_du_touch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31425-31220-le_plan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31425-31220-le_plan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31425-31220-le_plan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31425-31220-le_plan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31426-31210-pointis_de_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31426-31210-pointis_de_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31426-31210-pointis_de_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31426-31210-pointis_de_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31427-31800-pointis_inard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31427-31800-pointis_inard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31427-31800-pointis_inard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31427-31800-pointis_inard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31428-31430-polastron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31428-31430-polastron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31428-31430-polastron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31428-31430-polastron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31429-31450-pompertuzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31429-31450-pompertuzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31429-31450-pompertuzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31429-31450-pompertuzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31430-31210-ponlat_taillebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31430-31210-ponlat_taillebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31430-31210-ponlat_taillebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31430-31210-ponlat_taillebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31431-31160-portet_d_aspet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31431-31160-portet_d_aspet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31431-31160-portet_d_aspet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31431-31160-portet_d_aspet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31432-31110-portet_de_luchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31432-31110-portet_de_luchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31432-31110-portet_de_luchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31432-31110-portet_de_luchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31433-31120-portet_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31433-31120-portet_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31433-31120-portet_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31433-31120-portet_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31434-31110-poubeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31434-31110-poubeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31434-31110-poubeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31434-31110-poubeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31435-31370-poucharramet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31435-31370-poucharramet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31435-31370-poucharramet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31435-31370-poucharramet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31436-31430-pouy_de_touges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31436-31430-pouy_de_touges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31436-31430-pouy_de_touges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31436-31430-pouy_de_touges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31437-31450-pouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31437-31450-pouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31437-31450-pouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31437-31450-pouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31439-31570-preserville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31439-31570-preserville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31439-31570-preserville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31439-31570-preserville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31440-31360-proupiary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31440-31360-proupiary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31440-31360-proupiary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31440-31360-proupiary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31441-31460-prunet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31441-31460-prunet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31441-31460-prunet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31441-31460-prunet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31442-31190-puydaniel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31442-31190-puydaniel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31442-31190-puydaniel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31442-31190-puydaniel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31443-31230-puymaurin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31443-31230-puymaurin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31443-31230-puymaurin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31443-31230-puymaurin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31444-31480-puyssegur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31444-31480-puyssegur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31444-31480-puyssegur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31444-31480-puyssegur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31445-31130-quint_fonsegrives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31445-31130-quint_fonsegrives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31445-31130-quint_fonsegrives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31445-31130-quint_fonsegrives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31446-31520-ramonville_saint_agne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31446-31520-ramonville_saint_agne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31446-31520-ramonville_saint_agne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31446-31520-ramonville_saint_agne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31447-31160-razecueille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31447-31160-razecueille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31447-31160-razecueille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31447-31160-razecueille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31448-31320-rebigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31448-31320-rebigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31448-31320-rebigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31448-31320-rebigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31449-31800-regades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31449-31800-regades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31449-31800-regades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31449-31800-regades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31450-31290-renneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31450-31290-renneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31450-31290-renneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31450-31290-renneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31451-31250-revel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31451-31250-revel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31451-31250-revel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31451-31250-revel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31452-31800-rieucaze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31452-31800-rieucaze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31452-31800-rieucaze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31452-31800-rieucaze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31453-31290-rieumajou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31453-31290-rieumajou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31453-31290-rieumajou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31453-31290-rieumajou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31454-31370-rieumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31454-31370-rieumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31454-31370-rieumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31454-31370-rieumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31455-31310-rieux_volvestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31455-31310-rieux_volvestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31455-31310-rieux_volvestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31455-31310-rieux_volvestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31456-31230-riolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31456-31230-riolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31456-31230-riolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31456-31230-riolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31457-31360-roquefort_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31457-31360-roquefort_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31457-31360-roquefort_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31457-31360-roquefort_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31458-31120-roques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31458-31120-roques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31458-31120-roques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31458-31120-roques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31459-31380-roqueseriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31459-31380-roqueseriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31459-31380-roqueseriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31459-31380-roqueseriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31460-31120-roquettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31460-31120-roquettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31460-31120-roquettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31460-31120-roquettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31461-31160-rouede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31461-31160-rouede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31461-31160-rouede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31461-31160-rouede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31462-31180-rouffiac_tolosan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31462-31180-rouffiac_tolosan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31462-31180-rouffiac_tolosan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31462-31180-rouffiac_tolosan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31463-31540-roumens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31463-31540-roumens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31463-31540-roumens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31463-31540-roumens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31464-31370-sabonneres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31464-31370-sabonneres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31464-31370-sabonneres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31464-31370-sabonneres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31465-31110-saccourvielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31465-31110-saccourvielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31465-31110-saccourvielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31465-31110-saccourvielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31466-31470-saiguede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31466-31470-saiguede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31466-31470-saiguede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31466-31470-saiguede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31467-31140-saint_alban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31467-31140-saint_alban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31467-31140-saint_alban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31467-31140-saint_alban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31468-31420-saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31468-31420-saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31468-31420-saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31468-31420-saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31469-31430-saint_araille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31469-31430-saint_araille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31469-31430-saint_araille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31469-31430-saint_araille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31470-31110-saint_aventin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31470-31110-saint_aventin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31470-31110-saint_aventin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31470-31110-saint_aventin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31471-31440-saint_beat_lez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31471-31440-saint_beat_lez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31471-31440-saint_beat_lez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31471-31440-saint_beat_lez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31472-31510-saint_bertrand_de_comminges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31472-31510-saint_bertrand_de_comminges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31472-31510-saint_bertrand_de_comminges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31472-31510-saint_bertrand_de_comminges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31473-31330-saint_cezert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31473-31330-saint_cezert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31473-31330-saint_cezert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31473-31330-saint_cezert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31474-31310-saint_christaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31474-31310-saint_christaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31474-31310-saint_christaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31474-31310-saint_christaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31475-31600-saint_clar_de_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31475-31600-saint_clar_de_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31475-31600-saint_clar_de_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31475-31600-saint_clar_de_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31476-31430-saint_elix_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31476-31430-saint_elix_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31476-31430-saint_elix_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31476-31430-saint_elix_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31477-31420-saint_elix_seglan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31477-31420-saint_elix_seglan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31477-31420-saint_elix_seglan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31477-31420-saint_elix_seglan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31478-31540-saint_felix_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31478-31540-saint_felix_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31478-31540-saint_felix_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31478-31540-saint_felix_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31479-31350-saint_ferreol_de_comminges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31479-31350-saint_ferreol_de_comminges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31479-31350-saint_ferreol_de_comminges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31479-31350-saint_ferreol_de_comminges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31480-31570-sainte_foy_d_aigrefeuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31480-31570-sainte_foy_d_aigrefeuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31480-31570-sainte_foy_d_aigrefeuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31480-31570-sainte_foy_d_aigrefeuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31481-31470-sainte_foy_de_peyrolieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31481-31470-sainte_foy_de_peyrolieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31481-31470-sainte_foy_de_peyrolieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31481-31470-sainte_foy_de_peyrolieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31482-31230-saint_frajou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31482-31230-saint_frajou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31482-31230-saint_frajou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31482-31230-saint_frajou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31483-31800-saint_gaudens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31483-31800-saint_gaudens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31483-31800-saint_gaudens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31483-31800-saint_gaudens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31484-31180-saint_genies_bellevue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31484-31180-saint_genies_bellevue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31484-31180-saint_genies_bellevue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31484-31180-saint_genies_bellevue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31485-31290-saint_germier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31485-31290-saint_germier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31485-31290-saint_germier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31485-31290-saint_germier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31486-31410-saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31486-31410-saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31486-31410-saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31486-31410-saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31487-31800-saint_ignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31487-31800-saint_ignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31487-31800-saint_ignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31487-31800-saint_ignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31488-31240-saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31488-31240-saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31488-31240-saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31488-31240-saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31489-31380-saint_jean_lherm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31489-31380-saint_jean_lherm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31489-31380-saint_jean_lherm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31489-31380-saint_jean_lherm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31490-31790-saint_jory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31490-31790-saint_jory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31490-31790-saint_jory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31490-31790-saint_jory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31491-31540-saint_julia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31491-31540-saint_julia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31491-31540-saint_julia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31491-31540-saint_julia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31492-31220-saint_julien_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31492-31220-saint_julien_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31492-31220-saint_julien_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31492-31220-saint_julien_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31493-31350-saint_lary_boujean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31493-31350-saint_lary_boujean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31493-31350-saint_lary_boujean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31493-31350-saint_lary_boujean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31494-31230-saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31494-31230-saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31494-31230-saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31494-31230-saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31495-31560-saint_leon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31495-31560-saint_leon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31495-31560-saint_leon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31495-31560-saint_leon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31496-31530-sainte_livrade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31496-31530-sainte_livrade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31496-31530-sainte_livrade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31496-31530-sainte_livrade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31497-31140-saint_loup_cammas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31497-31140-saint_loup_cammas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31497-31140-saint_loup_cammas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31497-31140-saint_loup_cammas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31498-31350-saint_loup_en_comminges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31498-31350-saint_loup_en_comminges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31498-31350-saint_loup_en_comminges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31498-31350-saint_loup_en_comminges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31499-31470-saint_lys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31499-31470-saint_lys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31499-31470-saint_lys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31499-31470-saint_lys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31500-31110-saint_mamet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31500-31110-saint_mamet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31500-31110-saint_mamet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31500-31110-saint_mamet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31501-31590-saint_marcel_paulel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31501-31590-saint_marcel_paulel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31501-31590-saint_marcel_paulel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31501-31590-saint_marcel_paulel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31502-31800-saint_marcet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31502-31800-saint_marcet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31502-31800-saint_marcet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31502-31800-saint_marcet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31503-31360-saint_martory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31503-31360-saint_martory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31503-31360-saint_martory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31503-31360-saint_martory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31504-31360-saint_medard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31504-31360-saint_medard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31504-31360-saint_medard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31504-31360-saint_medard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31505-31220-saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31505-31220-saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31505-31220-saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31505-31220-saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31506-31650-saint_orens_de_gameville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31506-31650-saint_orens_de_gameville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31506-31650-saint_orens_de_gameville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31506-31650-saint_orens_de_gameville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31507-31530-saint_paul_sur_save/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31507-31530-saint_paul_sur_save/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31507-31530-saint_paul_sur_save/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31507-31530-saint_paul_sur_save/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31508-31110-saint_paul_d_oueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31508-31110-saint_paul_d_oueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31508-31110-saint_paul_d_oueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31508-31110-saint_paul_d_oueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31509-31510-saint_pe_d_ardet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31509-31510-saint_pe_d_ardet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31509-31510-saint_pe_d_ardet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31509-31510-saint_pe_d_ardet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31510-31350-saint_pe_delbosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31510-31350-saint_pe_delbosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31510-31350-saint_pe_delbosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31510-31350-saint_pe_delbosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31511-31590-saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31511-31590-saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31511-31590-saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31511-31590-saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31512-31570-saint_pierre_de_lages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31512-31570-saint_pierre_de_lages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31512-31570-saint_pierre_de_lages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31512-31570-saint_pierre_de_lages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31513-31580-saint_plancard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31513-31580-saint_plancard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31513-31580-saint_plancard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31513-31580-saint_plancard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31514-31290-saint_rome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31514-31290-saint_rome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31514-31290-saint_rome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31514-31290-saint_rome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31515-31620-saint_rustice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31515-31620-saint_rustice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31515-31620-saint_rustice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31515-31620-saint_rustice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31516-31790-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31516-31790-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31516-31790-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31516-31790-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31517-31410-saint_sulpice_sur_leze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31517-31410-saint_sulpice_sur_leze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31517-31410-saint_sulpice_sur_leze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31517-31410-saint_sulpice_sur_leze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31518-31470-saint_thomas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31518-31470-saint_thomas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31518-31470-saint_thomas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31518-31470-saint_thomas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31519-31290-saint_vincent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31519-31290-saint_vincent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31519-31290-saint_vincent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31519-31290-saint_vincent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31520-31370-sajas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31520-31370-sajas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31520-31370-sajas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31520-31370-sajas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31521-31260-saleich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31521-31260-saleich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31521-31260-saleich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31521-31260-saleich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31522-31230-salerm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31522-31230-salerm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31522-31230-salerm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31522-31230-salerm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31523-31260-salies_du_salat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31523-31260-salies_du_salat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31523-31260-salies_du_salat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31523-31260-salies_du_salat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31524-31110-salles_et_pratviel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31524-31110-salles_et_pratviel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31524-31110-salles_et_pratviel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31524-31110-salles_et_pratviel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31525-31390-salles_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31525-31390-salles_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31525-31390-salles_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31525-31390-salles_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31526-31880-la_salvetat_saint_gilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31526-31880-la_salvetat_saint_gilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31526-31880-la_salvetat_saint_gilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31526-31880-la_salvetat_saint_gilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31527-31460-la_salvetat_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31527-31460-la_salvetat_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31527-31460-la_salvetat_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31527-31460-la_salvetat_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31528-31350-saman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31528-31350-saman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31528-31350-saman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31528-31350-saman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31529-31420-samouillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31529-31420-samouillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31529-31420-samouillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31529-31420-samouillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31530-31220-sana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31530-31220-sana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31530-31220-sana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31530-31220-sana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31531-31350-sarrecave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31531-31350-sarrecave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31531-31350-sarrecave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31531-31350-sarrecave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31532-31350-sarremezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31532-31350-sarremezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31532-31350-sarremezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31532-31350-sarremezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31533-31600-saubens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31533-31600-saubens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31533-31600-saubens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31533-31600-saubens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31534-31460-saussens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31534-31460-saussens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31534-31460-saussens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31534-31460-saussens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31535-31510-sauveterre_de_comminges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31535-31510-sauveterre_de_comminges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31535-31510-sauveterre_de_comminges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31535-31510-sauveterre_de_comminges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31536-31800-saux_et_pomarede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31536-31800-saux_et_pomarede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31536-31800-saux_et_pomarede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31536-31800-saux_et_pomarede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31537-31800-savarthes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31537-31800-savarthes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31537-31800-savarthes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31537-31800-savarthes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31538-31370-saveres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31538-31370-saveres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31538-31370-saveres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31538-31370-saveres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31539-31580-sedeilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31539-31580-sedeilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31539-31580-sedeilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31539-31580-sedeilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31540-31460-segreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31540-31460-segreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31540-31460-segreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31540-31460-segreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31541-31840-seilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31541-31840-seilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31541-31840-seilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31541-31840-seilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31542-31510-seilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31542-31510-seilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31542-31510-seilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31542-31510-seilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31543-31430-senarens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31543-31430-senarens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31543-31430-senarens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31543-31430-senarens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31544-31160-sengouagnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31544-31160-sengouagnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31544-31160-sengouagnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31544-31160-sengouagnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31545-31360-sepx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31545-31360-sepx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31545-31360-sepx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31545-31360-sepx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31546-31560-seyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31546-31560-seyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31546-31560-seyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31546-31560-seyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31547-31600-seysses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31547-31600-seysses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31547-31600-seysses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31547-31600-seysses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31548-31440-signac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31548-31440-signac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31548-31440-signac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31548-31440-signac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31549-31110-sode/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31549-31110-sode/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31549-31110-sode/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31549-31110-sode/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31550-31160-soueich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31550-31160-soueich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31550-31160-soueich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31550-31160-soueich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31551-31570-tarabel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31551-31570-tarabel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31551-31570-tarabel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31551-31570-tarabel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31552-31420-terrebasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31552-31420-terrebasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31552-31420-terrebasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31552-31420-terrebasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31553-31530-thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31553-31530-thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31553-31530-thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31553-31530-thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31554-31260-touille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31554-31260-touille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31554-31260-touille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31554-31260-touille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31500-toulouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31500-toulouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31500-toulouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31500-toulouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31100-toulouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31100-toulouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31100-toulouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31100-toulouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31400-toulouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31400-toulouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31400-toulouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31400-toulouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31300-toulouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31300-toulouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31300-toulouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31300-toulouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31000-toulouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31000-toulouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31000-toulouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31000-toulouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31200-toulouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31200-toulouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31200-toulouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31200-toulouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31998-toulouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31998-toulouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31998-toulouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31555-31998-toulouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31556-31210-les_tourreilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31556-31210-les_tourreilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31556-31210-les_tourreilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31556-31210-les_tourreilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31557-31170-tournefeuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31557-31170-tournefeuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31557-31170-tournefeuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31557-31170-tournefeuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31558-31460-toutens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31558-31460-toutens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31558-31460-toutens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31558-31460-toutens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31559-31110-trebons_de_luchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31559-31110-trebons_de_luchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31559-31110-trebons_de_luchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31559-31110-trebons_de_luchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31560-31290-trebons_sur_la_grasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31560-31290-trebons_sur_la_grasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31560-31290-trebons_sur_la_grasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31560-31290-trebons_sur_la_grasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31561-31240-l_union/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31561-31240-l_union/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31561-31240-l_union/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31561-31240-l_union/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31562-31260-urau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31562-31260-urau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31562-31260-urau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31562-31260-urau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31563-31340-vacquiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31563-31340-vacquiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31563-31340-vacquiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31563-31340-vacquiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31564-31510-valcabrere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31564-31510-valcabrere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31564-31510-valcabrere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31564-31510-valcabrere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31565-31800-valentine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31565-31800-valentine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31565-31800-valentine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31565-31800-valentine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31566-31290-vallegue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31566-31290-vallegue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31566-31290-vallegue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31566-31290-vallegue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31567-31570-vallesvilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31567-31570-vallesvilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31567-31570-vallesvilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31567-31570-vallesvilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31568-31450-varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31568-31450-varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31568-31450-varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31568-31450-varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31569-31250-vaudreuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31569-31250-vaudreuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31569-31250-vaudreuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31569-31250-vaudreuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31570-31540-vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31570-31540-vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31570-31540-vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31570-31540-vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31571-31460-vendine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31571-31460-vendine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31571-31460-vendine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31571-31460-vendine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31572-31810-venerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31572-31810-venerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31572-31810-venerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31572-31810-venerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31573-31590-verfeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31573-31590-verfeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31573-31590-verfeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31573-31590-verfeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31574-31810-vernet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31574-31810-vernet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31574-31810-vernet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31574-31810-vernet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31575-31320-vieille_toulouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31575-31320-vieille_toulouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31575-31320-vieille_toulouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31575-31320-vieille_toulouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31576-31290-vieillevigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31576-31290-vieillevigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31576-31290-vieillevigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31576-31290-vieillevigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31577-31480-vignaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31577-31480-vignaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31577-31480-vignaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31577-31480-vignaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31578-31320-vigoulet_auzil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31578-31320-vigoulet_auzil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31578-31320-vigoulet_auzil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31578-31320-vigoulet_auzil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31579-31380-villaries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31579-31380-villaries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31579-31380-villaries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31579-31380-villaries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31580-31860-villate/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31580-31860-villate/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31580-31860-villate/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31580-31860-villate/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31581-31620-villaudric/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31581-31620-villaudric/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31581-31620-villaudric/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31581-31620-villaudric/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31582-31290-villefranche_de_lauragais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31582-31290-villefranche_de_lauragais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31582-31290-villefranche_de_lauragais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31582-31290-villefranche_de_lauragais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31583-31340-villematier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31583-31340-villematier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31583-31340-villematier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31583-31340-villematier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31584-31340-villemur_sur_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31584-31340-villemur_sur_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31584-31340-villemur_sur_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31584-31340-villemur_sur_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31585-31800-villeneuve_de_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31585-31800-villeneuve_de_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31585-31800-villeneuve_de_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31585-31800-villeneuve_de_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31586-31580-villeneuve_lecussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31586-31580-villeneuve_lecussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31586-31580-villeneuve_lecussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31586-31580-villeneuve_lecussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31587-31620-villeneuve_les_bouloc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31587-31620-villeneuve_les_bouloc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31587-31620-villeneuve_les_bouloc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31587-31620-villeneuve_les_bouloc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31588-31270-villeneuve_tolosane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31588-31270-villeneuve_tolosane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31588-31270-villeneuve_tolosane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31588-31270-villeneuve_tolosane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31589-31290-villenouvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31589-31290-villenouvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31589-31290-villenouvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31589-31290-villenouvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31590-31440-binos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31590-31440-binos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31590-31440-binos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31590-31440-binos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31591-31260-escoulis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31591-31260-escoulis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31591-31260-escoulis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31591-31260-escoulis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31592-31330-larra/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31592-31330-larra/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31592-31330-larra/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31592-31330-larra/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31593-31230-cazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31593-31230-cazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31593-31230-cazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt31-haute_garonne/commune31593-31230-cazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-32.xml
+++ b/public/sitemaps/sitemap-32.xml
@@ -5,928 +5,1852 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32001-32290-aignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32001-32290-aignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32001-32290-aignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32001-32290-aignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32002-32270-ansan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32002-32270-ansan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32002-32270-ansan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32002-32270-ansan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32003-32360-antras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32003-32360-antras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32003-32360-antras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32003-32360-antras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32004-32720-arblade_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32004-32720-arblade_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32004-32720-arblade_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32004-32720-arblade_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32005-32110-arblade_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32005-32110-arblade_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32005-32110-arblade_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32005-32110-arblade_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32007-32430-ardizas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32007-32430-ardizas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32007-32430-ardizas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32007-32430-ardizas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32008-32230-armentieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32008-32230-armentieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32008-32230-armentieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32008-32230-armentieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32009-32230-armous_et_cau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32009-32230-armous_et_cau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32009-32230-armous_et_cau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32009-32230-armous_et_cau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32010-32140-arrouede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32010-32140-arrouede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32010-32140-arrouede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32010-32140-arrouede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32012-32270-aubiet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32012-32270-aubiet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32012-32270-aubiet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32012-32270-aubiet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32013-32000-auch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32013-32000-auch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32013-32000-auch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32013-32000-auch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32014-32120-augnax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32014-32120-augnax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32014-32120-augnax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32014-32120-augnax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32015-32300-aujan_mournede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32015-32300-aujan_mournede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32015-32300-aujan_mournede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32015-32300-aujan_mournede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32016-32600-aurade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32016-32600-aurade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32016-32600-aurade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32016-32600-aurade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32017-32400-aurensan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32017-32400-aurensan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32017-32400-aurensan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32017-32400-aurensan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32018-32450-aurimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32018-32450-aurimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32018-32450-aurimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32018-32450-aurimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32019-32550-auterive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32019-32550-auterive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32019-32550-auterive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32019-32550-auterive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32020-32170-aux_aussat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32020-32170-aux_aussat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32020-32170-aux_aussat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32020-32170-aux_aussat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32021-32120-avensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32021-32120-avensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32021-32120-avensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32021-32120-avensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32022-32290-averon_bergelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32022-32290-averon_bergelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32022-32290-averon_bergelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32022-32290-averon_bergelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32023-32380-avezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32023-32380-avezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32023-32380-avezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32023-32380-avezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32024-32410-ayguetinte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32024-32410-ayguetinte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32024-32410-ayguetinte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32024-32410-ayguetinte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32025-32800-ayzieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32025-32800-ayzieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32025-32800-ayzieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32025-32800-ayzieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32026-32120-bajonnette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32026-32120-bajonnette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32026-32120-bajonnette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32026-32120-bajonnette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32027-32720-barcelonne_du_gers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32027-32720-barcelonne_du_gers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32027-32720-barcelonne_du_gers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32027-32720-barcelonne_du_gers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32028-32170-barcugnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32028-32170-barcugnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32028-32170-barcugnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32028-32170-barcugnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32029-32350-barran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32029-32350-barran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32029-32350-barran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32029-32350-barran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32030-32300-bars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32030-32300-bars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32030-32300-bars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32030-32300-bars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32031-32190-bascous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32031-32190-bascous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32031-32190-bascous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32031-32190-bascous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32032-32320-bassoues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32032-32320-bassoues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32032-32320-bassoues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32032-32320-bassoues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32033-32320-bazian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32033-32320-bazian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32033-32320-bazian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32033-32320-bazian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32034-32170-bazugues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32034-32170-bazugues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32034-32170-bazugues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32034-32170-bazugues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32035-32410-beaucaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32035-32410-beaucaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32035-32410-beaucaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32035-32410-beaucaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32036-32160-beaumarches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32036-32160-beaumarches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32036-32160-beaumarches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32036-32160-beaumarches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32037-32100-beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32037-32100-beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32037-32100-beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32037-32100-beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32038-32600-beaupuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32038-32600-beaupuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32038-32600-beaupuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32038-32600-beaupuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32039-32730-beccas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32039-32730-beccas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32039-32730-beccas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32039-32730-beccas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32040-32450-bedechan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32040-32450-bedechan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32040-32450-bedechan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32040-32450-bedechan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32041-32140-bellegarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32041-32140-bellegarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32041-32140-bellegarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32041-32140-bellegarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32042-32300-belloc_saint_clamens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32042-32300-belloc_saint_clamens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32042-32300-belloc_saint_clamens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32042-32300-belloc_saint_clamens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32043-32190-belmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32043-32190-belmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32043-32190-belmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32043-32190-belmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32044-32100-beraut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32044-32100-beraut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32044-32100-beraut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32044-32100-beraut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32045-32300-berdoues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32045-32300-berdoues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32045-32300-berdoues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32045-32300-berdoues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32046-32400-bernede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32046-32400-bernede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32046-32400-bernede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32046-32400-bernede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32047-32480-berrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32047-32480-berrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32047-32480-berrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32047-32480-berrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32048-32420-betcave_aguin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32048-32420-betcave_aguin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32048-32420-betcave_aguin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32048-32420-betcave_aguin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32049-32110-betous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32049-32110-betous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32049-32110-betous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32049-32110-betous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32050-32730-betplan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32050-32730-betplan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32050-32730-betplan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32050-32730-betplan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32051-32130-bezeril/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32051-32130-bezeril/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32051-32130-bezeril/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32051-32130-bezeril/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32052-32310-bezolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32052-32310-bezolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32052-32310-bezolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32052-32310-bezolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32053-32140-bezues_bajon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32053-32140-bezues_bajon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32053-32140-bezues_bajon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32053-32140-bezues_bajon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32054-32350-biran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32054-32350-biran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32054-32350-biran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32054-32350-biran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32055-32380-bives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32055-32380-bives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32055-32380-bives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32055-32380-bives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32056-32270-blanquefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32056-32270-blanquefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32056-32270-blanquefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32056-32270-blanquefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32057-32100-blaziert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32057-32100-blaziert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32057-32100-blaziert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32057-32100-blaziert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32058-32230-blousson_serian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32058-32230-blousson_serian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32058-32230-blousson_serian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32058-32230-blousson_serian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32059-32410-bonas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32059-32410-bonas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32059-32410-bonas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32059-32410-bonas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32060-32550-boucagneres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32060-32550-boucagneres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32060-32550-boucagneres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32060-32550-boucagneres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32061-32450-boulaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32061-32450-boulaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32061-32450-boulaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32061-32450-boulaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32062-32370-bourrouillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32062-32370-bourrouillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32062-32370-bourrouillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32062-32370-bourrouillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32063-32290-bouzon_gellenave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32063-32290-bouzon_gellenave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32063-32290-bouzon_gellenave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32063-32290-bouzon_gellenave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32064-32800-bretagne_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32064-32800-bretagne_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32064-32800-bretagne_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32064-32800-bretagne_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32065-32350-le_brouilh_monbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32065-32350-le_brouilh_monbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32065-32350-le_brouilh_monbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32065-32350-le_brouilh_monbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32066-32500-brugnens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32066-32500-brugnens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32066-32500-brugnens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32066-32500-brugnens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32067-32140-cabas_loumasses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32067-32140-cabas_loumasses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32067-32140-cabas_loumasses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32067-32140-cabas_loumasses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32068-32380-cadeilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32068-32380-cadeilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32068-32380-cadeilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32068-32380-cadeilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32069-32220-cadeillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32069-32220-cadeillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32069-32220-cadeillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32069-32220-cadeillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32070-32400-cahuzac_sur_adour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32070-32400-cahuzac_sur_adour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32070-32400-cahuzac_sur_adour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32070-32400-cahuzac_sur_adour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32071-32190-caillavet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32071-32190-caillavet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32071-32190-caillavet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32071-32190-caillavet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32072-32190-callian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32072-32190-callian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32072-32190-callian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32072-32190-callian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32073-32800-campagne_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32073-32800-campagne_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32073-32800-campagne_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32073-32800-campagne_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32075-32100-cassaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32075-32100-cassaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32075-32100-cassaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32075-32100-cassaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32076-32450-castelnau_barbarens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32076-32450-castelnau_barbarens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32076-32450-castelnau_barbarens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32076-32450-castelnau_barbarens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32077-32320-castelnau_d_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32077-32320-castelnau_d_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32077-32320-castelnau_d_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32077-32320-castelnau_d_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32078-32500-castelnau_d_arbieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32078-32500-castelnau_d_arbieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32078-32500-castelnau_d_arbieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32078-32500-castelnau_d_arbieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32079-32440-castelnau_d_auzan_labarrere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32079-32440-castelnau_d_auzan_labarrere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32079-32440-castelnau_d_auzan_labarrere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32079-32440-castelnau_d_auzan_labarrere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32080-32100-castelnau_sur_l_auvignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32080-32100-castelnau_sur_l_auvignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32080-32100-castelnau_sur_l_auvignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32080-32100-castelnau_sur_l_auvignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32081-32290-castelnavet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32081-32290-castelnavet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32081-32290-castelnavet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32081-32290-castelnavet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32082-32700-castera_lectourois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32082-32700-castera_lectourois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32082-32700-castera_lectourois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32082-32700-castera_lectourois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32083-32410-castera_verduzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32083-32410-castera_verduzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32083-32410-castera_verduzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32083-32410-castera_verduzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32084-32380-casteron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32084-32380-casteron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32084-32380-casteron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32084-32380-casteron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32085-32340-castet_arrouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32085-32340-castet_arrouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32085-32340-castet_arrouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32085-32340-castet_arrouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32086-32170-castex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32086-32170-castex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32086-32170-castex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32086-32170-castex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32087-32240-castex_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32087-32240-castex_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32087-32240-castex_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32087-32240-castex_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32088-32190-castillon_debats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32088-32190-castillon_debats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32088-32190-castillon_debats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32088-32190-castillon_debats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32089-32360-castillon_massas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32089-32360-castillon_massas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32089-32360-castillon_massas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32089-32360-castillon_massas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32090-32490-castillon_saves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32090-32490-castillon_saves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32090-32490-castillon_saves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32090-32490-castillon_saves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32091-32810-castin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32091-32810-castin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32091-32810-castin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32091-32810-castin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32092-32200-catonvielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32092-32200-catonvielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32092-32200-catonvielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32092-32200-catonvielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32093-32400-caumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32093-32400-caumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32093-32400-caumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32093-32400-caumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32094-32110-caupenne_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32094-32110-caupenne_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32094-32110-caupenne_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32094-32110-caupenne_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32095-32100-caussens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32095-32100-caussens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32095-32100-caussens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32095-32100-caussens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32096-32150-cazaubon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32096-32150-cazaubon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32096-32150-cazaubon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32096-32150-cazaubon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32097-32190-cazaux_d_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32097-32190-cazaux_d_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32097-32190-cazaux_d_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32097-32190-cazaux_d_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32098-32130-cazaux_saves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32098-32130-cazaux_saves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32098-32130-cazaux_saves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32098-32130-cazaux_saves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32099-32230-cazaux_villecomtal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32099-32230-cazaux_villecomtal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32099-32230-cazaux_villecomtal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32099-32230-cazaux_villecomtal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32100-32800-cazeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32100-32800-cazeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32100-32800-cazeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32100-32800-cazeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32101-32500-ceran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32101-32500-ceran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32101-32500-ceran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32101-32500-ceran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32102-32410-cezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32102-32410-cezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32102-32410-cezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32102-32410-cezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32103-32140-chelan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32103-32140-chelan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32103-32140-chelan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32103-32140-chelan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32104-32300-clermont_pouyguilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32104-32300-clermont_pouyguilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32104-32300-clermont_pouyguilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32104-32300-clermont_pouyguilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32105-32600-clermont_saves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32105-32600-clermont_saves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32105-32600-clermont_saves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32105-32600-clermont_saves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32106-32430-cologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32106-32430-cologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32106-32430-cologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32106-32430-cologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32107-32100-condom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32107-32100-condom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32107-32100-condom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32107-32100-condom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32108-32400-corneillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32108-32400-corneillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32108-32400-corneillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32108-32400-corneillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32109-32160-couloume_mondebat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32109-32160-couloume_mondebat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32109-32160-couloume_mondebat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32109-32160-couloume_mondebat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32110-32330-courrensan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32110-32330-courrensan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32110-32330-courrensan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32110-32330-courrensan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32111-32230-courties/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32111-32230-courties/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32111-32230-courties/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32111-32230-courties/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32112-32270-crastes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32112-32270-crastes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32112-32270-crastes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32112-32270-crastes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32113-32110-cravenceres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32113-32110-cravenceres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32113-32110-cravenceres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32113-32110-cravenceres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32114-32300-cuelas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32114-32300-cuelas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32114-32300-cuelas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32114-32300-cuelas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32115-32190-demu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32115-32190-demu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32115-32190-demu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32115-32190-demu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32116-32170-duffort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32116-32170-duffort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32116-32170-duffort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32116-32170-duffort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32117-32810-duran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32117-32810-duran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32117-32810-duran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32117-32810-duran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32118-32260-durban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32118-32260-durban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32118-32260-durban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32118-32260-durban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32119-32800-eauze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32119-32800-eauze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32119-32800-eauze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32119-32800-eauze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32120-32430-encausse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32120-32430-encausse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32120-32430-encausse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32120-32430-encausse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32121-32600-endoufielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32121-32600-endoufielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32121-32600-endoufielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32121-32600-endoufielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32122-32140-esclassan_labastide/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32122-32140-esclassan_labastide/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32122-32140-esclassan_labastide/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32122-32140-esclassan_labastide/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32123-32200-escorneboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32123-32200-escorneboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32123-32200-escorneboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32123-32200-escorneboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32124-32220-espaon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32124-32220-espaon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32124-32220-espaon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32124-32220-espaon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32125-32370-espas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32125-32370-espas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32125-32370-espas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32125-32370-espas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32126-32170-estampes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32126-32170-estampes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32126-32170-estampes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32126-32170-estampes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32127-32240-estang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32127-32240-estang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32127-32240-estang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32127-32240-estang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32128-32300-estipouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32128-32300-estipouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32128-32300-estipouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32128-32300-estipouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32129-32380-estramiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32129-32380-estramiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32129-32380-estramiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32129-32380-estramiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32130-32450-faget_abbatial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32130-32450-faget_abbatial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32130-32450-faget_abbatial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32130-32450-faget_abbatial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32131-32340-flamarens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32131-32340-flamarens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32131-32340-flamarens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32131-32340-flamarens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32132-32500-fleurance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32132-32500-fleurance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32132-32500-fleurance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32132-32500-fleurance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32133-32250-fources/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32133-32250-fources/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32133-32250-fources/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32133-32250-fources/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32134-32490-fregouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32134-32490-fregouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32134-32490-fregouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32134-32490-fregouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32135-32400-fusterouau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32135-32400-fusterouau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32135-32400-fusterouau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32135-32400-fusterouau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32136-32160-galiax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32136-32160-galiax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32136-32160-galiax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32136-32160-galiax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32138-32220-garravet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32138-32220-garravet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32138-32220-garravet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32138-32220-garravet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32139-32380-gaudonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32139-32380-gaudonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32139-32380-gaudonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32139-32380-gaudonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32140-32220-gaujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32140-32220-gaujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32140-32220-gaujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32140-32220-gaujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32141-32420-gaujan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32141-32420-gaujan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32141-32420-gaujan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32141-32420-gaujan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32142-32390-gavarret_sur_aulouste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32142-32390-gavarret_sur_aulouste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32142-32390-gavarret_sur_aulouste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32142-32390-gavarret_sur_aulouste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32143-32480-gazaupouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32143-32480-gazaupouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32143-32480-gazaupouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32143-32480-gazaupouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32144-32230-gazax_et_baccarisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32144-32230-gazax_et_baccarisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32144-32230-gazax_et_baccarisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32144-32230-gazax_et_baccarisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32145-32720-gee_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32145-32720-gee_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32145-32720-gee_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32145-32720-gee_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32146-32340-gimbrede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32146-32340-gimbrede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32146-32340-gimbrede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32146-32340-gimbrede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32147-32200-gimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32147-32200-gimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32147-32200-gimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32147-32200-gimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32148-32200-giscaro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32148-32200-giscaro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32148-32200-giscaro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32148-32200-giscaro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32149-32330-gondrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32149-32330-gondrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32149-32330-gondrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32149-32330-gondrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32150-32500-goutz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32150-32500-goutz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32150-32500-goutz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32150-32500-goutz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32151-32400-goux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32151-32400-goux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32151-32400-goux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32151-32400-goux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32152-32730-haget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32152-32730-haget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32152-32730-haget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32152-32730-haget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32153-32550-haulies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32153-32550-haulies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32153-32550-haulies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32153-32550-haulies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32154-32120-homps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32154-32120-homps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32154-32120-homps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32154-32120-homps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32155-32460-le_houga/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32155-32460-le_houga/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32155-32460-le_houga/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32155-32460-le_houga/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32156-32300-idrac_respailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32156-32300-idrac_respailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32156-32300-idrac_respailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32156-32300-idrac_respailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32157-32270-l_isle_arne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32157-32270-l_isle_arne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32157-32270-l_isle_arne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32157-32270-l_isle_arne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32158-32380-l_isle_bouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32158-32380-l_isle_bouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32158-32380-l_isle_bouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32158-32380-l_isle_bouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32159-32300-l_isle_de_noe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32159-32300-l_isle_de_noe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32159-32300-l_isle_de_noe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32159-32300-l_isle_de_noe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32160-32600-l_isle_jourdain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32160-32600-l_isle_jourdain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32160-32600-l_isle_jourdain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32160-32600-l_isle_jourdain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32161-32400-izotges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32161-32400-izotges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32161-32400-izotges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32161-32400-izotges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32162-32360-jegun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32162-32360-jegun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32162-32360-jegun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32162-32360-jegun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32163-32160-ju_belloc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32163-32160-ju_belloc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32163-32160-ju_belloc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32163-32160-ju_belloc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32164-32230-juillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32164-32230-juillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32164-32230-juillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32164-32230-juillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32165-32200-juilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32165-32200-juilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32165-32200-juilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32165-32200-juilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32166-32190-justian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32166-32190-justian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32166-32190-justian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32166-32190-justian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32167-32170-laas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32167-32170-laas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32167-32170-laas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32167-32170-laas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32169-32260-labarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32169-32260-labarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32169-32260-labarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32169-32260-labarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32170-32400-labarthete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32170-32400-labarthete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32170-32400-labarthete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32170-32400-labarthete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32171-32130-labastide_saves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32171-32130-labastide_saves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32171-32130-labastide_saves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32171-32130-labastide_saves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32172-32300-labejan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32172-32300-labejan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32172-32300-labejan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32172-32300-labejan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32173-32120-labrihe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32173-32120-labrihe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32173-32120-labrihe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32173-32120-labrihe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32174-32230-ladeveze_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32174-32230-ladeveze_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32174-32230-ladeveze_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32174-32230-ladeveze_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32175-32230-ladeveze_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32175-32230-ladeveze_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32175-32230-ladeveze_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32175-32230-ladeveze_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32176-32700-lagarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32176-32700-lagarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32176-32700-lagarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32176-32700-lagarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32177-32300-lagarde_hachan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32177-32300-lagarde_hachan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32177-32300-lagarde_hachan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32177-32300-lagarde_hachan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32178-32310-lagardere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32178-32310-lagardere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32178-32310-lagardere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32178-32310-lagardere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32180-32330-lagraulet_du_gers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32180-32330-lagraulet_du_gers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32180-32330-lagraulet_du_gers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32180-32330-lagraulet_du_gers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32181-32170-laguian_mazous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32181-32170-laguian_mazous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32181-32170-laguian_mazous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32181-32170-laguian_mazous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32182-32130-lahas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32182-32130-lahas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32182-32130-lahas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32182-32130-lahas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32183-32810-lahitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32183-32810-lahitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32183-32810-lahitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32183-32810-lahitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32184-32500-lalanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32184-32500-lalanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32184-32500-lalanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32184-32500-lalanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32185-32140-lalanne_arque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32185-32140-lalanne_arque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32185-32140-lalanne_arque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32185-32140-lalanne_arque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32186-32260-lamaguere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32186-32260-lamaguere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32186-32260-lamaguere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32186-32260-lamaguere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32187-32300-lamazere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32187-32300-lamazere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32187-32300-lamazere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32187-32300-lamazere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32188-32500-lamothe_goas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32188-32500-lamothe_goas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32188-32500-lamothe_goas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32188-32500-lamothe_goas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32189-32240-lannemaignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32189-32240-lannemaignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32189-32240-lannemaignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32189-32240-lannemaignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32190-32190-lannepax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32190-32190-lannepax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32190-32190-lannepax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32190-32190-lannepax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32191-32110-lanne_soubiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32191-32110-lanne_soubiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32191-32110-lanne_soubiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32191-32110-lanne_soubiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32192-32400-lannux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32192-32400-lannux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32192-32400-lannux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32192-32400-lannux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32193-32150-laree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32193-32150-laree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32193-32150-laree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32193-32150-laree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32194-32100-larressingle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32194-32100-larressingle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32194-32100-larressingle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32194-32100-larressingle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32195-32480-larroque_engalin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32195-32480-larroque_engalin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32195-32480-larroque_engalin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32195-32480-larroque_engalin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32196-32410-larroque_saint_sernin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32196-32410-larroque_saint_sernin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32196-32410-larroque_saint_sernin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32196-32410-larroque_saint_sernin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32197-32100-larroque_sur_l_osse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32197-32100-larroque_sur_l_osse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32197-32100-larroque_sur_l_osse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32197-32100-larroque_sur_l_osse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32198-32450-lartigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32198-32450-lartigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32198-32450-lartigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32198-32450-lartigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32199-32160-lasserade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32199-32160-lasserade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32199-32160-lasserade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32199-32160-lasserade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32200-32550-lasseran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32200-32550-lasseran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32200-32550-lasseran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32200-32550-lasseran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32201-32550-lasseube_propre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32201-32550-lasseube_propre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32201-32550-lasseube_propre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32201-32550-lasseube_propre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32202-32110-laujuzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32202-32110-laujuzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32202-32110-laujuzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32202-32110-laujuzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32203-32330-lauraet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32203-32330-lauraet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32203-32330-lauraet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32203-32330-lauraet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32204-32360-lavardens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32204-32360-lavardens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32204-32360-lavardens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32204-32360-lavardens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32205-32230-laveraet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32205-32230-laveraet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32205-32230-laveraet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32205-32230-laveraet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32206-32220-laymont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32206-32220-laymont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32206-32220-laymont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32206-32220-laymont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32207-32810-leboulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32207-32810-leboulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32207-32810-leboulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32207-32810-leboulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32208-32700-lectoure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32208-32700-lectoure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32208-32700-lectoure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32208-32700-lectoure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32209-32400-lelin_lapujolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32209-32400-lelin_lapujolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32209-32400-lelin_lapujolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32209-32400-lelin_lapujolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32210-32600-lias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32210-32600-lias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32210-32600-lias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32210-32600-lias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32211-32240-lias_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32211-32240-lias_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32211-32240-lias_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32211-32240-lias_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32212-32480-ligardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32212-32480-ligardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32212-32480-ligardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32212-32480-ligardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32213-32220-lombez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32213-32220-lombez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32213-32220-lombez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32213-32220-lombez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32214-32110-loubedat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32214-32110-loubedat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32214-32110-loubedat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32214-32110-loubedat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32215-32300-loubersan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32215-32300-loubersan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32215-32300-loubersan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32215-32300-loubersan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32216-32140-lourties_monbrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32216-32140-lourties_monbrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32216-32140-lourties_monbrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32216-32140-lourties_monbrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32217-32230-louslitges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32217-32230-louslitges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32217-32230-louslitges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32217-32230-louslitges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32218-32290-loussous_debat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32218-32290-loussous_debat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32218-32290-loussous_debat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32218-32290-loussous_debat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32219-32290-lupiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32219-32290-lupiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32219-32290-lupiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32219-32290-lupiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32220-32110-luppe_violles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32220-32110-luppe_violles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32220-32110-luppe_violles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32220-32110-luppe_violles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32221-32270-lussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32221-32270-lussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32221-32270-lussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32221-32270-lussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32222-32110-magnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32222-32110-magnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32222-32110-magnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32222-32110-magnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32223-32380-magnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32223-32380-magnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32223-32380-magnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32223-32380-magnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32224-32310-maignaut_tauzia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32224-32310-maignaut_tauzia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32224-32310-maignaut_tauzia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32224-32310-maignaut_tauzia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32225-32730-malabat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32225-32730-malabat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32225-32730-malabat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32225-32730-malabat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32226-32170-manas_bastanous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32226-32170-manas_bastanous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32226-32170-manas_bastanous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32226-32170-manas_bastanous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32227-32370-manciet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32227-32370-manciet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32227-32370-manciet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32227-32370-manciet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32228-32140-manent_montane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32228-32140-manent_montane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32228-32140-manent_montane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32228-32140-manent_montane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32229-32120-mansempuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32229-32120-mansempuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32229-32120-mansempuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32229-32120-mansempuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32230-32310-mansencome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32230-32310-mansencome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32230-32310-mansencome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32230-32310-mansencome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32231-32190-marambat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32231-32190-marambat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32231-32190-marambat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32231-32190-marambat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32232-32120-maravat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32232-32120-maravat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32232-32120-maravat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32232-32120-maravat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32233-32230-marciac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32233-32230-marciac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32233-32230-marciac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32233-32230-marciac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32234-32490-marestaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32234-32490-marestaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32234-32490-marestaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32234-32490-marestaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32235-32290-margouet_meymes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32235-32290-margouet_meymes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32235-32290-margouet_meymes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32235-32290-margouet_meymes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32236-32150-marguestau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32236-32150-marguestau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32236-32150-marguestau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32236-32150-marguestau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32237-32270-marsan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32237-32270-marsan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32237-32270-marsan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32237-32270-marsan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32238-32170-marseillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32238-32170-marseillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32238-32170-marseillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32238-32170-marseillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32239-32700-marsolan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32239-32700-marsolan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32239-32700-marsolan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32239-32700-marsolan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32240-32230-mascaras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32240-32230-mascaras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32240-32230-mascaras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32240-32230-mascaras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32241-32700-mas_d_auvignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32241-32700-mas_d_auvignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32241-32700-mas_d_auvignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32241-32700-mas_d_auvignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32242-32140-masseube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32242-32140-masseube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32242-32140-masseube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32242-32140-masseube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32243-32240-mauleon_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32243-32240-mauleon_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32243-32240-mauleon_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32243-32240-mauleon_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32244-32400-maulicheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32244-32400-maulicheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32244-32400-maulicheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32244-32400-maulicheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32245-32400-maumusson_laguian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32245-32400-maumusson_laguian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32245-32400-maumusson_laguian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32245-32400-maumusson_laguian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32246-32240-maupas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32246-32240-maupas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32246-32240-maupas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32246-32240-maupas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32247-32200-maurens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32247-32200-maurens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32247-32200-maurens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32247-32200-maurens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32248-32380-mauroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32248-32380-mauroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32248-32380-mauroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32248-32380-mauroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32249-32120-mauvezin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32249-32120-mauvezin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32249-32120-mauvezin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32249-32120-mauvezin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32250-32420-meilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32250-32420-meilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32250-32420-meilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32250-32420-meilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32251-32360-merens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32251-32360-merens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32251-32360-merens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32251-32360-merens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32252-32170-mielan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32252-32170-mielan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32252-32170-mielan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32252-32170-mielan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32253-32340-miradoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32253-32340-miradoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32253-32340-miradoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32253-32340-miradoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32254-32300-miramont_d_astarac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32254-32300-miramont_d_astarac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32254-32300-miramont_d_astarac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32254-32300-miramont_d_astarac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32255-32390-miramont_latour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32255-32390-miramont_latour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32255-32390-miramont_latour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32255-32390-miramont_latour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32256-32300-mirande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32256-32300-mirande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32256-32300-mirande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32256-32300-mirande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32257-32350-mirannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32257-32350-mirannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32257-32350-mirannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32257-32350-mirannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32258-32390-mirepoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32258-32390-mirepoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32258-32390-mirepoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32258-32390-mirepoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32260-32420-monbardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32260-32420-monbardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32260-32420-monbardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32260-32420-monbardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32261-32130-monblanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32261-32130-monblanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32261-32130-monblanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32261-32130-monblanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32262-32600-monbrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32262-32600-monbrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32262-32600-monbrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32262-32600-monbrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32263-32300-moncassin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32263-32300-moncassin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32263-32300-moncassin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32263-32300-moncassin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32264-32150-monclar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32264-32150-monclar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32264-32150-monclar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32264-32150-monclar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32265-32300-monclar_sur_losse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32265-32300-monclar_sur_losse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32265-32300-monclar_sur_losse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32265-32300-monclar_sur_losse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32266-32260-moncorneil_grazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32266-32260-moncorneil_grazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32266-32260-moncorneil_grazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32266-32260-moncorneil_grazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32267-32260-monferran_plaves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32267-32260-monferran_plaves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32267-32260-monferran_plaves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32267-32260-monferran_plaves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32268-32490-monferran_saves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32268-32490-monferran_saves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32268-32490-monferran_saves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32268-32490-monferran_saves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32269-32120-monfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32269-32120-monfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32269-32120-monfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32269-32120-monfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32270-32220-mongausy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32270-32220-mongausy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32270-32220-mongausy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32270-32220-mongausy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32271-32240-monguilhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32271-32240-monguilhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32271-32240-monguilhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32271-32240-monguilhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32272-32140-monlaur_bernet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32272-32140-monlaur_bernet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32272-32140-monlaur_bernet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32272-32140-monlaur_bernet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32273-32230-monlezun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32273-32230-monlezun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32273-32230-monlezun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32273-32230-monlezun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32274-32240-monlezun_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32274-32240-monlezun_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32274-32240-monlezun_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32274-32240-monlezun_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32275-32170-monpardiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32275-32170-monpardiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32275-32170-monpardiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32275-32170-monpardiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32276-32220-montadet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32276-32220-montadet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32276-32220-montadet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32276-32220-montadet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32277-32220-montamat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32277-32220-montamat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32277-32220-montamat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32277-32220-montamat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32278-32300-montaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32278-32300-montaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32278-32300-montaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32278-32300-montaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32279-32810-montaut_les_creneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32279-32810-montaut_les_creneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32279-32810-montaut_les_creneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32279-32810-montaut_les_creneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32280-32140-mont_d_astarac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32280-32140-mont_d_astarac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32280-32140-mont_d_astarac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32280-32140-mont_d_astarac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32281-32170-mont_de_marrast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32281-32170-mont_de_marrast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32281-32170-mont_de_marrast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32281-32170-mont_de_marrast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32282-32550-montegut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32282-32550-montegut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32282-32550-montegut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32282-32550-montegut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32283-32730-montegut_arros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32283-32730-montegut_arros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32283-32730-montegut_arros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32283-32730-montegut_arros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32284-32220-montegut_saves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32284-32220-montegut_saves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32284-32220-montegut_saves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32284-32220-montegut_saves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32285-32320-montesquiou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32285-32320-montesquiou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32285-32320-montesquiou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32285-32320-montesquiou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32286-32390-montestruc_sur_gers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32286-32390-montestruc_sur_gers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32286-32390-montestruc_sur_gers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32286-32390-montestruc_sur_gers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32287-32420-monties/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32287-32420-monties/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32287-32420-monties/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32287-32420-monties/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32288-32200-montiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32288-32200-montiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32288-32200-montiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32288-32200-montiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32289-32220-montpezat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32289-32220-montpezat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32289-32220-montpezat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32289-32220-montpezat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32290-32250-montreal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32290-32250-montreal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32290-32250-montreal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32290-32250-montreal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32291-32240-mormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32291-32240-mormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32291-32240-mormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32291-32240-mormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32292-32330-mouchan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32292-32330-mouchan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32292-32330-mouchan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32292-32330-mouchan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32293-32300-mouches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32293-32300-mouches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32293-32300-mouches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32293-32300-mouches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32294-32190-mourede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32294-32190-mourede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32294-32190-mourede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32294-32190-mourede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32295-32130-nizas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32295-32130-nizas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32295-32130-nizas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32295-32130-nizas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32296-32110-nogaro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32296-32110-nogaro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32296-32110-nogaro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32296-32110-nogaro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32297-32130-noilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32297-32130-noilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32297-32130-noilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32297-32130-noilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32298-32270-nougaroulet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32298-32270-nougaroulet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32298-32270-nougaroulet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32298-32270-nougaroulet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32299-32800-noulens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32299-32800-noulens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32299-32800-noulens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32299-32800-noulens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32300-32260-orbessan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32300-32260-orbessan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32300-32260-orbessan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32300-32260-orbessan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32301-32350-ordan_larroque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32301-32350-ordan_larroque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32301-32350-ordan_larroque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32301-32350-ordan_larroque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32302-32260-ornezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32302-32260-ornezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32302-32260-ornezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32302-32260-ornezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32303-32230-pallanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32303-32230-pallanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32303-32230-pallanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32303-32230-pallanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32304-32140-panassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32304-32140-panassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32304-32140-panassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32304-32140-panassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32305-32110-panjas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32305-32110-panjas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32305-32110-panjas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32305-32110-panjas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32306-32500-pauilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32306-32500-pauilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32306-32500-pauilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32306-32500-pauilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32307-32550-pavie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32307-32550-pavie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32307-32550-pavie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32307-32550-pavie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32308-32130-pebees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32308-32130-pebees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32308-32130-pebees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32308-32130-pebees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32309-32420-pellefigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32309-32420-pellefigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32309-32420-pellefigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32309-32420-pellefigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32310-32460-perchede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32310-32460-perchede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32310-32460-perchede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32310-32460-perchede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32311-32700-pergain_taillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32311-32700-pergain_taillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32311-32700-pergain_taillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32311-32700-pergain_taillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32312-32550-pessan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32312-32550-pessan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32312-32550-pessan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32312-32550-pessan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32313-32380-pessoulens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32313-32380-pessoulens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32313-32380-pessoulens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32313-32380-pessoulens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32314-32340-peyrecave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32314-32340-peyrecave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32314-32340-peyrecave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32314-32340-peyrecave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32315-32320-peyrusse_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32315-32320-peyrusse_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32315-32320-peyrusse_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32315-32320-peyrusse_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32316-32360-peyrusse_massas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32316-32360-peyrusse_massas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32316-32360-peyrusse_massas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32316-32360-peyrusse_massas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32317-32230-peyrusse_vieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32317-32230-peyrusse_vieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32317-32230-peyrusse_vieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32317-32230-peyrusse_vieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32318-32500-pis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32318-32500-pis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32318-32500-pis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32318-32500-pis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32319-32160-plaisance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32319-32160-plaisance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32319-32160-plaisance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32319-32160-plaisance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32320-32340-plieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32320-32340-plieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32320-32340-plieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32320-32340-plieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32321-32130-polastron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32321-32130-polastron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32321-32130-polastron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32321-32130-polastron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32322-32130-pompiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32322-32130-pompiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32322-32130-pompiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32322-32130-pompiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32323-32300-ponsampere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32323-32300-ponsampere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32323-32300-ponsampere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32323-32300-ponsampere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32324-32300-ponsan_soubiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32324-32300-ponsan_soubiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32324-32300-ponsan_soubiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32324-32300-ponsan_soubiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32325-32290-pouydraguin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32325-32290-pouydraguin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32325-32290-pouydraguin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32325-32290-pouydraguin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32326-32320-pouylebon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32326-32320-pouylebon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32326-32320-pouylebon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32326-32320-pouylebon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32327-32260-pouy_loubrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32327-32260-pouy_loubrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32327-32260-pouy_loubrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32327-32260-pouy_loubrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32328-32480-pouy_roquelaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32328-32480-pouy_roquelaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32328-32480-pouy_roquelaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32328-32480-pouy_roquelaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32329-32390-prechac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32329-32390-prechac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32329-32390-prechac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32329-32390-prechac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32330-32160-prechac_sur_adour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32330-32160-prechac_sur_adour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32330-32160-prechac_sur_adour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32330-32160-prechac_sur_adour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32331-32810-preignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32331-32810-preignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32331-32810-preignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32331-32810-preignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32332-32190-preneron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32332-32190-preneron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32332-32190-preneron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32332-32190-preneron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32333-32400-projan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32333-32400-projan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32333-32400-projan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32333-32400-projan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32334-32600-pujaudran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32334-32600-pujaudran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32334-32600-pujaudran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32334-32600-pujaudran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32335-32120-puycasquier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32335-32120-puycasquier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32335-32120-puycasquier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32335-32120-puycasquier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32336-32220-puylausic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32336-32220-puylausic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32336-32220-puylausic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32336-32220-puylausic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32337-32390-puysegur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32337-32390-puysegur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32337-32390-puysegur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32337-32390-puysegur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32338-32800-ramouzens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32338-32800-ramouzens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32338-32800-ramouzens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32338-32800-ramouzens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32339-32600-razengues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32339-32600-razengues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32339-32600-razengues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32339-32600-razengues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32340-32800-reans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32340-32800-reans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32340-32800-reans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32340-32800-reans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32341-32390-rejaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32341-32390-rejaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32341-32390-rejaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32341-32390-rejaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32342-32230-ricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32342-32230-ricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32342-32230-ricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32342-32230-ricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32343-32320-riguepeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32343-32320-riguepeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32343-32320-riguepeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32343-32320-riguepeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32344-32400-riscle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32344-32400-riscle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32344-32400-riscle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32344-32400-riscle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32345-32480-la_romieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32345-32480-la_romieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32345-32480-la_romieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32345-32480-la_romieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32346-32190-roquebrune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32346-32190-roquebrune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32346-32190-roquebrune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32346-32190-roquebrune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32347-32390-roquefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32347-32390-roquefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32347-32390-roquefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32347-32390-roquefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32348-32810-roquelaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32348-32810-roquelaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32348-32810-roquelaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32348-32810-roquelaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32349-32430-roquelaure_saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32349-32430-roquelaure_saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32349-32430-roquelaure_saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32349-32430-roquelaure_saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32350-32100-roquepine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32350-32100-roquepine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32350-32100-roquepine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32350-32100-roquepine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32351-32310-roques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32351-32310-roques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32351-32310-roques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32351-32310-roques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32352-32190-rozes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32352-32190-rozes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32352-32190-rozes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32352-32190-rozes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32353-32420-sabaillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32353-32420-sabaillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32353-32420-sabaillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32353-32420-sabaillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32354-32290-sabazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32354-32290-sabazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32354-32290-sabazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32354-32290-sabazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32355-32170-sadeillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32355-32170-sadeillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32355-32170-sadeillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32355-32170-sadeillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32356-32200-saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32356-32200-saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32356-32200-saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32356-32200-saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32357-32430-sainte_anne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32357-32430-sainte_anne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32357-32430-sainte_anne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32357-32430-sainte_anne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32358-32340-saint_antoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32358-32340-saint_antoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32358-32340-saint_antoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32358-32340-saint_antoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32359-32120-saint_antonin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32359-32120-saint_antonin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32359-32120-saint_antonin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32359-32120-saint_antonin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32360-32350-saint_arailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32360-32350-saint_arailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32360-32350-saint_arailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32360-32350-saint_arailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32361-32300-saint_arroman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32361-32300-saint_arroman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32361-32300-saint_arroman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32361-32300-saint_arroman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32362-32160-saint_aunix_lengros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32362-32160-saint_aunix_lengros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32362-32160-saint_aunix_lengros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32362-32160-saint_aunix_lengros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32363-32300-sainte_aurence_cazaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32363-32300-sainte_aurence_cazaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32363-32300-sainte_aurence_cazaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32363-32300-sainte_aurence_cazaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32364-32700-saint_avit_frandat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32364-32700-saint_avit_frandat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32364-32700-saint_avit_frandat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32364-32700-saint_avit_frandat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32365-32140-saint_blancard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32365-32140-saint_blancard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32365-32140-saint_blancard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32365-32140-saint_blancard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32366-32120-saint_bres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32366-32120-saint_bres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32366-32120-saint_bres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32366-32120-saint_bres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32367-32320-saint_christaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32367-32320-saint_christaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32367-32320-saint_christaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32367-32320-saint_christaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32368-32390-sainte_christie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32368-32390-sainte_christie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32368-32390-sainte_christie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32368-32390-sainte_christie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32369-32370-sainte_christie_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32369-32370-sainte_christie_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32369-32370-sainte_christie_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32369-32370-sainte_christie_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32370-32380-saint_clar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32370-32380-saint_clar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32370-32380-saint_clar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32370-32380-saint_clar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32371-32380-saint_creac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32371-32380-saint_creac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32371-32380-saint_creac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32371-32380-saint_creac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32372-32430-saint_cricq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32372-32430-saint_cricq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32372-32430-saint_cricq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32372-32430-saint_cricq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32373-32170-sainte_dode/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32373-32170-sainte_dode/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32373-32170-sainte_dode/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32373-32170-sainte_dode/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32374-32450-saint_elix_d_astarac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32374-32450-saint_elix_d_astarac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32374-32450-saint_elix_d_astarac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32374-32450-saint_elix_d_astarac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32375-32300-saint_elix_theux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32375-32300-saint_elix_theux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32375-32300-saint_elix_theux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32375-32300-saint_elix_theux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32376-32120-sainte_gemme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32376-32120-sainte_gemme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32376-32120-sainte_gemme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32376-32120-sainte_gemme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32377-32430-saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32377-32430-saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32377-32430-saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32377-32430-saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32378-32400-saint_germe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32378-32400-saint_germe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32378-32400-saint_germe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32378-32400-saint_germe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32379-32200-saint_germier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32379-32200-saint_germier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32379-32200-saint_germier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32379-32200-saint_germier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32380-32110-saint_griede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32380-32110-saint_griede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32380-32110-saint_griede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32380-32110-saint_griede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32381-32550-saint_jean_le_comtal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32381-32550-saint_jean_le_comtal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32381-32550-saint_jean_le_comtal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32381-32550-saint_jean_le_comtal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32382-32190-saint_jean_poutge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32382-32190-saint_jean_poutge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32382-32190-saint_jean_poutge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32382-32190-saint_jean_poutge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32383-32230-saint_justin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32383-32230-saint_justin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32383-32230-saint_justin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32383-32230-saint_justin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32384-32360-saint_lary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32384-32360-saint_lary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32384-32360-saint_lary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32384-32360-saint_lary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32385-32380-saint_leonard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32385-32380-saint_leonard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32385-32380-saint_leonard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32385-32380-saint_leonard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32386-32220-saint_lizier_du_plante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32386-32220-saint_lizier_du_plante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32386-32220-saint_lizier_du_plante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32386-32220-saint_lizier_du_plante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32387-32220-saint_loube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32387-32220-saint_loube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32387-32220-saint_loube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32387-32220-saint_loube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32388-32200-sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32388-32200-sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32388-32200-sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32388-32200-sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32389-32300-saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32389-32300-saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32389-32300-saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32389-32300-saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32390-32110-saint_martin_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32390-32110-saint_martin_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32390-32110-saint_martin_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32390-32110-saint_martin_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32391-32480-saint_martin_de_goyne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32391-32480-saint_martin_de_goyne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32391-32480-saint_martin_de_goyne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32391-32480-saint_martin_de_goyne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32392-32450-saint_martin_gimois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32392-32450-saint_martin_gimois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32392-32450-saint_martin_gimois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32392-32450-saint_martin_gimois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32393-32300-saint_maur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32393-32300-saint_maur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32393-32300-saint_maur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32393-32300-saint_maur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32394-32300-saint_medard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32394-32300-saint_medard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32394-32300-saint_medard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32394-32300-saint_medard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32395-32700-sainte_mere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32395-32700-sainte_mere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32395-32700-sainte_mere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32395-32700-sainte_mere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32396-32700-saint_mezard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32396-32700-saint_mezard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32396-32700-saint_mezard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32396-32700-saint_mezard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32397-32300-saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32397-32300-saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32397-32300-saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32397-32300-saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32398-32400-saint_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32398-32400-saint_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32398-32400-saint_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32398-32400-saint_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32399-32120-saint_orens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32399-32120-saint_orens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32399-32120-saint_orens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32399-32120-saint_orens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32400-32100-saint_orens_pouy_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32400-32100-saint_orens_pouy_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32400-32100-saint_orens_pouy_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32400-32100-saint_orens_pouy_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32401-32300-saint_ost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32401-32300-saint_ost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32401-32300-saint_ost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32401-32300-saint_ost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32402-32190-saint_paul_de_baise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32402-32190-saint_paul_de_baise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32402-32190-saint_paul_de_baise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32402-32190-saint_paul_de_baise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32403-32290-saint_pierre_d_aubezies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32403-32290-saint_pierre_d_aubezies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32403-32290-saint_pierre_d_aubezies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32403-32290-saint_pierre_d_aubezies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32404-32310-saint_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32404-32310-saint_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32404-32310-saint_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32404-32310-saint_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32405-32500-sainte_radegonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32405-32500-sainte_radegonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32405-32500-sainte_radegonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32405-32500-sainte_radegonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32406-32270-saint_sauvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32406-32270-saint_sauvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32406-32270-saint_sauvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32406-32270-saint_sauvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32407-32220-saint_soulan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32407-32220-saint_soulan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32407-32220-saint_soulan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32407-32220-saint_soulan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32408-32370-salles_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32408-32370-salles_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32408-32370-salles_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32408-32370-salles_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32409-32140-samaran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32409-32140-samaran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32409-32140-samaran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32409-32140-samaran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32410-32130-samatan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32410-32130-samatan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32410-32130-samatan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32410-32130-samatan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32411-32260-sansan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32411-32260-sansan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32411-32260-sansan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32411-32260-sansan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32412-32450-saramon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32412-32450-saramon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32412-32450-saramon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32412-32450-saramon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32413-32420-sarcos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32413-32420-sarcos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32413-32420-sarcos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32413-32420-sarcos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32414-32400-sarragachies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32414-32400-sarragachies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32414-32400-sarragachies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32414-32400-sarragachies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32415-32170-sarraguzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32415-32170-sarraguzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32415-32170-sarraguzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32415-32170-sarraguzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32416-32120-sarrant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32416-32120-sarrant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32416-32120-sarrant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32416-32120-sarrant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32417-32500-la_sauvetat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32417-32500-la_sauvetat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32417-32500-la_sauvetat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32417-32500-la_sauvetat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32418-32220-sauveterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32418-32220-sauveterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32418-32220-sauveterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32418-32220-sauveterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32419-32300-sauviac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32419-32300-sauviac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32419-32300-sauviac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32419-32300-sauviac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32420-32220-sauvimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32420-32220-sauvimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32420-32220-sauvimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32420-32220-sauvimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32421-32130-savignac_mona/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32421-32130-savignac_mona/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32421-32130-savignac_mona/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32421-32130-savignac_mona/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32422-32230-scieurac_et_floures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32422-32230-scieurac_et_floures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32422-32230-scieurac_et_floures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32422-32230-scieurac_et_floures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32423-32190-seailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32423-32190-seailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32423-32190-seailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32423-32190-seailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32424-32400-segos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32424-32400-segos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32424-32400-segos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32424-32400-segos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32425-32600-segoufielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32425-32600-segoufielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32425-32600-segoufielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32425-32600-segoufielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32426-32260-seissan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32426-32260-seissan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32426-32260-seissan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32426-32260-seissan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32427-32230-semboues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32427-32230-semboues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32427-32230-semboues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32427-32230-semboues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32428-32450-semezies_cachan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32428-32450-semezies_cachan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32428-32450-semezies_cachan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32428-32450-semezies_cachan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32429-32700-sempesserre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32429-32700-sempesserre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32429-32700-sempesserre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32429-32700-sempesserre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32430-32140-sere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32430-32140-sere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32430-32140-sere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32430-32140-sere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32431-32120-serempuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32431-32120-serempuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32431-32120-serempuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32431-32120-serempuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32432-32130-seysses_saves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32432-32130-seysses_saves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32432-32130-seysses_saves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32432-32130-seysses_saves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32433-32420-simorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32433-32420-simorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32433-32420-simorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32433-32420-simorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32434-32110-sion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32434-32110-sion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32434-32110-sion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32434-32110-sion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32435-32430-sirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32435-32430-sirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32435-32430-sirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32435-32430-sirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32436-32120-solomiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32436-32120-solomiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32436-32120-solomiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32436-32120-solomiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32437-32110-sorbets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32437-32110-sorbets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32437-32110-sorbets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32437-32110-sorbets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32438-32260-tachoires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32438-32260-tachoires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32438-32260-tachoires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32438-32260-tachoires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32439-32400-tarsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32439-32400-tarsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32439-32400-tarsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32439-32400-tarsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32440-32160-tasque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32440-32160-tasque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32440-32160-tasque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32440-32160-tasque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32441-32120-taybosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32441-32120-taybosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32441-32120-taybosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32441-32120-taybosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32442-32700-terraube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32442-32700-terraube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32442-32700-terraube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32442-32700-terraube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32443-32400-termes_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32443-32400-termes_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32443-32400-termes_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32443-32400-termes_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32444-32430-thoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32444-32430-thoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32444-32430-thoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32444-32430-thoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32445-32160-tieste_uragnoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32445-32160-tieste_uragnoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32445-32160-tieste_uragnoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32445-32160-tieste_uragnoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32446-32170-tillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32446-32170-tillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32446-32170-tillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32446-32170-tillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32447-32450-tirent_pontejac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32447-32450-tirent_pontejac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32447-32450-tirent_pontejac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32447-32450-tirent_pontejac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32448-32430-touget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32448-32430-touget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32448-32430-touget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32448-32430-touget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32449-32240-toujouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32449-32240-toujouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32449-32240-toujouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32449-32240-toujouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32450-32230-tourdun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32450-32230-tourdun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32450-32230-tourdun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32450-32230-tourdun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32451-32420-tournan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32451-32420-tournan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32451-32420-tournan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32451-32420-tournan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32452-32380-tournecoupe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32452-32380-tournecoupe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32452-32380-tournecoupe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32452-32380-tournecoupe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32453-32390-tourrenquets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32453-32390-tourrenquets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32453-32390-tourrenquets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32453-32390-tourrenquets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32454-32450-traverseres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32454-32450-traverseres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32454-32450-traverseres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32454-32450-traverseres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32455-32230-troncens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32455-32230-troncens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32455-32230-troncens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32455-32230-troncens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32456-32190-tudelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32456-32190-tudelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32456-32190-tudelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32456-32190-tudelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32457-32500-urdens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32457-32500-urdens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32457-32500-urdens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32457-32500-urdens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32458-32110-urgosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32458-32110-urgosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32458-32110-urgosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32458-32110-urgosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32459-32310-valence_sur_baise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32459-32310-valence_sur_baise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32459-32310-valence_sur_baise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32459-32310-valence_sur_baise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32460-32720-vergoignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32460-32720-vergoignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32460-32720-vergoignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32460-32720-vergoignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32461-32400-verlus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32461-32400-verlus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32461-32400-verlus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32461-32400-verlus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32462-32190-vic_fezensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32462-32190-vic_fezensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32462-32190-vic_fezensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32462-32190-vic_fezensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32463-32400-viella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32463-32400-viella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32463-32400-viella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32463-32400-viella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32464-32730-villecomtal_sur_arros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32464-32730-villecomtal_sur_arros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32464-32730-villecomtal_sur_arros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32464-32730-villecomtal_sur_arros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32465-32420-villefranche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32465-32420-villefranche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32465-32420-villefranche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32465-32420-villefranche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32466-32300-viozan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32466-32300-viozan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32466-32300-viozan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32466-32300-viozan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32467-32200-saint_caprais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32467-32200-saint_caprais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32467-32200-saint_caprais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32467-32200-saint_caprais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32468-32140-aussos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32468-32140-aussos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32468-32140-aussos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt32-gers/commune32468-32140-aussos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-33.xml
+++ b/public/sitemaps/sitemap-33.xml
@@ -5,1098 +5,2192 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33001-33230-abzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33001-33230-abzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33001-33230-abzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33001-33230-abzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33002-33124-aillas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33002-33124-aillas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33002-33124-aillas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33002-33124-aillas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33003-33440-ambares_et_lagrave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33003-33440-ambares_et_lagrave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33003-33440-ambares_et_lagrave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33003-33440-ambares_et_lagrave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33004-33810-ambes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33004-33810-ambes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33004-33810-ambes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33004-33810-ambes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33005-33510-andernos_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33005-33510-andernos_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33005-33510-andernos_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33005-33510-andernos_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33006-33390-anglade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33006-33390-anglade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33006-33390-anglade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33006-33390-anglade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33007-33640-arbanats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33007-33640-arbanats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33007-33640-arbanats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33007-33640-arbanats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33008-33760-porte_de_benauge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33008-33760-porte_de_benauge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33008-33760-porte_de_benauge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33008-33760-porte_de_benauge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33009-33120-arcachon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33009-33120-arcachon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33009-33120-arcachon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33009-33120-arcachon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33010-33460-arcins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33010-33460-arcins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33010-33460-arcins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33010-33460-arcins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33011-33740-ares/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33011-33740-ares/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33011-33740-ares/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33011-33740-ares/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33012-33460-arsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33012-33460-arsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33012-33460-arsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33012-33460-arsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33013-33370-artigues_pres_bordeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33013-33370-artigues_pres_bordeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33013-33370-artigues_pres_bordeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33013-33370-artigues_pres_bordeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33014-33570-les_artigues_de_lussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33014-33570-les_artigues_de_lussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33014-33570-les_artigues_de_lussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33014-33570-les_artigues_de_lussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33015-33500-arveyres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33015-33500-arveyres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33015-33500-arveyres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33015-33500-arveyres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33016-33240-asques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33016-33240-asques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33016-33240-asques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33016-33240-asques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33017-33430-aubiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33017-33430-aubiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33017-33430-aubiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33017-33430-aubiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33018-33240-val_de_virvee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33018-33240-val_de_virvee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33018-33240-val_de_virvee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33018-33240-val_de_virvee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33019-33980-audenge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33019-33980-audenge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33019-33980-audenge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33019-33980-audenge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33020-33790-auriolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33020-33790-auriolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33020-33790-auriolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33020-33790-auriolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33021-33124-auros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33021-33124-auros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33021-33124-auros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33021-33124-auros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33022-33480-avensan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33022-33480-avensan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33022-33480-avensan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33022-33480-avensan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33023-33640-ayguemorte_les_graves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33023-33640-ayguemorte_les_graves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33023-33640-ayguemorte_les_graves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33023-33640-ayguemorte_les_graves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33024-33190-bagas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33024-33190-bagas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33024-33190-bagas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33024-33190-bagas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33025-33760-baigneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33025-33760-baigneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33025-33760-baigneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33025-33760-baigneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33026-33730-balizac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33026-33730-balizac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33026-33730-balizac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33026-33730-balizac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33027-33190-barie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33027-33190-barie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33027-33190-barie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33027-33190-barie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33028-33750-baron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33028-33750-baron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33028-33750-baron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33028-33750-baron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33029-33114-le_barp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33029-33114-le_barp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33029-33114-le_barp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33029-33114-le_barp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33030-33720-barsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33030-33720-barsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33030-33720-barsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33030-33720-barsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33031-33190-bassanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33031-33190-bassanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33031-33190-bassanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33031-33190-bassanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33032-33530-bassens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33032-33530-bassens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33032-33530-bassens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33032-33530-bassens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33033-33880-baurech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33033-33880-baurech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33033-33880-baurech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33033-33880-baurech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33034-33230-bayas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33034-33230-bayas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33034-33230-bayas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33034-33230-bayas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33035-33710-bayon_sur_gironde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33035-33710-bayon_sur_gironde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33035-33710-bayon_sur_gironde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33035-33710-bayon_sur_gironde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33036-33430-bazas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33036-33430-bazas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33036-33430-bazas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33036-33430-bazas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33037-33640-beautiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33037-33640-beautiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33037-33640-beautiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33037-33640-beautiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33038-33340-begadan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33038-33340-begadan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33038-33340-begadan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33038-33340-begadan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33039-33130-begles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33039-33130-begles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33039-33130-begles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33039-33130-begles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33040-33410-beguey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33040-33410-beguey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33040-33410-beguey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33040-33410-beguey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33042-33830-belin_beliet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33042-33830-belin_beliet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33042-33830-belin_beliet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33042-33830-belin_beliet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33043-33760-bellebat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33043-33760-bellebat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33043-33760-bellebat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33043-33760-bellebat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33044-33760-bellefond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33044-33760-bellefond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33044-33760-bellefond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33044-33760-bellefond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33045-33350-belves_de_castillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33045-33350-belves_de_castillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33045-33350-belves_de_castillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33045-33350-belves_de_castillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33046-33430-bernos_beaulac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33046-33430-bernos_beaulac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33046-33430-bernos_beaulac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33046-33430-bernos_beaulac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33047-33390-berson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33047-33390-berson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33047-33390-berson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33047-33390-berson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33048-33124-berthez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33048-33124-berthez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33048-33124-berthez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33048-33124-berthez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33049-33750-beychac_et_caillau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33049-33750-beychac_et_caillau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33049-33750-beychac_et_caillau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33049-33750-beychac_et_caillau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33050-33210-bieujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33050-33210-bieujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33050-33210-bieujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33050-33210-bieujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33051-33380-biganos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33051-33380-biganos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33051-33380-biganos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33051-33380-biganos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33052-33500-les_billaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33052-33500-les_billaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33052-33500-les_billaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33052-33500-les_billaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33053-33430-birac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33053-33430-birac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33053-33430-birac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33053-33430-birac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33054-33190-blaignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33054-33190-blaignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33054-33190-blaignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33054-33190-blaignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33055-33340-blaignan_prignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33055-33340-blaignan_prignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33055-33340-blaignan_prignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33055-33340-blaignan_prignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33056-33290-blanquefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33056-33290-blanquefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33056-33290-blanquefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33056-33290-blanquefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33057-33540-blasimon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33057-33540-blasimon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33057-33540-blasimon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33057-33540-blasimon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33058-33390-blaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33058-33390-blaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33058-33390-blaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33058-33390-blaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33059-33670-blesignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33059-33670-blesignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33059-33670-blesignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33059-33670-blesignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33060-33210-bommes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33060-33210-bommes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33060-33210-bommes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33060-33210-bommes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33061-33370-bonnetan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33061-33370-bonnetan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33061-33370-bonnetan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33061-33370-bonnetan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33062-33910-bonzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33062-33910-bonzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33062-33910-bonzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33062-33910-bonzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33000-bordeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33000-bordeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33000-bordeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33000-bordeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33300-bordeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33300-bordeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33300-bordeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33300-bordeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33100-bordeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33100-bordeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33100-bordeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33100-bordeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33090-bordeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33090-bordeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33090-bordeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33090-bordeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33800-bordeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33800-bordeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33800-bordeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33800-bordeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33200-bordeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33200-bordeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33200-bordeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33063-33200-bordeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33064-33350-bossugan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33064-33350-bossugan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33064-33350-bossugan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33064-33350-bossugan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33065-33270-bouliac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33065-33270-bouliac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33065-33270-bouliac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33065-33270-bouliac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33066-33190-bourdelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33066-33190-bourdelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33066-33190-bourdelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33066-33190-bourdelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33067-33710-bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33067-33710-bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33067-33710-bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33067-33710-bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33068-33113-bourideys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33068-33113-bourideys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33068-33113-bourideys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33068-33113-bourideys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33069-33110-le_bouscat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33069-33110-le_bouscat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33069-33110-le_bouscat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33069-33110-le_bouscat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33070-33480-brach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33070-33480-brach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33070-33480-brach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33070-33480-brach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33071-33420-branne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33071-33420-branne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33071-33420-branne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33071-33420-branne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33072-33124-brannens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33072-33124-brannens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33072-33124-brannens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33072-33124-brannens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33073-33820-braud_et_saint_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33073-33820-braud_et_saint_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33073-33820-braud_et_saint_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33073-33820-braud_et_saint_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33074-33124-brouqueyran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33074-33124-brouqueyran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33074-33124-brouqueyran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33074-33124-brouqueyran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33075-33520-bruges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33075-33520-bruges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33075-33520-bruges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33075-33520-bruges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33076-33720-budos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33076-33720-budos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33076-33720-budos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33076-33720-budos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33077-33650-cabanac_et_villagrains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33077-33650-cabanac_et_villagrains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33077-33650-cabanac_et_villagrains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33077-33650-cabanac_et_villagrains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33078-33420-cabara/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33078-33420-cabara/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33078-33420-cabara/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33078-33420-cabara/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33079-33750-cadarsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33079-33750-cadarsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33079-33750-cadarsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33079-33750-cadarsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33080-33140-cadaujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33080-33140-cadaujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33080-33140-cadaujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33080-33140-cadaujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33081-33410-cadillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33081-33410-cadillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33081-33410-cadillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33081-33410-cadillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33082-33240-cadillac_en_fronsadais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33082-33240-cadillac_en_fronsadais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33082-33240-cadillac_en_fronsadais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33082-33240-cadillac_en_fronsadais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33083-33750-camarsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33083-33750-camarsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33083-33750-camarsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33083-33750-camarsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33084-33880-cambes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33084-33880-cambes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33084-33880-cambes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33084-33880-cambes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33085-33360-camblanes_et_meynac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33085-33360-camblanes_et_meynac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33085-33360-camblanes_et_meynac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33085-33360-camblanes_et_meynac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33086-33420-camiac_et_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33086-33420-camiac_et_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33086-33420-camiac_et_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33086-33420-camiac_et_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33087-33190-camiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33087-33190-camiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33087-33190-camiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33087-33190-camiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33088-33660-camps_sur_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33088-33660-camps_sur_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33088-33660-camps_sur_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33088-33660-camps_sur_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33089-33390-campugnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33089-33390-campugnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33089-33390-campugnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33089-33390-campugnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33090-33610-canejan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33090-33610-canejan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33090-33610-canejan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33090-33610-canejan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33093-33550-capian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33093-33550-capian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33093-33550-capian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33093-33550-capian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33094-33220-caplong/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33094-33220-caplong/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33094-33220-caplong/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33094-33220-caplong/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33095-33840-captieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33095-33840-captieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33095-33840-captieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33095-33840-captieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33096-33560-carbon_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33096-33560-carbon_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33096-33560-carbon_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33096-33560-carbon_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33097-33121-carcans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33097-33121-carcans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33097-33121-carcans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33097-33121-carcans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33098-33410-cardan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33098-33410-cardan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33098-33410-cardan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33098-33410-cardan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33099-33360-carignan_de_bordeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33099-33360-carignan_de_bordeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33099-33360-carignan_de_bordeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33099-33360-carignan_de_bordeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33100-33390-cars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33100-33390-cars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33100-33390-cars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33100-33390-cars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33101-33390-cartelegue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33101-33390-cartelegue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33101-33390-cartelegue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33101-33390-cartelegue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33102-33190-casseuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33102-33190-casseuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33102-33190-casseuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33102-33190-casseuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33103-33540-castelmoron_d_albret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33103-33540-castelmoron_d_albret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33103-33540-castelmoron_d_albret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33103-33540-castelmoron_d_albret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33104-33480-castelnau_de_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33104-33480-castelnau_de_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33104-33480-castelnau_de_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33104-33480-castelnau_de_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33105-33540-castelviel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33105-33540-castelviel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33105-33540-castelviel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33105-33540-castelviel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33106-33210-castets_et_castillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33106-33210-castets_et_castillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33106-33210-castets_et_castillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33106-33210-castets_et_castillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33108-33350-castillon_la_bataille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33108-33350-castillon_la_bataille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33108-33350-castillon_la_bataille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33108-33350-castillon_la_bataille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33109-33640-castres_gironde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33109-33640-castres_gironde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33109-33640-castres_gironde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33109-33640-castres_gironde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33111-33490-caudrot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33111-33490-caudrot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33111-33490-caudrot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33111-33490-caudrot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33112-33540-caumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33112-33540-caumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33112-33540-caumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33112-33540-caumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33113-33690-cauvignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33113-33690-cauvignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33113-33690-cauvignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33113-33690-cauvignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33114-33620-cavignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33114-33620-cavignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33114-33620-cavignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33114-33620-cavignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33115-33113-cazalis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33115-33113-cazalis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33115-33113-cazalis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33115-33113-cazalis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33116-33430-cazats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33116-33430-cazats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33116-33430-cazats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33116-33430-cazats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33117-33790-cazaugitat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33117-33790-cazaugitat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33117-33790-cazaugitat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33117-33790-cazaugitat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33118-33360-cenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33118-33360-cenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33118-33360-cenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33118-33360-cenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33119-33150-cenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33119-33150-cenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33119-33150-cenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33119-33150-cenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33120-33720-cerons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33120-33720-cerons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33120-33720-cerons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33120-33720-cerons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33121-33760-cessac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33121-33760-cessac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33121-33760-cessac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33121-33760-cessac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33122-33610-cestas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33122-33610-cestas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33122-33610-cestas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33122-33610-cestas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33123-33620-cezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33123-33620-cezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33123-33620-cezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33123-33620-cezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33124-33230-chamadelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33124-33230-chamadelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33124-33230-chamadelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33124-33230-chamadelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33125-33250-cissac_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33125-33250-cissac_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33125-33250-cissac_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33125-33250-cissac_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33126-33920-civrac_de_blaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33126-33920-civrac_de_blaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33126-33920-civrac_de_blaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33126-33920-civrac_de_blaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33127-33350-civrac_sur_dordogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33127-33350-civrac_sur_dordogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33127-33350-civrac_sur_dordogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33127-33350-civrac_sur_dordogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33128-33340-civrac_en_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33128-33340-civrac_en_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33128-33340-civrac_en_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33128-33340-civrac_en_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33129-33540-cleyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33129-33540-cleyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33129-33540-cleyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33129-33540-cleyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33130-33210-coimeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33130-33210-coimeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33130-33210-coimeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33130-33210-coimeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33131-33540-coirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33131-33540-coirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33131-33540-coirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33131-33540-coirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33132-33710-comps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33132-33710-comps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33132-33710-comps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33132-33710-comps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33133-33890-coubeyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33133-33890-coubeyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33133-33890-coubeyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33133-33890-coubeyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33134-33340-couqueques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33134-33340-couqueques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33134-33340-couqueques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33134-33340-couqueques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33135-33760-courpiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33135-33760-courpiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33135-33760-courpiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33135-33760-courpiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33136-33580-cours_de_monsegur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33136-33580-cours_de_monsegur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33136-33580-cours_de_monsegur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33136-33580-cours_de_monsegur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33137-33690-cours_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33137-33690-cours_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33137-33690-cours_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33137-33690-cours_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33138-33230-coutras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33138-33230-coutras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33138-33230-coutras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33138-33230-coutras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33139-33580-coutures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33139-33580-coutures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33139-33580-coutures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33139-33580-coutures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33140-33670-creon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33140-33670-creon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33140-33670-creon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33140-33670-creon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33141-33750-croignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33141-33750-croignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33141-33750-croignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33141-33750-croignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33142-33620-cubnezais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33142-33620-cubnezais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33142-33620-cubnezais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33142-33620-cubnezais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33143-33240-cubzac_les_ponts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33143-33240-cubzac_les_ponts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33143-33240-cubzac_les_ponts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33143-33240-cubzac_les_ponts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33144-33430-cudos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33144-33430-cudos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33144-33430-cudos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33144-33430-cudos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33145-33670-cursan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33145-33670-cursan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33145-33670-cursan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33145-33670-cursan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33146-33460-cussac_fort_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33146-33460-cussac_fort_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33146-33460-cussac_fort_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33146-33460-cussac_fort_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33147-33420-daignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33147-33420-daignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33147-33420-daignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33147-33420-daignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33148-33420-dardenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33148-33420-dardenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33148-33420-dardenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33148-33420-dardenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33149-33540-daubeze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33149-33540-daubeze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33149-33540-daubeze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33149-33540-daubeze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33150-33580-dieulivol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33150-33580-dieulivol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33150-33580-dieulivol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33150-33580-dieulivol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33151-33860-donnezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33151-33860-donnezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33151-33860-donnezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33151-33860-donnezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33152-33410-donzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33152-33410-donzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33152-33410-donzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33152-33410-donzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33153-33350-doulezon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33153-33350-doulezon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33153-33350-doulezon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33153-33350-doulezon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33154-33230-les_eglisottes_et_chalaures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33154-33230-les_eglisottes_et_chalaures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33154-33230-les_eglisottes_et_chalaures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33154-33230-les_eglisottes_et_chalaures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33155-33840-escaudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33155-33840-escaudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33155-33840-escaudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33155-33840-escaudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33156-33760-escoussans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33156-33760-escoussans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33156-33760-escoussans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33156-33760-escoussans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33157-33420-espiet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33157-33420-espiet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33157-33420-espiet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33157-33420-espiet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33158-33190-les_esseintes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33158-33190-les_esseintes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33158-33190-les_esseintes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33158-33190-les_esseintes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33159-33820-etauliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33159-33820-etauliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33159-33820-etauliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33159-33820-etauliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33160-33220-eynesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33160-33220-eynesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33160-33220-eynesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33160-33220-eynesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33161-33390-eyrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33161-33390-eyrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33161-33390-eyrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33161-33390-eyrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33162-33320-eysines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33162-33320-eysines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33162-33320-eysines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33162-33320-eysines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33163-33760-faleyras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33163-33760-faleyras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33163-33760-faleyras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33163-33760-faleyras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33164-33210-fargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33164-33210-fargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33164-33210-fargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33164-33210-fargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33165-33370-fargues_saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33165-33370-fargues_saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33165-33370-fargues_saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33165-33370-fargues_saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33166-33230-le_fieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33166-33230-le_fieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33166-33230-le_fieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33166-33230-le_fieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33167-33270-floirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33167-33270-floirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33167-33270-floirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33167-33270-floirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33168-33350-flaujagues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33168-33350-flaujagues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33168-33350-flaujagues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33168-33350-flaujagues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33169-33190-floudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33169-33190-floudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33169-33190-floudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33169-33190-floudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33170-33190-fontet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33170-33190-fontet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33170-33190-fontet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33170-33190-fontet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33171-33190-fosses_et_baleyssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33171-33190-fosses_et_baleyssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33171-33190-fosses_et_baleyssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33171-33190-fosses_et_baleyssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33172-33390-fours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33172-33390-fours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33172-33390-fours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33172-33390-fours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33173-33570-francs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33173-33570-francs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33173-33570-francs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33173-33570-francs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33174-33126-fronsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33174-33126-fronsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33174-33126-fronsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33174-33126-fronsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33175-33760-frontenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33175-33760-frontenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33175-33760-frontenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33175-33760-frontenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33176-33410-gabarnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33176-33410-gabarnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33176-33410-gabarnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33176-33410-gabarnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33177-33340-gaillan_en_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33177-33340-gaillan_en_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33177-33340-gaillan_en_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33177-33340-gaillan_en_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33178-33430-gajac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33178-33430-gajac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33178-33430-gajac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33178-33430-gajac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33179-33133-galgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33179-33133-galgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33179-33133-galgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33179-33133-galgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33180-33430-gans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33180-33430-gans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33180-33430-gans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33180-33430-gans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33181-33350-gardegan_et_tourtirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33181-33350-gardegan_et_tourtirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33181-33350-gardegan_et_tourtirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33181-33350-gardegan_et_tourtirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33182-33710-gauriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33182-33710-gauriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33182-33710-gauriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33182-33710-gauriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33183-33240-gauriaguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33183-33240-gauriaguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33183-33240-gauriaguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33183-33240-gauriaguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33184-33920-generac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33184-33920-generac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33184-33920-generac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33184-33920-generac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33185-33420-genissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33185-33420-genissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33185-33420-genissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33185-33420-genissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33186-33890-gensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33186-33890-gensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33186-33890-gensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33186-33890-gensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33187-33190-gironde_sur_dropt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33187-33190-gironde_sur_dropt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33187-33190-gironde_sur_dropt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33187-33190-gironde_sur_dropt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33188-33840-giscos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33188-33840-giscos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33188-33840-giscos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33188-33840-giscos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33189-33540-gornac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33189-33540-gornac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33189-33540-gornac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33189-33540-gornac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33190-33840-goualade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33190-33840-goualade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33190-33840-goualade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33190-33840-goualade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33191-33660-gours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33191-33660-gours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33191-33660-gours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33191-33660-gours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33192-33170-gradignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33192-33170-gradignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33192-33170-gradignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33192-33170-gradignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33193-33590-grayan_et_l_hopital/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33193-33590-grayan_et_l_hopital/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33193-33590-grayan_et_l_hopital/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33193-33590-grayan_et_l_hopital/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33194-33420-grezillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33194-33420-grezillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33194-33420-grezillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33194-33420-grezillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33195-33690-grignols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33195-33690-grignols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33195-33690-grignols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33195-33690-grignols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33196-33420-guillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33196-33420-guillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33196-33420-guillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33196-33420-guillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33197-33720-guillos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33197-33720-guillos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33197-33720-guillos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33197-33720-guillos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33198-33230-guitres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33198-33230-guitres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33198-33230-guitres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33198-33230-guitres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33199-33470-gujan_mestras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33199-33470-gujan_mestras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33199-33470-gujan_mestras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33199-33470-gujan_mestras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33200-33185-le_haillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33200-33185-le_haillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33200-33185-le_haillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33200-33185-le_haillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33201-33550-haux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33201-33550-haux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33201-33550-haux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33201-33550-haux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33202-33125-hostens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33202-33125-hostens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33202-33125-hostens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33202-33125-hostens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33203-33990-hourtin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33203-33990-hourtin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33203-33990-hourtin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33203-33990-hourtin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33204-33190-hure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33204-33190-hure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33204-33190-hure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33204-33190-hure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33205-33720-illats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33205-33720-illats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33205-33720-illats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33205-33720-illats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33206-33640-isle_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33206-33640-isle_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33206-33640-isle_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33206-33640-isle_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33207-33450-izon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33207-33450-izon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33207-33450-izon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33207-33450-izon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33208-33590-jau_dignac_et_loirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33208-33590-jau_dignac_et_loirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33208-33590-jau_dignac_et_loirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33208-33590-jau_dignac_et_loirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33209-33420-jugazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33209-33420-jugazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33209-33420-jugazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33209-33420-jugazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33210-33890-juillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33210-33890-juillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33210-33890-juillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33210-33890-juillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33211-33460-labarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33211-33460-labarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33211-33460-labarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33211-33460-labarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33212-33690-labescau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33212-33690-labescau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33212-33690-labescau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33212-33690-labescau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33213-33650-la_brede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33213-33650-la_brede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33213-33650-la_brede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33213-33650-la_brede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33214-33680-lacanau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33214-33680-lacanau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33214-33680-lacanau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33214-33680-lacanau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33215-33760-ladaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33215-33760-ladaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33215-33760-ladaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33215-33760-ladaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33216-33124-lados/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33216-33124-lados/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33216-33124-lados/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33216-33124-lados/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33218-33230-lagorce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33218-33230-lagorce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33218-33230-lagorce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33218-33230-lagorce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33219-33240-la_lande_de_fronsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33219-33240-la_lande_de_fronsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33219-33240-la_lande_de_fronsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33219-33240-la_lande_de_fronsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33220-33460-lamarque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33220-33460-lamarque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33220-33460-lamarque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33220-33460-lamarque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33221-33190-lamothe_landerron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33221-33190-lamothe_landerron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33221-33190-lamothe_landerron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33221-33190-lamothe_landerron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33222-33500-lalande_de_pomerol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33222-33500-lalande_de_pomerol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33222-33500-lalande_de_pomerol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33222-33500-lalande_de_pomerol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33223-33790-landerrouat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33223-33790-landerrouat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33223-33790-landerrouat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33223-33790-landerrouat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33224-33540-landerrouet_sur_segur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33224-33540-landerrouet_sur_segur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33224-33540-landerrouet_sur_segur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33224-33540-landerrouet_sur_segur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33225-33720-landiras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33225-33720-landiras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33225-33720-landiras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33225-33720-landiras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33226-33550-langoiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33226-33550-langoiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33226-33550-langoiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33226-33550-langoiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33227-33210-langon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33227-33210-langon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33227-33210-langon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33227-33210-langon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33228-33710-lansac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33228-33710-lansac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33228-33710-lansac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33228-33710-lansac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33229-33138-lanton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33229-33138-lanton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33229-33138-lanton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33229-33138-lanton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33230-33620-lapouyade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33230-33620-lapouyade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33230-33620-lapouyade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33230-33620-lapouyade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33231-33410-laroque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33231-33410-laroque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33231-33410-laroque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33231-33410-laroque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33232-33840-lartigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33232-33840-lartigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33232-33840-lartigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33232-33840-lartigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33233-33620-laruscade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33233-33620-laruscade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33233-33620-laruscade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33233-33620-laruscade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33234-33360-latresne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33234-33360-latresne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33234-33360-latresne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33234-33360-latresne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33235-33690-lavazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33235-33690-lavazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33235-33690-lavazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33235-33690-lavazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33236-33950-lege_cap_ferret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33236-33950-lege_cap_ferret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33236-33950-lege_cap_ferret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33236-33950-lege_cap_ferret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33236-33970-lege_cap_ferret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33236-33970-lege_cap_ferret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33236-33970-lege_cap_ferret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33236-33970-lege_cap_ferret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33237-33210-leogeats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33237-33210-leogeats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33237-33210-leogeats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33237-33210-leogeats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33238-33850-leognan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33238-33850-leognan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33238-33850-leognan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33238-33850-leognan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33239-33840-lerm_et_musset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33239-33840-lerm_et_musset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33239-33840-lerm_et_musset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33239-33840-lerm_et_musset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33240-33340-lesparre_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33240-33340-lesparre_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33240-33340-lesparre_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33240-33340-lesparre_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33241-33550-lestiac_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33241-33550-lestiac_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33241-33550-lestiac_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33241-33550-lestiac_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33242-33220-les_leves_et_thoumeyragues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33242-33220-les_leves_et_thoumeyragues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33242-33220-les_leves_et_thoumeyragues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33242-33220-les_leves_et_thoumeyragues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33243-33500-libourne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33243-33500-libourne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33243-33500-libourne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33243-33500-libourne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33244-33430-lignan_de_bazas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33244-33430-lignan_de_bazas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33244-33430-lignan_de_bazas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33244-33430-lignan_de_bazas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33245-33360-lignan_de_bordeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33245-33360-lignan_de_bordeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33245-33360-lignan_de_bordeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33245-33360-lignan_de_bordeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33246-33220-ligueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33246-33220-ligueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33246-33220-ligueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33246-33220-ligueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33247-33790-listrac_de_dureze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33247-33790-listrac_de_dureze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33247-33790-listrac_de_dureze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33247-33790-listrac_de_dureze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33248-33480-listrac_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33248-33480-listrac_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33248-33480-listrac_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33248-33480-listrac_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33249-33310-lormont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33249-33310-lormont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33249-33310-lormont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33249-33310-lormont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33250-33190-loubens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33250-33190-loubens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33250-33190-loubens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33250-33190-loubens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33251-33125-louchats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33251-33125-louchats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33251-33125-louchats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33251-33125-louchats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33252-33370-loupes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33252-33370-loupes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33252-33370-loupes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33252-33370-loupes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33253-33410-loupiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33253-33410-loupiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33253-33410-loupiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33253-33410-loupiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33254-33190-loupiac_de_la_reole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33254-33190-loupiac_de_la_reole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33254-33190-loupiac_de_la_reole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33254-33190-loupiac_de_la_reole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33255-33840-lucmau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33255-33840-lucmau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33255-33840-lucmau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33255-33840-lucmau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33256-33290-ludon_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33256-33290-ludon_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33256-33290-ludon_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33256-33290-ludon_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33257-33420-lugaignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33257-33420-lugaignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33257-33420-lugaignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33257-33420-lugaignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33258-33760-lugasson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33258-33760-lugasson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33258-33760-lugasson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33258-33760-lugasson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33259-33240-lugon_et_l_ile_du_carnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33259-33240-lugon_et_l_ile_du_carnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33259-33240-lugon_et_l_ile_du_carnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33259-33240-lugon_et_l_ile_du_carnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33260-33830-lugos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33260-33830-lugos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33260-33830-lugos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33260-33830-lugos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33261-33570-lussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33261-33570-lussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33261-33570-lussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33261-33570-lussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33262-33460-macau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33262-33460-macau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33262-33460-macau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33262-33460-macau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33263-33670-madirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33263-33670-madirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33263-33670-madirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33263-33670-madirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33264-33230-maransin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33264-33230-maransin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33264-33230-maransin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33264-33230-maransin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33266-33620-marcenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33266-33620-marcenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33266-33620-marcenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33266-33620-marcenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33268-33460-margaux_cantenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33268-33460-margaux_cantenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33268-33460-margaux_cantenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33268-33460-margaux_cantenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33269-33220-margueron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33269-33220-margueron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33269-33220-margueron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33269-33220-margueron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33270-33430-marimbault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33270-33430-marimbault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33270-33430-marimbault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33270-33430-marimbault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33271-33690-marions/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33271-33690-marions/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33271-33690-marions/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33271-33690-marions/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33272-33620-marsas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33272-33620-marsas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33272-33620-marsas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33272-33620-marsas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33273-33127-martignas_sur_jalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33273-33127-martignas_sur_jalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33273-33127-martignas_sur_jalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33273-33127-martignas_sur_jalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33274-33650-martillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33274-33650-martillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33274-33650-martillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33274-33650-martillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33275-33760-martres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33275-33760-martres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33275-33760-martres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33275-33760-martres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33276-33690-masseilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33276-33690-masseilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33276-33690-masseilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33276-33690-masseilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33277-33790-massugas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33277-33790-massugas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33277-33790-massugas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33277-33790-massugas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33278-33540-mauriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33278-33540-mauriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33278-33540-mauriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33278-33540-mauriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33279-33210-mazeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33279-33210-mazeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33279-33210-mazeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33279-33210-mazeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33280-33390-mazion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33280-33390-mazion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33280-33390-mazion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33280-33390-mazion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33281-33700-merignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33281-33700-merignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33281-33700-merignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33281-33700-merignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33281-33693-merignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33281-33693-merignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33281-33693-merignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33281-33693-merignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33282-33350-merignas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33282-33350-merignas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33282-33350-merignas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33282-33350-merignas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33283-33540-mesterrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33283-33540-mesterrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33283-33540-mesterrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33283-33540-mesterrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33284-33380-mios/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33284-33380-mios/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33284-33380-mios/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33284-33380-mios/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33285-33710-mombrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33285-33710-mombrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33285-33710-mombrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33285-33710-mombrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33287-33190-mongauzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33287-33190-mongauzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33287-33190-mongauzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33287-33190-mongauzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33288-33410-monprimblanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33288-33410-monprimblanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33288-33410-monprimblanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33288-33410-monprimblanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33289-33580-monsegur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33289-33580-monsegur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33289-33580-monsegur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33289-33580-monsegur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33290-33570-montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33290-33570-montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33290-33570-montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33290-33570-montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33291-33190-montagoudin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33291-33190-montagoudin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33291-33190-montagoudin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33291-33190-montagoudin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33292-33760-montignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33292-33760-montignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33292-33760-montignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33292-33760-montignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33293-33450-montussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33293-33450-montussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33293-33450-montussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33293-33450-montussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33294-33190-morizes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33294-33190-morizes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33294-33190-morizes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33294-33190-morizes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33295-33240-mouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33295-33240-mouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33295-33240-mouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33295-33240-mouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33296-33350-mouliets_et_villemartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33296-33350-mouliets_et_villemartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33296-33350-mouliets_et_villemartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33296-33350-mouliets_et_villemartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33297-33480-moulis_en_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33297-33480-moulis_en_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33297-33480-moulis_en_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33297-33480-moulis_en_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33298-33420-moulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33298-33420-moulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33298-33420-moulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33298-33420-moulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33299-33410-mourens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33299-33410-mourens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33299-33410-mourens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33299-33410-mourens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33300-33990-naujac_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33300-33990-naujac_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33300-33990-naujac_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33300-33990-naujac_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33301-33420-naujan_et_postiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33301-33420-naujan_et_postiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33301-33420-naujan_et_postiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33301-33420-naujan_et_postiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33302-33500-neac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33302-33500-neac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33302-33500-neac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33302-33500-neac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33303-33750-nerigean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33303-33750-nerigean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33303-33750-nerigean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33303-33750-nerigean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33304-33580-neuffons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33304-33580-neuffons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33304-33580-neuffons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33304-33580-neuffons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33305-33430-le_nizan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33305-33430-le_nizan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33305-33430-le_nizan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33305-33430-le_nizan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33306-33190-noaillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33306-33190-noaillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33306-33190-noaillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33306-33190-noaillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33307-33730-noaillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33307-33730-noaillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33307-33730-noaillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33307-33730-noaillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33308-33410-omet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33308-33410-omet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33308-33410-omet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33308-33410-omet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33309-33340-ordonnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33309-33340-ordonnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33309-33340-ordonnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33309-33340-ordonnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33310-33113-origne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33310-33113-origne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33310-33113-origne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33310-33113-origne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33311-33550-paillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33311-33550-paillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33311-33550-paillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33311-33550-paillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33312-33290-parempuyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33312-33290-parempuyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33312-33290-parempuyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33312-33290-parempuyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33314-33250-pauillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33314-33250-pauillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33314-33250-pauillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33314-33250-pauillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33315-33230-les_peintures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33315-33230-les_peintures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33315-33230-les_peintures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33315-33230-les_peintures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33316-33790-pellegrue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33316-33790-pellegrue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33316-33790-pellegrue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33316-33790-pellegrue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33317-33240-perissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33317-33240-perissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33317-33240-perissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33317-33240-perissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33318-33600-pessac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33318-33600-pessac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33318-33600-pessac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33318-33600-pessac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33318-33400-pessac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33318-33400-pessac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33318-33400-pessac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33318-33400-pessac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33319-33890-pessac_sur_dordogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33319-33890-pessac_sur_dordogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33319-33890-pessac_sur_dordogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33319-33890-pessac_sur_dordogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33320-33570-petit_palais_et_cornemps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33320-33570-petit_palais_et_cornemps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33320-33570-petit_palais_et_cornemps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33320-33570-petit_palais_et_cornemps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33321-33240-peujard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33321-33240-peujard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33321-33240-peujard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33321-33240-peujard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33322-33290-le_pian_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33322-33290-le_pian_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33322-33290-le_pian_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33322-33290-le_pian_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33323-33490-le_pian_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33323-33490-le_pian_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33323-33490-le_pian_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33323-33490-le_pian_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33324-33220-pineuilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33324-33220-pineuilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33324-33220-pineuilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33324-33220-pineuilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33325-33390-plassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33325-33390-plassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33325-33390-plassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33325-33390-plassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33326-33820-pleine_selve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33326-33820-pleine_selve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33326-33820-pleine_selve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33326-33820-pleine_selve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33327-33720-podensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33327-33720-podensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33327-33720-podensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33327-33720-podensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33328-33500-pomerol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33328-33500-pomerol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33328-33500-pomerol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33328-33500-pomerol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33329-33730-pompejac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33329-33730-pompejac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33329-33730-pompejac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33329-33730-pompejac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33330-33370-pompignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33330-33370-pompignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33330-33370-pompignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33330-33370-pompignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33331-33190-pondaurat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33331-33190-pondaurat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33331-33190-pondaurat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33331-33190-pondaurat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33332-33660-porcheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33332-33660-porcheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33332-33660-porcheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33332-33660-porcheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33333-33680-le_porge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33333-33680-le_porge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33333-33680-le_porge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33333-33680-le_porge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33334-33640-portets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33334-33640-portets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33334-33640-portets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33334-33640-portets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33335-33670-le_pout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33335-33670-le_pout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33335-33670-le_pout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33335-33670-le_pout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33336-33730-prechac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33336-33730-prechac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33336-33730-prechac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33336-33730-prechac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33337-33210-preignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33337-33210-preignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33337-33210-preignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33337-33210-preignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33339-33710-prignac_et_marcamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33339-33710-prignac_et_marcamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33339-33710-prignac_et_marcamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33339-33710-prignac_et_marcamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33341-33710-pugnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33341-33710-pugnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33341-33710-pugnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33341-33710-pugnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33342-33570-puisseguin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33342-33570-puisseguin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33342-33570-puisseguin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33342-33570-puisseguin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33343-33210-pujols_sur_ciron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33343-33210-pujols_sur_ciron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33343-33210-pujols_sur_ciron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33343-33210-pujols_sur_ciron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33344-33350-pujols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33344-33350-pujols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33344-33350-pujols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33344-33350-pujols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33345-33580-le_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33345-33580-le_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33345-33580-le_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33345-33580-le_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33346-33190-puybarban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33346-33190-puybarban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33346-33190-puybarban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33346-33190-puybarban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33347-33660-puynormand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33347-33660-puynormand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33347-33660-puynormand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33347-33660-puynormand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33348-33340-queyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33348-33340-queyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33348-33340-queyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33348-33340-queyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33349-33360-quinsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33349-33360-quinsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33349-33360-quinsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33349-33360-quinsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33350-33420-rauzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33350-33420-rauzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33350-33420-rauzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33350-33420-rauzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33351-33860-reignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33351-33860-reignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33351-33860-reignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33351-33860-reignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33352-33190-la_reole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33352-33190-la_reole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33352-33190-la_reole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33352-33190-la_reole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33353-33580-rimons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33353-33580-rimons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33353-33580-rimons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33353-33580-rimons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33354-33220-riocaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33354-33220-riocaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33354-33220-riocaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33354-33220-riocaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33355-33410-rions/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33355-33410-rions/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33355-33410-rions/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33355-33410-rions/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33356-33126-la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33356-33126-la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33356-33126-la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33356-33126-la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33357-33210-roaillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33357-33210-roaillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33357-33210-roaillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33357-33210-roaillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33358-33760-romagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33358-33760-romagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33358-33760-romagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33358-33760-romagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33359-33580-roquebrune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33359-33580-roquebrune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33359-33580-roquebrune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33359-33580-roquebrune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33360-33220-la_roquille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33360-33220-la_roquille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33360-33220-la_roquille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33360-33220-la_roquille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33361-33350-ruch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33361-33350-ruch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33361-33350-ruch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33361-33350-ruch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33362-33910-sablons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33362-33910-sablons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33362-33910-sablons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33362-33910-sablons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33363-33670-sadirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33363-33670-sadirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33363-33670-sadirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33363-33670-sadirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33364-33141-saillans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33364-33141-saillans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33364-33141-saillans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33364-33141-saillans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33365-33126-saint_aignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33365-33126-saint_aignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33365-33126-saint_aignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33365-33126-saint_aignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33366-33240-saint_andre_de_cubzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33366-33240-saint_andre_de_cubzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33366-33240-saint_andre_de_cubzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33366-33240-saint_andre_de_cubzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33367-33490-saint_andre_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33367-33490-saint_andre_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33367-33490-saint_andre_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33367-33490-saint_andre_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33369-33220-saint_andre_et_appelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33369-33220-saint_andre_et_appelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33369-33220-saint_andre_et_appelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33369-33220-saint_andre_et_appelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33370-33390-saint_androny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33370-33390-saint_androny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33370-33390-saint_androny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33370-33390-saint_androny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33372-33790-saint_antoine_du_queyret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33372-33790-saint_antoine_du_queyret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33372-33790-saint_antoine_du_queyret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33372-33790-saint_antoine_du_queyret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33373-33660-saint_antoine_sur_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33373-33660-saint_antoine_sur_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33373-33660-saint_antoine_sur_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33373-33660-saint_antoine_sur_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33374-33820-saint_aubin_de_blaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33374-33820-saint_aubin_de_blaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33374-33820-saint_aubin_de_blaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33374-33820-saint_aubin_de_blaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33375-33420-saint_aubin_de_branne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33375-33420-saint_aubin_de_branne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33375-33420-saint_aubin_de_branne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33375-33420-saint_aubin_de_branne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33376-33160-saint_aubin_de_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33376-33160-saint_aubin_de_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33376-33160-saint_aubin_de_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33376-33160-saint_aubin_de_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33377-33220-saint_avit_de_soulege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33377-33220-saint_avit_de_soulege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33377-33220-saint_avit_de_soulege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33377-33220-saint_avit_de_soulege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33378-33220-saint_avit_saint_nazaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33378-33220-saint_avit_saint_nazaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33378-33220-saint_avit_saint_nazaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33378-33220-saint_avit_saint_nazaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33379-33540-saint_brice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33379-33540-saint_brice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33379-33540-saint_brice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33379-33540-saint_brice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33380-33820-val_de_livenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33380-33820-val_de_livenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33380-33820-val_de_livenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33380-33820-val_de_livenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33380-33860-val_de_livenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33380-33860-val_de_livenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33380-33860-val_de_livenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33380-33860-val_de_livenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33381-33880-saint_caprais_de_bordeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33381-33880-saint_caprais_de_bordeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33381-33880-saint_caprais_de_bordeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33381-33880-saint_caprais_de_bordeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33382-33920-saint_christoly_de_blaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33382-33920-saint_christoly_de_blaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33382-33920-saint_christoly_de_blaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33382-33920-saint_christoly_de_blaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33383-33340-saint_christoly_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33383-33340-saint_christoly_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33383-33340-saint_christoly_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33383-33340-saint_christoly_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33384-33330-saint_christophe_des_bardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33384-33330-saint_christophe_des_bardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33384-33330-saint_christophe_des_bardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33384-33330-saint_christophe_des_bardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33385-33230-saint_christophe_de_double/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33385-33230-saint_christophe_de_double/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33385-33230-saint_christophe_de_double/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33385-33230-saint_christophe_de_double/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33386-33570-saint_cibard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33386-33570-saint_cibard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33386-33570-saint_cibard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33386-33570-saint_cibard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33387-33910-saint_ciers_d_abzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33387-33910-saint_ciers_d_abzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33387-33910-saint_ciers_d_abzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33387-33910-saint_ciers_d_abzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33388-33710-saint_ciers_de_canesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33388-33710-saint_ciers_de_canesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33388-33710-saint_ciers_de_canesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33388-33710-saint_ciers_de_canesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33389-33820-saint_ciers_sur_gironde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33389-33820-saint_ciers_sur_gironde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33389-33820-saint_ciers_sur_gironde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33389-33820-saint_ciers_sur_gironde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33390-33350-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33390-33350-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33390-33350-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33390-33350-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33391-33430-saint_come/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33391-33430-saint_come/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33391-33430-saint_come/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33391-33430-saint_come/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33392-33410-sainte_croix_du_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33392-33410-sainte_croix_du_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33392-33410-sainte_croix_du_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33392-33410-sainte_croix_du_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33393-33910-saint_denis_de_pile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33393-33910-saint_denis_de_pile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33393-33910-saint_denis_de_pile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33393-33910-saint_denis_de_pile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33394-33330-saint_emilion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33394-33330-saint_emilion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33394-33330-saint_emilion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33394-33330-saint_emilion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33395-33180-saint_estephe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33395-33180-saint_estephe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33395-33180-saint_estephe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33395-33180-saint_estephe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33396-33330-saint_etienne_de_lisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33396-33330-saint_etienne_de_lisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33396-33330-saint_etienne_de_lisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33396-33330-saint_etienne_de_lisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33397-33560-sainte_eulalie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33397-33560-sainte_eulalie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33397-33560-sainte_eulalie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33397-33560-sainte_eulalie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33398-33190-saint_exupery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33398-33190-saint_exupery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33398-33190-saint_exupery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33398-33190-saint_exupery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33399-33540-saint_felix_de_foncaude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33399-33540-saint_felix_de_foncaude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33399-33540-saint_felix_de_foncaude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33399-33540-saint_felix_de_foncaude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33400-33580-saint_ferme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33400-33580-saint_ferme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33400-33580-saint_ferme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33400-33580-saint_ferme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33401-33350-sainte_florence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33401-33350-sainte_florence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33401-33350-sainte_florence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33401-33350-sainte_florence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33402-33220-sainte_foy_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33402-33220-sainte_foy_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33402-33220-sainte_foy_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33402-33220-sainte_foy_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33403-33490-sainte_foy_la_longue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33403-33490-sainte_foy_la_longue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33403-33490-sainte_foy_la_longue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33403-33490-sainte_foy_la_longue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33404-33580-sainte_gemme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33404-33580-sainte_gemme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33404-33580-sainte_gemme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33404-33580-sainte_gemme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33405-33390-saint_genes_de_blaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33405-33390-saint_genes_de_blaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33405-33390-saint_genes_de_blaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33405-33390-saint_genes_de_blaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33406-33350-saint_genes_de_castillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33406-33350-saint_genes_de_castillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33406-33350-saint_genes_de_castillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33406-33350-saint_genes_de_castillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33407-33240-saint_genes_de_fronsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33407-33240-saint_genes_de_fronsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33407-33240-saint_genes_de_fronsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33407-33240-saint_genes_de_fronsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33408-33670-saint_genes_de_lombaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33408-33670-saint_genes_de_lombaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33408-33670-saint_genes_de_lombaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33408-33670-saint_genes_de_lombaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33409-33760-saint_genis_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33409-33760-saint_genis_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33409-33760-saint_genis_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33409-33760-saint_genis_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33411-33490-saint_germain_de_grave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33411-33490-saint_germain_de_grave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33411-33490-saint_germain_de_grave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33411-33490-saint_germain_de_grave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33412-33340-saint_germain_d_esteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33412-33340-saint_germain_d_esteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33412-33340-saint_germain_d_esteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33412-33340-saint_germain_d_esteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33413-33750-saint_germain_du_puch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33413-33750-saint_germain_du_puch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33413-33750-saint_germain_du_puch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33413-33750-saint_germain_du_puch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33414-33240-saint_germain_de_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33414-33240-saint_germain_de_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33414-33240-saint_germain_de_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33414-33240-saint_germain_de_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33415-33240-saint_gervais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33415-33240-saint_gervais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33415-33240-saint_gervais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33415-33240-saint_gervais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33416-33920-saint_girons_d_aiguevives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33416-33920-saint_girons_d_aiguevives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33416-33920-saint_girons_d_aiguevives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33416-33920-saint_girons_d_aiguevives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33417-33480-sainte_helene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33417-33480-sainte_helene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33417-33480-sainte_helene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33417-33480-sainte_helene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33418-33190-saint_hilaire_de_la_noaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33418-33190-saint_hilaire_de_la_noaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33418-33190-saint_hilaire_de_la_noaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33418-33190-saint_hilaire_de_la_noaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33419-33540-saint_hilaire_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33419-33540-saint_hilaire_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33419-33540-saint_hilaire_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33419-33540-saint_hilaire_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33420-33330-saint_hippolyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33420-33330-saint_hippolyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33420-33330-saint_hippolyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33420-33330-saint_hippolyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33421-33420-saint_jean_de_blaignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33421-33420-saint_jean_de_blaignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33421-33420-saint_jean_de_blaignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33421-33420-saint_jean_de_blaignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33422-33127-saint_jean_d_illac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33422-33127-saint_jean_d_illac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33422-33127-saint_jean_d_illac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33422-33127-saint_jean_d_illac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33423-33250-saint_julien_beychevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33423-33250-saint_julien_beychevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33423-33250-saint_julien_beychevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33423-33250-saint_julien_beychevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33424-33112-saint_laurent_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33424-33112-saint_laurent_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33424-33112-saint_laurent_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33424-33112-saint_laurent_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33425-33240-saint_laurent_d_arce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33425-33240-saint_laurent_d_arce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33425-33240-saint_laurent_d_arce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33425-33240-saint_laurent_d_arce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33426-33330-saint_laurent_des_combes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33426-33330-saint_laurent_des_combes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33426-33330-saint_laurent_des_combes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33426-33330-saint_laurent_des_combes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33427-33540-saint_laurent_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33427-33540-saint_laurent_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33427-33540-saint_laurent_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33427-33540-saint_laurent_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33428-33190-saint_laurent_du_plan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33428-33190-saint_laurent_du_plan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33428-33190-saint_laurent_du_plan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33428-33190-saint_laurent_du_plan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33429-33113-saint_leger_de_balson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33429-33113-saint_leger_de_balson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33429-33113-saint_leger_de_balson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33429-33113-saint_leger_de_balson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33431-33670-saint_leon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33431-33670-saint_leon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33431-33670-saint_leon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33431-33670-saint_leon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33432-33210-saint_loubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33432-33210-saint_loubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33432-33210-saint_loubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33432-33210-saint_loubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33433-33450-saint_loubes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33433-33450-saint_loubes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33433-33450-saint_loubes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33433-33450-saint_loubes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33434-33440-saint_louis_de_montferrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33434-33440-saint_louis_de_montferrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33434-33440-saint_louis_de_montferrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33434-33440-saint_louis_de_montferrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33435-33490-saint_macaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33435-33490-saint_macaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33435-33490-saint_macaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33435-33490-saint_macaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33436-33125-saint_magne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33436-33125-saint_magne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33436-33125-saint_magne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33436-33125-saint_magne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33437-33350-saint_magne_de_castillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33437-33350-saint_magne_de_castillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33437-33350-saint_magne_de_castillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33437-33350-saint_magne_de_castillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33438-33490-saint_maixant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33438-33490-saint_maixant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33438-33490-saint_maixant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33438-33490-saint_maixant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33439-33620-saint_mariens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33439-33620-saint_mariens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33439-33620-saint_mariens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33439-33620-saint_mariens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33440-33490-saint_martial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33440-33490-saint_martial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33440-33490-saint_martial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33440-33490-saint_martial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33441-33390-saint_martin_lacaussade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33441-33390-saint_martin_lacaussade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33441-33390-saint_martin_lacaussade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33441-33390-saint_martin_lacaussade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33442-33910-saint_martin_de_laye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33442-33910-saint_martin_de_laye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33442-33910-saint_martin_de_laye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33442-33910-saint_martin_de_laye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33443-33540-saint_martin_de_lerm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33443-33540-saint_martin_de_lerm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33443-33540-saint_martin_de_lerm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33443-33540-saint_martin_de_lerm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33444-33490-saint_martin_de_sescas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33444-33490-saint_martin_de_sescas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33444-33490-saint_martin_de_sescas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33444-33490-saint_martin_de_sescas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33445-33910-saint_martin_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33445-33910-saint_martin_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33445-33910-saint_martin_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33445-33910-saint_martin_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33446-33540-saint_martin_du_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33446-33540-saint_martin_du_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33446-33540-saint_martin_du_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33446-33540-saint_martin_du_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33447-33230-saint_medard_de_guizieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33447-33230-saint_medard_de_guizieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33447-33230-saint_medard_de_guizieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33447-33230-saint_medard_de_guizieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33448-33650-saint_medard_d_eyrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33448-33650-saint_medard_d_eyrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33448-33650-saint_medard_d_eyrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33448-33650-saint_medard_d_eyrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33449-33160-saint_medard_en_jalles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33449-33160-saint_medard_en_jalles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33449-33160-saint_medard_en_jalles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33449-33160-saint_medard_en_jalles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33450-33840-saint_michel_de_castelnau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33450-33840-saint_michel_de_castelnau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33450-33840-saint_michel_de_castelnau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33450-33840-saint_michel_de_castelnau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33451-33126-saint_michel_de_fronsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33451-33126-saint_michel_de_fronsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33451-33126-saint_michel_de_fronsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33451-33126-saint_michel_de_fronsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33452-33720-saint_michel_de_rieufret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33452-33720-saint_michel_de_rieufret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33452-33720-saint_michel_de_rieufret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33452-33720-saint_michel_de_rieufret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33453-33190-saint_michel_de_lapujade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33453-33190-saint_michel_de_lapujade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33453-33190-saint_michel_de_lapujade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33453-33190-saint_michel_de_lapujade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33454-33650-saint_morillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33454-33650-saint_morillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33454-33650-saint_morillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33454-33650-saint_morillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33456-33820-saint_palais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33456-33820-saint_palais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33456-33820-saint_palais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33456-33820-saint_palais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33457-33210-saint_pardon_de_conques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33457-33210-saint_pardon_de_conques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33457-33210-saint_pardon_de_conques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33457-33210-saint_pardon_de_conques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33458-33390-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33458-33390-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33458-33390-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33458-33390-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33459-33330-saint_pey_d_armens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33459-33330-saint_pey_d_armens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33459-33330-saint_pey_d_armens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33459-33330-saint_pey_d_armens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33460-33350-saint_pey_de_castets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33460-33350-saint_pey_de_castets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33460-33350-saint_pey_de_castets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33460-33350-saint_pey_de_castets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33461-33350-saint_philippe_d_aiguille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33461-33350-saint_philippe_d_aiguille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33461-33350-saint_philippe_d_aiguille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33461-33350-saint_philippe_d_aiguille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33462-33220-saint_philippe_du_seignal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33462-33220-saint_philippe_du_seignal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33462-33220-saint_philippe_du_seignal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33462-33220-saint_philippe_du_seignal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33463-33490-saint_pierre_d_aurillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33463-33490-saint_pierre_d_aurillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33463-33490-saint_pierre_d_aurillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33463-33490-saint_pierre_d_aurillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33464-33760-saint_pierre_de_bat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33464-33760-saint_pierre_de_bat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33464-33760-saint_pierre_de_bat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33464-33760-saint_pierre_de_bat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33465-33210-saint_pierre_de_mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33465-33210-saint_pierre_de_mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33465-33210-saint_pierre_de_mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33465-33210-saint_pierre_de_mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33466-33750-saint_quentin_de_baron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33466-33750-saint_quentin_de_baron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33466-33750-saint_quentin_de_baron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33466-33750-saint_quentin_de_baron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33467-33220-saint_quentin_de_caplong/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33467-33220-saint_quentin_de_caplong/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33467-33220-saint_quentin_de_caplong/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33467-33220-saint_quentin_de_caplong/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33468-33350-sainte_radegonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33468-33350-sainte_radegonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33468-33350-sainte_radegonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33468-33350-sainte_radegonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33470-33240-saint_romain_la_virvee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33470-33240-saint_romain_la_virvee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33470-33240-saint_romain_la_virvee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33470-33240-saint_romain_la_virvee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33471-33250-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33471-33250-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33471-33250-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33471-33250-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33472-33660-saint_sauveur_de_puynormand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33472-33660-saint_sauveur_de_puynormand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33472-33660-saint_sauveur_de_puynormand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33472-33660-saint_sauveur_de_puynormand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33473-33920-saint_savin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33473-33920-saint_savin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33473-33920-saint_savin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33473-33920-saint_savin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33474-33650-saint_selve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33474-33650-saint_selve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33474-33650-saint_selve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33474-33650-saint_selve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33475-33710-saint_seurin_de_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33475-33710-saint_seurin_de_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33475-33710-saint_seurin_de_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33475-33710-saint_seurin_de_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33476-33180-saint_seurin_de_cadourne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33476-33180-saint_seurin_de_cadourne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33476-33180-saint_seurin_de_cadourne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33476-33180-saint_seurin_de_cadourne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33477-33390-saint_seurin_de_cursac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33477-33390-saint_seurin_de_cursac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33477-33390-saint_seurin_de_cursac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33477-33390-saint_seurin_de_cursac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33478-33660-saint_seurin_sur_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33478-33660-saint_seurin_sur_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33478-33660-saint_seurin_sur_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33478-33660-saint_seurin_sur_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33479-33190-saint_seve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33479-33190-saint_seve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33479-33190-saint_seve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33479-33190-saint_seve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33480-33330-saint_sulpice_de_faleyrens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33480-33330-saint_sulpice_de_faleyrens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33480-33330-saint_sulpice_de_faleyrens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33480-33330-saint_sulpice_de_faleyrens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33481-33580-saint_sulpice_de_guilleragues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33481-33580-saint_sulpice_de_guilleragues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33481-33580-saint_sulpice_de_guilleragues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33481-33580-saint_sulpice_de_guilleragues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33482-33540-saint_sulpice_de_pommiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33482-33540-saint_sulpice_de_pommiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33482-33540-saint_sulpice_de_pommiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33482-33540-saint_sulpice_de_pommiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33483-33450-saint_sulpice_et_cameyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33483-33450-saint_sulpice_et_cameyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33483-33450-saint_sulpice_et_cameyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33483-33450-saint_sulpice_et_cameyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33484-33113-saint_symphorien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33484-33113-saint_symphorien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33484-33113-saint_symphorien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33484-33113-saint_symphorien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33485-33350-sainte_terre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33485-33350-sainte_terre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33485-33350-sainte_terre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33485-33350-sainte_terre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33486-33710-saint_trojan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33486-33710-saint_trojan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33486-33710-saint_trojan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33486-33710-saint_trojan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33487-33440-saint_vincent_de_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33487-33440-saint_vincent_de_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33487-33440-saint_vincent_de_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33487-33440-saint_vincent_de_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33488-33420-saint_vincent_de_pertignas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33488-33420-saint_vincent_de_pertignas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33488-33420-saint_vincent_de_pertignas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33488-33420-saint_vincent_de_pertignas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33489-33920-saint_vivien_de_blaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33489-33920-saint_vivien_de_blaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33489-33920-saint_vivien_de_blaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33489-33920-saint_vivien_de_blaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33490-33590-saint_vivien_de_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33490-33590-saint_vivien_de_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33490-33590-saint_vivien_de_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33490-33590-saint_vivien_de_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33491-33580-saint_vivien_de_monsegur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33491-33580-saint_vivien_de_monsegur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33491-33580-saint_vivien_de_monsegur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33491-33580-saint_vivien_de_monsegur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33492-33920-saint_yzan_de_soudiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33492-33920-saint_yzan_de_soudiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33492-33920-saint_yzan_de_soudiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33492-33920-saint_yzan_de_soudiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33493-33340-saint_yzans_de_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33493-33340-saint_yzans_de_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33493-33340-saint_yzans_de_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33493-33340-saint_yzans_de_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33494-33160-salaunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33494-33160-salaunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33494-33160-salaunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33494-33160-salaunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33496-33370-salleboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33496-33370-salleboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33496-33370-salleboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33496-33370-salleboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33498-33770-salles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33498-33770-salles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33498-33770-salles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33498-33770-salles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33499-33350-les_salles_de_castillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33499-33350-les_salles_de_castillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33499-33350-les_salles_de_castillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33499-33350-les_salles_de_castillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33500-33710-samonac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33500-33710-samonac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33500-33710-samonac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33500-33710-samonac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33501-33650-saucats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33501-33650-saucats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33501-33650-saucats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33501-33650-saucats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33502-33920-saugon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33502-33920-saugon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33502-33920-saugon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33502-33920-saugon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33503-33680-saumos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33503-33680-saumos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33503-33680-saumos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33503-33680-saumos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33504-33210-sauternes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33504-33210-sauternes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33504-33210-sauternes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33504-33210-sauternes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33505-33670-la_sauve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33505-33670-la_sauve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33505-33670-la_sauve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33505-33670-la_sauve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33506-33540-sauveterre_de_guyenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33506-33540-sauveterre_de_guyenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33506-33540-sauveterre_de_guyenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33506-33540-sauveterre_de_guyenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33507-33430-sauviac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33507-33430-sauviac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33507-33430-sauviac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33507-33430-sauviac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33508-33124-savignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33508-33124-savignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33508-33124-savignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33508-33124-savignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33509-33910-savignac_de_l_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33509-33910-savignac_de_l_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33509-33910-savignac_de_l_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33509-33910-savignac_de_l_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33510-33490-semens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33510-33490-semens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33510-33490-semens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33510-33490-semens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33511-33690-sendets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33511-33690-sendets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33511-33690-sendets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33511-33690-sendets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33512-33690-sigalens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33512-33690-sigalens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33512-33690-sigalens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33512-33690-sigalens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33513-33690-sillas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33513-33690-sillas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33513-33690-sillas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33513-33690-sillas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33514-33780-soulac_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33514-33780-soulac_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33514-33780-soulac_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33514-33780-soulac_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33515-33760-soulignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33515-33760-soulignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33515-33760-soulignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33515-33760-soulignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33516-33790-soussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33516-33790-soussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33516-33790-soussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33516-33790-soussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33517-33460-soussans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33517-33460-soussans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33517-33460-soussans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33517-33460-soussans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33518-33550-tabanac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33518-33550-tabanac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33518-33550-tabanac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33518-33550-tabanac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33519-33320-le_taillan_medoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33519-33320-le_taillan_medoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33519-33320-le_taillan_medoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33519-33320-le_taillan_medoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33520-33580-taillecavat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33520-33580-taillecavat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33520-33580-taillecavat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33520-33580-taillecavat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33521-33590-talais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33521-33590-talais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33521-33590-talais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33521-33590-talais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33522-33400-talence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33522-33400-talence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33522-33400-talence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33522-33400-talence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33523-33760-targon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33523-33760-targon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33523-33760-targon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33523-33760-targon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33524-33240-tarnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33524-33240-tarnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33524-33240-tarnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33524-33240-tarnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33525-33710-tauriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33525-33710-tauriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33525-33710-tauriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33525-33710-tauriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33526-33570-tayac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33526-33570-tayac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33526-33570-tayac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33526-33570-tayac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33527-33470-le_teich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33527-33470-le_teich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33527-33470-le_teich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33527-33470-le_teich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33528-33680-le_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33528-33680-le_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33528-33680-le_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33528-33680-le_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33260-la_teste_de_buch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33260-la_teste_de_buch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33260-la_teste_de_buch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33260-la_teste_de_buch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33115-la_teste_de_buch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33115-la_teste_de_buch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33115-la_teste_de_buch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33115-la_teste_de_buch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33164-la_teste_de_buch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33164-la_teste_de_buch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33164-la_teste_de_buch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33529-33164-la_teste_de_buch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33530-33710-teuillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33530-33710-teuillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33530-33710-teuillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33530-33710-teuillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33531-33420-tizac_de_curton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33531-33420-tizac_de_curton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33531-33420-tizac_de_curton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33531-33420-tizac_de_curton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33532-33620-tizac_de_lapouyade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33532-33620-tizac_de_lapouyade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33532-33620-tizac_de_lapouyade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33532-33620-tizac_de_lapouyade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33533-33210-toulenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33533-33210-toulenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33533-33210-toulenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33533-33210-toulenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33534-33550-le_tourne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33534-33550-le_tourne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33534-33550-le_tourne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33534-33550-le_tourne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33535-33370-tresses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33535-33370-tresses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33535-33370-tresses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33535-33370-tresses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33536-33125-le_tuzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33536-33125-le_tuzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33536-33125-le_tuzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33536-33125-le_tuzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33537-33730-uzeste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33537-33730-uzeste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33537-33730-uzeste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33537-33730-uzeste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33538-33340-valeyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33538-33340-valeyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33538-33340-valeyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33538-33340-valeyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33539-33870-vayres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33539-33870-vayres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33539-33870-vayres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33539-33870-vayres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33540-33930-vendays_montalivet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33540-33930-vendays_montalivet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33540-33930-vendays_montalivet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33540-33930-vendays_montalivet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33541-33590-vensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33541-33590-vensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33541-33590-vensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33541-33590-vensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33542-33240-verac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33542-33240-verac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33542-33240-verac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33542-33240-verac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33543-33490-verdelais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33543-33490-verdelais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33543-33490-verdelais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33543-33490-verdelais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33544-33123-le_verdon_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33544-33123-le_verdon_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33544-33123-le_verdon_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33544-33123-le_verdon_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33545-33180-vertheuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33545-33180-vertheuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33545-33180-vertheuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33545-33180-vertheuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33546-33330-vignonet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33546-33330-vignonet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33546-33330-vignonet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33546-33330-vignonet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33547-33730-villandraut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33547-33730-villandraut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33547-33730-villandraut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33547-33730-villandraut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33548-33141-villegouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33548-33141-villegouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33548-33141-villegouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33548-33141-villegouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33549-33550-villenave_de_rions/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33549-33550-villenave_de_rions/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33549-33550-villenave_de_rions/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33549-33550-villenave_de_rions/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33550-33140-villenave_d_ornon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33550-33140-villenave_d_ornon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33550-33140-villenave_d_ornon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33550-33140-villenave_d_ornon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33551-33710-villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33551-33710-villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33551-33710-villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33551-33710-villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33552-33720-virelade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33552-33720-virelade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33552-33720-virelade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33552-33720-virelade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33553-33240-virsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33553-33240-virsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33553-33240-virsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33553-33240-virsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33554-33370-yvrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33554-33370-yvrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33554-33370-yvrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33554-33370-yvrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33555-33380-marcheprime/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33555-33380-marcheprime/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33555-33380-marcheprime/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt33-gironde/commune33555-33380-marcheprime/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-34.xml
+++ b/public/sitemaps/sitemap-34.xml
@@ -5,712 +5,1420 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34001-34290-abeilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34001-34290-abeilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34001-34290-abeilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34001-34290-abeilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34002-34230-adissan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34002-34230-adissan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34002-34230-adissan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34002-34230-adissan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34003-34300-agde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34003-34300-agde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34003-34300-agde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34003-34300-agde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34004-34210-agel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34004-34210-agel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34004-34210-agel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34004-34210-agel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34005-34190-agones/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34005-34190-agones/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34005-34190-agones/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34005-34190-agones/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34006-34210-aigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34006-34210-aigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34006-34210-aigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34006-34210-aigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34007-34210-aigues_vives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34007-34210-aigues_vives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34007-34210-aigues_vives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34007-34210-aigues_vives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34008-34600-les_aires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34008-34600-les_aires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34008-34600-les_aires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34008-34600-les_aires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34009-34290-alignan_du_vent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34009-34290-alignan_du_vent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34009-34290-alignan_du_vent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34009-34290-alignan_du_vent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34010-34150-aniane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34010-34150-aniane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34010-34150-aniane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34010-34150-aniane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34011-34150-arboras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34011-34150-arboras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34011-34150-arboras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34011-34150-arboras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34012-34380-argelliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34012-34380-argelliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34012-34380-argelliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34012-34380-argelliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34013-34800-aspiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34013-34800-aspiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34013-34800-aspiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34013-34800-aspiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34014-34820-assas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34014-34820-assas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34014-34820-assas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34014-34820-assas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34015-34360-assignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34015-34360-assignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34015-34360-assignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34015-34360-assignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34016-34230-aumelas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34016-34230-aumelas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34016-34230-aumelas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34016-34230-aumelas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34017-34530-aumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34017-34530-aumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34017-34530-aumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34017-34530-aumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34018-34480-autignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34018-34480-autignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34018-34480-autignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34018-34480-autignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34019-34260-avene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34019-34260-avene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34019-34260-avene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34019-34260-avene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34020-34210-azillanet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34020-34210-azillanet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34020-34210-azillanet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34020-34210-azillanet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34021-34360-babeau_bouldoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34021-34360-babeau_bouldoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34021-34360-babeau_bouldoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34021-34360-babeau_bouldoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34022-34670-baillargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34022-34670-baillargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34022-34670-baillargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34022-34670-baillargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34023-34540-balaruc_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34023-34540-balaruc_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34023-34540-balaruc_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34023-34540-balaruc_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34024-34540-balaruc_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34024-34540-balaruc_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34024-34540-balaruc_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34024-34540-balaruc_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34025-34290-bassan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34025-34290-bassan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34025-34290-bassan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34025-34290-bassan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34026-34210-beaufort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34026-34210-beaufort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34026-34210-beaufort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34026-34210-beaufort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34027-34160-beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34027-34160-beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34027-34160-beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34027-34160-beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34028-34600-bedarieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34028-34600-bedarieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34028-34600-bedarieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34028-34600-bedarieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34029-34230-belarga/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34029-34230-belarga/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34029-34230-belarga/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34029-34230-belarga/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34030-34360-berlou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34030-34360-berlou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34030-34360-berlou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34030-34360-berlou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34031-34550-bessan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34031-34550-bessan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34031-34550-bessan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34031-34550-bessan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34032-34500-beziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34032-34500-beziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34032-34500-beziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34032-34500-beziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34033-34160-boisseron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34033-34160-boisseron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34033-34160-boisseron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34033-34160-boisseron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34034-34220-boisset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34034-34220-boisset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34034-34220-boisset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34034-34220-boisset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34035-34150-la_boissiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34035-34150-la_boissiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34035-34150-la_boissiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34035-34150-la_boissiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34036-34700-le_bosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34036-34700-le_bosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34036-34700-le_bosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34036-34700-le_bosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34037-34760-boujan_sur_libron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34037-34760-boujan_sur_libron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34037-34760-boujan_sur_libron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34037-34760-boujan_sur_libron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34038-34260-le_bousquet_d_orb/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34038-34260-le_bousquet_d_orb/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34038-34260-le_bousquet_d_orb/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34038-34260-le_bousquet_d_orb/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34039-34140-bouzigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34039-34140-bouzigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34039-34140-bouzigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34039-34140-bouzigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34040-34650-brenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34040-34650-brenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34040-34650-brenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34040-34650-brenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34041-34800-brignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34041-34800-brignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34041-34800-brignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34041-34800-brignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34042-34190-brissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34042-34190-brissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34042-34190-brissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34042-34190-brissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34043-34160-buzignargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34043-34160-buzignargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34043-34160-buzignargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34043-34160-buzignargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34044-34480-cabrerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34044-34480-cabrerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34044-34480-cabrerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34044-34480-cabrerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34045-34800-cabrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34045-34800-cabrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34045-34800-cabrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34045-34800-cabrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34046-34330-cambon_et_salvergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34046-34330-cambon_et_salvergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34046-34330-cambon_et_salvergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34046-34330-cambon_et_salvergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34047-34230-campagnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34047-34230-campagnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34047-34230-campagnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34047-34230-campagnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34048-34160-campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34048-34160-campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34048-34160-campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34048-34160-campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34049-34260-camplong/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34049-34260-camplong/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34049-34260-camplong/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34049-34260-camplong/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34050-34130-candillargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34050-34130-candillargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34050-34130-candillargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34050-34130-candillargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34051-34800-canet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34051-34800-canet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34051-34800-canet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34051-34800-canet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34052-34310-capestang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34052-34310-capestang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34052-34310-capestang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34052-34310-capestang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34053-34600-carlencas_et_levas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34053-34600-carlencas_et_levas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34053-34600-carlencas_et_levas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34053-34600-carlencas_et_levas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34054-34210-cassagnoles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34054-34210-cassagnoles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34054-34210-cassagnoles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34054-34210-cassagnoles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34055-34610-castanet_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34055-34610-castanet_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34055-34610-castanet_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34055-34610-castanet_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34056-34120-castelnau_de_guers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34056-34120-castelnau_de_guers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34056-34120-castelnau_de_guers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34056-34120-castelnau_de_guers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34057-34170-castelnau_le_lez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34057-34170-castelnau_le_lez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34057-34170-castelnau_le_lez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34057-34170-castelnau_le_lez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34058-34160-castries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34058-34160-castries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34058-34160-castries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34058-34160-castries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34059-34210-la_caunette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34059-34210-la_caunette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34059-34210-la_caunette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34059-34210-la_caunette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34060-34380-causse_de_la_selle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34060-34380-causse_de_la_selle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34060-34380-causse_de_la_selle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34060-34380-causse_de_la_selle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34061-34490-causses_et_veyran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34061-34490-causses_et_veyran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34061-34490-causses_et_veyran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34061-34490-causses_et_veyran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34062-34600-caussiniojouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34062-34600-caussiniojouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34062-34600-caussiniojouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34062-34600-caussiniojouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34063-34720-caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34063-34720-caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34063-34720-caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34063-34720-caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34064-34520-le_caylar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34064-34520-le_caylar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34064-34520-le_caylar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34064-34520-le_caylar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34065-34460-cazedarnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34065-34460-cazedarnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34065-34460-cazedarnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34065-34460-cazedarnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34066-34270-cazevieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34066-34270-cazevieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34066-34270-cazevieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34066-34270-cazevieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34067-34190-cazilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34067-34190-cazilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34067-34190-cazilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34067-34190-cazilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34068-34120-cazouls_d_herault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34068-34120-cazouls_d_herault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34068-34120-cazouls_d_herault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34068-34120-cazouls_d_herault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34069-34370-cazouls_les_beziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34069-34370-cazouls_les_beziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34069-34370-cazouls_les_beziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34069-34370-cazouls_les_beziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34070-34360-cebazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34070-34360-cebazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34070-34360-cebazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34070-34360-cebazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34071-34260-ceilhes_et_rocozels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34071-34260-ceilhes_et_rocozels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34071-34260-ceilhes_et_rocozels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34071-34260-ceilhes_et_rocozels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34072-34700-celles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34072-34700-celles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34072-34700-celles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34072-34700-celles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34073-34420-cers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34073-34420-cers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34073-34420-cers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34073-34420-cers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34074-34460-cessenon_sur_orb/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34074-34460-cessenon_sur_orb/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34074-34460-cessenon_sur_orb/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34074-34460-cessenon_sur_orb/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34075-34210-cesseras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34075-34210-cesseras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34075-34210-cesseras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34075-34210-cesseras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34076-34800-ceyras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34076-34800-ceyras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34076-34800-ceyras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34076-34800-ceyras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34077-34830-clapiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34077-34830-clapiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34077-34830-clapiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34077-34830-clapiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34078-34270-claret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34078-34270-claret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34078-34270-claret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34078-34270-claret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34079-34800-clermont_l_herault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34079-34800-clermont_l_herault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34079-34800-clermont_l_herault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34079-34800-clermont_l_herault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34080-34390-colombieres_sur_orb/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34080-34390-colombieres_sur_orb/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34080-34390-colombieres_sur_orb/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34080-34390-colombieres_sur_orb/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34081-34440-colombiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34081-34440-colombiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34081-34440-colombiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34081-34440-colombiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34082-34980-combaillaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34082-34980-combaillaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34082-34980-combaillaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34082-34980-combaillaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34083-34240-combes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34083-34240-combes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34083-34240-combes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34083-34240-combes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34084-34490-corneilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34084-34490-corneilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34084-34490-corneilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34084-34490-corneilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34085-34290-coulobres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34085-34290-coulobres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34085-34290-coulobres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34085-34290-coulobres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34086-34220-courniou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34086-34220-courniou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34086-34220-courniou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34086-34220-courniou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34087-34660-cournonsec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34087-34660-cournonsec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34087-34660-cournonsec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34087-34660-cournonsec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34088-34660-cournonterral/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34088-34660-cournonterral/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34088-34660-cournonterral/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34088-34660-cournonterral/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34089-34370-creissan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34089-34370-creissan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34089-34370-creissan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34089-34370-creissan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34090-34920-le_cres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34090-34920-le_cres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34090-34920-le_cres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34090-34920-le_cres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34091-34520-le_cros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34091-34520-le_cros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34091-34520-le_cros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34091-34520-le_cros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34092-34310-cruzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34092-34310-cruzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34092-34310-cruzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34092-34310-cruzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34093-34650-dio_et_valquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34093-34650-dio_et_valquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34093-34650-dio_et_valquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34093-34650-dio_et_valquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34094-34290-espondeilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34094-34290-espondeilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34094-34290-espondeilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34094-34290-espondeilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34095-34690-fabregues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34095-34690-fabregues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34095-34690-fabregues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34095-34690-fabregues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34096-34600-faugeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34096-34600-faugeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34096-34600-faugeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34096-34600-faugeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34097-34210-felines_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34097-34210-felines_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34097-34210-felines_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34097-34210-felines_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34098-34210-ferrals_les_montagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34098-34210-ferrals_les_montagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34098-34210-ferrals_les_montagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34098-34210-ferrals_les_montagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34099-34190-ferrieres_les_verreries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34099-34190-ferrieres_les_verreries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34099-34190-ferrieres_les_verreries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34099-34190-ferrieres_les_verreries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34100-34360-ferrieres_poussarou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34100-34360-ferrieres_poussarou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34100-34360-ferrieres_poussarou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34100-34360-ferrieres_poussarou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34510-florensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34510-florensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34510-florensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34510-florensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34110-florensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34110-florensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34110-florensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34110-florensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34550-florensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34550-florensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34550-florensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34101-34550-florensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34102-34270-fontanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34102-34270-fontanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34102-34270-fontanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34102-34270-fontanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34103-34320-fontes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34103-34320-fontes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34103-34320-fontes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34103-34320-fontes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34104-34320-fos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34104-34320-fos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34104-34320-fos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34104-34320-fos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34105-34480-fouzilhon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34105-34480-fouzilhon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34105-34480-fouzilhon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34105-34480-fouzilhon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34106-34700-fozieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34106-34700-fozieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34106-34700-fozieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34106-34700-fozieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34107-34330-fraisse_sur_agout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34107-34330-fraisse_sur_agout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34107-34330-fraisse_sur_agout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34107-34330-fraisse_sur_agout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34108-34110-frontignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34108-34110-frontignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34108-34110-frontignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34108-34110-frontignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34109-34320-gabian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34109-34320-gabian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34109-34320-gabian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34109-34320-gabian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34110-34160-galargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34110-34160-galargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34110-34160-galargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34110-34160-galargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34111-34190-ganges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34111-34190-ganges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34111-34190-ganges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34111-34190-ganges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34112-34160-garrigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34112-34160-garrigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34112-34160-garrigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34112-34160-garrigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34113-34770-gigean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34113-34770-gigean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34113-34770-gigean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34113-34770-gigean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34114-34150-gignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34114-34150-gignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34114-34150-gignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34114-34150-gignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34115-34190-gornies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34115-34190-gornies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34115-34190-gornies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34115-34190-gornies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34116-34790-grabels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34116-34790-grabels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34116-34790-grabels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34116-34790-grabels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34117-34260-graissessac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34117-34260-graissessac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34117-34260-graissessac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34117-34260-graissessac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34118-34820-guzargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34118-34820-guzargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34118-34820-guzargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34118-34820-guzargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34119-34600-herepian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34119-34600-herepian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34119-34600-herepian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34119-34600-herepian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34120-34830-jacou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34120-34830-jacou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34120-34830-jacou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34120-34830-jacou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34121-34650-joncels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34121-34650-joncels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34121-34650-joncels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34121-34650-joncels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34122-34725-jonquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34122-34725-jonquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34122-34725-jonquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34122-34725-jonquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34123-34990-juvignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34123-34990-juvignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34123-34990-juvignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34123-34990-juvignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34124-34800-lacoste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34124-34800-lacoste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34124-34800-lacoste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34124-34800-lacoste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34125-34150-lagamas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34125-34150-lagamas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34125-34150-lagamas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34125-34150-lagamas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34126-34240-lamalou_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34126-34240-lamalou_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34126-34240-lamalou_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34126-34240-lamalou_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34127-34130-lansargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34127-34130-lansargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34127-34130-lansargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34127-34130-lansargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34128-34190-laroque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34128-34190-laroque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34128-34190-laroque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34128-34190-laroque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34129-34970-lattes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34129-34970-lattes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34129-34970-lattes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34129-34970-lattes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34130-34480-laurens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34130-34480-laurens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34130-34480-laurens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34130-34480-laurens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34131-34270-lauret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34131-34270-lauret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34131-34270-lauret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34131-34270-lauret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34132-34700-lauroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34132-34700-lauroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34132-34700-lauroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34132-34700-lauroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34133-34700-lavalette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34133-34700-lavalette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34133-34700-lavalette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34133-34700-lavalette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34134-34880-laverune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34134-34880-laverune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34134-34880-laverune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34134-34880-laverune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34135-34710-lespignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34135-34710-lespignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34135-34710-lespignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34135-34710-lespignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34136-34120-lezignan_la_cebe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34136-34120-lezignan_la_cebe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34136-34120-lezignan_la_cebe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34136-34120-lezignan_la_cebe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34137-34800-liausson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34137-34800-liausson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34137-34800-liausson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34137-34800-liausson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34138-34800-lieuran_cabrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34138-34800-lieuran_cabrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34138-34800-lieuran_cabrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34138-34800-lieuran_cabrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34139-34290-lieuran_les_beziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34139-34290-lieuran_les_beziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34139-34290-lieuran_les_beziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34139-34290-lieuran_les_beziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34140-34490-lignan_sur_orb/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34140-34490-lignan_sur_orb/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34140-34490-lignan_sur_orb/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34140-34490-lignan_sur_orb/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34141-34210-la_liviniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34141-34210-la_liviniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34141-34210-la_liviniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34141-34210-la_liviniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34142-34700-lodeve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34142-34700-lodeve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34142-34700-lodeve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34142-34700-lodeve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34143-34140-loupian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34143-34140-loupian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34143-34140-loupian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34143-34140-loupian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34144-34650-lunas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34144-34650-lunas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34144-34650-lunas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34144-34650-lunas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34145-34400-lunel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34145-34400-lunel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34145-34400-lunel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34145-34400-lunel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34146-34400-lunel_viel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34146-34400-lunel_viel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34146-34400-lunel_viel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34146-34400-lunel_viel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34147-34480-magalas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34147-34480-magalas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34147-34480-magalas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34147-34480-magalas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34148-34370-maraussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34148-34370-maraussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34148-34370-maraussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34148-34370-maraussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34149-34320-margon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34149-34320-margon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34149-34320-margon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34149-34320-margon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34150-34340-marseillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34150-34340-marseillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34150-34340-marseillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34150-34340-marseillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34151-34590-marsillargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34151-34590-marsillargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34151-34590-marsillargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34151-34590-marsillargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34152-34380-mas_de_londres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34152-34380-mas_de_londres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34152-34380-mas_de_londres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34152-34380-mas_de_londres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34153-34270-les_matelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34153-34270-les_matelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34153-34270-les_matelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34153-34270-les_matelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34154-34280-mauguio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34154-34280-mauguio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34154-34280-mauguio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34154-34280-mauguio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34154-34130-mauguio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34154-34130-mauguio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34154-34130-mauguio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34154-34130-mauguio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34155-34370-maureilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34155-34370-maureilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34155-34370-maureilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34155-34370-maureilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34156-34800-merifons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34156-34800-merifons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34156-34800-merifons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34156-34800-merifons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34157-34140-meze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34157-34140-meze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34157-34140-meze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34157-34140-meze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34158-34210-minerve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34158-34210-minerve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34158-34210-minerve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34158-34210-minerve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34159-34110-mireval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34159-34110-mireval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34159-34110-mireval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34159-34110-mireval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34160-34390-mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34160-34390-mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34160-34390-mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34160-34390-mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34161-34310-montady/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34161-34310-montady/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34161-34310-montady/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34161-34310-montady/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34162-34530-montagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34162-34530-montagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34162-34530-montagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34162-34530-montagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34163-34570-montarnaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34163-34570-montarnaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34163-34570-montarnaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34163-34570-montarnaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34164-34160-montaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34164-34160-montaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34164-34160-montaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34164-34160-montaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34165-34560-montbazin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34165-34560-montbazin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34165-34560-montbazin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34165-34560-montbazin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34166-34290-montblanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34166-34290-montblanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34166-34290-montblanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34166-34290-montblanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34167-34310-montels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34167-34310-montels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34167-34310-montels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34167-34310-montels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34168-34320-montesquieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34168-34320-montesquieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34168-34320-montesquieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34168-34320-montesquieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34169-34980-montferrier_sur_lez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34169-34980-montferrier_sur_lez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34169-34980-montferrier_sur_lez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34169-34980-montferrier_sur_lez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34170-34310-montouliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34170-34310-montouliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34170-34310-montouliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34170-34310-montouliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34171-34190-montoulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34171-34190-montoulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34171-34190-montoulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34171-34190-montoulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34000-montpellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34000-montpellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34000-montpellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34000-montpellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34080-montpellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34080-montpellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34080-montpellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34080-montpellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34090-montpellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34090-montpellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34090-montpellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34090-montpellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34070-montpellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34070-montpellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34070-montpellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34070-montpellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34295-montpellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34295-montpellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34295-montpellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34172-34295-montpellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34173-34150-montpeyroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34173-34150-montpeyroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34173-34150-montpeyroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34173-34150-montpeyroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34174-34190-moules_et_baucels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34174-34190-moules_et_baucels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34174-34190-moules_et_baucels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34174-34190-moules_et_baucels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34175-34800-moureze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34175-34800-moureze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34175-34800-moureze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34175-34800-moureze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34176-34130-mudaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34176-34130-mudaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34176-34130-mudaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34176-34130-mudaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34177-34980-murles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34177-34980-murles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34177-34980-murles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34177-34980-murles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34178-34490-murviel_les_beziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34178-34490-murviel_les_beziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34178-34490-murviel_les_beziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34178-34490-murviel_les_beziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34179-34570-murviel_les_montpellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34179-34570-murviel_les_montpellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34179-34570-murviel_les_montpellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34179-34570-murviel_les_montpellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34180-34800-nebian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34180-34800-nebian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34180-34800-nebian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34180-34800-nebian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34181-34320-neffies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34181-34320-neffies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34181-34320-neffies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34181-34320-neffies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34182-34120-nezignan_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34182-34120-nezignan_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34182-34120-nezignan_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34182-34120-nezignan_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34183-34440-nissan_lez_enserune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34183-34440-nissan_lez_enserune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34183-34440-nissan_lez_enserune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34183-34440-nissan_lez_enserune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34184-34320-nizas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34184-34320-nizas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34184-34320-nizas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34184-34320-nizas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34185-34380-notre_dame_de_londres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34185-34380-notre_dame_de_londres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34185-34380-notre_dame_de_londres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34185-34380-notre_dame_de_londres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34186-34800-octon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34186-34800-octon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34186-34800-octon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34186-34800-octon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34186-34650-octon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34186-34650-octon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34186-34650-octon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34186-34650-octon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34187-34390-olargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34187-34390-olargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34187-34390-olargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34187-34390-olargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34188-34700-olmet_et_villecun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34188-34700-olmet_et_villecun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34188-34700-olmet_et_villecun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34188-34700-olmet_et_villecun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34189-34210-olonzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34189-34210-olonzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34189-34210-olonzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34189-34210-olonzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34190-34210-oupia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34190-34210-oupia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34190-34210-oupia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34190-34210-oupia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34191-34490-pailhes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34191-34490-pailhes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34191-34490-pailhes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34191-34490-pailhes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34192-34250-palavas_les_flots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34192-34250-palavas_les_flots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34192-34250-palavas_les_flots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34192-34250-palavas_les_flots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34193-34360-pardailhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34193-34360-pardailhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34193-34360-pardailhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34193-34360-pardailhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34194-34230-paulhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34194-34230-paulhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34194-34230-paulhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34194-34230-paulhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34195-34380-pegairolles_de_bueges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34195-34380-pegairolles_de_bueges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34195-34380-pegairolles_de_bueges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34195-34380-pegairolles_de_bueges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34196-34700-pegairolles_de_l_escalette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34196-34700-pegairolles_de_l_escalette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34196-34700-pegairolles_de_l_escalette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34196-34700-pegairolles_de_l_escalette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34197-34800-peret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34197-34800-peret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34197-34800-peret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34197-34800-peret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34198-34470-perols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34198-34470-perols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34198-34470-perols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34198-34470-perols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34199-34120-pezenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34199-34120-pezenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34199-34120-pezenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34199-34120-pezenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34200-34600-pezenes_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34200-34600-pezenes_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34200-34600-pezenes_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34200-34600-pezenes_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34201-34360-pierrerue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34201-34360-pierrerue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34201-34360-pierrerue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34201-34360-pierrerue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34202-34570-pignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34202-34570-pignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34202-34570-pignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34202-34570-pignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34203-34850-pinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34203-34850-pinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34203-34850-pinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34203-34850-pinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34204-34230-plaissan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34204-34230-plaissan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34204-34230-plaissan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34204-34230-plaissan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34205-34700-les_plans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34205-34700-les_plans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34205-34700-les_plans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34205-34700-les_plans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34206-34310-poilhes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34206-34310-poilhes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34206-34310-poilhes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34206-34310-poilhes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34207-34810-pomerols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34207-34810-pomerols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34207-34810-pomerols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34207-34810-pomerols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34208-34230-popian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34208-34230-popian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34208-34230-popian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34208-34230-popian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34209-34420-portiragnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34209-34420-portiragnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34209-34420-portiragnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34209-34420-portiragnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34210-34230-le_pouget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34210-34230-le_pouget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34210-34230-le_pouget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34210-34230-le_pouget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34211-34600-le_poujol_sur_orb/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34211-34600-le_poujol_sur_orb/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34211-34600-le_poujol_sur_orb/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34211-34600-le_poujol_sur_orb/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34212-34700-poujols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34212-34700-poujols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34212-34700-poujols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34212-34700-poujols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34213-34560-poussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34213-34560-poussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34213-34560-poussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34213-34560-poussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34214-34480-pouzolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34214-34480-pouzolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34214-34480-pouzolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34214-34480-pouzolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34215-34230-pouzols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34215-34230-pouzols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34215-34230-pouzols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34215-34230-pouzols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34216-34600-le_pradal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34216-34600-le_pradal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34216-34600-le_pradal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34216-34600-le_pradal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34217-34730-prades_le_lez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34217-34730-prades_le_lez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34217-34730-prades_le_lez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34217-34730-prades_le_lez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34218-34360-prades_sur_vernazobre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34218-34360-prades_sur_vernazobre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34218-34360-prades_sur_vernazobre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34218-34360-prades_sur_vernazobre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34219-34390-premian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34219-34390-premian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34219-34390-premian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34219-34390-premian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34220-34700-le_puech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34220-34700-le_puech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34220-34700-le_puech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34220-34700-le_puech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34221-34150-puechabon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34221-34150-puechabon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34221-34150-puechabon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34221-34150-puechabon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34222-34230-puilacher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34222-34230-puilacher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34222-34230-puilacher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34222-34230-puilacher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34223-34480-puimisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34223-34480-puimisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34223-34480-puimisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34223-34480-puimisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34224-34480-puissalicon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34224-34480-puissalicon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34224-34480-puissalicon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34224-34480-puissalicon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34225-34620-puisserguier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34225-34620-puisserguier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34225-34620-puisserguier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34225-34620-puisserguier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34226-34310-quarante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34226-34310-quarante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34226-34310-quarante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34226-34310-quarante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34227-34160-restinclieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34227-34160-restinclieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34227-34160-restinclieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34227-34160-restinclieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34228-34220-rieussec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34228-34220-rieussec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34228-34220-rieussec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34228-34220-rieussec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34229-34220-riols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34229-34220-riols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34229-34220-riols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34229-34220-riols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34230-34520-les_rives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34230-34520-les_rives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34230-34520-les_rives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34230-34520-les_rives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34231-34650-romiguieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34231-34650-romiguieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34231-34650-romiguieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34231-34650-romiguieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34232-34460-roquebrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34232-34460-roquebrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34232-34460-roquebrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34232-34460-roquebrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34233-34650-roqueredonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34233-34650-roqueredonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34233-34650-roqueredonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34233-34650-roqueredonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34234-34320-roquessels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34234-34320-roquessels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34234-34320-roquessels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34234-34320-roquessels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34235-34610-rosis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34235-34610-rosis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34235-34610-rosis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34235-34610-rosis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34236-34380-rouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34236-34380-rouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34236-34380-rouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34236-34380-rouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34237-34320-roujan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34237-34320-roujan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34237-34320-roujan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34237-34320-roujan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34238-34190-saint_andre_de_bueges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34238-34190-saint_andre_de_bueges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34238-34190-saint_andre_de_bueges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34238-34190-saint_andre_de_bueges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34239-34725-saint_andre_de_sangonis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34239-34725-saint_andre_de_sangonis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34239-34725-saint_andre_de_sangonis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34239-34725-saint_andre_de_sangonis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34240-34130-saint_aunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34240-34130-saint_aunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34240-34130-saint_aunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34240-34130-saint_aunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34241-34230-saint_bauzille_de_la_sylve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34241-34230-saint_bauzille_de_la_sylve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34241-34230-saint_bauzille_de_la_sylve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34241-34230-saint_bauzille_de_la_sylve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34242-34160-saint_bauzille_de_montmel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34242-34160-saint_bauzille_de_montmel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34242-34160-saint_bauzille_de_montmel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34242-34160-saint_bauzille_de_montmel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34243-34190-saint_bauzille_de_putois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34243-34190-saint_bauzille_de_putois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34243-34190-saint_bauzille_de_putois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34243-34190-saint_bauzille_de_putois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34244-34670-saint_bres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34244-34670-saint_bres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34244-34670-saint_bres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34244-34670-saint_bres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34245-34360-saint_chinian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34245-34360-saint_chinian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34245-34360-saint_chinian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34245-34360-saint_chinian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34246-34400-entre_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34246-34400-entre_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34246-34400-entre_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34246-34400-entre_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34247-34980-saint_clement_de_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34247-34980-saint_clement_de_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34247-34980-saint_clement_de_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34247-34980-saint_clement_de_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34248-34270-sainte_croix_de_quintillargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34248-34270-sainte_croix_de_quintillargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34248-34270-sainte_croix_de_quintillargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34248-34270-sainte_croix_de_quintillargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34249-34160-saint_drezery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34249-34160-saint_drezery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34249-34160-saint_drezery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34249-34160-saint_drezery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34250-34390-saint_etienne_d_albagnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34250-34390-saint_etienne_d_albagnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34250-34390-saint_etienne_d_albagnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34250-34390-saint_etienne_d_albagnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34251-34700-saint_etienne_de_gourgas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34251-34700-saint_etienne_de_gourgas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34251-34700-saint_etienne_de_gourgas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34251-34700-saint_etienne_de_gourgas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34252-34260-saint_etienne_estrechoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34252-34260-saint_etienne_estrechoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34252-34260-saint_etienne_estrechoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34252-34260-saint_etienne_estrechoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34253-34520-saint_felix_de_l_heras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34253-34520-saint_felix_de_l_heras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34253-34520-saint_felix_de_l_heras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34253-34520-saint_felix_de_l_heras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34254-34725-saint_felix_de_lodez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34254-34725-saint_felix_de_lodez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34254-34725-saint_felix_de_lodez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34254-34725-saint_felix_de_lodez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34255-34980-saint_gely_du_fesc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34255-34980-saint_gely_du_fesc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34255-34980-saint_gely_du_fesc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34255-34980-saint_gely_du_fesc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34256-34160-saint_genies_des_mourgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34256-34160-saint_genies_des_mourgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34256-34160-saint_genies_des_mourgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34256-34160-saint_genies_des_mourgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34257-34610-saint_genies_de_varensal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34257-34610-saint_genies_de_varensal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34257-34610-saint_genies_de_varensal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34257-34610-saint_genies_de_varensal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34258-34480-saint_genies_de_fontedit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34258-34480-saint_genies_de_fontedit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34258-34480-saint_genies_de_fontedit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34258-34480-saint_genies_de_fontedit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34259-34680-saint_georges_d_orques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34259-34680-saint_georges_d_orques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34259-34680-saint_georges_d_orques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34259-34680-saint_georges_d_orques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34260-34610-saint_gervais_sur_mare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34260-34610-saint_gervais_sur_mare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34260-34610-saint_gervais_sur_mare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34260-34610-saint_gervais_sur_mare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34261-34150-saint_guilhem_le_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34261-34150-saint_guilhem_le_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34261-34150-saint_guilhem_le_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34261-34150-saint_guilhem_le_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34262-34725-saint_guiraud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34262-34725-saint_guiraud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34262-34725-saint_guiraud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34262-34725-saint_guiraud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34263-34160-saint_hilaire_de_beauvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34263-34160-saint_hilaire_de_beauvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34263-34160-saint_hilaire_de_beauvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34263-34160-saint_hilaire_de_beauvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34264-34380-saint_jean_de_bueges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34264-34380-saint_jean_de_bueges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34264-34380-saint_jean_de_bueges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34264-34380-saint_jean_de_bueges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34265-34160-saint_jean_de_cornies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34265-34160-saint_jean_de_cornies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34265-34160-saint_jean_de_cornies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34265-34160-saint_jean_de_cornies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34266-34270-saint_jean_de_cuculles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34266-34270-saint_jean_de_cuculles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34266-34270-saint_jean_de_cuculles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34266-34270-saint_jean_de_cuculles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34267-34150-saint_jean_de_fos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34267-34150-saint_jean_de_fos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34267-34150-saint_jean_de_fos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34267-34150-saint_jean_de_fos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34268-34700-saint_jean_de_la_blaquiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34268-34700-saint_jean_de_la_blaquiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34268-34700-saint_jean_de_la_blaquiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34268-34700-saint_jean_de_la_blaquiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34269-34360-saint_jean_de_minervois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34269-34360-saint_jean_de_minervois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34269-34360-saint_jean_de_minervois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34269-34360-saint_jean_de_minervois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34270-34430-saint_jean_de_vedas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34270-34430-saint_jean_de_vedas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34270-34430-saint_jean_de_vedas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34270-34430-saint_jean_de_vedas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34271-34390-saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34271-34390-saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34271-34390-saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34271-34390-saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34272-34400-saint_just/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34272-34400-saint_just/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34272-34400-saint_just/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34272-34400-saint_just/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34273-34390-saint_martin_de_l_arcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34273-34390-saint_martin_de_l_arcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34273-34390-saint_martin_de_l_arcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34273-34390-saint_martin_de_l_arcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34274-34380-saint_martin_de_londres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34274-34380-saint_martin_de_londres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34274-34380-saint_martin_de_londres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34274-34380-saint_martin_de_londres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34276-34270-saint_mathieu_de_treviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34276-34270-saint_mathieu_de_treviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34276-34270-saint_mathieu_de_treviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34276-34270-saint_mathieu_de_treviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34277-34520-saint_maurice_navacelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34277-34520-saint_maurice_navacelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34277-34520-saint_maurice_navacelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34277-34520-saint_maurice_navacelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34278-34520-saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34278-34520-saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34278-34520-saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34278-34520-saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34279-34490-saint_nazaire_de_ladarez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34279-34490-saint_nazaire_de_ladarez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34279-34490-saint_nazaire_de_ladarez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34279-34490-saint_nazaire_de_ladarez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34280-34400-saint_nazaire_de_pezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34280-34400-saint_nazaire_de_pezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34280-34400-saint_nazaire_de_pezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34280-34400-saint_nazaire_de_pezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34281-34230-saint_pargoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34281-34230-saint_pargoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34281-34230-saint_pargoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34281-34230-saint_pargoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34282-34570-saint_paul_et_valmalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34282-34570-saint_paul_et_valmalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34282-34570-saint_paul_et_valmalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34282-34570-saint_paul_et_valmalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34283-34520-saint_pierre_de_la_fage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34283-34520-saint_pierre_de_la_fage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34283-34520-saint_pierre_de_la_fage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34283-34520-saint_pierre_de_la_fage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34284-34220-saint_pons_de_thomieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34284-34220-saint_pons_de_thomieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34284-34220-saint_pons_de_thomieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34284-34220-saint_pons_de_thomieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34285-34230-saint_pons_de_mauchiens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34285-34230-saint_pons_de_mauchiens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34285-34230-saint_pons_de_mauchiens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34285-34230-saint_pons_de_mauchiens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34286-34700-saint_privat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34286-34700-saint_privat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34286-34700-saint_privat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34286-34700-saint_privat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34287-34725-saint_saturnin_de_lucian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34287-34725-saint_saturnin_de_lucian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34287-34725-saint_saturnin_de_lucian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34287-34725-saint_saturnin_de_lucian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34287-34700-saint_saturnin_de_lucian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34287-34700-saint_saturnin_de_lucian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34287-34700-saint_saturnin_de_lucian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34287-34700-saint_saturnin_de_lucian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34288-34400-saint_series/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34288-34400-saint_series/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34288-34400-saint_series/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34288-34400-saint_series/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34289-34630-saint_thibery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34289-34630-saint_thibery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34289-34630-saint_thibery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34289-34630-saint_thibery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34290-34730-saint_vincent_de_barbeyrargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34290-34730-saint_vincent_de_barbeyrargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34290-34730-saint_vincent_de_barbeyrargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34290-34730-saint_vincent_de_barbeyrargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34291-34390-saint_vincent_d_olargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34291-34390-saint_vincent_d_olargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34291-34390-saint_vincent_d_olargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34291-34390-saint_vincent_d_olargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34292-34800-salasc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34292-34800-salasc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34292-34800-salasc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34292-34800-salasc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34293-34330-la_salvetat_sur_agout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34293-34330-la_salvetat_sur_agout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34293-34330-la_salvetat_sur_agout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34293-34330-la_salvetat_sur_agout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34294-34400-saturargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34294-34400-saturargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34294-34400-saturargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34294-34400-saturargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34295-34570-saussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34295-34570-saussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34295-34570-saussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34295-34570-saussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34296-34160-saussines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34296-34160-saussines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34296-34160-saussines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34296-34160-saussines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34297-34270-sauteyrargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34297-34270-sauteyrargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34297-34270-sauteyrargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34297-34270-sauteyrargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34298-34410-sauvian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34298-34410-sauvian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34298-34410-sauvian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34298-34410-sauvian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34299-34410-serignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34299-34410-serignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34299-34410-serignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34299-34410-serignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34300-34290-servian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34300-34290-servian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34300-34290-servian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34300-34290-servian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34301-34200-sete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34301-34200-sete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34301-34200-sete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34301-34200-sete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34302-34210-siran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34302-34210-siran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34302-34210-siran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34302-34210-siran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34303-34520-sorbs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34303-34520-sorbs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34303-34520-sorbs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34303-34520-sorbs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34304-34700-soubes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34304-34700-soubes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34304-34700-soubes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34304-34700-soubes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34305-34330-le_soulie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34305-34330-le_soulie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34305-34330-le_soulie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34305-34330-le_soulie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34306-34700-soumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34306-34700-soumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34306-34700-soumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34306-34700-soumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34307-34160-sussargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34307-34160-sussargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34307-34160-sussargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34307-34160-sussargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34308-34600-taussac_la_billiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34308-34600-taussac_la_billiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34308-34600-taussac_la_billiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34308-34600-taussac_la_billiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34309-34820-teyran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34309-34820-teyran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34309-34820-teyran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34309-34820-teyran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34310-34490-thezan_les_beziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34310-34490-thezan_les_beziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34310-34490-thezan_les_beziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34310-34490-thezan_les_beziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34311-34120-tourbes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34311-34120-tourbes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34311-34120-tourbes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34311-34120-tourbes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34312-34260-la_tour_sur_orb/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34312-34260-la_tour_sur_orb/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34312-34260-la_tour_sur_orb/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34312-34260-la_tour_sur_orb/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34313-34230-tressan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34313-34230-tressan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34313-34230-tressan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34313-34230-tressan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34314-34270-le_triadou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34314-34270-le_triadou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34314-34270-le_triadou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34314-34270-le_triadou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34315-34230-usclas_d_herault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34315-34230-usclas_d_herault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34315-34230-usclas_d_herault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34315-34230-usclas_d_herault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34316-34700-usclas_du_bosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34316-34700-usclas_du_bosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34316-34700-usclas_du_bosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34316-34700-usclas_du_bosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34317-34520-la_vacquerie_et_saint_martin_de_castries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34317-34520-la_vacquerie_et_saint_martin_de_castries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34317-34520-la_vacquerie_et_saint_martin_de_castries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34317-34520-la_vacquerie_et_saint_martin_de_castries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34318-34270-vacquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34318-34270-vacquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34318-34270-vacquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34318-34270-vacquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34319-34320-vailhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34319-34320-vailhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34319-34320-vailhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34319-34320-vailhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34320-34570-vailhauques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34320-34570-vailhauques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34320-34570-vailhauques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34320-34570-vailhauques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34321-34130-valergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34321-34130-valergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34321-34130-valergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34321-34130-valergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34322-34270-valflaunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34322-34270-valflaunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34322-34270-valflaunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34322-34270-valflaunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34323-34800-valmascle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34323-34800-valmascle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34323-34800-valmascle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34323-34800-valmascle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34324-34350-valras_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34324-34350-valras_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34324-34350-valras_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34324-34350-valras_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34325-34290-valros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34325-34290-valros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34325-34290-valros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34325-34290-valros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34326-34220-velieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34326-34220-velieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34326-34220-velieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34326-34220-velieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34327-34740-vendargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34327-34740-vendargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34327-34740-vendargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34327-34740-vendargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34328-34230-vendemian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34328-34230-vendemian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34328-34230-vendemian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34328-34230-vendemian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34329-34350-vendres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34329-34350-vendres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34329-34350-vendres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34329-34350-vendres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34331-34220-verreries_de_moussans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34331-34220-verreries_de_moussans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34331-34220-verreries_de_moussans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34331-34220-verreries_de_moussans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34332-34450-vias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34332-34450-vias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34332-34450-vias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34332-34450-vias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34333-34110-vic_la_gardiole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34333-34110-vic_la_gardiole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34333-34110-vic_la_gardiole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34333-34110-vic_la_gardiole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34334-34390-vieussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34334-34390-vieussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34334-34390-vieussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34334-34390-vieussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34335-34600-villemagne_l_argentiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34335-34600-villemagne_l_argentiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34335-34600-villemagne_l_argentiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34335-34600-villemagne_l_argentiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34420-villeneuve_les_beziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34420-villeneuve_les_beziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34420-villeneuve_les_beziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34420-villeneuve_les_beziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34220-villeneuve_les_beziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34220-villeneuve_les_beziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34220-villeneuve_les_beziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34220-villeneuve_les_beziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34500-villeneuve_les_beziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34500-villeneuve_les_beziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34500-villeneuve_les_beziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34336-34500-villeneuve_les_beziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34337-34750-villeneuve_les_maguelone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34337-34750-villeneuve_les_maguelone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34337-34750-villeneuve_les_maguelone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34337-34750-villeneuve_les_maguelone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34338-34800-villeneuvette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34338-34800-villeneuvette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34338-34800-villeneuvette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34338-34800-villeneuvette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34339-34360-villespassans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34339-34360-villespassans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34339-34360-villespassans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34339-34360-villespassans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34340-34400-villetelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34340-34400-villetelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34340-34400-villetelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34340-34400-villetelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34341-34560-villeveyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34341-34560-villeveyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34341-34560-villeveyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34341-34560-villeveyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34342-34380-viols_en_laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34342-34380-viols_en_laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34342-34380-viols_en_laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34342-34380-viols_en_laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34343-34380-viols_le_fort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34343-34380-viols_le_fort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34343-34380-viols_le_fort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34343-34380-viols_le_fort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34344-34280-la_grande_motte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34344-34280-la_grande_motte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34344-34280-la_grande_motte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt34-herault/commune34344-34280-la_grande_motte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-35.xml
+++ b/public/sitemaps/sitemap-35.xml
@@ -5,682 +5,1360 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35001-35690-acigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35001-35690-acigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35001-35690-acigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35001-35690-acigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35002-35150-amanlis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35002-35150-amanlis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35002-35150-amanlis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35002-35150-amanlis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35003-35250-andouille_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35003-35250-andouille_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35003-35250-andouille_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35003-35250-andouille_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35004-35560-val_couesnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35004-35560-val_couesnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35004-35560-val_couesnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35004-35560-val_couesnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35004-35460-val_couesnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35004-35460-val_couesnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35004-35460-val_couesnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35004-35460-val_couesnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35005-35130-arbrissel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35005-35130-arbrissel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35005-35130-arbrissel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35005-35130-arbrissel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35006-35370-argentre_du_plessis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35006-35370-argentre_du_plessis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35006-35370-argentre_du_plessis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35006-35370-argentre_du_plessis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35007-35250-aubigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35007-35250-aubigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35007-35250-aubigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35007-35250-aubigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35008-35130-availles_sur_seiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35008-35130-availles_sur_seiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35008-35130-availles_sur_seiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35008-35130-availles_sur_seiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35009-35120-baguer_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35009-35120-baguer_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35009-35120-baguer_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35009-35120-baguer_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35010-35120-baguer_pican/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35010-35120-baguer_pican/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35010-35120-baguer_pican/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35010-35120-baguer_pican/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35012-35470-bain_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35012-35470-bain_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35012-35470-bain_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35012-35470-bain_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35013-35600-bains_sur_oust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35013-35600-bains_sur_oust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35013-35600-bains_sur_oust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35013-35600-bains_sur_oust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35014-35680-bais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35014-35680-bais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35014-35680-bais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35014-35680-bais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35015-35500-balaze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35015-35500-balaze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35015-35500-balaze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35015-35500-balaze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35016-35580-baulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35016-35580-baulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35016-35580-baulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35016-35580-baulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35017-35190-la_baussaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35017-35190-la_baussaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35017-35190-la_baussaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35017-35190-la_baussaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35018-35420-la_bazouge_du_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35018-35420-la_bazouge_du_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35018-35420-la_bazouge_du_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35018-35420-la_bazouge_du_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35019-35560-bazouges_la_perouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35019-35560-bazouges_la_perouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35019-35560-bazouges_la_perouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35019-35560-bazouges_la_perouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35021-35133-beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35021-35133-beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35021-35133-beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35021-35133-beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35022-35190-becherel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35022-35190-becherel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35022-35190-becherel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35022-35190-becherel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35023-35137-bedee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35023-35137-bedee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35023-35137-bedee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35023-35137-bedee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35024-35830-betton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35024-35830-betton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35024-35830-betton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35024-35830-betton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35025-35133-bille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35025-35133-bille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35025-35133-bille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35025-35133-bille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35026-35750-bleruais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35026-35750-bleruais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35026-35750-bleruais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35026-35750-bleruais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35027-35360-boisgervilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35027-35360-boisgervilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35027-35360-boisgervilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35027-35360-boisgervilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35028-35150-boistrudan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35028-35150-boistrudan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35028-35150-boistrudan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35028-35150-boistrudan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35029-35270-bonnemain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35029-35270-bonnemain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35029-35270-bonnemain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35029-35270-bonnemain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35030-35320-la_bosse_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35030-35320-la_bosse_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35030-35320-la_bosse_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35030-35320-la_bosse_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35031-35340-la_bouexiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35031-35340-la_bouexiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35031-35340-la_bouexiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35031-35340-la_bouexiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35032-35230-bourgbarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35032-35230-bourgbarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35032-35230-bourgbarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35032-35230-bourgbarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35033-35890-bourg_des_comptes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35033-35890-bourg_des_comptes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35033-35890-bourg_des_comptes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35033-35890-bourg_des_comptes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35034-35120-la_boussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35034-35120-la_boussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35034-35120-la_boussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35034-35120-la_boussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35035-35330-bovel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35035-35330-bovel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35035-35330-bovel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35035-35330-bovel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35037-35310-breal_sous_montfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35037-35310-breal_sous_montfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35037-35310-breal_sous_montfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35037-35310-breal_sous_montfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35038-35370-breal_sous_vitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35038-35370-breal_sous_vitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35038-35370-breal_sous_vitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35038-35370-breal_sous_vitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35039-35530-brece/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35039-35530-brece/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35039-35530-brece/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35039-35530-brece/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35040-35160-breteil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35040-35160-breteil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35040-35160-breteil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35040-35160-breteil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35041-35150-brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35041-35150-brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35041-35150-brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35041-35150-brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35042-35370-brielles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35042-35370-brielles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35042-35370-brielles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35042-35370-brielles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35044-35120-broualan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35044-35120-broualan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35044-35120-broualan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35044-35120-broualan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35045-35550-bruc_sur_aff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35045-35550-bruc_sur_aff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35045-35550-bruc_sur_aff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35045-35550-bruc_sur_aff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35046-35330-les_brulais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35046-35330-les_brulais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35046-35330-les_brulais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35046-35330-les_brulais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35047-35170-bruz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35047-35170-bruz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35047-35170-bruz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35047-35170-bruz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35049-35260-cancale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35049-35260-cancale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35049-35260-cancale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35049-35260-cancale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35050-35190-cardroc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35050-35190-cardroc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35050-35190-cardroc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35050-35190-cardroc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35051-35510-cesson_sevigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35051-35510-cesson_sevigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35051-35510-cesson_sevigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35051-35510-cesson_sevigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35052-35500-champeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35052-35500-champeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35052-35500-champeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35052-35500-champeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35054-35150-chanteloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35054-35150-chanteloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35054-35150-chanteloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35054-35150-chanteloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35055-35135-chantepie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35055-35135-chantepie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35055-35135-chantepie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35055-35135-chantepie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35056-35190-la_chapelle_aux_filtzmeens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35056-35190-la_chapelle_aux_filtzmeens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35056-35190-la_chapelle_aux_filtzmeens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35056-35190-la_chapelle_aux_filtzmeens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35057-35330-la_chapelle_bouexic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35057-35330-la_chapelle_bouexic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35057-35330-la_chapelle_bouexic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35057-35330-la_chapelle_bouexic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35058-35630-la_chapelle_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35058-35630-la_chapelle_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35058-35630-la_chapelle_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35058-35630-la_chapelle_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35059-35520-la_chapelle_des_fougeretz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35059-35520-la_chapelle_des_fougeretz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35059-35520-la_chapelle_des_fougeretz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35059-35520-la_chapelle_des_fougeretz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35060-35360-la_chapelle_du_lou_du_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35060-35360-la_chapelle_du_lou_du_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35060-35360-la_chapelle_du_lou_du_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35060-35360-la_chapelle_du_lou_du_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35061-35500-la_chapelle_erbree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35061-35500-la_chapelle_erbree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35061-35500-la_chapelle_erbree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35061-35500-la_chapelle_erbree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35062-35133-la_chapelle_janson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35062-35133-la_chapelle_janson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35062-35133-la_chapelle_janson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35062-35133-la_chapelle_janson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35063-35140-la_chapelle_saint_aubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35063-35140-la_chapelle_saint_aubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35063-35140-la_chapelle_saint_aubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35063-35140-la_chapelle_saint_aubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35064-35660-la_chapelle_de_brain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35064-35660-la_chapelle_de_brain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35064-35660-la_chapelle_de_brain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35064-35660-la_chapelle_de_brain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35065-35590-la_chapelle_thouarault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35065-35590-la_chapelle_thouarault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35065-35590-la_chapelle_thouarault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35065-35590-la_chapelle_thouarault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35066-35131-chartres_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35066-35131-chartres_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35066-35131-chartres_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35066-35131-chartres_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35067-35250-chasne_sur_illet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35067-35250-chasne_sur_illet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35067-35250-chasne_sur_illet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35067-35250-chasne_sur_illet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35068-35220-chateaubourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35068-35220-chateaubourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35068-35220-chateaubourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35068-35220-chateaubourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35069-35410-chateaugiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35069-35410-chateaugiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35069-35410-chateaugiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35069-35410-chateaugiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35070-35430-chateauneuf_d_ille_et_vilaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35070-35430-chateauneuf_d_ille_et_vilaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35070-35430-chateauneuf_d_ille_et_vilaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35070-35430-chateauneuf_d_ille_et_vilaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35071-35133-le_chatellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35071-35133-le_chatellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35071-35133-le_chatellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35071-35133-le_chatellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35072-35210-chatillon_en_vendelais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35072-35210-chatillon_en_vendelais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35072-35210-chatillon_en_vendelais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35072-35210-chatillon_en_vendelais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35075-35490-chauvigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35075-35490-chauvigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35075-35490-chauvigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35075-35490-chauvigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35076-35310-chavagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35076-35310-chavagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35076-35310-chavagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35076-35310-chavagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35077-35640-chelun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35077-35640-chelun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35077-35640-chelun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35077-35640-chelun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35078-35120-cherrueix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35078-35120-cherrueix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35078-35120-cherrueix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35078-35120-cherrueix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35079-35250-chevaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35079-35250-chevaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35079-35250-chevaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35079-35250-chevaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35080-35310-cintre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35080-35310-cintre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35080-35310-cintre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35080-35310-cintre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35081-35590-clayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35081-35590-clayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35081-35590-clayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35081-35590-clayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35082-35134-coesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35082-35134-coesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35082-35134-coesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35082-35134-coesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35084-35330-comblessac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35084-35330-comblessac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35084-35330-comblessac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35084-35330-comblessac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35085-35270-combourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35085-35270-combourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35085-35270-combourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35085-35270-combourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35086-35210-combourtille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35086-35210-combourtille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35086-35210-combourtille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35086-35210-combourtille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35087-35500-cornille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35087-35500-cornille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35087-35500-cornille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35087-35500-cornille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35088-35150-corps_nuds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35088-35150-corps_nuds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35088-35150-corps_nuds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35088-35150-corps_nuds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35089-35320-la_couyere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35089-35320-la_couyere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35089-35320-la_couyere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35089-35320-la_couyere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35090-35320-crevin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35090-35320-crevin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35090-35320-crevin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35090-35320-crevin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35091-35290-le_crouais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35091-35290-le_crouais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35091-35290-le_crouais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35091-35290-le_crouais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35092-35270-cuguen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35092-35270-cuguen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35092-35270-cuguen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35092-35270-cuguen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35093-35800-dinard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35093-35800-dinard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35093-35800-dinard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35093-35800-dinard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35094-35440-dinge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35094-35440-dinge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35094-35440-dinge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35094-35440-dinge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35095-35120-dol_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35095-35120-dol_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35095-35120-dol_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35095-35120-dol_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35096-35113-domagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35096-35113-domagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35096-35113-domagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35096-35113-domagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35097-35680-domalain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35097-35680-domalain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35097-35680-domalain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35097-35680-domalain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35098-35390-la_dominelais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35098-35390-la_dominelais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35098-35390-la_dominelais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35098-35390-la_dominelais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35099-35410-domloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35099-35410-domloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35099-35410-domloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35099-35410-domloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35101-35450-dourdain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35101-35450-dourdain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35101-35450-dourdain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35101-35450-dourdain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35102-35130-drouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35102-35130-drouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35102-35130-drouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35102-35130-drouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35103-35640-eance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35103-35640-eance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35103-35640-eance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35103-35640-eance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35104-35120-epiniac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35104-35120-epiniac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35104-35120-epiniac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35104-35120-epiniac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35105-35500-erbree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35105-35500-erbree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35105-35500-erbree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35105-35500-erbree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35106-35620-erce_en_lamee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35106-35620-erce_en_lamee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35106-35620-erce_en_lamee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35106-35620-erce_en_lamee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35107-35340-erce_pres_liffre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35107-35340-erce_pres_liffre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35107-35340-erce_pres_liffre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35107-35340-erce_pres_liffre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35108-35150-esse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35108-35150-esse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35108-35150-esse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35108-35150-esse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35109-35370-etrelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35109-35370-etrelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35109-35370-etrelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35109-35370-etrelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35110-35440-feins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35110-35440-feins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35110-35440-feins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35110-35440-feins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35111-35420-le_ferre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35111-35420-le_ferre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35111-35420-le_ferre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35111-35420-le_ferre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35112-35133-fleurigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35112-35133-fleurigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35112-35133-fleurigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35112-35133-fleurigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35114-35640-forges_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35114-35640-forges_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35114-35640-forges_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35114-35640-forges_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35115-35300-fougeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35115-35300-fougeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35115-35300-fougeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35115-35300-fougeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35116-35111-la_fresnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35116-35111-la_fresnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35116-35111-la_fresnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35116-35111-la_fresnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35117-35290-gael/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35117-35290-gael/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35117-35290-gael/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35117-35290-gael/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35118-35490-gahard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35118-35490-gahard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35118-35490-gahard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35118-35490-gahard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35119-35370-gennes_sur_seiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35119-35370-gennes_sur_seiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35119-35370-gennes_sur_seiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35119-35370-gennes_sur_seiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35120-35850-geveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35120-35850-geveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35120-35850-geveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35120-35850-geveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35121-35140-gosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35121-35140-gosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35121-35140-gosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35121-35140-gosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35122-35350-la_gouesniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35122-35350-la_gouesniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35122-35350-la_gouesniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35122-35350-la_gouesniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35123-35580-goven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35123-35580-goven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35123-35580-goven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35123-35580-goven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35124-35390-grand_fougeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35124-35390-grand_fougeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35124-35390-grand_fougeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35124-35390-grand_fougeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35125-35130-la_guerche_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35125-35130-la_guerche_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35125-35130-la_guerche_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35125-35130-la_guerche_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35126-35580-guichen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35126-35580-guichen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35126-35580-guichen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35126-35580-guichen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35127-35580-guignen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35127-35580-guignen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35127-35580-guignen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35127-35580-guignen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35128-35440-guipel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35128-35440-guipel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35128-35440-guipel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35128-35440-guipel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35130-35630-hede_bazouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35130-35630-hede_bazouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35130-35630-hede_bazouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35130-35630-hede_bazouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35131-35590-l_hermitage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35131-35590-l_hermitage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35131-35590-l_hermitage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35131-35590-l_hermitage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35132-35120-hirel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35132-35120-hirel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35132-35120-hirel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35132-35120-hirel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35133-35750-iffendic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35133-35750-iffendic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35133-35750-iffendic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35133-35750-iffendic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35134-35630-les_iffs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35134-35630-les_iffs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35134-35630-les_iffs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35134-35630-les_iffs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35135-35850-irodouer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35135-35850-irodouer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35135-35850-irodouer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35135-35850-irodouer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35136-35150-janze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35136-35150-janze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35136-35150-janze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35136-35150-janze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35137-35133-javene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35137-35133-javene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35137-35133-javene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35137-35133-javene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35138-35133-laignelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35138-35133-laignelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35138-35133-laignelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35138-35133-laignelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35139-35890-laille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35139-35890-laille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35139-35890-laille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35139-35890-laille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35140-35320-lalleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35140-35320-lalleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35140-35320-lalleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35140-35320-lalleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35141-35450-landavran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35141-35450-landavran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35141-35450-landavran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35141-35450-landavran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35142-35133-landean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35142-35133-landean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35142-35133-landean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35142-35133-landean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35143-35360-landujan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35143-35360-landujan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35143-35360-landujan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35143-35360-landujan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35144-35850-langan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35144-35850-langan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35144-35850-langan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35144-35850-langan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35145-35660-langon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35145-35660-langon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35145-35660-langon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35145-35660-langon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35146-35630-langouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35146-35630-langouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35146-35630-langouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35146-35630-langouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35148-35270-lanrigan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35148-35270-lanrigan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35148-35270-lanrigan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35148-35270-lanrigan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35149-35580-lassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35149-35580-lassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35149-35580-lassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35149-35580-lassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35150-35133-lecousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35150-35133-lecousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35150-35133-lecousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35150-35133-lecousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35151-35550-lieuron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35151-35550-lieuron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35151-35550-lieuron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35151-35550-lieuron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35152-35340-liffre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35152-35340-liffre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35152-35340-liffre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35152-35340-liffre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35153-35111-lillemer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35153-35111-lillemer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35153-35111-lillemer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35153-35111-lillemer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35154-35450-livre_sur_changeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35154-35450-livre_sur_changeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35154-35450-livre_sur_changeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35154-35450-livre_sur_changeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35155-35550-loheac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35155-35550-loheac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35155-35550-loheac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35155-35550-loheac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35156-35190-longaulnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35156-35190-longaulnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35156-35190-longaulnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35156-35190-longaulnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35157-35133-le_loroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35157-35133-le_loroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35157-35133-le_loroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35157-35133-le_loroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35159-35270-lourmais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35159-35270-lourmais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35159-35270-lourmais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35159-35270-lourmais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35160-35330-loutehel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35160-35330-loutehel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35160-35330-loutehel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35160-35330-loutehel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35161-35680-louvigne_de_bais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35161-35680-louvigne_de_bais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35161-35680-louvigne_de_bais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35161-35680-louvigne_de_bais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35162-35420-louvigne_du_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35162-35420-louvigne_du_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35162-35420-louvigne_du_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35162-35420-louvigne_du_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35163-35133-luitre_dompierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35163-35133-luitre_dompierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35163-35133-luitre_dompierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35163-35133-luitre_dompierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35163-35210-luitre_dompierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35163-35210-luitre_dompierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35163-35210-luitre_dompierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35163-35210-luitre_dompierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35164-35560-marcille_raoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35164-35560-marcille_raoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35164-35560-marcille_raoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35164-35560-marcille_raoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35165-35240-marcille_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35165-35240-marcille_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35165-35240-marcille_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35165-35240-marcille_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35166-35220-marpire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35166-35220-marpire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35166-35220-marpire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35166-35220-marpire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35167-35640-martigne_ferchaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35167-35640-martigne_ferchaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35167-35640-martigne_ferchaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35167-35640-martigne_ferchaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35168-35330-val_d_anast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35168-35330-val_d_anast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35168-35330-val_d_anast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35168-35330-val_d_anast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35169-35380-maxent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35169-35380-maxent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35169-35380-maxent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35169-35380-maxent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35170-35450-mece/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35170-35450-mece/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35170-35450-mece/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35170-35450-mece/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35171-35360-medreac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35171-35360-medreac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35171-35360-medreac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35171-35360-medreac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35172-35270-meillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35172-35270-meillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35172-35270-meillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35172-35270-meillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35173-35520-melesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35173-35520-melesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35173-35520-melesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35173-35520-melesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35174-35420-melle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35174-35420-melle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35174-35420-melle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35174-35420-melle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35175-35330-mernel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35175-35330-mernel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35175-35330-mernel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35175-35330-mernel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35176-35480-guipry_messac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35176-35480-guipry_messac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35176-35480-guipry_messac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35176-35480-guipry_messac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35177-35520-la_meziere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35177-35520-la_meziere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35177-35520-la_meziere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35177-35520-la_meziere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35178-35140-mezieres_sur_couesnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35178-35140-mezieres_sur_couesnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35178-35140-mezieres_sur_couesnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35178-35140-mezieres_sur_couesnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35179-35540-miniac_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35179-35540-miniac_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35179-35540-miniac_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35179-35540-miniac_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35180-35190-miniac_sous_becherel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35180-35190-miniac_sous_becherel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35180-35190-miniac_sous_becherel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35180-35190-miniac_sous_becherel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35181-35870-le_minihic_sur_rance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35181-35870-le_minihic_sur_rance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35181-35870-le_minihic_sur_rance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35181-35870-le_minihic_sur_rance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35183-35370-mondevert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35183-35370-mondevert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35183-35370-mondevert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35183-35370-mondevert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35184-35360-montauban_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35184-35360-montauban_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35184-35360-montauban_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35184-35360-montauban_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35185-35210-montautour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35185-35210-montautour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35185-35210-montautour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35185-35210-montautour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35186-35120-mont_dol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35186-35120-mont_dol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35186-35120-mont_dol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35186-35120-mont_dol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35187-35160-monterfil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35187-35160-monterfil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35187-35160-monterfil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35187-35160-monterfil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35188-35160-montfort_sur_meu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35188-35160-montfort_sur_meu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35188-35160-montfort_sur_meu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35188-35160-montfort_sur_meu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35189-35760-montgermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35189-35760-montgermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35189-35760-montgermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35189-35760-montgermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35190-35420-monthault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35190-35420-monthault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35190-35420-monthault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35190-35420-monthault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35191-35460-les_portes_du_coglais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35191-35460-les_portes_du_coglais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35191-35460-les_portes_du_coglais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35191-35460-les_portes_du_coglais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35192-35210-montreuil_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35192-35210-montreuil_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35192-35210-montreuil_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35192-35210-montreuil_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35193-35520-montreuil_le_gast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35193-35520-montreuil_le_gast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35193-35520-montreuil_le_gast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35193-35520-montreuil_le_gast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35194-35500-montreuil_sous_perouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35194-35500-montreuil_sous_perouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35194-35500-montreuil_sous_perouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35194-35500-montreuil_sous_perouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35195-35440-montreuil_sur_ille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35195-35440-montreuil_sur_ille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35195-35440-montreuil_sur_ille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35195-35440-montreuil_sur_ille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35196-35310-mordelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35196-35310-mordelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35196-35310-mordelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35196-35310-mordelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35197-35250-mouaze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35197-35250-mouaze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35197-35250-mouaze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35197-35250-mouaze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35198-35680-moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35198-35680-moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35198-35680-moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35198-35680-moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35199-35130-mousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35199-35130-mousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35199-35130-mousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35199-35130-mousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35200-35130-moutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35200-35130-moutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35200-35130-moutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35200-35130-moutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35201-35290-muel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35201-35290-muel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35201-35290-muel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35201-35290-muel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35202-35470-la_noe_blanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35202-35470-la_noe_blanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35202-35470-la_noe_blanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35202-35470-la_noe_blanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35203-35137-la_nouaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35203-35137-la_nouaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35203-35137-la_nouaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35203-35137-la_nouaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35204-35410-nouvoitou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35204-35410-nouvoitou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35204-35410-nouvoitou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35204-35410-nouvoitou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35205-35560-noyal_sous_bazouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35205-35560-noyal_sous_bazouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35205-35560-noyal_sous_bazouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35205-35560-noyal_sous_bazouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35206-35230-noyal_chatillon_sur_seiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35206-35230-noyal_chatillon_sur_seiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35206-35230-noyal_chatillon_sur_seiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35206-35230-noyal_chatillon_sur_seiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35207-35530-noyal_sur_vilaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35207-35530-noyal_sur_vilaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35207-35530-noyal_sur_vilaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35207-35530-noyal_sur_vilaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35208-35230-orgeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35208-35230-orgeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35208-35230-orgeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35208-35230-orgeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35210-35740-pace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35210-35740-pace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35210-35740-pace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35210-35740-pace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35211-35380-paimpont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35211-35380-paimpont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35211-35380-paimpont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35211-35380-paimpont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35212-35320-pance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35212-35320-pance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35212-35320-pance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35212-35320-pance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35214-35210-parce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35214-35210-parce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35214-35210-parce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35214-35210-parce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35215-35133-parigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35215-35133-parigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35215-35133-parigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35215-35133-parigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35216-35850-parthenay_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35216-35850-parthenay_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35216-35850-parthenay_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35216-35850-parthenay_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35217-35370-le_pertre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35217-35370-le_pertre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35217-35370-le_pertre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35217-35370-le_pertre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35218-35320-le_petit_fougeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35218-35320-le_petit_fougeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35218-35320-le_petit_fougeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35218-35320-le_petit_fougeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35219-35550-pipriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35219-35550-pipriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35219-35550-pipriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35219-35550-pipriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35220-35150-pire_chance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35220-35150-pire_chance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35220-35150-pire_chance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35220-35150-pire_chance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35220-35680-pire_chance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35220-35680-pire_chance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35220-35680-pire_chance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35220-35680-pire_chance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35221-35470-plechatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35221-35470-plechatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35221-35470-plechatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35221-35470-plechatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35222-35610-pleine_fougeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35222-35610-pleine_fougeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35222-35610-pleine_fougeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35222-35610-pleine_fougeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35223-35380-plelan_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35223-35380-plelan_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35223-35380-plelan_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35223-35380-plelan_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35224-35540-plerguer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35224-35540-plerguer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35224-35540-plerguer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35224-35540-plerguer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35225-35720-plesder/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35225-35720-plesder/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35225-35720-plesder/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35225-35720-plesder/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35226-35720-pleugueneuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35226-35720-pleugueneuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35226-35720-pleugueneuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35226-35720-pleugueneuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35227-35137-pleumeleuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35227-35137-pleumeleuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35227-35137-pleumeleuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35227-35137-pleumeleuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35228-35730-pleurtuit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35228-35730-pleurtuit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35228-35730-pleurtuit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35228-35730-pleurtuit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35229-35500-poce_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35229-35500-poce_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35229-35500-poce_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35229-35500-poce_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35230-35420-poilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35230-35420-poilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35230-35420-poilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35230-35420-poilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35231-35320-poligne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35231-35320-poligne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35231-35320-poligne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35231-35320-poligne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35232-35210-prince/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35232-35210-prince/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35232-35210-prince/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35232-35210-prince/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35233-35190-quebriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35233-35190-quebriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35233-35190-quebriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35233-35190-quebriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35234-35290-quedillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35234-35290-quedillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35234-35290-quedillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35234-35290-quedillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35235-35130-rannee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35235-35130-rannee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35235-35130-rannee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35235-35130-rannee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35236-35600-redon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35236-35600-redon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35236-35600-redon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35236-35600-redon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35237-35660-renac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35237-35660-renac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35237-35660-renac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35237-35660-renac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35000-rennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35000-rennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35000-rennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35000-rennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35700-rennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35700-rennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35700-rennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35700-rennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35200-rennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35200-rennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35200-rennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35238-35200-rennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35239-35240-retiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35239-35240-retiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35239-35240-retiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35239-35240-retiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35240-35650-le_rheu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35240-35650-le_rheu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35240-35650-le_rheu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35240-35650-le_rheu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35241-35780-la_richardais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35241-35780-la_richardais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35241-35780-la_richardais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35241-35780-la_richardais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35242-35560-rimou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35242-35560-rimou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35242-35560-rimou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35242-35560-rimou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35243-35133-romagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35243-35133-romagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35243-35133-romagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35243-35133-romagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35244-35490-romazy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35244-35490-romazy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35244-35490-romazy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35244-35490-romazy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35245-35850-romille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35245-35850-romille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35245-35850-romille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35245-35850-romille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35246-35120-roz_landrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35246-35120-roz_landrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35246-35120-roz_landrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35246-35120-roz_landrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35247-35610-roz_sur_couesnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35247-35610-roz_sur_couesnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35247-35610-roz_sur_couesnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35247-35610-roz_sur_couesnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35248-35610-sains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35248-35610-sains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35248-35610-sains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35248-35610-sains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35249-35390-sainte_anne_sur_vilaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35249-35390-sainte_anne_sur_vilaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35249-35390-sainte_anne_sur_vilaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35249-35390-sainte_anne_sur_vilaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35250-35230-saint_armel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35250-35230-saint_armel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35250-35230-saint_armel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35250-35230-saint_armel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35251-35250-saint_aubin_d_aubigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35251-35250-saint_aubin_d_aubigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35251-35250-saint_aubin_d_aubigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35251-35250-saint_aubin_d_aubigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35252-35500-saint_aubin_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35252-35500-saint_aubin_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35252-35500-saint_aubin_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35252-35500-saint_aubin_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35253-35140-saint_aubin_du_cormier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35253-35140-saint_aubin_du_cormier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35253-35140-saint_aubin_du_cormier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35253-35140-saint_aubin_du_cormier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35255-35114-saint_benoit_des_ondes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35255-35114-saint_benoit_des_ondes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35255-35114-saint_benoit_des_ondes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35255-35114-saint_benoit_des_ondes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35256-35800-saint_briac_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35256-35800-saint_briac_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35256-35800-saint_briac_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35256-35800-saint_briac_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35257-35460-maen_roch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35257-35460-maen_roch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35257-35460-maen_roch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35257-35460-maen_roch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35258-35630-saint_brieuc_des_iffs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35258-35630-saint_brieuc_des_iffs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35258-35630-saint_brieuc_des_iffs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35258-35630-saint_brieuc_des_iffs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35259-35120-saint_broladre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35259-35120-saint_broladre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35259-35120-saint_broladre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35259-35120-saint_broladre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35260-35210-saint_christophe_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35260-35210-saint_christophe_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35260-35210-saint_christophe_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35260-35210-saint_christophe_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35261-35140-saint_christophe_de_valains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35261-35140-saint_christophe_de_valains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35261-35140-saint_christophe_de_valains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35261-35140-saint_christophe_de_valains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35262-35134-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35262-35134-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35262-35134-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35262-35134-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35263-35350-saint_coulomb/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35263-35350-saint_coulomb/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35263-35350-saint_coulomb/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35263-35350-saint_coulomb/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35264-35220-saint_didier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35264-35220-saint_didier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35264-35220-saint_didier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35264-35220-saint_didier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35265-35190-saint_domineuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35265-35190-saint_domineuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35265-35190-saint_domineuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35265-35190-saint_domineuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35266-35230-saint_erblon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35266-35230-saint_erblon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35266-35230-saint_erblon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35266-35230-saint_erblon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35268-35550-saint_ganton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35268-35550-saint_ganton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35268-35550-saint_ganton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35268-35550-saint_ganton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35270-35610-saint_georges_de_grehaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35270-35610-saint_georges_de_grehaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35270-35610-saint_georges_de_grehaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35270-35610-saint_georges_de_grehaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35271-35420-saint_georges_de_reintembault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35271-35420-saint_georges_de_reintembault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35271-35420-saint_georges_de_reintembault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35271-35420-saint_georges_de_reintembault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35272-35370-saint_germain_du_pinel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35272-35370-saint_germain_du_pinel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35272-35370-saint_germain_du_pinel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35272-35370-saint_germain_du_pinel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35273-35133-saint_germain_en_cogles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35273-35133-saint_germain_en_cogles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35273-35133-saint_germain_en_cogles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35273-35133-saint_germain_en_cogles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35274-35250-saint_germain_sur_ille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35274-35250-saint_germain_sur_ille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35274-35250-saint_germain_sur_ille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35274-35250-saint_germain_sur_ille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35275-35590-saint_gilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35275-35590-saint_gilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35275-35590-saint_gilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35275-35590-saint_gilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35276-35630-saint_gondran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35276-35630-saint_gondran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35276-35630-saint_gondran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35276-35630-saint_gondran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35277-35750-saint_gonlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35277-35750-saint_gonlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35277-35750-saint_gonlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35277-35750-saint_gonlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35278-35760-saint_gregoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35278-35760-saint_gregoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35278-35760-saint_gregoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35278-35760-saint_gregoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35279-35430-saint_guinoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35279-35430-saint_guinoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35279-35430-saint_guinoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35279-35430-saint_guinoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35280-35140-saint_hilaire_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35280-35140-saint_hilaire_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35280-35140-saint_hilaire_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35280-35140-saint_hilaire_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35281-35136-saint_jacques_de_la_lande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35281-35136-saint_jacques_de_la_lande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35281-35136-saint_jacques_de_la_lande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35281-35136-saint_jacques_de_la_lande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35282-35140-rives_du_couesnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35282-35140-rives_du_couesnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35282-35140-rives_du_couesnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35282-35140-rives_du_couesnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35283-35220-saint_jean_sur_vilaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35283-35220-saint_jean_sur_vilaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35283-35220-saint_jean_sur_vilaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35283-35220-saint_jean_sur_vilaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35284-35430-saint_jouan_des_guerets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35284-35430-saint_jouan_des_guerets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35284-35430-saint_jouan_des_guerets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35284-35430-saint_jouan_des_guerets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35285-35550-saint_just/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35285-35550-saint_just/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35285-35550-saint_just/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35285-35550-saint_just/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35286-35270-saint_leger_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35286-35270-saint_leger_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35286-35270-saint_leger_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35286-35270-saint_leger_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35287-35800-saint_lunaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35287-35800-saint_lunaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35287-35800-saint_lunaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35287-35800-saint_lunaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35288-35400-saint_malo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35288-35400-saint_malo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35288-35400-saint_malo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35288-35400-saint_malo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35289-35480-saint_malo_de_phily/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35289-35480-saint_malo_de_phily/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35289-35480-saint_malo_de_phily/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35289-35480-saint_malo_de_phily/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35290-35750-saint_malon_sur_mel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35290-35750-saint_malon_sur_mel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35290-35750-saint_malon_sur_mel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35290-35750-saint_malon_sur_mel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35291-35120-saint_marcan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35291-35120-saint_marcan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35291-35120-saint_marcan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35291-35120-saint_marcan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35292-35460-saint_marc_le_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35292-35460-saint_marc_le_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35292-35460-saint_marc_le_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35292-35460-saint_marc_le_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35294-35600-sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35294-35600-sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35294-35600-sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35294-35600-sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35295-35750-saint_maugan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35295-35750-saint_maugan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35295-35750-saint_maugan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35295-35750-saint_maugan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35296-35250-saint_medard_sur_ille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35296-35250-saint_medard_sur_ille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35296-35250-saint_medard_sur_ille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35296-35250-saint_medard_sur_ille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35297-35290-saint_meen_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35297-35290-saint_meen_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35297-35290-saint_meen_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35297-35290-saint_meen_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35299-35350-saint_meloir_des_ondes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35299-35350-saint_meloir_des_ondes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35299-35350-saint_meloir_des_ondes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35299-35350-saint_meloir_des_ondes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35300-35500-saint_m_herve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35300-35500-saint_m_herve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35300-35500-saint_m_herve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35300-35500-saint_m_herve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35302-35290-saint_onen_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35302-35290-saint_onen_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35302-35290-saint_onen_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35302-35290-saint_onen_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35304-35140-saint_ouen_des_alleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35304-35140-saint_ouen_des_alleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35304-35140-saint_ouen_des_alleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35304-35140-saint_ouen_des_alleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35305-35380-saint_peran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35305-35380-saint_peran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35305-35380-saint_peran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35305-35380-saint_peran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35306-35430-saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35306-35430-saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35306-35430-saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35306-35430-saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35307-35190-saint_pern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35307-35190-saint_pern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35307-35190-saint_pern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35307-35190-saint_pern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35308-35720-mesnil_roc’h/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35308-35720-mesnil_roc’h/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35308-35720-mesnil_roc’h/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35308-35720-mesnil_roc’h/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35309-35560-saint_remy_du_plain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35309-35560-saint_remy_du_plain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35309-35560-saint_remy_du_plain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35309-35560-saint_remy_du_plain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35310-35133-saint_sauveur_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35310-35133-saint_sauveur_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35310-35133-saint_sauveur_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35310-35133-saint_sauveur_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35311-35330-saint_seglin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35311-35330-saint_seglin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35311-35330-saint_seglin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35311-35330-saint_seglin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35312-35580-saint_senoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35312-35580-saint_senoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35312-35580-saint_senoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35312-35580-saint_senoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35314-35430-saint_suliac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35314-35430-saint_suliac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35314-35430-saint_suliac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35314-35430-saint_suliac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35315-35250-saint_sulpice_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35315-35250-saint_sulpice_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35315-35250-saint_sulpice_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35315-35250-saint_sulpice_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35316-35390-saint_sulpice_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35316-35390-saint_sulpice_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35316-35390-saint_sulpice_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35316-35390-saint_sulpice_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35317-35630-saint_symphorien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35317-35630-saint_symphorien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35317-35630-saint_symphorien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35317-35630-saint_symphorien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35318-35190-saint_thual/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35318-35190-saint_thual/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35318-35190-saint_thual/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35318-35190-saint_thual/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35319-35310-saint_thurial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35319-35310-saint_thurial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35319-35310-saint_thurial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35319-35310-saint_thurial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35320-35360-saint_uniac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35320-35360-saint_uniac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35320-35360-saint_uniac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35320-35360-saint_uniac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35321-35320-saulnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35321-35320-saulnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35321-35320-saulnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35321-35320-saulnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35322-35320-le_sel_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35322-35320-le_sel_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35322-35320-le_sel_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35322-35320-le_sel_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35324-35133-la_selle_en_luitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35324-35133-la_selle_en_luitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35324-35133-la_selle_en_luitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35324-35133-la_selle_en_luitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35325-35130-la_selle_guerchaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35325-35130-la_selle_guerchaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35325-35130-la_selle_guerchaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35325-35130-la_selle_guerchaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35326-35490-sens_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35326-35490-sens_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35326-35490-sens_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35326-35490-sens_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35327-35530-servon_sur_vilaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35327-35530-servon_sur_vilaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35327-35530-servon_sur_vilaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35327-35530-servon_sur_vilaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35328-35550-sixt_sur_aff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35328-35550-sixt_sur_aff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35328-35550-sixt_sur_aff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35328-35550-sixt_sur_aff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35329-35610-sougeal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35329-35610-sougeal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35329-35610-sougeal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35329-35610-sougeal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35330-35500-taillis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35330-35500-taillis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35330-35500-taillis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35330-35500-taillis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35331-35160-talensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35331-35160-talensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35331-35160-talensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35331-35160-talensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35332-35620-teillay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35332-35620-teillay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35332-35620-teillay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35332-35620-teillay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35333-35240-le_theil_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35333-35240-le_theil_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35333-35240-le_theil_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35333-35240-le_theil_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35334-35235-thorigne_fouillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35334-35235-thorigne_fouillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35334-35235-thorigne_fouillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35334-35235-thorigne_fouillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35335-35134-thourie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35335-35134-thourie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35335-35134-thourie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35335-35134-thourie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35336-35460-le_tiercent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35336-35460-le_tiercent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35336-35460-le_tiercent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35336-35460-le_tiercent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35337-35190-tinteniac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35337-35190-tinteniac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35337-35190-tinteniac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35337-35190-tinteniac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35338-35370-torce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35338-35370-torce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35338-35370-torce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35338-35370-torce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35339-35610-trans_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35339-35610-trans_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35339-35610-trans_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35339-35610-trans_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35340-35380-treffendel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35340-35380-treffendel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35340-35380-treffendel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35340-35380-treffendel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35342-35270-tremeheuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35342-35270-tremeheuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35342-35270-tremeheuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35342-35270-tremeheuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35343-35320-tresboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35343-35320-tresboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35343-35320-tresboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35343-35320-tresboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35345-35190-treverien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35345-35190-treverien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35345-35190-treverien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35345-35190-treverien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35346-35190-trimer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35346-35190-trimer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35346-35190-trimer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35346-35190-trimer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35347-35450-val_d_ize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35347-35450-val_d_ize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35347-35450-val_d_ize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35347-35450-val_d_ize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35350-35680-vergeal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35350-35680-vergeal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35350-35680-vergeal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35350-35680-vergeal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35351-35160-le_verger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35351-35160-le_verger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35351-35160-le_verger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35351-35160-le_verger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35352-35770-vern_sur_seiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35352-35770-vern_sur_seiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35352-35770-vern_sur_seiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35352-35770-vern_sur_seiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35353-35132-vezin_le_coquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35353-35132-vezin_le_coquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35353-35132-vezin_le_coquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35353-35132-vezin_le_coquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35354-35610-vieux_viel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35354-35610-vieux_viel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35354-35610-vieux_viel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35354-35610-vieux_viel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35355-35490-vieux_vy_sur_couesnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35355-35490-vieux_vy_sur_couesnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35355-35490-vieux_vy_sur_couesnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35355-35490-vieux_vy_sur_couesnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35356-35630-vignoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35356-35630-vignoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35356-35630-vignoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35356-35630-vignoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35357-35420-villamee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35357-35420-villamee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35357-35420-villamee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35357-35420-villamee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35358-35430-la_ville_es_nonais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35358-35430-la_ville_es_nonais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35358-35430-la_ville_es_nonais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35358-35430-la_ville_es_nonais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35359-35130-visseiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35359-35130-visseiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35359-35130-visseiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35359-35130-visseiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35360-35500-vitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35360-35500-vitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35360-35500-vitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35360-35500-vitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35361-35960-le_vivier_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35361-35960-le_vivier_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35361-35960-le_vivier_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35361-35960-le_vivier_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35362-35540-le_tronchet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35362-35540-le_tronchet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35362-35540-le_tronchet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35362-35540-le_tronchet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35363-35131-pont_pean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35363-35131-pont_pean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35363-35131-pont_pean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt35-ille_et_vilaine/commune35363-35131-pont_pean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-36.xml
+++ b/public/sitemaps/sitemap-36.xml
@@ -5,490 +5,976 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36001-36140-aigurande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36001-36140-aigurande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36001-36140-aigurande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36001-36140-aigurande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36002-36150-aize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36002-36150-aize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36002-36150-aize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36002-36150-aize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36003-36120-ambrault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36003-36120-ambrault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36003-36120-ambrault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36003-36120-ambrault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36004-36210-anjouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36004-36210-anjouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36004-36210-anjouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36004-36210-anjouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36005-36120-ardentes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36005-36120-ardentes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36005-36120-ardentes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36005-36120-ardentes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36006-36200-argenton_sur_creuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36006-36200-argenton_sur_creuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36006-36200-argenton_sur_creuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36006-36200-argenton_sur_creuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36007-36500-argy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36007-36500-argy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36007-36500-argy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36007-36500-argy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36008-36700-arpheuilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36008-36700-arpheuilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36008-36700-arpheuilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36008-36700-arpheuilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36009-36330-arthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36009-36330-arthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36009-36330-arthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36009-36330-arthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36010-36290-azay_le_ferron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36010-36290-azay_le_ferron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36010-36290-azay_le_ferron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36010-36290-azay_le_ferron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36011-36210-bagneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36011-36210-bagneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36011-36210-bagneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36011-36210-bagneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36012-36270-baraize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36012-36270-baraize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36012-36270-baraize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36012-36270-baraize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36013-36110-baudres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36013-36110-baudres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36013-36110-baudres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36013-36110-baudres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36014-36270-bazaiges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36014-36270-bazaiges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36014-36270-bazaiges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36014-36270-bazaiges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36015-36310-beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36015-36310-beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36015-36310-beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36015-36310-beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36016-36370-belabre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36016-36370-belabre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36016-36370-belabre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36016-36370-belabre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36017-36400-la_berthenoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36017-36400-la_berthenoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36017-36400-la_berthenoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36017-36400-la_berthenoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36018-36300-le_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36018-36300-le_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36018-36300-le_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36018-36300-le_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36019-36120-bommiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36019-36120-bommiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36019-36120-bommiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36019-36120-bommiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36020-36310-bonneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36020-36310-bonneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36020-36310-bonneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36020-36310-bonneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36021-36100-les_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36021-36100-les_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36021-36100-les_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36021-36100-les_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36022-36200-bouesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36022-36200-bouesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36022-36200-bouesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36022-36200-bouesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36023-36110-bouges_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36023-36110-bouges_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36023-36110-bouges_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36023-36110-bouges_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36024-36110-bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36024-36110-bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36024-36110-bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36024-36110-bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36025-36400-briantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36025-36400-briantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36025-36400-briantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36025-36400-briantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36026-36110-brion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36026-36110-brion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36026-36110-brion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36026-36110-brion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36027-36100-brives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36027-36100-brives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36027-36100-brives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36027-36100-brives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36028-36140-la_buxerette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36028-36140-la_buxerette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36028-36140-la_buxerette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36028-36140-la_buxerette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36029-36150-buxeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36029-36150-buxeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36029-36150-buxeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36029-36150-buxeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36030-36230-buxieres_d_aillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36030-36230-buxieres_d_aillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36030-36230-buxieres_d_aillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36030-36230-buxieres_d_aillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36031-36500-buzancais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36031-36500-buzancais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36031-36500-buzancais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36031-36500-buzancais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36032-36200-ceaulmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36032-36200-ceaulmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36032-36200-ceaulmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36032-36200-ceaulmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36033-36200-celon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36033-36200-celon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36033-36200-celon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36033-36200-celon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36034-36210-chabris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36034-36210-chabris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36034-36210-chabris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36034-36210-chabris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36035-36310-chaillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36035-36310-chaillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36035-36310-chaillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36035-36310-chaillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36036-36370-chalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36036-36370-chalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36036-36370-chalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36036-36370-chalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36037-36100-la_champenoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36037-36100-la_champenoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36037-36100-la_champenoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36037-36100-la_champenoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36038-36160-champillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36038-36160-champillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36038-36160-champillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36038-36160-champillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36040-36500-la_chapelle_orthemale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36040-36500-la_chapelle_orthemale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36040-36500-la_chapelle_orthemale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36040-36500-la_chapelle_orthemale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36041-36150-la_chapelle_saint_laurian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36041-36150-la_chapelle_saint_laurian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36041-36150-la_chapelle_saint_laurian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36041-36150-la_chapelle_saint_laurian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36042-36800-chasseneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36042-36800-chasseneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36042-36800-chasseneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36042-36800-chasseneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36043-36400-chassignolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36043-36400-chassignolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36043-36400-chassignolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36043-36400-chassignolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36044-36000-chateauroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36044-36000-chateauroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36044-36000-chateauroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36044-36000-chateauroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36045-36700-chatillon_sur_indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36045-36700-chatillon_sur_indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36045-36700-chatillon_sur_indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36045-36700-chatillon_sur_indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36046-36400-la_chatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36046-36400-la_chatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36046-36400-la_chatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36046-36400-la_chatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36047-36170-la_chatre_langlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36047-36170-la_chatre_langlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36047-36170-la_chatre_langlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36047-36170-la_chatre_langlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36048-36200-chavin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36048-36200-chavin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36048-36200-chavin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36048-36200-chavin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36049-36170-chazelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36049-36170-chazelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36049-36170-chazelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36049-36170-chazelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36050-36500-chezelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36050-36500-chezelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36050-36500-chezelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36050-36500-chezelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36051-36800-chitray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36051-36800-chitray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36051-36800-chitray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36051-36800-chitray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36052-36100-chouday/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36052-36100-chouday/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36052-36100-chouday/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36052-36100-chouday/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36053-36300-ciron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36053-36300-ciron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36053-36300-ciron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36053-36300-ciron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36054-36700-clere_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36054-36700-clere_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36054-36700-clere_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36054-36700-clere_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36055-36700-clion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36055-36700-clion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36055-36700-clion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36055-36700-clion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36056-36340-cluis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36056-36340-cluis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36056-36340-cluis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36056-36340-cluis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36057-36130-coings/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36057-36130-coings/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36057-36130-coings/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36057-36130-coings/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36058-36300-concremiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36058-36300-concremiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36058-36300-concremiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36058-36300-concremiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36059-36100-conde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36059-36100-conde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36059-36100-conde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36059-36100-conde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36060-36140-crevant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36060-36140-crevant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36060-36140-crevant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36060-36140-crevant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36061-36140-crozon_sur_vauvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36061-36140-crozon_sur_vauvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36061-36140-crozon_sur_vauvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36061-36140-crozon_sur_vauvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36062-36190-cuzion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36062-36190-cuzion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36062-36190-cuzion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36062-36190-cuzion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36063-36130-deols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36063-36130-deols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36063-36130-deols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36063-36130-deols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36064-36130-diors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36064-36130-diors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36064-36130-diors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36064-36130-diors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36065-36260-diou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36065-36260-diou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36065-36260-diou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36065-36260-diou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36066-36300-douadic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36066-36300-douadic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36066-36300-douadic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36066-36300-douadic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36067-36310-dunet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36067-36310-dunet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36067-36310-dunet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36067-36310-dunet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36068-36210-dun_le_poelier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36068-36210-dun_le_poelier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36068-36210-dun_le_poelier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36068-36210-dun_le_poelier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36069-36240-ecueille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36069-36240-ecueille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36069-36240-ecueille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36069-36240-ecueille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36070-36270-eguzon_chantome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36070-36270-eguzon_chantome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36070-36270-eguzon_chantome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36070-36270-eguzon_chantome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36071-36120-etrechet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36071-36120-etrechet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36071-36120-etrechet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36071-36120-etrechet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36073-36160-feusines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36073-36160-feusines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36073-36160-feusines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36073-36160-feusines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36074-36700-flere_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36074-36700-flere_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36074-36700-flere_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36074-36700-flere_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36075-36150-fontenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36075-36150-fontenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36075-36150-fontenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36075-36150-fontenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36076-36220-fontgombault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36076-36220-fontgombault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36076-36220-fontgombault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36076-36220-fontgombault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36077-36600-fontguenand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36077-36600-fontguenand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36077-36600-fontguenand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36077-36600-fontguenand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36078-36230-fougerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36078-36230-fougerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36078-36230-fougerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36078-36230-fougerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36079-36110-francillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36079-36110-francillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36079-36110-francillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36079-36110-francillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36080-36180-fredille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36080-36180-fredille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36080-36180-fredille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36080-36180-fredille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36081-36190-gargilesse_dampierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36081-36190-gargilesse_dampierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36081-36190-gargilesse_dampierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36081-36190-gargilesse_dampierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36082-36240-gehee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36082-36240-gehee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36082-36240-gehee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36082-36240-gehee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36083-36150-giroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36083-36150-giroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36083-36150-giroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36083-36150-giroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36084-36230-gournay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36084-36230-gournay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36084-36230-gournay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36084-36230-gournay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36085-36150-guilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36085-36150-guilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36085-36150-guilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36085-36150-guilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36086-36180-heugnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36086-36180-heugnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36086-36180-heugnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36086-36180-heugnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36087-36300-ingrandes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36087-36300-ingrandes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36087-36300-ingrandes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36087-36300-ingrandes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36088-36100-issoudun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36088-36100-issoudun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36088-36100-issoudun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36088-36100-issoudun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36089-36120-jeu_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36089-36120-jeu_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36089-36120-jeu_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36089-36120-jeu_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36090-36240-jeu_maloches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36090-36240-jeu_maloches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36090-36240-jeu_maloches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36090-36240-jeu_maloches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36091-36400-lacs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36091-36400-lacs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36091-36400-lacs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36091-36400-lacs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36092-36600-lange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36092-36600-lange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36092-36600-lange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36092-36600-lange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36093-36110-levroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36093-36110-levroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36093-36110-levroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36093-36110-levroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36094-36370-lignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36094-36370-lignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36094-36370-lignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36094-36370-lignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36095-36160-lignerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36095-36160-lignerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36095-36160-lignerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36095-36160-lignerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36096-36220-linge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36096-36220-linge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36096-36220-linge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36096-36220-linge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36097-36150-liniez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36097-36150-liniez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36097-36150-liniez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36097-36150-liniez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36098-36100-lizeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36098-36100-lizeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36098-36100-lizeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36098-36100-lizeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36099-36140-lourdoueix_saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36099-36140-lourdoueix_saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36099-36140-lourdoueix_saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36099-36140-lourdoueix_saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36100-36400-lourouer_saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36100-36400-lourouer_saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36100-36400-lourouer_saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36100-36400-lourouer_saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36101-36350-luant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36101-36350-luant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36101-36350-luant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36101-36350-luant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36102-36150-lucay_le_libre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36102-36150-lucay_le_libre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36102-36150-lucay_le_libre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36102-36150-lucay_le_libre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36103-36360-lucay_le_male/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36103-36360-lucay_le_male/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36103-36360-lucay_le_male/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36103-36360-lucay_le_male/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36104-36220-lurais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36104-36220-lurais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36104-36220-lurais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36104-36220-lurais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36105-36220-lureuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36105-36220-lureuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36105-36220-lureuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36105-36220-lureuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36106-36800-luzeret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36106-36800-luzeret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36106-36800-luzeret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36106-36800-luzeret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36107-36600-lye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36107-36600-lye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36107-36600-lye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36107-36600-lye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36108-36230-lys_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36108-36230-lys_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36108-36230-lys_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36108-36230-lys_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36109-36400-le_magny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36109-36400-le_magny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36109-36400-le_magny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36109-36400-le_magny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36110-36340-maillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36110-36340-maillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36110-36340-maillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36110-36340-maillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36111-36340-malicornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36111-36340-malicornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36111-36340-malicornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36111-36340-malicornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36112-36120-maron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36112-36120-maron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36112-36120-maron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36112-36120-maron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36113-36220-martizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36113-36220-martizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36113-36220-martizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36113-36220-martizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36114-36370-mauvieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36114-36370-mauvieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36114-36370-mauvieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36114-36370-mauvieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36115-36210-menetou_sur_nahon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36115-36210-menetou_sur_nahon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36115-36210-menetou_sur_nahon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36115-36210-menetou_sur_nahon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36116-36150-menetreols_sous_vatan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36116-36150-menetreols_sous_vatan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36116-36150-menetreols_sous_vatan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36116-36150-menetreols_sous_vatan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36117-36200-le_menoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36117-36200-le_menoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36117-36200-le_menoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36117-36200-le_menoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36118-36500-meobecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36118-36500-meobecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36118-36500-meobecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36118-36500-meobecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36119-36220-merigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36119-36220-merigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36119-36220-merigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36119-36220-merigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36120-36230-mers_sur_indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36120-36230-mers_sur_indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36120-36230-mers_sur_indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36120-36230-mers_sur_indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36121-36100-meunet_planches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36121-36100-meunet_planches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36121-36100-meunet_planches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36121-36100-meunet_planches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36122-36150-meunet_sur_vatan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36122-36150-meunet_sur_vatan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36122-36150-meunet_sur_vatan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36122-36150-meunet_sur_vatan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36123-36290-mezieres_en_brenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36123-36290-mezieres_en_brenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36123-36290-mezieres_en_brenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36123-36290-mezieres_en_brenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36124-36800-migne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36124-36800-migne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36124-36800-migne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36124-36800-migne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36125-36260-migny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36125-36260-migny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36125-36260-migny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36125-36260-migny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36126-36140-montchevrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36126-36140-montchevrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36126-36140-montchevrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36126-36140-montchevrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36127-36400-montgivray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36127-36400-montgivray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36127-36400-montgivray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36127-36400-montgivray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36128-36130-montierchaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36128-36130-montierchaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36128-36130-montierchaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36128-36130-montierchaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36129-36230-montipouret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36129-36230-montipouret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36129-36230-montipouret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36129-36230-montipouret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36130-36400-montlevicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36130-36400-montlevicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36130-36400-montlevicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36130-36400-montlevicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36131-36200-mosnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36131-36200-mosnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36131-36200-mosnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36131-36200-mosnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36132-36160-la_motte_feuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36132-36160-la_motte_feuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36132-36160-la_motte_feuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36132-36160-la_motte_feuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36133-36340-mouhers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36133-36340-mouhers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36133-36340-mouhers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36133-36340-mouhers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36134-36170-mouhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36134-36170-mouhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36134-36170-mouhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36134-36170-mouhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36135-36110-moulins_sur_cephons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36135-36110-moulins_sur_cephons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36135-36110-moulins_sur_cephons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36135-36110-moulins_sur_cephons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36136-36700-murs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36136-36700-murs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36136-36700-murs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36136-36700-murs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36137-36220-neons_sur_creuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36137-36220-neons_sur_creuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36137-36220-neons_sur_creuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36137-36220-neons_sur_creuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36138-36400-neret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36138-36400-neret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36138-36400-neret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36138-36400-neret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36139-36500-neuillay_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36139-36500-neuillay_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36139-36500-neuillay_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36139-36500-neuillay_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36140-36100-neuvy_pailloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36140-36100-neuvy_pailloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36140-36100-neuvy_pailloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36140-36100-neuvy_pailloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36141-36230-neuvy_saint_sepulchre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36141-36230-neuvy_saint_sepulchre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36141-36230-neuvy_saint_sepulchre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36141-36230-neuvy_saint_sepulchre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36142-36250-niherne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36142-36250-niherne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36142-36250-niherne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36142-36250-niherne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36143-36400-nohant_vic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36143-36400-nohant_vic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36143-36400-nohant_vic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36143-36400-nohant_vic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36144-36800-nuret_le_ferron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36144-36800-nuret_le_ferron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36144-36800-nuret_le_ferron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36144-36800-nuret_le_ferron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36145-36290-obterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36145-36290-obterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36145-36290-obterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36145-36290-obterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36146-36190-orsennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36146-36190-orsennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36146-36190-orsennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36146-36190-orsennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36147-36210-orville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36147-36210-orville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36147-36210-orville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36147-36210-orville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36148-36800-oulches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36148-36800-oulches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36148-36800-oulches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36148-36800-oulches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36149-36500-palluau_sur_indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36149-36500-palluau_sur_indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36149-36500-palluau_sur_indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36149-36500-palluau_sur_indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36150-36170-parnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36150-36170-parnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36150-36170-parnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36150-36170-parnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36152-36260-paudy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36152-36260-paudy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36152-36260-paudy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36152-36260-paudy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36153-36290-paulnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36153-36290-paulnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36153-36290-paulnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36153-36290-paulnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36154-36200-le_pechereau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36154-36200-le_pechereau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36154-36200-le_pechereau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36154-36200-le_pechereau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36155-36180-pellevoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36155-36180-pellevoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36155-36180-pellevoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36155-36180-pellevoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36156-36160-perassay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36156-36160-perassay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36156-36160-perassay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36156-36160-perassay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36157-36350-la_perouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36157-36350-la_perouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36157-36350-la_perouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36157-36350-la_perouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36158-36200-badecon_le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36158-36200-badecon_le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36158-36200-badecon_le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36158-36200-badecon_le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36159-36330-le_poinconnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36159-36330-le_poinconnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36159-36330-le_poinconnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36159-36330-le_poinconnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36160-36190-pommiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36160-36190-pommiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36160-36190-pommiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36160-36190-pommiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36161-36800-le_pont_chretien_chabenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36161-36800-le_pont_chretien_chabenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36161-36800-le_pont_chretien_chabenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36161-36800-le_pont_chretien_chabenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36162-36210-poulaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36162-36210-poulaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36162-36210-poulaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36162-36210-poulaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36163-36160-pouligny_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36163-36160-pouligny_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36163-36160-pouligny_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36163-36160-pouligny_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36164-36160-pouligny_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36164-36160-pouligny_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36164-36160-pouligny_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36164-36160-pouligny_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36165-36300-pouligny_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36165-36300-pouligny_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36165-36300-pouligny_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36165-36300-pouligny_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36166-36240-preaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36166-36240-preaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36166-36240-preaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36166-36240-preaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36167-36220-preuilly_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36167-36220-preuilly_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36167-36220-preuilly_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36167-36220-preuilly_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36168-36370-prissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36168-36370-prissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36168-36370-prissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36168-36370-prissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36169-36120-pruniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36169-36120-pruniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36169-36120-pruniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36169-36120-pruniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36170-36150-reboursin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36170-36150-reboursin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36170-36150-reboursin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36170-36150-reboursin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36171-36260-reuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36171-36260-reuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36171-36260-reuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36171-36260-reuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36172-36800-rivarennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36172-36800-rivarennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36172-36800-rivarennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36172-36800-rivarennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36173-36300-rosnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36173-36300-rosnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36173-36300-rosnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36173-36300-rosnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36174-36170-roussines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36174-36170-roussines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36174-36170-roussines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36174-36170-roussines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36175-36110-rouvres_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36175-36110-rouvres_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36175-36110-rouvres_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36175-36110-rouvres_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36176-36300-ruffec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36176-36300-ruffec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36176-36300-ruffec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36176-36300-ruffec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36177-36170-sacierges_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36177-36170-sacierges_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36177-36170-sacierges_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36177-36170-sacierges_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36178-36300-saint_aigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36178-36300-saint_aigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36178-36300-saint_aigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36178-36300-saint_aigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36179-36100-saint_aoustrille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36179-36100-saint_aoustrille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36179-36100-saint_aoustrille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36179-36100-saint_aoustrille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36180-36120-saint_aout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36180-36120-saint_aout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36180-36120-saint_aout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36180-36120-saint_aout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36181-36100-saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36181-36100-saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36181-36100-saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36181-36100-saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36182-36170-saint_benoit_du_sault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36182-36170-saint_benoit_du_sault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36182-36170-saint_benoit_du_sault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36182-36170-saint_benoit_du_sault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36184-36400-saint_chartier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36184-36400-saint_chartier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36184-36400-saint_chartier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36184-36400-saint_chartier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36185-36210-saint_christophe_en_bazelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36185-36210-saint_christophe_en_bazelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36185-36210-saint_christophe_en_bazelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36185-36210-saint_christophe_en_bazelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36186-36400-saint_christophe_en_boucherie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36186-36400-saint_christophe_en_boucherie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36186-36400-saint_christophe_en_boucherie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36186-36400-saint_christophe_en_boucherie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36187-36170-saint_civran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36187-36170-saint_civran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36187-36170-saint_civran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36187-36170-saint_civran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36188-36700-saint_cyran_du_jambot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36188-36700-saint_cyran_du_jambot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36188-36700-saint_cyran_du_jambot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36188-36700-saint_cyran_du_jambot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36189-36230-saint_denis_de_jouhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36189-36230-saint_denis_de_jouhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36189-36230-saint_denis_de_jouhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36189-36230-saint_denis_de_jouhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36190-36100-sainte_fauste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36190-36100-sainte_fauste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36190-36100-sainte_fauste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36190-36100-sainte_fauste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36191-36150-saint_florentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36191-36150-saint_florentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36191-36150-saint_florentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36191-36150-saint_florentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36192-36800-saint_gaultier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36192-36800-saint_gaultier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36192-36800-saint_gaultier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36192-36800-saint_gaultier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36193-36500-sainte_gemme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36193-36500-sainte_gemme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36193-36500-sainte_gemme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36193-36500-sainte_gemme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36194-36500-saint_genou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36194-36500-saint_genou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36194-36500-saint_genou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36194-36500-saint_genou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36195-36100-saint_georges_sur_arnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36195-36100-saint_georges_sur_arnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36195-36100-saint_georges_sur_arnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36195-36100-saint_georges_sur_arnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36196-36170-saint_gilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36196-36170-saint_gilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36196-36170-saint_gilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36196-36170-saint_gilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36197-36370-saint_hilaire_sur_benaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36197-36370-saint_hilaire_sur_benaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36197-36370-saint_hilaire_sur_benaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36197-36370-saint_hilaire_sur_benaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36198-36500-saint_lactencin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36198-36500-saint_lactencin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36198-36500-saint_lactencin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36198-36500-saint_lactencin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36199-36260-sainte_lizaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36199-36260-sainte_lizaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36199-36260-sainte_lizaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36199-36260-sainte_lizaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36200-36200-saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36200-36200-saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36200-36200-saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36200-36200-saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36202-36250-saint_maur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36202-36250-saint_maur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36202-36250-saint_maur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36202-36250-saint_maur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36203-36700-saint_medard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36203-36700-saint_medard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36203-36700-saint_medard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36203-36700-saint_medard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36204-36290-saint_michel_en_brenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36204-36290-saint_michel_en_brenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36204-36290-saint_michel_en_brenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36204-36290-saint_michel_en_brenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36205-36260-saint_pierre_de_jards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36205-36260-saint_pierre_de_jards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36205-36260-saint_pierre_de_jards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36205-36260-saint_pierre_de_jards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36207-36190-saint_plantaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36207-36190-saint_plantaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36207-36190-saint_plantaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36207-36190-saint_plantaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36208-36160-sainte_severe_sur_indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36208-36160-sainte_severe_sur_indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36208-36160-sainte_severe_sur_indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36208-36160-sainte_severe_sur_indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36209-36100-saint_valentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36209-36100-saint_valentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36209-36100-saint_valentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36209-36100-saint_valentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36210-36230-sarzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36210-36230-sarzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36210-36230-sarzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36210-36230-sarzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36211-36120-sassierges_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36211-36120-sassierges_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36211-36120-sassierges_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36211-36120-sassierges_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36212-36290-saulnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36212-36290-saulnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36212-36290-saulnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36212-36290-saulnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36213-36220-sauzelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36213-36220-sauzelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36213-36220-sauzelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36213-36220-sauzelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36214-36160-sazeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36214-36160-sazeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36214-36160-sazeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36214-36160-sazeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36215-36100-segry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36215-36100-segry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36215-36100-segry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36215-36100-segry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36216-36180-selles_sur_nahon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36216-36180-selles_sur_nahon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36216-36180-selles_sur_nahon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36216-36180-selles_sur_nahon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36217-36210-semblecay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36217-36210-semblecay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36217-36210-semblecay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36217-36210-semblecay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36218-36500-souge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36218-36500-souge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36218-36500-souge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36218-36500-souge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36219-36200-tendu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36219-36200-tendu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36219-36200-tendu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36219-36200-tendu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36220-36800-thenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36220-36800-thenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36220-36800-thenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36220-36800-thenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36221-36400-thevet_saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36221-36400-thevet_saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36221-36400-thevet_saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36221-36400-thevet_saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36222-36100-thizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36222-36100-thizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36222-36100-thizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36222-36100-thizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36223-36310-tilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36223-36310-tilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36223-36310-tilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36223-36310-tilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36224-36220-tournon_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36224-36220-tournon_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36224-36220-tournon_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36224-36220-tournon_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36225-36700-le_tranger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36225-36700-le_tranger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36225-36700-le_tranger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36225-36700-le_tranger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36226-36230-tranzault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36226-36230-tranzault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36226-36230-tranzault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36226-36230-tranzault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36227-36160-urciers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36227-36160-urciers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36227-36160-urciers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36227-36160-urciers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36228-36600-valencay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36228-36600-valencay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36228-36600-valencay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36228-36600-valencay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36229-36210-val_fouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36229-36210-val_fouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36229-36210-val_fouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36229-36210-val_fouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36230-36150-vatan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36230-36150-vatan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36230-36150-vatan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36230-36150-vatan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36231-36330-velles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36231-36330-velles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36231-36330-velles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36231-36330-velles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36232-36500-vendoeuvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36232-36500-vendoeuvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36232-36500-vendoeuvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36232-36500-vendoeuvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36233-36600-la_vernelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36233-36600-la_vernelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36233-36600-la_vernelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36233-36600-la_vernelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36234-36400-verneuil_sur_igneraie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36234-36400-verneuil_sur_igneraie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36234-36400-verneuil_sur_igneraie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36234-36400-verneuil_sur_igneraie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36235-36600-veuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36235-36600-veuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36235-36600-veuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36235-36600-veuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36236-36400-vicq_exemplet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36236-36400-vicq_exemplet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36236-36400-vicq_exemplet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36236-36400-vicq_exemplet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36237-36600-vicq_sur_nahon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36237-36600-vicq_sur_nahon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36237-36600-vicq_sur_nahon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36237-36600-vicq_sur_nahon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36238-36160-vigoulant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36238-36160-vigoulant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36238-36160-vigoulant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36238-36160-vigoulant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36239-36170-vigoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36239-36170-vigoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36239-36170-vigoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36239-36170-vigoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36240-36160-vijon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36240-36160-vijon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36240-36160-vijon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36240-36160-vijon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36241-36320-villedieu_sur_indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36241-36320-villedieu_sur_indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36241-36320-villedieu_sur_indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36241-36320-villedieu_sur_indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36242-36110-villegongis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36242-36110-villegongis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36242-36110-villegongis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36242-36110-villegongis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36243-36500-villegouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36243-36500-villegouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36243-36500-villegouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36243-36500-villegouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36244-36600-villentrois_faverolles_en_berry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36244-36600-villentrois_faverolles_en_berry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36244-36600-villentrois_faverolles_en_berry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36244-36600-villentrois_faverolles_en_berry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36244-36360-villentrois_faverolles_en_berry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36244-36360-villentrois_faverolles_en_berry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36244-36360-villentrois_faverolles_en_berry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36244-36360-villentrois_faverolles_en_berry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36246-36290-villiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36246-36290-villiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36246-36290-villiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36246-36290-villiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36247-36110-vineuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36247-36110-vineuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36247-36110-vineuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36247-36110-vineuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36248-36100-vouillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36248-36100-vouillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36248-36100-vouillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt36-indre/commune36248-36100-vouillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-37.xml
+++ b/public/sitemaps/sitemap-37.xml
@@ -5,562 +5,1120 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37001-37160-abilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37001-37160-abilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37001-37160-abilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37001-37160-abilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37002-37340-ambillou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37002-37340-ambillou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37002-37340-ambillou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37002-37340-ambillou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37003-37400-amboise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37003-37400-amboise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37003-37400-amboise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37003-37400-amboise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37004-37500-anche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37004-37500-anche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37004-37500-anche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37004-37500-anche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37005-37800-antogny_le_tillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37005-37800-antogny_le_tillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37005-37800-antogny_le_tillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37005-37800-antogny_le_tillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37006-37260-artannes_sur_indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37006-37260-artannes_sur_indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37006-37260-artannes_sur_indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37006-37260-artannes_sur_indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37007-37120-assay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37007-37120-assay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37007-37120-assay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37007-37120-assay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37008-37270-athee_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37008-37270-athee_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37008-37270-athee_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37008-37270-athee_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37009-37110-autreche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37009-37110-autreche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37009-37110-autreche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37009-37110-autreche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37010-37110-auzouer_en_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37010-37110-auzouer_en_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37010-37110-auzouer_en_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37010-37110-auzouer_en_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37011-37420-avoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37011-37420-avoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37011-37420-avoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37011-37420-avoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37012-37220-avon_les_roches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37012-37220-avon_les_roches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37012-37220-avon_les_roches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37012-37220-avon_les_roches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37013-37340-avrille_les_ponceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37013-37340-avrille_les_ponceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37013-37340-avrille_les_ponceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37013-37340-avrille_les_ponceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37014-37190-azay_le_rideau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37014-37190-azay_le_rideau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37014-37190-azay_le_rideau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37014-37190-azay_le_rideau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37015-37270-azay_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37015-37270-azay_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37015-37270-azay_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37015-37270-azay_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37016-37310-azay_sur_indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37016-37310-azay_sur_indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37016-37310-azay_sur_indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37016-37310-azay_sur_indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37018-37510-ballan_mire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37018-37510-ballan_mire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37018-37510-ballan_mire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37018-37510-ballan_mire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37019-37350-barrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37019-37350-barrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37019-37350-barrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37019-37350-barrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37020-37600-beaulieu_les_loches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37020-37600-beaulieu_les_loches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37020-37600-beaulieu_les_loches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37020-37600-beaulieu_les_loches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37021-37360-beaumont_louestault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37021-37360-beaumont_louestault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37021-37360-beaumont_louestault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37021-37360-beaumont_louestault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37021-37370-beaumont_louestault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37021-37370-beaumont_louestault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37021-37370-beaumont_louestault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37021-37370-beaumont_louestault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37022-37420-beaumont_en_veron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37022-37420-beaumont_en_veron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37022-37420-beaumont_en_veron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37022-37420-beaumont_en_veron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37023-37460-beaumont_village/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37023-37460-beaumont_village/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37023-37460-beaumont_village/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37023-37460-beaumont_village/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37024-37140-benais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37024-37140-benais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37024-37140-benais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37024-37140-benais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37025-37510-berthenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37025-37510-berthenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37025-37510-berthenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37025-37510-berthenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37026-37600-betz_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37026-37600-betz_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37026-37600-betz_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37026-37600-betz_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37027-37150-blere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37027-37150-blere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37027-37150-blere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37027-37150-blere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37028-37290-bossay_sur_claise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37028-37290-bossay_sur_claise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37028-37290-bossay_sur_claise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37028-37290-bossay_sur_claise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37029-37240-bossee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37029-37240-bossee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37029-37240-bossee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37029-37240-bossee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37030-37110-le_boulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37030-37110-le_boulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37030-37110-le_boulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37030-37110-le_boulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37031-37140-bourgueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37031-37140-bourgueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37031-37140-bourgueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37031-37140-bourgueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37032-37240-bournan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37032-37240-bournan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37032-37240-bournan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37032-37240-bournan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37033-37290-boussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37033-37290-boussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37033-37290-boussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37033-37290-boussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37034-37120-braslou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37034-37120-braslou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37034-37120-braslou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37034-37120-braslou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37035-37120-braye_sous_faye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37035-37120-braye_sous_faye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37035-37120-braye_sous_faye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37035-37120-braye_sous_faye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37036-37330-braye_sur_maulne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37036-37330-braye_sur_maulne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37036-37330-braye_sur_maulne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37036-37330-braye_sur_maulne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37037-37330-breches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37037-37330-breches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37037-37330-breches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37037-37330-breches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37038-37130-brehemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37038-37130-brehemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37038-37130-brehemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37038-37130-brehemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37039-37600-bridore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37039-37600-bridore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37039-37600-bridore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37039-37600-bridore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37040-37220-brizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37040-37220-brizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37040-37220-brizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37040-37220-brizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37041-37370-bueil_en_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37041-37370-bueil_en_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37041-37370-bueil_en_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37041-37370-bueil_en_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37042-37500-candes_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37042-37500-candes_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37042-37500-candes_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37042-37500-candes_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37043-37530-cangey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37043-37530-cangey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37043-37530-cangey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37043-37530-cangey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37044-37350-la_celle_guenand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37044-37350-la_celle_guenand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37044-37350-la_celle_guenand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37044-37350-la_celle_guenand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37045-37160-la_celle_saint_avant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37045-37160-la_celle_saint_avant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37045-37160-la_celle_saint_avant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37045-37160-la_celle_saint_avant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37046-37460-cere_la_ronde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37046-37460-cere_la_ronde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37046-37460-cere_la_ronde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37046-37460-cere_la_ronde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37047-37390-cerelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37047-37390-cerelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37047-37390-cerelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37047-37390-cerelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37048-37290-chambon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37048-37290-chambon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37048-37290-chambon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37048-37290-chambon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37049-37310-chambourg_sur_indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37049-37310-chambourg_sur_indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37049-37310-chambourg_sur_indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37049-37310-chambourg_sur_indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37050-37170-chambray_les_tours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37050-37170-chambray_les_tours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37050-37170-chambray_les_tours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37050-37170-chambray_les_tours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37051-37120-champigny_sur_veude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37051-37120-champigny_sur_veude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37051-37120-champigny_sur_veude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37051-37120-champigny_sur_veude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37052-37210-chancay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37052-37210-chancay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37052-37210-chancay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37052-37210-chancay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37053-37600-chanceaux_pres_loches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37053-37600-chanceaux_pres_loches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37053-37600-chanceaux_pres_loches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37053-37600-chanceaux_pres_loches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37054-37390-chanceaux_sur_choisille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37054-37390-chanceaux_sur_choisille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37054-37390-chanceaux_sur_choisille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37054-37390-chanceaux_sur_choisille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37055-37330-channay_sur_lathan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37055-37330-channay_sur_lathan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37055-37330-channay_sur_lathan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37055-37330-channay_sur_lathan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37056-37130-la_chapelle_aux_naux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37056-37130-la_chapelle_aux_naux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37056-37130-la_chapelle_aux_naux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37056-37130-la_chapelle_aux_naux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37057-37240-la_chapelle_blanche_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37057-37240-la_chapelle_blanche_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37057-37240-la_chapelle_blanche_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37057-37240-la_chapelle_blanche_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37058-37140-la_chapelle_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37058-37140-la_chapelle_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37058-37140-la_chapelle_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37058-37140-la_chapelle_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37059-37390-charentilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37059-37390-charentilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37059-37390-charentilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37059-37390-charentilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37060-37530-charge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37060-37530-charge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37060-37530-charge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37060-37530-charge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37061-37290-charnizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37061-37290-charnizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37061-37290-charnizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37061-37290-charnizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37062-37330-chateau_la_valliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37062-37330-chateau_la_valliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37062-37330-chateau_la_valliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37062-37330-chateau_la_valliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37063-37110-chateau_renault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37063-37110-chateau_renault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37063-37110-chateau_renault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37063-37110-chateau_renault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37064-37350-chaumussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37064-37350-chaumussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37064-37350-chaumussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37064-37350-chaumussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37065-37120-chaveignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37065-37120-chaveignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37065-37120-chaveignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37065-37120-chaveignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37066-37310-chedigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37066-37310-chedigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37066-37310-chedigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37066-37310-chedigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37067-37190-cheille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37067-37190-cheille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37067-37190-cheille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37067-37190-cheille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37068-37370-chemille_sur_deme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37068-37370-chemille_sur_deme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37068-37370-chemille_sur_deme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37068-37370-chemille_sur_deme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37069-37460-chemille_sur_indrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37069-37460-chemille_sur_indrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37069-37460-chemille_sur_indrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37069-37460-chemille_sur_indrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37070-37150-chenonceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37070-37150-chenonceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37070-37150-chenonceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37070-37150-chenonceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37071-37220-chezelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37071-37220-chezelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37071-37220-chezelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37071-37220-chezelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37071-37120-chezelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37071-37120-chezelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37071-37120-chezelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37071-37120-chezelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37072-37500-chinon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37072-37500-chinon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37072-37500-chinon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37072-37500-chinon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37073-37150-chisseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37073-37150-chisseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37073-37150-chisseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37073-37150-chisseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37074-37140-chouze_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37074-37140-chouze_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37074-37140-chouze_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37074-37140-chouze_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37075-37310-cigogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37075-37310-cigogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37075-37310-cigogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37075-37310-cigogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37076-37500-cinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37076-37500-cinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37076-37500-cinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37076-37500-cinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37077-37130-cinq_mars_la_pile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37077-37130-cinq_mars_la_pile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37077-37130-cinq_mars_la_pile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37077-37130-cinq_mars_la_pile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37078-37240-ciran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37078-37240-ciran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37078-37240-ciran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37078-37240-ciran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37079-37150-civray_de_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37079-37150-civray_de_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37079-37150-civray_de_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37079-37150-civray_de_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37080-37160-civray_sur_esves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37080-37160-civray_sur_esves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37080-37160-civray_sur_esves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37080-37160-civray_sur_esves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37081-37340-clere_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37081-37340-clere_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37081-37340-clere_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37081-37340-clere_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37082-37340-continvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37082-37340-continvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37082-37340-continvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37082-37340-continvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37083-37320-cormery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37083-37320-cormery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37083-37320-cormery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37083-37320-cormery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37084-37330-couesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37084-37330-couesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37084-37330-couesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37084-37330-couesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37085-37310-courcay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37085-37310-courcay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37085-37310-courcay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37085-37310-courcay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37086-37330-courcelles_de_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37086-37330-courcelles_de_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37086-37330-courcelles_de_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37086-37330-courcelles_de_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37087-37120-courcoue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37087-37120-courcoue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37087-37120-courcoue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37087-37120-courcoue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37088-37500-couziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37088-37500-couziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37088-37500-couziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37088-37500-couziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37089-37500-cravant_les_coteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37089-37500-cravant_les_coteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37089-37500-cravant_les_coteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37089-37500-cravant_les_coteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37090-37220-crissay_sur_manse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37090-37220-crissay_sur_manse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37090-37220-crissay_sur_manse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37090-37220-crissay_sur_manse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37091-37150-la_croix_en_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37091-37150-la_croix_en_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37091-37150-la_croix_en_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37091-37150-la_croix_en_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37092-37380-crotelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37092-37380-crotelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37092-37380-crotelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37092-37380-crotelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37093-37220-crouzilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37093-37220-crouzilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37093-37220-crouzilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37093-37220-crouzilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37094-37240-cussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37094-37240-cussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37094-37240-cussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37094-37240-cussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37095-37110-dame_marie_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37095-37110-dame_marie_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37095-37110-dame_marie_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37095-37110-dame_marie_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37096-37150-dierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37096-37150-dierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37096-37150-dierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37096-37150-dierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37097-37310-dolus_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37097-37310-dolus_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37097-37310-dolus_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37097-37310-dolus_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37098-37800-drache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37098-37800-drache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37098-37800-drache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37098-37800-drache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37099-37190-druye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37099-37190-druye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37099-37190-druye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37099-37190-druye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37100-37150-epeigne_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37100-37150-epeigne_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37100-37150-epeigne_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37100-37150-epeigne_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37101-37370-epeigne_sur_deme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37101-37370-epeigne_sur_deme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37101-37370-epeigne_sur_deme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37101-37370-epeigne_sur_deme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37103-37240-esves_le_moutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37103-37240-esves_le_moutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37103-37240-esves_le_moutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37103-37240-esves_le_moutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37104-37320-esvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37104-37320-esvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37104-37320-esvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37104-37320-esvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37105-37120-faye_la_vineuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37105-37120-faye_la_vineuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37105-37120-faye_la_vineuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37105-37120-faye_la_vineuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37106-37110-la_ferriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37106-37110-la_ferriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37106-37110-la_ferriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37106-37110-la_ferriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37107-37350-ferriere_larcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37107-37350-ferriere_larcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37107-37350-ferriere_larcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37107-37350-ferriere_larcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37108-37600-ferriere_sur_beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37108-37600-ferriere_sur_beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37108-37600-ferriere_sur_beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37108-37600-ferriere_sur_beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37109-37230-fondettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37109-37230-fondettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37109-37230-fondettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37109-37230-fondettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37110-37150-francueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37110-37150-francueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37110-37150-francueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37110-37150-francueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37111-37460-genille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37111-37460-genille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37111-37460-genille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37111-37460-genille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37112-37340-gizeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37112-37340-gizeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37112-37340-gizeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37112-37340-gizeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37113-37350-le_grand_pressigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37113-37350-le_grand_pressigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37113-37350-le_grand_pressigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37113-37350-le_grand_pressigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37114-37350-la_guerche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37114-37350-la_guerche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37114-37350-la_guerche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37114-37350-la_guerche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37115-37160-descartes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37115-37160-descartes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37115-37160-descartes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37115-37160-descartes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37116-37110-les_hermites/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37116-37110-les_hermites/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37116-37110-les_hermites/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37116-37110-les_hermites/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37117-37340-hommes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37117-37340-hommes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37117-37340-hommes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37117-37340-hommes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37118-37420-huismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37118-37420-huismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37118-37420-huismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37118-37420-huismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37119-37220-l_ile_bouchard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37119-37220-l_ile_bouchard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37119-37220-l_ile_bouchard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37119-37220-l_ile_bouchard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37121-37120-jaulnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37121-37120-jaulnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37121-37120-jaulnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37121-37120-jaulnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37122-37300-joue_les_tours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37122-37300-joue_les_tours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37122-37300-joue_les_tours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37122-37300-joue_les_tours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37123-37130-langeais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37123-37130-langeais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37123-37130-langeais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37123-37130-langeais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37124-37270-larcay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37124-37270-larcay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37124-37270-larcay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37124-37270-larcay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37125-37120-lemere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37125-37120-lemere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37125-37120-lemere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37125-37120-lemere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37126-37500-lerne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37126-37500-lerne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37126-37500-lerne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37126-37500-lerne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37127-37460-le_liege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37127-37460-le_liege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37127-37460-le_liege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37127-37460-le_liege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37128-37130-lignieres_de_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37128-37130-lignieres_de_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37128-37130-lignieres_de_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37128-37130-lignieres_de_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37129-37500-ligre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37129-37500-ligre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37129-37500-ligre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37129-37500-ligre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37130-37240-ligueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37130-37240-ligueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37130-37240-ligueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37130-37240-ligueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37131-37530-limeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37131-37530-limeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37131-37530-limeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37131-37530-limeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37132-37600-loches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37132-37600-loches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37132-37600-loches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37132-37600-loches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37133-37460-loche_sur_indrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37133-37460-loche_sur_indrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37133-37460-loche_sur_indrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37133-37460-loche_sur_indrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37134-37320-louans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37134-37320-louans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37134-37320-louans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37134-37320-louans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37136-37240-le_louroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37136-37240-le_louroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37136-37240-le_louroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37136-37240-le_louroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37137-37330-luble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37137-37330-luble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37137-37330-luble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37137-37330-luble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37138-37400-lussault_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37138-37400-lussault_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37138-37400-lussault_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37138-37400-lussault_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37139-37230-luynes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37139-37230-luynes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37139-37230-luynes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37139-37230-luynes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37140-37120-luze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37140-37120-luze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37140-37120-luze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37140-37120-luze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37141-37150-luzille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37141-37150-luzille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37141-37150-luzille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37141-37150-luzille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37142-37800-maille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37142-37800-maille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37142-37800-maille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37142-37800-maille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37143-37240-manthelan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37143-37240-manthelan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37143-37240-manthelan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37143-37240-manthelan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37144-37500-marcay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37144-37500-marcay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37144-37500-marcay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37144-37500-marcay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37145-37160-marce_sur_esves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37145-37160-marce_sur_esves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37145-37160-marce_sur_esves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37145-37160-marce_sur_esves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37146-37330-marcilly_sur_maulne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37146-37330-marcilly_sur_maulne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37146-37330-marcilly_sur_maulne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37146-37330-marcilly_sur_maulne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37147-37800-marcilly_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37147-37800-marcilly_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37147-37800-marcilly_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37147-37800-marcilly_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37148-37120-marigny_marmande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37148-37120-marigny_marmande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37148-37120-marigny_marmande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37148-37120-marigny_marmande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37149-37370-marray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37149-37370-marray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37149-37370-marray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37149-37370-marray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37150-37130-mazieres_de_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37150-37130-mazieres_de_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37150-37130-mazieres_de_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37150-37130-mazieres_de_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37151-37390-la_membrolle_sur_choisille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37151-37390-la_membrolle_sur_choisille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37151-37390-la_membrolle_sur_choisille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37151-37390-la_membrolle_sur_choisille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37152-37390-mettray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37152-37390-mettray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37152-37390-mettray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37152-37390-mettray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37153-37380-monnaie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37153-37380-monnaie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37153-37380-monnaie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37153-37380-monnaie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37154-37250-montbazon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37154-37250-montbazon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37154-37250-montbazon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37154-37250-montbazon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37155-37110-monthodon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37155-37110-monthodon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37155-37110-monthodon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37155-37110-monthodon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37156-37270-montlouis_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37156-37270-montlouis_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37156-37270-montlouis_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37156-37270-montlouis_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37157-37460-montresor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37157-37460-montresor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37157-37460-montresor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37157-37460-montresor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37158-37530-montreuil_en_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37158-37530-montreuil_en_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37158-37530-montreuil_en_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37158-37530-montreuil_en_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37159-37260-monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37159-37260-monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37159-37260-monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37159-37260-monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37160-37110-morand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37160-37110-morand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37160-37110-morand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37160-37110-morand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37161-37530-mosnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37161-37530-mosnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37161-37530-mosnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37161-37530-mosnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37162-37600-mouzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37162-37600-mouzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37162-37600-mouzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37162-37600-mouzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37163-37530-nazelles_negron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37163-37530-nazelles_negron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37163-37530-nazelles_negron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37163-37530-nazelles_negron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37165-37190-neuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37165-37190-neuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37165-37190-neuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37165-37190-neuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37166-37380-neuille_le_lierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37166-37380-neuille_le_lierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37166-37380-neuille_le_lierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37166-37380-neuille_le_lierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37167-37360-neuille_pont_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37167-37360-neuille_pont_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37167-37360-neuille_pont_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37167-37360-neuille_pont_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37168-37160-neuilly_le_brignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37168-37160-neuilly_le_brignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37168-37160-neuilly_le_brignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37168-37160-neuilly_le_brignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37169-37110-neuville_sur_brenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37169-37110-neuville_sur_brenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37169-37110-neuville_sur_brenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37169-37110-neuville_sur_brenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37170-37370-neuvy_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37170-37370-neuvy_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37170-37370-neuvy_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37170-37370-neuvy_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37171-37210-noizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37171-37210-noizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37171-37210-noizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37171-37210-noizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37172-37390-notre_dame_d_oe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37172-37390-notre_dame_d_oe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37172-37390-notre_dame_d_oe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37172-37390-notre_dame_d_oe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37173-37460-nouans_les_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37173-37460-nouans_les_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37173-37460-nouans_les_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37173-37460-nouans_les_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37174-37800-nouatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37174-37800-nouatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37174-37800-nouatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37174-37800-nouatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37175-37380-nouzilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37175-37380-nouzilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37175-37380-nouzilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37175-37380-nouzilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37176-37800-noyant_de_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37176-37800-noyant_de_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37176-37800-noyant_de_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37176-37800-noyant_de_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37177-37460-orbigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37177-37460-orbigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37177-37460-orbigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37177-37460-orbigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37178-37220-panzoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37178-37220-panzoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37178-37220-panzoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37178-37220-panzoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37179-37210-parcay_meslay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37179-37210-parcay_meslay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37179-37210-parcay_meslay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37179-37210-parcay_meslay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37180-37220-parcay_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37180-37220-parcay_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37180-37220-parcay_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37180-37220-parcay_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37181-37350-paulmy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37181-37350-paulmy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37181-37350-paulmy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37181-37350-paulmy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37182-37230-pernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37182-37230-pernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37182-37230-pernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37182-37230-pernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37183-37600-perrusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37183-37600-perrusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37183-37600-perrusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37183-37600-perrusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37184-37350-le_petit_pressigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37184-37350-le_petit_pressigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37184-37350-le_petit_pressigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37184-37350-le_petit_pressigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37185-37530-poce_sur_cisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37185-37530-poce_sur_cisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37185-37530-poce_sur_cisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37185-37530-poce_sur_cisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37186-37260-pont_de_ruan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37186-37260-pont_de_ruan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37186-37260-pont_de_ruan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37186-37260-pont_de_ruan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37187-37800-ports/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37187-37800-ports/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37187-37800-ports/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37187-37800-ports/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37188-37800-pouzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37188-37800-pouzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37188-37800-pouzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37188-37800-pouzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37189-37290-preuilly_sur_claise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37189-37290-preuilly_sur_claise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37189-37290-preuilly_sur_claise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37189-37290-preuilly_sur_claise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37190-37800-pussigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37190-37800-pussigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37190-37800-pussigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37190-37800-pussigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37191-37120-razines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37191-37120-razines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37191-37120-razines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37191-37120-razines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37192-37310-reignac_sur_indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37192-37310-reignac_sur_indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37192-37310-reignac_sur_indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37192-37310-reignac_sur_indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37193-37140-restigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37193-37140-restigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37193-37140-restigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37193-37140-restigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37194-37380-reugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37194-37380-reugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37194-37380-reugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37194-37380-reugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37195-37520-la_riche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37195-37520-la_riche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37195-37520-la_riche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37195-37520-la_riche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37196-37120-richelieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37196-37120-richelieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37196-37120-richelieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37196-37120-richelieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37197-37420-rigny_usse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37197-37420-rigny_usse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37197-37420-rigny_usse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37197-37420-rigny_usse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37198-37340-rille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37198-37340-rille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37198-37340-rille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37198-37340-rille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37199-37220-rilly_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37199-37220-rilly_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37199-37220-rilly_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37199-37220-rilly_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37200-37190-rivarennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37200-37190-rivarennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37200-37190-rivarennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37200-37190-rivarennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37201-37500-riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37201-37500-riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37201-37500-riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37201-37500-riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37202-37500-la_roche_clermault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37202-37500-la_roche_clermault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37202-37500-la_roche_clermault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37202-37500-la_roche_clermault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37203-37210-rochecorbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37203-37210-rochecorbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37203-37210-rochecorbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37203-37210-rochecorbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37204-37360-rouziers_de_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37204-37360-rouziers_de_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37204-37360-rouziers_de_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37204-37360-rouziers_de_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37205-37190-sache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37205-37190-sache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37205-37190-sache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37205-37190-sache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37205-37260-sache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37205-37260-sache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37205-37260-sache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37205-37260-sache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37206-37360-saint_antoine_du_rocher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37206-37360-saint_antoine_du_rocher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37206-37360-saint_antoine_du_rocher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37206-37360-saint_antoine_du_rocher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37207-37370-saint_aubin_le_depeint/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37207-37370-saint_aubin_le_depeint/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37207-37370-saint_aubin_le_depeint/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37207-37370-saint_aubin_le_depeint/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37208-37550-saint_avertin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37208-37550-saint_avertin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37208-37550-saint_avertin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37208-37550-saint_avertin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37210-37500-saint_benoit_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37210-37500-saint_benoit_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37210-37500-saint_benoit_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37210-37500-saint_benoit_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37211-37320-saint_branchs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37211-37320-saint_branchs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37211-37320-saint_branchs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37211-37320-saint_branchs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37212-37800-sainte_catherine_de_fierbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37212-37800-sainte_catherine_de_fierbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37212-37800-sainte_catherine_de_fierbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37212-37800-sainte_catherine_de_fierbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37213-37370-saint_christophe_sur_le_nais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37213-37370-saint_christophe_sur_le_nais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37213-37370-saint_christophe_sur_le_nais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37213-37370-saint_christophe_sur_le_nais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37214-37540-saint_cyr_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37214-37540-saint_cyr_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37214-37540-saint_cyr_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37214-37540-saint_cyr_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37216-37800-saint_epain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37216-37800-saint_epain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37216-37800-saint_epain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37216-37800-saint_epain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37217-37230-saint_etienne_de_chigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37217-37230-saint_etienne_de_chigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37217-37230-saint_etienne_de_chigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37217-37230-saint_etienne_de_chigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37218-37600-saint_flovier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37218-37600-saint_flovier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37218-37600-saint_flovier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37218-37600-saint_flovier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37219-37510-saint_genouph/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37219-37510-saint_genouph/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37219-37510-saint_genouph/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37219-37510-saint_genouph/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37220-37500-saint_germain_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37220-37500-saint_germain_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37220-37500-saint_germain_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37220-37500-saint_germain_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37221-37600-saint_hippolyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37221-37600-saint_hippolyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37221-37600-saint_hippolyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37221-37600-saint_hippolyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37222-37600-saint_jean_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37222-37600-saint_jean_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37222-37600-saint_jean_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37222-37600-saint_jean_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37223-37330-saint_laurent_de_lin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37223-37330-saint_laurent_de_lin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37223-37330-saint_laurent_de_lin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37223-37330-saint_laurent_de_lin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37224-37380-saint_laurent_en_gatines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37224-37380-saint_laurent_en_gatines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37224-37380-saint_laurent_en_gatines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37224-37380-saint_laurent_en_gatines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37225-37270-saint_martin_le_beau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37225-37270-saint_martin_le_beau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37225-37270-saint_martin_le_beau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37225-37270-saint_martin_le_beau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37226-37800-sainte_maure_de_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37226-37800-sainte_maure_de_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37226-37800-sainte_maure_de_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37226-37800-sainte_maure_de_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37228-37140-saint_nicolas_de_bourgueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37228-37140-saint_nicolas_de_bourgueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37228-37140-saint_nicolas_de_bourgueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37228-37140-saint_nicolas_de_bourgueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37229-37110-saint_nicolas_des_motets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37229-37110-saint_nicolas_des_motets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37229-37110-saint_nicolas_des_motets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37229-37110-saint_nicolas_des_motets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37230-37530-saint_ouen_les_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37230-37530-saint_ouen_les_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37230-37530-saint_ouen_les_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37230-37530-saint_ouen_les_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37231-37370-saint_paterne_racan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37231-37370-saint_paterne_racan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37231-37370-saint_paterne_racan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37231-37370-saint_paterne_racan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37232-37130-coteaux_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37232-37130-coteaux_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37232-37130-coteaux_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37232-37130-coteaux_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37232-37140-coteaux_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37232-37140-coteaux_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37232-37140-coteaux_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37232-37140-coteaux_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37233-37700-saint_pierre_des_corps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37233-37700-saint_pierre_des_corps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37233-37700-saint_pierre_des_corps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37233-37700-saint_pierre_des_corps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37234-37310-saint_quentin_sur_indrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37234-37310-saint_quentin_sur_indrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37234-37310-saint_quentin_sur_indrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37234-37310-saint_quentin_sur_indrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37236-37530-saint_regle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37236-37530-saint_regle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37236-37530-saint_regle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37236-37530-saint_regle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37237-37390-saint_roch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37237-37390-saint_roch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37237-37390-saint_roch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37237-37390-saint_roch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37238-37600-saint_senoch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37238-37600-saint_senoch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37238-37600-saint_senoch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37238-37600-saint_senoch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37240-37110-saunay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37240-37110-saunay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37240-37110-saunay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37240-37110-saunay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37241-37340-savigne_sur_lathan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37241-37340-savigne_sur_lathan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37241-37340-savigne_sur_lathan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37241-37340-savigne_sur_lathan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37242-37420-savigny_en_veron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37242-37420-savigny_en_veron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37242-37420-savigny_en_veron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37242-37420-savigny_en_veron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37243-37510-savonnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37243-37510-savonnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37243-37510-savonnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37243-37510-savonnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37244-37220-sazilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37244-37220-sazilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37244-37220-sazilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37244-37220-sazilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37245-37360-semblancay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37245-37360-semblancay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37245-37360-semblancay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37245-37360-semblancay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37246-37600-sennevieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37246-37600-sennevieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37246-37600-sennevieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37246-37600-sennevieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37247-37800-sepmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37247-37800-sepmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37247-37800-sepmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37247-37800-sepmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37248-37500-seuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37248-37500-seuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37248-37500-seuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37248-37500-seuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37249-37360-sonzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37249-37360-sonzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37249-37360-sonzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37249-37360-sonzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37250-37250-sorigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37250-37250-sorigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37250-37250-sorigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37250-37250-sorigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37251-37330-souvigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37251-37330-souvigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37251-37330-souvigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37251-37330-souvigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37252-37530-souvigny_de_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37252-37530-souvigny_de_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37252-37530-souvigny_de_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37252-37530-souvigny_de_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37253-37310-sublaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37253-37310-sublaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37253-37310-sublaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37253-37310-sublaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37254-37310-tauxigny_saint_bauld/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37254-37310-tauxigny_saint_bauld/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37254-37310-tauxigny_saint_bauld/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37254-37310-tauxigny_saint_bauld/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37255-37220-tavant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37255-37220-tavant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37255-37220-tavant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37255-37220-tavant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37256-37220-theneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37256-37220-theneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37256-37220-theneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37256-37220-theneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37257-37260-thilouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37257-37260-thilouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37257-37260-thilouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37257-37260-thilouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37258-37500-thizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37258-37500-thizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37258-37500-thizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37258-37500-thizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37259-37290-tournon_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37259-37290-tournon_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37259-37290-tournon_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37259-37290-tournon_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37260-37120-la_tour_saint_gelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37260-37120-la_tour_saint_gelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37260-37120-la_tour_saint_gelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37260-37120-la_tour_saint_gelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37200-tours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37200-tours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37200-tours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37200-tours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37000-tours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37000-tours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37000-tours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37000-tours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37100-tours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37100-tours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37100-tours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37261-37100-tours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37262-37220-trogues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37262-37220-trogues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37262-37220-trogues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37262-37220-trogues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37263-37320-truyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37263-37320-truyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37263-37320-truyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37263-37320-truyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37264-37190-valleres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37264-37190-valleres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37264-37190-valleres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37264-37190-valleres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37265-37600-varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37265-37600-varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37265-37600-varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37265-37600-varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37266-37250-veigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37266-37250-veigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37266-37250-veigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37266-37250-veigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37267-37270-veretz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37267-37270-veretz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37267-37270-veretz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37267-37270-veretz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37268-37120-verneuil_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37268-37120-verneuil_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37268-37120-verneuil_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37268-37120-verneuil_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37269-37600-verneuil_sur_indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37269-37600-verneuil_sur_indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37269-37600-verneuil_sur_indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37269-37600-verneuil_sur_indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37270-37210-vernou_sur_brenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37270-37210-vernou_sur_brenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37270-37210-vernou_sur_brenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37270-37210-vernou_sur_brenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37271-37190-villaines_les_rochers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37271-37190-villaines_les_rochers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37271-37190-villaines_les_rochers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37271-37190-villaines_les_rochers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37272-37510-villandry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37272-37510-villandry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37272-37510-villandry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37272-37510-villandry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37273-37700-la_ville_aux_dames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37273-37700-la_ville_aux_dames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37273-37700-la_ville_aux_dames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37273-37700-la_ville_aux_dames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37274-37370-villebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37274-37370-villebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37274-37370-villebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37274-37370-villebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37275-37460-villedomain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37275-37460-villedomain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37275-37460-villedomain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37275-37460-villedomain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37276-37110-villedomer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37276-37110-villedomer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37276-37110-villedomer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37276-37110-villedomer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37277-37460-villeloin_coulange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37277-37460-villeloin_coulange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37277-37460-villeloin_coulange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37277-37460-villeloin_coulange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37278-37260-villeperdue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37278-37260-villeperdue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37278-37260-villeperdue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37278-37260-villeperdue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37279-37330-villiers_au_bouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37279-37330-villiers_au_bouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37279-37330-villiers_au_bouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37279-37330-villiers_au_bouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37280-37240-vou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37280-37240-vou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37280-37240-vou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37280-37240-vou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37281-37210-vouvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37281-37210-vouvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37281-37210-vouvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37281-37210-vouvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37282-37290-yzeures_sur_creuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37282-37290-yzeures_sur_creuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37282-37290-yzeures_sur_creuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt37-indre_et_loire/commune37282-37290-yzeures_sur_creuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-38.xml
+++ b/public/sitemaps/sitemap-38.xml
@@ -5,1054 +5,2104 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38001-38490-les_abrets_en_dauphine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38001-38490-les_abrets_en_dauphine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38001-38490-les_abrets_en_dauphine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38001-38490-les_abrets_en_dauphine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38002-38190-les_adrets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38002-38190-les_adrets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38002-38190-les_adrets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38002-38190-les_adrets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38003-38150-agnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38003-38150-agnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38003-38150-agnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38003-38150-agnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38004-38470-l_albenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38004-38470-l_albenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38004-38470-l_albenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38004-38470-l_albenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38005-38114-allemond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38005-38114-allemond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38005-38114-allemond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38005-38114-allemond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38006-38580-allevard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38006-38580-allevard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38006-38580-allevard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38006-38580-allevard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38008-38970-ambel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38008-38970-ambel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38008-38970-ambel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38008-38970-ambel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38009-38150-anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38009-38150-anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38009-38150-anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38009-38150-anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38010-38460-annoisin_chatelans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38010-38460-annoisin_chatelans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38010-38460-annoisin_chatelans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38010-38460-annoisin_chatelans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38011-38280-anthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38011-38280-anthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38011-38280-anthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38011-38280-anthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38012-38490-aoste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38012-38490-aoste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38012-38490-aoste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38012-38490-aoste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38013-38140-apprieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38013-38140-apprieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38013-38140-apprieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38013-38140-apprieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38015-38440-artas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38015-38440-artas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38015-38440-artas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38015-38440-artas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38017-38150-assieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38017-38150-assieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38017-38150-assieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38017-38150-assieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38018-38680-auberives_en_royans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38018-38680-auberives_en_royans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38018-38680-auberives_en_royans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38018-38680-auberives_en_royans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38019-38550-auberives_sur_vareze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38019-38550-auberives_sur_vareze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38019-38550-auberives_sur_vareze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38019-38550-auberives_sur_vareze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38020-38142-auris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38020-38142-auris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38020-38142-auris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38020-38142-auris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38022-38630-les_avenieres_veyrins_thuellin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38022-38630-les_avenieres_veyrins_thuellin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38022-38630-les_avenieres_veyrins_thuellin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38022-38630-les_avenieres_veyrins_thuellin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38023-38650-avignonet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38023-38650-avignonet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38023-38650-avignonet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38023-38650-avignonet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38026-38390-la_balme_les_grottes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38026-38390-la_balme_les_grottes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38026-38390-la_balme_les_grottes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38026-38390-la_balme_les_grottes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38027-38530-barraux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38027-38530-barraux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38027-38530-barraux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38027-38530-barraux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38029-38110-la_batie_montgascon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38029-38110-la_batie_montgascon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38029-38110-la_batie_montgascon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38029-38110-la_batie_montgascon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38030-38140-beaucroissant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38030-38140-beaucroissant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38030-38140-beaucroissant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38030-38140-beaucroissant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38031-38970-beaufin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38031-38970-beaufin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38031-38970-beaufin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38031-38970-beaufin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38032-38270-beaufort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38032-38270-beaufort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38032-38270-beaufort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38032-38270-beaufort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38033-38470-beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38033-38470-beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38033-38470-beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38033-38470-beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38034-38270-beaurepaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38034-38270-beaurepaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38034-38270-beaurepaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38034-38270-beaurepaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38035-38440-beauvoir_de_marc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38035-38440-beauvoir_de_marc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38035-38440-beauvoir_de_marc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38035-38440-beauvoir_de_marc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38036-38160-beauvoir_en_royans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38036-38160-beauvoir_en_royans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38036-38160-beauvoir_en_royans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38036-38160-beauvoir_en_royans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38037-38270-bellegarde_poussieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38037-38270-bellegarde_poussieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38037-38270-bellegarde_poussieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38037-38270-bellegarde_poussieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38038-38690-belmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38038-38690-belmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38038-38690-belmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38038-38690-belmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38039-38190-bernin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38039-38190-bernin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38039-38190-bernin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38039-38190-bernin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38040-38142-besse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38040-38142-besse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38040-38142-besse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38040-38142-besse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38041-38160-bessins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38041-38160-bessins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38041-38160-bessins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38041-38160-bessins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38042-38690-bevenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38042-38690-bevenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38042-38690-bevenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38042-38690-bevenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38043-38850-bilieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38043-38850-bilieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38043-38850-bilieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38043-38850-bilieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38044-38690-biol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38044-38690-biol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38044-38690-biol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38044-38690-biol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38045-38330-biviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38045-38330-biviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38045-38330-biviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38045-38330-biviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38046-38690-bizonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38046-38690-bizonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38046-38690-bizonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38046-38690-bizonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38047-38730-blandin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38047-38730-blandin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38047-38730-blandin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38047-38730-blandin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38048-38090-bonnefamille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38048-38090-bonnefamille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38048-38090-bonnefamille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38048-38090-bonnefamille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38049-38260-bossieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38049-38260-bossieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38049-38260-bossieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38049-38260-bossieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38050-38510-le_bouchage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38050-38510-le_bouchage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38050-38510-le_bouchage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38050-38510-le_bouchage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38051-38150-bouge_chambalud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38051-38150-bouge_chambalud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38051-38150-bouge_chambalud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38051-38150-bouge_chambalud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38052-38520-le_bourg_d_oisans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38052-38520-le_bourg_d_oisans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38052-38520-le_bourg_d_oisans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38052-38520-le_bourg_d_oisans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38053-38300-bourgoin_jallieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38053-38300-bourgoin_jallieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38053-38300-bourgoin_jallieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38053-38300-bourgoin_jallieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38054-38390-bouvesse_quirieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38054-38390-bouvesse_quirieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38054-38390-bouvesse_quirieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38054-38390-bouvesse_quirieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38055-38510-brangues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38055-38510-brangues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38055-38510-brangues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38055-38510-brangues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38056-38870-bressieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38056-38870-bressieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38056-38870-bressieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38056-38870-bressieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38057-38320-bresson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38057-38320-bresson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38057-38320-bresson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38057-38320-bresson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38058-38590-brezins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38058-38590-brezins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38058-38590-brezins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38058-38590-brezins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38059-38320-brie_et_angonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38059-38320-brie_et_angonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38059-38320-brie_et_angonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38059-38320-brie_et_angonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38060-38590-brion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38060-38590-brion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38060-38590-brion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38060-38590-brion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38061-38500-la_buisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38061-38500-la_buisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38061-38500-la_buisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38061-38500-la_buisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38062-38530-la_buissiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38062-38530-la_buissiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38062-38530-la_buissiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38062-38530-la_buissiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38063-38690-burcin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38063-38690-burcin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38063-38690-burcin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38063-38690-burcin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38064-38110-cessieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38064-38110-cessieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38064-38110-cessieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38064-38110-cessieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38065-38690-chabons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38065-38690-chabons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38065-38690-chabons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38065-38690-chabons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38066-38122-chalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38066-38122-chalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38066-38122-chalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38066-38122-chalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38067-38460-chamagnieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38067-38460-chamagnieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38067-38460-chamagnieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38067-38460-chamagnieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38068-38800-champagnier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38068-38800-champagnier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38068-38800-champagnier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38068-38800-champagnier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38069-38260-champier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38069-38260-champier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38069-38260-champier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38069-38260-champier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38070-38190-le_champ_pres_froges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38070-38190-le_champ_pres_froges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38070-38190-le_champ_pres_froges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38070-38190-le_champ_pres_froges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38071-38560-champ_sur_drac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38071-38560-champ_sur_drac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38071-38560-champ_sur_drac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38071-38560-champ_sur_drac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38072-38150-chanas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38072-38150-chanas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38072-38150-chanas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38072-38150-chanas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38073-38740-chanteperier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38073-38740-chanteperier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38073-38740-chanteperier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38073-38740-chanteperier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38074-38470-chantesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38074-38470-chantesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38074-38470-chantesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38074-38470-chantesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38075-38530-chapareillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38075-38530-chapareillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38075-38530-chapareillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38075-38530-chapareillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38076-38110-la_chapelle_de_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38076-38110-la_chapelle_de_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38076-38110-la_chapelle_de_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38076-38110-la_chapelle_de_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38077-38150-la_chapelle_de_surieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38077-38150-la_chapelle_de_surieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38077-38150-la_chapelle_de_surieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38077-38150-la_chapelle_de_surieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38078-38580-la_chapelle_du_bard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38078-38580-la_chapelle_du_bard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38078-38580-la_chapelle_du_bard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38078-38580-la_chapelle_du_bard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38080-38490-charancieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38080-38490-charancieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38080-38490-charancieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38080-38490-charancieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38081-38790-charantonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38081-38790-charantonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38081-38790-charantonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38081-38790-charantonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38082-38850-charavines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38082-38850-charavines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38082-38850-charavines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38082-38850-charavines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38083-38390-charette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38083-38390-charette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38083-38390-charette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38083-38390-charette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38084-38140-charnecles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38084-38140-charnecles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38084-38140-charnecles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38084-38140-charnecles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38085-38230-charvieu_chavagneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38085-38230-charvieu_chavagneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38085-38230-charvieu_chavagneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38085-38230-charvieu_chavagneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38086-38470-chasselay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38086-38470-chasselay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38086-38470-chasselay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38086-38470-chasselay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38087-38670-chasse_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38087-38670-chasse_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38087-38670-chasse_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38087-38670-chasse_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38089-38730-chassignieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38089-38730-chassignieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38089-38730-chassignieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38089-38730-chassignieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38090-38650-chateau_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38090-38650-chateau_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38090-38650-chateau_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38090-38650-chateau_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38091-38300-chateauvilain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38091-38300-chateauvilain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38091-38300-chateauvilain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38091-38300-chateauvilain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38092-38680-chatelus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38092-38680-chatelus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38092-38680-chatelus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38092-38680-chatelus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38093-38980-chatenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38093-38980-chatenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38093-38980-chatenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38093-38980-chatenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38094-38440-chatonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38094-38440-chatonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38094-38440-chatonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38094-38440-chatonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38095-38160-chatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38095-38160-chatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38095-38160-chatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38095-38160-chatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38097-38230-chavanoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38097-38230-chavanoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38097-38230-chavanoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38097-38230-chavanoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38098-38730-chelieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38098-38730-chelieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38098-38730-chelieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38098-38730-chelieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38099-38160-chevrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38099-38160-chevrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38099-38160-chevrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38099-38160-chevrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38100-38570-le_cheylas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38100-38570-le_cheylas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38100-38570-le_cheylas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38100-38570-le_cheylas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38101-38550-cheyssieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38101-38550-cheyssieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38101-38550-cheyssieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38101-38550-cheyssieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38102-38300-chezeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38102-38300-chezeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38102-38300-chezeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38102-38300-chezeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38103-38930-chichilianne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38103-38930-chichilianne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38103-38930-chichilianne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38103-38930-chichilianne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38104-38490-chimilin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38104-38490-chimilin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38104-38490-chimilin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38104-38490-chimilin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38105-38850-chirens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38105-38850-chirens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38105-38850-chirens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38105-38850-chirens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38106-38220-cholonge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38106-38220-cholonge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38106-38220-cholonge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38106-38220-cholonge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38107-38121-chonas_l_amballan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38107-38121-chonas_l_amballan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38107-38121-chonas_l_amballan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38107-38121-chonas_l_amballan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38108-38680-choranche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38108-38680-choranche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38108-38680-choranche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38108-38680-choranche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38109-38460-chozeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38109-38460-chozeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38109-38460-chozeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38109-38460-chozeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38110-38200-chuzelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38110-38200-chuzelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38110-38200-chuzelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38110-38200-chuzelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38111-38640-claix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38111-38640-claix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38111-38640-claix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38111-38640-claix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38112-38142-clavans_en_haut_oisans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38112-38142-clavans_en_haut_oisans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38112-38142-clavans_en_haut_oisans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38112-38142-clavans_en_haut_oisans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38113-38930-clelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38113-38930-clelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38113-38930-clelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38113-38930-clelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38114-38550-clonas_sur_vareze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38114-38550-clonas_sur_vareze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38114-38550-clonas_sur_vareze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38114-38550-clonas_sur_vareze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38115-38650-saint_martin_de_la_cluze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38115-38650-saint_martin_de_la_cluze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38115-38650-saint_martin_de_la_cluze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38115-38650-saint_martin_de_la_cluze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38116-38350-cognet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38116-38350-cognet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38116-38350-cognet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38116-38350-cognet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38117-38470-cognin_les_gorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38117-38470-cognin_les_gorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38117-38470-cognin_les_gorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38117-38470-cognin_les_gorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38118-38690-colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38118-38690-colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38118-38690-colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38118-38690-colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38120-38190-la_combe_de_lancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38120-38190-la_combe_de_lancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38120-38190-la_combe_de_lancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38120-38190-la_combe_de_lancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38124-38630-corbelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38124-38630-corbelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38124-38630-corbelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38124-38630-corbelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38126-38700-corenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38126-38700-corenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38126-38700-corenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38126-38700-corenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38126-38240-corenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38126-38240-corenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38126-38240-corenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38126-38240-corenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38127-38710-cornillon_en_trieves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38127-38710-cornillon_en_trieves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38127-38710-cornillon_en_trieves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38127-38710-cornillon_en_trieves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38128-38970-corps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38128-38970-corps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38128-38970-corps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38128-38970-corps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38129-38250-correncon_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38129-38250-correncon_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38129-38250-correncon_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38129-38250-correncon_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38130-38260-la_cote_saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38130-38260-la_cote_saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38130-38260-la_cote_saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38130-38260-la_cote_saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38131-38138-les_cotes_d_arey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38131-38138-les_cotes_d_arey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38131-38138-les_cotes_d_arey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38131-38138-les_cotes_d_arey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38132-38970-les_cotes_de_corps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38132-38970-les_cotes_de_corps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38132-38970-les_cotes_de_corps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38132-38970-les_cotes_de_corps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38133-38500-coublevie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38133-38500-coublevie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38133-38500-coublevie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38133-38500-coublevie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38134-38122-cour_et_buis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38134-38122-cour_et_buis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38134-38122-cour_et_buis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38134-38122-cour_et_buis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38135-38510-courtenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38135-38510-courtenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38135-38510-courtenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38135-38510-courtenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38136-38300-crachier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38136-38300-crachier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38136-38300-crachier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38136-38300-crachier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38137-38210-cras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38137-38210-cras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38137-38210-cras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38137-38210-cras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38138-38460-cremieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38138-38460-cremieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38138-38460-cremieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38138-38460-cremieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38139-38510-creys_mepieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38139-38510-creys_mepieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38139-38510-creys_mepieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38139-38510-creys_mepieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38140-38920-crolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38140-38920-crolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38140-38920-crolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38140-38920-crolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38141-38300-culin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38141-38300-culin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38141-38300-culin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38141-38300-culin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38144-38790-diemoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38144-38790-diemoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38144-38790-diemoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38144-38790-diemoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38146-38460-dizimieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38146-38460-dizimieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38146-38460-dizimieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38146-38460-dizimieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38147-38730-doissin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38147-38730-doissin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38147-38730-doissin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38147-38730-doissin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38148-38110-dolomieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38148-38110-dolomieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38148-38110-dolomieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38148-38110-dolomieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38149-38300-domarin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38149-38300-domarin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38149-38300-domarin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38149-38300-domarin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38150-38420-domene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38150-38420-domene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38150-38420-domene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38150-38420-domene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38151-38130-echirolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38151-38130-echirolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38151-38130-echirolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38151-38130-echirolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38152-38300-eclose_badinieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38152-38300-eclose_badinieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38152-38300-eclose_badinieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38152-38300-eclose_badinieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38153-38360-engins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38153-38360-engins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38153-38360-engins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38153-38360-engins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38154-38740-entraigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38154-38740-entraigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38154-38740-entraigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38154-38740-entraigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38155-38380-entre_deux_guiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38155-38380-entre_deux_guiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38155-38380-entre_deux_guiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38155-38380-entre_deux_guiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38156-38300-les_eparres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38156-38300-les_eparres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38156-38300-les_eparres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38156-38300-les_eparres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38157-38780-estrablin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38157-38780-estrablin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38157-38780-estrablin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38157-38780-estrablin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38158-38320-eybens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38158-38320-eybens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38158-38320-eybens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38158-38320-eybens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38159-38690-eydoche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38159-38690-eydoche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38159-38690-eydoche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38159-38690-eydoche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38160-38780-eyzin_pinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38160-38780-eyzin_pinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38160-38780-eyzin_pinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38160-38780-eyzin_pinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38161-38260-faramans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38161-38260-faramans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38161-38260-faramans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38161-38260-faramans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38162-38110-faverges_de_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38162-38110-faverges_de_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38162-38110-faverges_de_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38162-38110-faverges_de_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38163-38580-le_haut_breda/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38163-38580-le_haut_breda/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38163-38580-le_haut_breda/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38163-38580-le_haut_breda/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38166-38530-la_flachere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38166-38530-la_flachere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38166-38530-la_flachere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38166-38530-la_flachere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38167-38690-flacheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38167-38690-flacheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38167-38690-flacheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38167-38690-flacheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38169-38600-fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38169-38600-fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38169-38600-fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38169-38600-fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38170-38120-fontanil_cornillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38170-38120-fontanil_cornillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38170-38120-fontanil_cornillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38170-38120-fontanil_cornillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38171-38590-la_forteresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38171-38590-la_forteresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38171-38590-la_forteresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38171-38590-la_forteresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38172-38080-four/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38172-38080-four/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38172-38080-four/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38172-38080-four/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38173-38142-le_freney_d_oisans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38173-38142-le_freney_d_oisans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38173-38142-le_freney_d_oisans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38173-38142-le_freney_d_oisans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38174-38260-la_frette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38174-38260-la_frette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38174-38260-la_frette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38174-38260-la_frette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38175-38190-froges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38175-38190-froges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38175-38190-froges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38175-38190-froges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38176-38290-frontonas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38176-38290-frontonas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38176-38290-frontonas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38176-38290-frontonas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38177-38520-la_garde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38177-38520-la_garde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38177-38520-la_garde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38177-38520-la_garde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38179-38610-gieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38179-38610-gieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38179-38610-gieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38179-38610-gieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38180-38260-gillonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38180-38260-gillonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38180-38260-gillonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38180-38260-gillonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38181-38570-goncelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38181-38570-goncelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38181-38570-goncelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38181-38570-goncelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38182-38690-le_grand_lemps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38182-38690-le_grand_lemps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38182-38690-le_grand_lemps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38182-38690-le_grand_lemps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38183-38490-granieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38183-38490-granieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38183-38490-granieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38183-38490-granieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38184-38540-grenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38184-38540-grenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38184-38540-grenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38184-38540-grenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38000-grenoble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38000-grenoble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38000-grenoble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38000-grenoble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38100-grenoble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38100-grenoble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38100-grenoble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38100-grenoble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38700-grenoble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38700-grenoble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38700-grenoble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38185-38700-grenoble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38186-38650-gresse_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38186-38650-gresse_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38186-38650-gresse_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38186-38650-gresse_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38187-38450-le_gua/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38187-38450-le_gua/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38187-38450-le_gua/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38187-38450-le_gua/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38188-38320-herbeys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38188-38320-herbeys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38188-38320-herbeys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38188-38320-herbeys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38189-38540-heyrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38189-38540-heyrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38189-38540-heyrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38189-38540-heyrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38190-38118-hieres_sur_amby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38190-38118-hieres_sur_amby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38190-38118-hieres_sur_amby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38190-38118-hieres_sur_amby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38191-38750-huez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38191-38750-huez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38191-38750-huez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38191-38750-huez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38191-38520-huez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38191-38520-huez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38191-38520-huez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38191-38520-huez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38192-38570-hurtieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38192-38570-hurtieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38192-38570-hurtieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38192-38570-hurtieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38193-38080-l_isle_d_abeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38193-38080-l_isle_d_abeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38193-38080-l_isle_d_abeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38193-38080-l_isle_d_abeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38194-38140-izeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38194-38140-izeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38194-38140-izeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38194-38140-izeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38195-38160-izeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38195-38160-izeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38195-38160-izeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38195-38160-izeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38197-38280-janneyrias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38197-38280-janneyrias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38197-38280-janneyrias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38197-38280-janneyrias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38198-38270-jarcieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38198-38270-jarcieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38198-38270-jarcieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38198-38270-jarcieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38199-38200-jardin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38199-38200-jardin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38199-38200-jardin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38199-38200-jardin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38200-38560-jarrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38200-38560-jarrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38200-38560-jarrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38200-38560-jarrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38203-38220-laffrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38203-38220-laffrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38203-38220-laffrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38203-38220-laffrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38204-38930-lalley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38204-38930-lalley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38204-38930-lalley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38204-38930-lalley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38205-38250-lans_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38205-38250-lans_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38205-38250-lans_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38205-38250-lans_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38206-38190-laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38206-38190-laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38206-38190-laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38206-38190-laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38207-38350-lavaldens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38207-38350-lavaldens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38207-38350-lavaldens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38207-38350-lavaldens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38208-38710-lavars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38208-38710-lavars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38208-38710-lavars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38208-38710-lavars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38209-38270-lentiol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38209-38270-lentiol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38209-38270-lentiol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38209-38270-lentiol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38210-38460-leyrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38210-38460-leyrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38210-38460-leyrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38210-38460-leyrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38211-38440-lieudieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38211-38440-lieudieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38211-38440-lieudieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38211-38440-lieudieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38212-38220-livet_et_gavet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38212-38220-livet_et_gavet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38212-38220-livet_et_gavet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38212-38220-livet_et_gavet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38213-38690-longechenal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38213-38690-longechenal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38213-38690-longechenal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38213-38690-longechenal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38214-38660-lumbin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38214-38660-lumbin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38214-38660-lumbin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38214-38660-lumbin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38215-38200-luzinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38215-38200-luzinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38215-38200-luzinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38215-38200-luzinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38216-38470-malleval_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38216-38470-malleval_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38216-38470-malleval_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38216-38470-malleval_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38217-38350-marcieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38217-38350-marcieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38217-38350-marcieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38217-38350-marcieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38218-38260-marcilloles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38218-38260-marcilloles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38218-38260-marcilloles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38218-38260-marcilloles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38219-38270-marcollin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38219-38270-marcollin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38219-38270-marcollin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38219-38270-marcollin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38221-38980-marnans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38221-38980-marnans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38221-38980-marnans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38221-38980-marnans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38222-38620-massieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38222-38620-massieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38222-38620-massieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38222-38620-massieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38223-38300-maubec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38223-38300-maubec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38223-38300-maubec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38223-38300-maubec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38224-38350-mayres_savel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38224-38350-mayres_savel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38224-38350-mayres_savel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38224-38350-mayres_savel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38225-38112-autrans_meaudre_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38225-38112-autrans_meaudre_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38225-38112-autrans_meaudre_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38225-38112-autrans_meaudre_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38225-38880-autrans_meaudre_en_vercors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38225-38880-autrans_meaudre_en_vercors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38225-38880-autrans_meaudre_en_vercors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38225-38880-autrans_meaudre_en_vercors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38226-38710-mens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38226-38710-mens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38226-38710-mens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38226-38710-mens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38228-38620-merlas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38228-38620-merlas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38228-38620-merlas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38228-38620-merlas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38229-38240-meylan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38229-38240-meylan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38229-38240-meylan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38229-38240-meylan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38230-38300-meyrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38230-38300-meyrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38230-38300-meyrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38230-38300-meyrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38231-38440-meyrieu_les_etangs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38231-38440-meyrieu_les_etangs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38231-38440-meyrieu_les_etangs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38231-38440-meyrieu_les_etangs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38232-38440-meyssiez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38232-38440-meyssiez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38232-38440-meyssiez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38232-38440-meyssiez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38235-38450-miribel_lanchatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38235-38450-miribel_lanchatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38235-38450-miribel_lanchatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38235-38450-miribel_lanchatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38236-38380-miribel_les_echelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38236-38380-miribel_les_echelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38236-38380-miribel_les_echelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38236-38380-miribel_les_echelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38237-38142-mizoen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38237-38142-mizoen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38237-38142-mizoen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38237-38142-mizoen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38238-38440-moidieu_detourbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38238-38440-moidieu_detourbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38238-38440-moidieu_detourbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38238-38440-moidieu_detourbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38239-38430-moirans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38239-38430-moirans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38239-38430-moirans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38239-38430-moirans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38240-38270-moissieu_sur_dolon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38240-38270-moissieu_sur_dolon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38240-38270-moissieu_sur_dolon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38240-38270-moissieu_sur_dolon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38241-38970-monestier_d_ambel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38241-38970-monestier_d_ambel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38241-38970-monestier_d_ambel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38241-38970-monestier_d_ambel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38242-38650-monestier_de_clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38242-38650-monestier_de_clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38242-38650-monestier_de_clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38242-38650-monestier_de_clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38243-38930-le_monestier_du_percy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38243-38930-le_monestier_du_percy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38243-38930-le_monestier_du_percy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38243-38930-le_monestier_du_percy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38244-38122-monsteroux_milieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38244-38122-monsteroux_milieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38244-38122-monsteroux_milieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38244-38122-monsteroux_milieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38245-38160-montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38245-38160-montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38245-38160-montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38245-38160-montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38246-38110-montagnieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38246-38110-montagnieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38246-38110-montagnieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38246-38110-montagnieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38247-38390-montalieu_vercieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38247-38390-montalieu_vercieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38247-38390-montalieu_vercieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38247-38390-montalieu_vercieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38248-38210-montaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38248-38210-montaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38248-38210-montaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38248-38210-montaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38249-38330-montbonnot_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38249-38330-montbonnot_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38249-38330-montbonnot_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38249-38330-montbonnot_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38250-38890-montcarra/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38250-38890-montcarra/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38250-38890-montcarra/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38250-38890-montcarra/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38252-38220-montchaboud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38252-38220-montchaboud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38252-38220-montchaboud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38252-38220-montchaboud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38253-38860-les_deux_alpes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38253-38860-les_deux_alpes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38253-38860-les_deux_alpes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38253-38860-les_deux_alpes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38253-38520-les_deux_alpes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38253-38520-les_deux_alpes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38253-38520-les_deux_alpes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38253-38520-les_deux_alpes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38254-38770-monteynard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38254-38770-monteynard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38254-38770-monteynard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38254-38770-monteynard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38255-38940-montfalcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38255-38940-montfalcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38255-38940-montfalcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38255-38940-montfalcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38256-38620-montferrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38256-38620-montferrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38256-38620-montferrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38256-38620-montferrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38257-38690-montrevel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38257-38690-montrevel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38257-38690-montrevel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38257-38690-montrevel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38258-38120-mont_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38258-38120-mont_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38258-38120-mont_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38258-38120-mont_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38259-38122-montseveroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38259-38122-montseveroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38259-38122-montseveroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38259-38122-montseveroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38260-38460-moras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38260-38460-moras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38260-38460-moras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38260-38460-moras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38261-38510-morestel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38261-38510-morestel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38261-38510-morestel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38261-38510-morestel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38263-38210-morette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38263-38210-morette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38263-38210-morette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38263-38210-morette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38264-38350-la_morte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38264-38350-la_morte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38264-38350-la_morte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38264-38350-la_morte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38265-38770-la_motte_d_aveillans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38265-38770-la_motte_d_aveillans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38265-38770-la_motte_d_aveillans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38265-38770-la_motte_d_aveillans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38266-38770-la_motte_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38266-38770-la_motte_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38266-38770-la_motte_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38266-38770-la_motte_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38267-38260-mottier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38267-38260-mottier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38267-38260-mottier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38267-38260-mottier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38268-38580-le_moutaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38268-38580-le_moutaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38268-38580-le_moutaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38268-38580-le_moutaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38269-38350-la_mure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38269-38350-la_mure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38269-38350-la_mure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38269-38350-la_mure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38270-38140-la_murette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38270-38140-la_murette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38270-38140-la_murette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38270-38140-la_murette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38271-38420-murianette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38271-38420-murianette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38271-38420-murianette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38271-38420-murianette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38272-38160-murinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38272-38160-murinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38272-38160-murinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38272-38160-murinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38273-38350-nantes_en_ratier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38273-38350-nantes_en_ratier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38273-38350-nantes_en_ratier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38273-38350-nantes_en_ratier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38275-38470-serre_nerpol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38275-38470-serre_nerpol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38275-38470-serre_nerpol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38275-38470-serre_nerpol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38276-38300-nivolas_vermelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38276-38300-nivolas_vermelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38276-38300-nivolas_vermelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38276-38300-nivolas_vermelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38277-38450-notre_dame_de_commiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38277-38450-notre_dame_de_commiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38277-38450-notre_dame_de_commiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38277-38450-notre_dame_de_commiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38278-38470-notre_dame_de_l_osier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38278-38470-notre_dame_de_l_osier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38278-38470-notre_dame_de_l_osier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38278-38470-notre_dame_de_l_osier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38279-38220-notre_dame_de_mesage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38279-38220-notre_dame_de_mesage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38279-38220-notre_dame_de_mesage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38279-38220-notre_dame_de_mesage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38279-38560-notre_dame_de_mesage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38279-38560-notre_dame_de_mesage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38279-38560-notre_dame_de_mesage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38279-38560-notre_dame_de_mesage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38280-38144-notre_dame_de_vaulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38280-38144-notre_dame_de_vaulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38280-38144-notre_dame_de_vaulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38280-38144-notre_dame_de_vaulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38281-38360-noyarey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38281-38360-noyarey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38281-38360-noyarey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38281-38360-noyarey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38282-38460-optevoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38282-38460-optevoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38282-38460-optevoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38282-38460-optevoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38283-38350-oris_en_rattier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38283-38350-oris_en_rattier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38283-38350-oris_en_rattier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38283-38350-oris_en_rattier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38284-38260-ornacieux_balbins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38284-38260-ornacieux_balbins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38284-38260-ornacieux_balbins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38284-38260-ornacieux_balbins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38285-38520-ornon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38285-38520-ornon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38285-38520-ornon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38285-38520-ornon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38286-38520-oulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38286-38520-oulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38286-38520-oulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38286-38520-oulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38287-38690-oyeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38287-38690-oyeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38287-38690-oyeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38287-38690-oyeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38288-38780-oytier_saint_oblas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38288-38780-oytier_saint_oblas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38288-38780-oytier_saint_oblas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38288-38780-oytier_saint_oblas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38289-38114-oz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38289-38114-oz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38289-38114-oz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38289-38114-oz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38290-38270-pact/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38290-38270-pact/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38290-38270-pact/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38290-38270-pact/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38291-38260-pajay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38291-38260-pajay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38291-38260-pajay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38291-38260-pajay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38292-38850-villages_du_lac_de_paladru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38292-38850-villages_du_lac_de_paladru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38292-38850-villages_du_lac_de_paladru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38292-38850-villages_du_lac_de_paladru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38292-38730-villages_du_lac_de_paladru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38292-38730-villages_du_lac_de_paladru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38292-38730-villages_du_lac_de_paladru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38292-38730-villages_du_lac_de_paladru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38294-38460-panossas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38294-38460-panossas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38294-38460-panossas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38294-38460-panossas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38295-38390-parmilieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38295-38390-parmilieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38295-38390-parmilieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38295-38390-parmilieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38296-38490-le_passage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38296-38490-le_passage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38296-38490-le_passage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38296-38490-le_passage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38297-38510-arandon_passins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38297-38510-arandon_passins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38297-38510-arandon_passins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38297-38510-arandon_passins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38298-38550-le_peage_de_roussillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38298-38550-le_peage_de_roussillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38298-38550-le_peage_de_roussillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38298-38550-le_peage_de_roussillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38299-38970-pellafol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38299-38970-pellafol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38299-38970-pellafol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38299-38970-pellafol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38300-38260-penol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38300-38260-penol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38300-38260-penol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38300-38260-penol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38301-38930-percy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38301-38930-percy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38301-38930-percy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38301-38930-percy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38303-38570-la_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38303-38570-la_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38303-38570-la_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38303-38570-la_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38304-38119-pierre_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38304-38119-pierre_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38304-38119-pierre_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38304-38119-pierre_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38307-38270-pisieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38307-38270-pisieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38307-38270-pisieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38307-38270-pisieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38308-38590-plan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38308-38590-plan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38308-38590-plan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38308-38590-plan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38309-38320-poisat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38309-38320-poisat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38309-38320-poisat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38309-38320-poisat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38310-38210-polienas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38310-38210-polienas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38310-38210-polienas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38310-38210-polienas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38311-38260-pommier_de_beaurepaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38311-38260-pommier_de_beaurepaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38311-38260-pommier_de_beaurepaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38311-38260-pommier_de_beaurepaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38313-38350-ponsonnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38313-38350-ponsonnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38313-38350-ponsonnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38313-38350-ponsonnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38314-38530-pontcharra/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38314-38530-pontcharra/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38314-38530-pontcharra/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38314-38530-pontcharra/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38315-38480-le_pont_de_beauvoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38315-38480-le_pont_de_beauvoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38315-38480-le_pont_de_beauvoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38315-38480-le_pont_de_beauvoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38316-38230-pont_de_cheruy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38316-38230-pont_de_cheruy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38316-38230-pont_de_cheruy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38316-38230-pont_de_cheruy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38317-38800-le_pont_de_claix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38317-38800-le_pont_de_claix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38317-38800-le_pont_de_claix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38317-38800-le_pont_de_claix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38318-38780-pont_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38318-38780-pont_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38318-38780-pont_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38318-38780-pont_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38319-38680-pont_en_royans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38319-38680-pont_en_royans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38319-38680-pont_en_royans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38319-38680-pont_en_royans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38320-38390-porcieu_amblagnieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38320-38390-porcieu_amblagnieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38320-38390-porcieu_amblagnieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38320-38390-porcieu_amblagnieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38321-38710-prebois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38321-38710-prebois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38321-38710-prebois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38321-38710-prebois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38322-38680-presles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38322-38680-presles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38322-38680-presles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38322-38680-presles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38323-38480-pressins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38323-38480-pressins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38323-38480-pressins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38323-38480-pressins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38324-38270-primarette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38324-38270-primarette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38324-38270-primarette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38324-38270-primarette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38325-38120-proveysieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38325-38120-proveysieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38325-38120-proveysieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38325-38120-proveysieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38326-38350-prunieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38326-38350-prunieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38326-38350-prunieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38326-38350-prunieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38328-38950-quaix_en_chartreuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38328-38950-quaix_en_chartreuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38328-38950-quaix_en_chartreuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38328-38950-quaix_en_chartreuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38329-38970-quet_en_beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38329-38970-quet_en_beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38329-38970-quet_en_beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38329-38970-quet_en_beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38330-38470-quincieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38330-38470-quincieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38330-38470-quincieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38330-38470-quincieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38331-38140-reaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38331-38140-reaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38331-38140-reaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38331-38140-reaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38332-38140-renage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38332-38140-renage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38332-38140-renage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38332-38140-renage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38333-38680-rencurel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38333-38680-rencurel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38333-38680-rencurel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38333-38680-rencurel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38334-38420-revel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38334-38420-revel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38334-38420-revel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38334-38420-revel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38335-38270-revel_tourdan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38335-38270-revel_tourdan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38335-38270-revel_tourdan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38335-38270-revel_tourdan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38336-38121-reventin_vaugris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38336-38121-reventin_vaugris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38336-38121-reventin_vaugris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38336-38121-reventin_vaugris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38337-38140-rives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38337-38140-rives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38337-38140-rives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38337-38140-rives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38338-38210-la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38338-38210-la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38338-38210-la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38338-38210-la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38339-38090-roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38339-38090-roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38339-38090-roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38339-38090-roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38340-38370-les_roches_de_condrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38340-38370-les_roches_de_condrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38340-38370-les_roches_de_condrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38340-38370-les_roches_de_condrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38341-38110-rochetoirin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38341-38110-rochetoirin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38341-38110-rochetoirin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38341-38110-rochetoirin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38342-38650-roissard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38342-38650-roissard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38342-38650-roissard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38342-38650-roissard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38343-38480-romagnieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38343-38480-romagnieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38343-38480-romagnieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38343-38480-romagnieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38344-38150-roussillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38344-38150-roussillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38344-38150-roussillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38344-38150-roussillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38345-38470-rovon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38345-38470-rovon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38345-38470-rovon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38345-38470-rovon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38346-38440-royas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38346-38440-royas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38346-38440-royas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38346-38440-royas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38347-38940-roybon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38347-38940-roybon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38347-38940-roybon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38347-38940-roybon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38348-38300-ruy_montceau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38348-38300-ruy_montceau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38348-38300-ruy_montceau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38348-38300-ruy_montceau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38349-38550-sablons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38349-38550-sablons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38349-38550-sablons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38349-38550-sablons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38350-38190-sainte_agnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38350-38190-sainte_agnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38350-38190-sainte_agnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38350-38190-sainte_agnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38351-38300-saint_agnin_sur_bion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38351-38300-saint_agnin_sur_bion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38351-38300-saint_agnin_sur_bion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38351-38300-saint_agnin_sur_bion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38352-38080-saint_alban_de_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38352-38080-saint_alban_de_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38352-38080-saint_alban_de_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38352-38080-saint_alban_de_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38353-38370-saint_alban_du_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38353-38370-saint_alban_du_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38353-38370-saint_alban_du_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38353-38370-saint_alban_du_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38354-38480-saint_albin_de_vaulserre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38354-38480-saint_albin_de_vaulserre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38354-38480-saint_albin_de_vaulserre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38354-38480-saint_albin_de_vaulserre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38355-38650-saint_andeol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38355-38650-saint_andeol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38355-38650-saint_andeol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38355-38650-saint_andeol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38356-38680-saint_andre_en_royans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38356-38680-saint_andre_en_royans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38356-38680-saint_andre_en_royans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38356-38680-saint_andre_en_royans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38357-38490-saint_andre_le_gaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38357-38490-saint_andre_le_gaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38357-38490-saint_andre_le_gaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38357-38490-saint_andre_le_gaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38358-38440-sainte_anne_sur_gervonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38358-38440-sainte_anne_sur_gervonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38358-38440-sainte_anne_sur_gervonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38358-38440-sainte_anne_sur_gervonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38359-38160-saint_antoine_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38359-38160-saint_antoine_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38359-38160-saint_antoine_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38359-38160-saint_antoine_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38360-38160-saint_appolinard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38360-38160-saint_appolinard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38360-38160-saint_appolinard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38360-38160-saint_appolinard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38361-38350-saint_arey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38361-38350-saint_arey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38361-38350-saint_arey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38361-38350-saint_arey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38362-38960-saint_aupre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38362-38960-saint_aupre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38362-38960-saint_aupre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38362-38960-saint_aupre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38363-38270-saint_barthelemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38363-38270-saint_barthelemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38363-38270-saint_barthelemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38363-38270-saint_barthelemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38364-38220-saint_barthelemy_de_sechilienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38364-38220-saint_barthelemy_de_sechilienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38364-38220-saint_barthelemy_de_sechilienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38364-38220-saint_barthelemy_de_sechilienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38365-38118-saint_baudille_de_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38365-38118-saint_baudille_de_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38365-38118-saint_baudille_de_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38365-38118-saint_baudille_de_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38366-38710-saint_baudille_et_pipet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38366-38710-saint_baudille_et_pipet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38366-38710-saint_baudille_et_pipet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38366-38710-saint_baudille_et_pipet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38368-38140-saint_blaise_du_buis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38368-38140-saint_blaise_du_buis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38368-38140-saint_blaise_du_buis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38368-38140-saint_blaise_du_buis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38369-38110-sainte_blandine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38369-38110-sainte_blandine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38369-38110-sainte_blandine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38369-38110-sainte_blandine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38370-38840-saint_bonnet_de_chavagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38370-38840-saint_bonnet_de_chavagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38370-38840-saint_bonnet_de_chavagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38370-38840-saint_bonnet_de_chavagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38372-38620-saint_bueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38372-38620-saint_bueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38372-38620-saint_bueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38372-38620-saint_bueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38373-38500-saint_cassien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38373-38500-saint_cassien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38373-38500-saint_cassien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38373-38500-saint_cassien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38374-38890-saint_chef/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38374-38890-saint_chef/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38374-38890-saint_chef/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38374-38890-saint_chef/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38375-38520-saint_christophe_en_oisans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38375-38520-saint_christophe_en_oisans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38375-38520-saint_christophe_en_oisans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38375-38520-saint_christophe_en_oisans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38376-38380-saint_christophe_sur_guiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38376-38380-saint_christophe_sur_guiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38376-38380-saint_christophe_sur_guiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38376-38380-saint_christophe_sur_guiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38377-38110-saint_clair_de_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38377-38110-saint_clair_de_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38377-38110-saint_clair_de_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38377-38110-saint_clair_de_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38378-38370-saint_clair_du_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38378-38370-saint_clair_du_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38378-38370-saint_clair_du_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38378-38370-saint_clair_du_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38379-38940-saint_clair_sur_galaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38379-38940-saint_clair_sur_galaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38379-38940-saint_clair_sur_galaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38379-38940-saint_clair_sur_galaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38380-38690-saint_didier_de_bizonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38380-38690-saint_didier_de_bizonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38380-38690-saint_didier_de_bizonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38380-38690-saint_didier_de_bizonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38381-38110-saint_didier_de_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38381-38110-saint_didier_de_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38381-38110-saint_didier_de_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38381-38110-saint_didier_de_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38382-38120-saint_egreve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38382-38120-saint_egreve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38382-38120-saint_egreve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38382-38120-saint_egreve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38383-38960-saint_etienne_de_crossey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38383-38960-saint_etienne_de_crossey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38383-38960-saint_etienne_de_crossey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38383-38960-saint_etienne_de_crossey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38384-38590-saint_etienne_de_saint_geoirs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38384-38590-saint_etienne_de_saint_geoirs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38384-38590-saint_etienne_de_saint_geoirs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38384-38590-saint_etienne_de_saint_geoirs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38386-38620-saint_geoire_en_valdaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38386-38620-saint_geoire_en_valdaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38386-38620-saint_geoire_en_valdaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38386-38620-saint_geoire_en_valdaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38387-38590-saint_geoirs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38387-38590-saint_geoirs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38387-38590-saint_geoirs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38387-38590-saint_geoirs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38388-38450-saint_georges_de_commiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38388-38450-saint_georges_de_commiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38388-38450-saint_georges_de_commiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38388-38450-saint_georges_de_commiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38389-38790-saint_georges_d_esperanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38389-38790-saint_georges_d_esperanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38389-38790-saint_georges_d_esperanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38389-38790-saint_georges_d_esperanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38390-38470-saint_gervais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38390-38470-saint_gervais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38390-38470-saint_gervais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38390-38470-saint_gervais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38391-38650-saint_guillaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38391-38650-saint_guillaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38391-38650-saint_guillaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38391-38650-saint_guillaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38392-38460-saint_hilaire_de_brens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38392-38460-saint_hilaire_de_brens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38392-38460-saint_hilaire_de_brens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38392-38460-saint_hilaire_de_brens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38393-38260-saint_hilaire_de_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38393-38260-saint_hilaire_de_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38393-38260-saint_hilaire_de_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38393-38260-saint_hilaire_de_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38394-38840-saint_hilaire_du_rosier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38394-38840-saint_hilaire_du_rosier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38394-38840-saint_hilaire_du_rosier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38394-38840-saint_hilaire_du_rosier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38395-38660-plateau_des_petites_roches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38395-38660-plateau_des_petites_roches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38395-38660-plateau_des_petites_roches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38395-38660-plateau_des_petites_roches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38396-38350-saint_honore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38396-38350-saint_honore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38396-38350-saint_honore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38396-38350-saint_honore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38397-38330-saint_ismier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38397-38330-saint_ismier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38397-38330-saint_ismier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38397-38330-saint_ismier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38398-38480-saint_jean_d_avelanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38398-38480-saint_jean_d_avelanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38398-38480-saint_jean_d_avelanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38398-38480-saint_jean_d_avelanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38399-38440-saint_jean_de_bournay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38399-38440-saint_jean_de_bournay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38399-38440-saint_jean_de_bournay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38399-38440-saint_jean_de_bournay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38400-38430-saint_jean_de_moirans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38400-38430-saint_jean_de_moirans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38400-38430-saint_jean_de_moirans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38400-38430-saint_jean_de_moirans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38401-38110-saint_jean_de_soudain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38401-38110-saint_jean_de_soudain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38401-38110-saint_jean_de_soudain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38401-38110-saint_jean_de_soudain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38402-38220-saint_jean_de_vaulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38402-38220-saint_jean_de_vaulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38402-38220-saint_jean_de_vaulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38402-38220-saint_jean_de_vaulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38403-38710-saint_jean_d_herans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38403-38710-saint_jean_d_herans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38403-38710-saint_jean_d_herans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38403-38710-saint_jean_d_herans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38404-38420-saint_jean_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38404-38420-saint_jean_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38404-38420-saint_jean_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38404-38420-saint_jean_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38405-38134-saint_joseph_de_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38405-38134-saint_joseph_de_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38405-38134-saint_joseph_de_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38405-38134-saint_joseph_de_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38406-38122-saint_julien_de_l_herms/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38406-38122-saint_julien_de_l_herms/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38406-38122-saint_julien_de_l_herms/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38406-38122-saint_julien_de_l_herms/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38407-38134-la_sure_en_chartreuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38407-38134-la_sure_en_chartreuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38407-38134-la_sure_en_chartreuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38407-38134-la_sure_en_chartreuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38407-38340-la_sure_en_chartreuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38407-38340-la_sure_en_chartreuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38407-38340-la_sure_en_chartreuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38407-38340-la_sure_en_chartreuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38408-38540-saint_just_chaleyssin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38408-38540-saint_just_chaleyssin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38408-38540-saint_just_chaleyssin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38408-38540-saint_just_chaleyssin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38409-38680-saint_just_de_claix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38409-38680-saint_just_de_claix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38409-38680-saint_just_de_claix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38409-38680-saint_just_de_claix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38410-38840-saint_lattier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38410-38840-saint_lattier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38410-38840-saint_lattier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38410-38840-saint_lattier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38412-38380-saint_laurent_du_pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38412-38380-saint_laurent_du_pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38412-38380-saint_laurent_du_pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38412-38380-saint_laurent_du_pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38413-38350-saint_laurent_en_beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38413-38350-saint_laurent_en_beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38413-38350-saint_laurent_en_beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38413-38350-saint_laurent_en_beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38414-38970-sainte_luce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38414-38970-sainte_luce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38414-38970-sainte_luce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38414-38970-sainte_luce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38415-38080-saint_marcel_bel_accueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38415-38080-saint_marcel_bel_accueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38415-38080-saint_marcel_bel_accueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38415-38080-saint_marcel_bel_accueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38416-38160-saint_marcellin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38416-38160-saint_marcellin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38416-38160-saint_marcellin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38416-38160-saint_marcellin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38417-38660-sainte_marie_d_alloix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38417-38660-sainte_marie_d_alloix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38417-38660-sainte_marie_d_alloix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38417-38660-sainte_marie_d_alloix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38418-38660-sainte_marie_du_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38418-38660-sainte_marie_du_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38418-38660-sainte_marie_du_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38418-38660-sainte_marie_du_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38419-38930-saint_martin_de_clelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38419-38930-saint_martin_de_clelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38419-38930-saint_martin_de_clelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38419-38930-saint_martin_de_clelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38420-38480-saint_martin_de_vaulserre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38420-38480-saint_martin_de_vaulserre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38420-38480-saint_martin_de_vaulserre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38420-38480-saint_martin_de_vaulserre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38421-38400-saint_martin_d_heres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38421-38400-saint_martin_d_heres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38421-38400-saint_martin_d_heres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38421-38400-saint_martin_d_heres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38422-38410-saint_martin_d_uriage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38422-38410-saint_martin_d_uriage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38422-38410-saint_martin_d_uriage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38422-38410-saint_martin_d_uriage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38423-38950-saint_martin_le_vinoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38423-38950-saint_martin_le_vinoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38423-38950-saint_martin_le_vinoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38423-38950-saint_martin_le_vinoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38424-38930-saint_maurice_en_trieves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38424-38930-saint_maurice_en_trieves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38424-38930-saint_maurice_en_trieves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38424-38930-saint_maurice_en_trieves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38425-38550-saint_maurice_l_exil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38425-38550-saint_maurice_l_exil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38425-38550-saint_maurice_l_exil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38425-38550-saint_maurice_l_exil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38426-38530-saint_maximin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38426-38530-saint_maximin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38426-38530-saint_maximin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38426-38530-saint_maximin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38427-38590-saint_michel_de_saint_geoirs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38427-38590-saint_michel_de_saint_geoirs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38427-38590-saint_michel_de_saint_geoirs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38427-38590-saint_michel_de_saint_geoirs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38428-38350-saint_michel_en_beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38428-38350-saint_michel_en_beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38428-38350-saint_michel_en_beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38428-38350-saint_michel_en_beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38429-38650-saint_michel_les_portes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38429-38650-saint_michel_les_portes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38429-38650-saint_michel_les_portes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38429-38650-saint_michel_les_portes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38430-38190-saint_mury_monteymond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38430-38190-saint_mury_monteymond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38430-38190-saint_mury_monteymond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38430-38190-saint_mury_monteymond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38431-38330-saint_nazaire_les_eymes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38431-38330-saint_nazaire_les_eymes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38431-38330-saint_nazaire_les_eymes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38431-38330-saint_nazaire_les_eymes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38432-38500-saint_nicolas_de_macherin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38432-38500-saint_nicolas_de_macherin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38432-38500-saint_nicolas_de_macherin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38432-38500-saint_nicolas_de_macherin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38433-38250-saint_nizier_du_moucherotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38433-38250-saint_nizier_du_moucherotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38433-38250-saint_nizier_du_moucherotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38433-38250-saint_nizier_du_moucherotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38434-38490-saint_ondras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38434-38490-saint_ondras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38434-38490-saint_ondras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38434-38490-saint_ondras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38436-38760-saint_paul_de_varces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38436-38760-saint_paul_de_varces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38436-38760-saint_paul_de_varces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38436-38760-saint_paul_de_varces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38437-38140-saint_paul_d_izeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38437-38140-saint_paul_d_izeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38437-38140-saint_paul_d_izeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38437-38140-saint_paul_d_izeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38438-38650-saint_paul_les_monestier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38438-38650-saint_paul_les_monestier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38438-38650-saint_paul_les_monestier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38438-38650-saint_paul_les_monestier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38439-38830-crets_en_belledonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38439-38830-crets_en_belledonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38439-38830-crets_en_belledonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38439-38830-crets_en_belledonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38439-38570-crets_en_belledonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38439-38570-crets_en_belledonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38439-38570-crets_en_belledonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38439-38570-crets_en_belledonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38440-38870-saint_pierre_de_bressieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38440-38870-saint_pierre_de_bressieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38440-38870-saint_pierre_de_bressieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38440-38870-saint_pierre_de_bressieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38442-38380-saint_pierre_de_chartreuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38442-38380-saint_pierre_de_chartreuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38442-38380-saint_pierre_de_chartreuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38442-38380-saint_pierre_de_chartreuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38443-38160-saint_pierre_de_cherennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38443-38160-saint_pierre_de_cherennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38443-38160-saint_pierre_de_cherennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38443-38160-saint_pierre_de_cherennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38444-38350-saint_pierre_de_mearoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38444-38350-saint_pierre_de_mearoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38444-38350-saint_pierre_de_mearoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38444-38350-saint_pierre_de_mearoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38445-38220-saint_pierre_de_mesage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38445-38220-saint_pierre_de_mesage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38445-38220-saint_pierre_de_mesage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38445-38220-saint_pierre_de_mesage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38446-73670-saint_pierre_d_entremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38446-73670-saint_pierre_d_entremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38446-73670-saint_pierre_d_entremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38446-73670-saint_pierre_d_entremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38448-38370-saint_prim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38448-38370-saint_prim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38448-38370-saint_prim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38448-38370-saint_prim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38448-38121-saint_prim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38448-38121-saint_prim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38448-38121-saint_prim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38448-38121-saint_prim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38449-38070-saint_quentin_fallavier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38449-38070-saint_quentin_fallavier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38449-38070-saint_quentin_fallavier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38449-38070-saint_quentin_fallavier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38450-38210-saint_quentin_sur_isere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38450-38210-saint_quentin_sur_isere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38450-38210-saint_quentin_sur_isere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38450-38210-saint_quentin_sur_isere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38451-38460-saint_romain_de_jalionas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38451-38460-saint_romain_de_jalionas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38451-38460-saint_romain_de_jalionas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38451-38460-saint_romain_de_jalionas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38452-38150-saint_romain_de_surieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38452-38150-saint_romain_de_surieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38452-38150-saint_romain_de_surieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38452-38150-saint_romain_de_surieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38453-38160-saint_romans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38453-38160-saint_romans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38453-38160-saint_romans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38453-38160-saint_romans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38454-38160-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38454-38160-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38454-38160-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38454-38160-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38455-38300-saint_savin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38455-38300-saint_savin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38455-38300-saint_savin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38455-38300-saint_savin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38456-38710-chatel_en_trieves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38456-38710-chatel_en_trieves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38456-38710-chatel_en_trieves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38456-38710-chatel_en_trieves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38457-38870-saint_simeon_de_bressieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38457-38870-saint_simeon_de_bressieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38457-38870-saint_simeon_de_bressieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38457-38870-saint_simeon_de_bressieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38458-38510-saint_sorlin_de_morestel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38458-38510-saint_sorlin_de_morestel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38458-38510-saint_sorlin_de_morestel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38458-38510-saint_sorlin_de_morestel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38459-38200-saint_sorlin_de_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38459-38200-saint_sorlin_de_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38459-38200-saint_sorlin_de_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38459-38200-saint_sorlin_de_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38460-38620-saint_sulpice_des_rivoires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38460-38620-saint_sulpice_des_rivoires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38460-38620-saint_sulpice_des_rivoires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38460-38620-saint_sulpice_des_rivoires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38462-38119-saint_theoffrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38462-38119-saint_theoffrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38462-38119-saint_theoffrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38462-38119-saint_theoffrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38463-38160-saint_verand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38463-38160-saint_verand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38463-38160-saint_verand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38463-38160-saint_verand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38464-38110-saint_victor_de_cessieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38464-38110-saint_victor_de_cessieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38464-38110-saint_victor_de_cessieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38464-38110-saint_victor_de_cessieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38465-38510-saint_victor_de_morestel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38465-38510-saint_victor_de_morestel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38465-38510-saint_victor_de_morestel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38465-38510-saint_victor_de_morestel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38466-38660-saint_vincent_de_mercuze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38466-38660-saint_vincent_de_mercuze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38466-38660-saint_vincent_de_mercuze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38466-38660-saint_vincent_de_mercuze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38467-38890-salagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38467-38890-salagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38467-38890-salagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38467-38890-salagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38468-38150-salaise_sur_sanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38468-38150-salaise_sur_sanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38468-38150-salaise_sur_sanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38468-38150-salaise_sur_sanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38469-38970-la_salette_fallavaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38469-38970-la_salette_fallavaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38469-38970-la_salette_fallavaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38469-38970-la_salette_fallavaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38470-38350-la_salle_en_beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38470-38350-la_salle_en_beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38470-38350-la_salle_en_beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38470-38350-la_salle_en_beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38471-38700-le_sappey_en_chartreuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38471-38700-le_sappey_en_chartreuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38471-38700-le_sappey_en_chartreuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38471-38700-le_sappey_en_chartreuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38472-38700-sarcenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38472-38700-sarcenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38472-38700-sarcenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38472-38700-sarcenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38473-38260-sardieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38473-38260-sardieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38473-38260-sardieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38473-38260-sardieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38474-38360-sassenage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38474-38360-sassenage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38474-38360-sassenage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38474-38360-sassenage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38475-38290-satolas_et_bonce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38475-38290-satolas_et_bonce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38475-38290-satolas_et_bonce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38475-38290-satolas_et_bonce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38476-38440-savas_mepin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38476-38440-savas_mepin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38476-38440-savas_mepin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38476-38440-savas_mepin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38478-38220-sechilienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38478-38220-sechilienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38478-38220-sechilienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38478-38220-sechilienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38479-38260-porte_des_bonnevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38479-38260-porte_des_bonnevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38479-38260-porte_des_bonnevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38479-38260-porte_des_bonnevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38480-38780-septeme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38480-38780-septeme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38480-38780-septeme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38480-38780-septeme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38481-38300-serezin_de_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38481-38300-serezin_de_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38481-38300-serezin_de_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38481-38300-serezin_de_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38483-38510-sermerieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38483-38510-sermerieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38483-38510-sermerieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38483-38510-sermerieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38484-38200-serpaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38484-38200-serpaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38484-38200-serpaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38484-38200-serpaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38485-38170-seyssinet_pariset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38485-38170-seyssinet_pariset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38485-38170-seyssinet_pariset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38485-38170-seyssinet_pariset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38485-38180-seyssinet_pariset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38485-38180-seyssinet_pariset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38485-38180-seyssinet_pariset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38485-38180-seyssinet_pariset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38486-38180-seyssins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38486-38180-seyssins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38486-38180-seyssins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38486-38180-seyssins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38487-38200-seyssuel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38487-38200-seyssuel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38487-38200-seyssuel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38487-38200-seyssuel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38488-38460-siccieu_saint_julien_et_carisieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38488-38460-siccieu_saint_julien_et_carisieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38488-38460-siccieu_saint_julien_et_carisieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38488-38460-siccieu_saint_julien_et_carisieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38489-38350-sievoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38489-38350-sievoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38489-38350-sievoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38489-38350-sievoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38490-38590-sillans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38490-38590-sillans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38490-38590-sillans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38490-38590-sillans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38492-38650-sinard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38492-38650-sinard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38492-38650-sinard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38492-38650-sinard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38494-38460-soleymieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38494-38460-soleymieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38494-38460-soleymieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38494-38460-soleymieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38495-38840-la_sone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38495-38840-la_sone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38495-38840-la_sone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38495-38840-la_sone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38496-38150-sonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38496-38150-sonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38496-38150-sonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38496-38150-sonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38497-38350-sousville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38497-38350-sousville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38497-38350-sousville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38497-38350-sousville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38498-38300-succieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38498-38300-succieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38498-38300-succieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38498-38300-succieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38499-38350-susville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38499-38350-susville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38499-38350-susville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38499-38350-susville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38500-38470-teche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38500-38470-teche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38500-38470-teche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38500-38470-teche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38501-38570-tencin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38501-38570-tencin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38501-38570-tencin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38501-38570-tencin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38503-38660-la_terrasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38503-38660-la_terrasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38503-38660-la_terrasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38503-38660-la_terrasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38504-38570-theys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38504-38570-theys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38504-38570-theys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38504-38570-theys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38505-38260-thodure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38505-38260-thodure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38505-38260-thodure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38505-38260-thodure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38507-38230-tignieu_jameyzieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38507-38230-tignieu_jameyzieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38507-38230-tignieu_jameyzieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38507-38230-tignieu_jameyzieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38508-38690-torchefelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38508-38690-torchefelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38508-38690-torchefelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38508-38690-torchefelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38509-38110-la_tour_du_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38509-38110-la_tour_du_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38509-38110-la_tour_du_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38509-38110-la_tour_du_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38511-38660-le_touvet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38511-38660-le_touvet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38511-38660-le_touvet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38511-38660-le_touvet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38512-38300-tramole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38512-38300-tramole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38512-38300-tramole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38512-38300-tramole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38513-38650-treffort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38513-38650-treffort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38513-38650-treffort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38513-38650-treffort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38514-38710-treminis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38514-38710-treminis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38514-38710-treminis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38514-38710-treminis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38515-38460-trept/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38515-38460-trept/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38515-38460-trept/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38515-38460-trept/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38516-38700-la_tronche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38516-38700-la_tronche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38516-38700-la_tronche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38516-38700-la_tronche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38517-38210-tullins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38517-38210-tullins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38517-38210-tullins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38517-38210-tullins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38518-38740-valbonnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38518-38740-valbonnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38518-38740-valbonnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38518-38740-valbonnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38519-38540-valencin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38519-38540-valencin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38519-38540-valencin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38519-38540-valencin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38520-38730-valencogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38520-38730-valencogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38520-38730-valencogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38520-38730-valencogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38521-38350-la_valette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38521-38350-la_valette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38521-38350-la_valette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38521-38350-la_valette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38522-38740-valjouffrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38522-38740-valjouffrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38522-38740-valjouffrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38522-38740-valjouffrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38523-38470-varacieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38523-38470-varacieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38523-38470-varacieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38523-38470-varacieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38524-38760-varces_allieres_et_risset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38524-38760-varces_allieres_et_risset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38524-38760-varces_allieres_et_risset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38524-38760-varces_allieres_et_risset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38525-38890-vasselin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38525-38890-vasselin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38525-38890-vasselin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38525-38890-vasselin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38526-38470-vatilieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38526-38470-vatilieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38526-38470-vatilieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38526-38470-vatilieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38527-38114-vaujany/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38527-38114-vaujany/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38527-38114-vaujany/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38527-38114-vaujany/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38528-38410-vaulnaveys_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38528-38410-vaulnaveys_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38528-38410-vaulnaveys_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38528-38410-vaulnaveys_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38529-38410-vaulnaveys_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38529-38410-vaulnaveys_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38529-38410-vaulnaveys_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38529-38410-vaulnaveys_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38530-38090-vaulx_milieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38530-38090-vaulx_milieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38530-38090-vaulx_milieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38530-38090-vaulx_milieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38531-38620-velanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38531-38620-velanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38531-38620-velanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38531-38620-velanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38532-38460-venerieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38532-38460-venerieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38532-38460-venerieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38532-38460-venerieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38533-38610-venon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38533-38610-venon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38533-38610-venon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38533-38610-venon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38535-38460-vernas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38535-38460-vernas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38535-38460-vernas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38535-38460-vernas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38536-38150-vernioz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38536-38150-vernioz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38536-38150-vernioz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38536-38150-vernioz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38537-38290-la_verpilliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38537-38290-la_verpilliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38537-38290-la_verpilliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38537-38290-la_verpilliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38538-38420-le_versoud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38538-38420-le_versoud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38538-38420-le_versoud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38538-38420-le_versoud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38539-38390-vertrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38539-38390-vertrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38539-38390-vertrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38539-38390-vertrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38540-38113-veurey_voroize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38540-38113-veurey_voroize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38540-38113-veurey_voroize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38540-38113-veurey_voroize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38542-38460-veyssilieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38542-38460-veyssilieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38542-38460-veyssilieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38542-38460-veyssilieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38543-38510-vezeronce_curtin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38543-38510-vezeronce_curtin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38543-38510-vezeronce_curtin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38543-38510-vezeronce_curtin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38544-38200-vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38544-38200-vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38544-38200-vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38544-38200-vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38545-38450-vif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38545-38450-vif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38545-38450-vif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38545-38450-vif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38546-38890-vignieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38546-38890-vignieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38546-38890-vignieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38546-38890-vignieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38547-38190-villard_bonnot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38547-38190-villard_bonnot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38547-38190-villard_bonnot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38547-38190-villard_bonnot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38548-38250-villard_de_lans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38548-38250-villard_de_lans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38548-38250-villard_de_lans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38548-38250-villard_de_lans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38549-38520-villard_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38549-38520-villard_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38549-38520-villard_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38549-38520-villard_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38550-38114-villard_reculas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38550-38114-villard_reculas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38550-38114-villard_reculas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38550-38114-villard_reculas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38551-38520-villard_reymond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38551-38520-villard_reymond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38551-38520-villard_reymond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38551-38520-villard_reymond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38552-38119-villard_saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38552-38119-villard_saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38552-38119-villard_saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38552-38119-villard_saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38553-38090-villefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38553-38090-villefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38553-38090-villefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38553-38090-villefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38554-38460-villemoirieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38554-38460-villemoirieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38554-38460-villemoirieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38554-38460-villemoirieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38555-38440-villeneuve_de_marc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38555-38440-villeneuve_de_marc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38555-38440-villeneuve_de_marc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38555-38440-villeneuve_de_marc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38556-38150-ville_sous_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38556-38150-ville_sous_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38556-38150-ville_sous_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38556-38150-ville_sous_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38557-38280-villette_d_anthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38557-38280-villette_d_anthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38557-38280-villette_d_anthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38557-38280-villette_d_anthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38558-38200-villette_de_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38558-38200-villette_de_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38558-38200-villette_de_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38558-38200-villette_de_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38559-38470-vinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38559-38470-vinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38559-38470-vinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38559-38470-vinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38560-38730-val_de_virieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38560-38730-val_de_virieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38560-38730-val_de_virieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38560-38730-val_de_virieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38561-38980-viriville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38561-38980-viriville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38561-38980-viriville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38561-38980-viriville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38562-38220-vizille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38562-38220-vizille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38562-38220-vizille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38562-38220-vizille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38563-38500-voiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38563-38500-voiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38563-38500-voiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38563-38500-voiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38564-38620-voissant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38564-38620-voissant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38564-38620-voissant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38564-38620-voissant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38565-38340-voreppe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38565-38340-voreppe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38565-38340-voreppe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38565-38340-voreppe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38566-38210-vourey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38566-38210-vourey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38566-38210-vourey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38566-38210-vourey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38567-38410-chamrousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38567-38410-chamrousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38567-38410-chamrousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt38-isere/commune38567-38410-chamrousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-39.xml
+++ b/public/sitemaps/sitemap-39.xml
@@ -5,1028 +5,2052 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39001-39500-abergement_la_ronce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39001-39500-abergement_la_ronce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39001-39500-abergement_la_ronce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39001-39500-abergement_la_ronce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39002-39600-abergement_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39002-39600-abergement_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39002-39600-abergement_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39002-39600-abergement_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39003-39800-abergement_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39003-39800-abergement_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39003-39800-abergement_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39003-39800-abergement_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39004-39110-abergement_les_thesy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39004-39110-abergement_les_thesy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39004-39110-abergement_les_thesy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39004-39110-abergement_les_thesy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39006-39110-aiglepierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39006-39110-aiglepierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39006-39110-aiglepierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39006-39110-aiglepierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39007-39270-alieze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39007-39270-alieze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39007-39270-alieze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39007-39270-alieze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39008-39700-amange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39008-39700-amange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39008-39700-amange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39008-39700-amange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39009-39110-andelot_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39009-39110-andelot_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39009-39110-andelot_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39009-39110-andelot_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39010-39320-andelot_morval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39010-39320-andelot_morval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39010-39320-andelot_morval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39010-39320-andelot_morval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39011-39120-annoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39011-39120-annoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39011-39120-annoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39011-39120-annoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39013-39600-arbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39013-39600-arbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39013-39600-arbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39013-39600-arbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39014-39290-archelange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39014-39290-archelange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39014-39290-archelange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39014-39290-archelange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39015-39300-ardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39015-39300-ardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39015-39300-ardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39015-39300-ardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39016-39240-arinthod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39016-39240-arinthod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39016-39240-arinthod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39016-39240-arinthod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39017-39140-arlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39017-39140-arlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39017-39140-arlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39017-39140-arlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39017-39210-arlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39017-39210-arlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39017-39210-arlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39017-39210-arlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39018-39240-aromas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39018-39240-aromas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39018-39240-aromas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39018-39240-aromas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39019-39600-les_arsures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39019-39600-les_arsures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39019-39600-les_arsures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39019-39600-les_arsures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39020-39250-arsure_arsurette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39020-39250-arsure_arsurette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39020-39250-arsure_arsurette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39020-39250-arsure_arsurette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39021-39570-la_chailleuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39021-39570-la_chailleuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39021-39570-la_chailleuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39021-39570-la_chailleuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39021-39270-la_chailleuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39021-39270-la_chailleuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39021-39270-la_chailleuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39021-39270-la_chailleuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39022-39120-asnans_beauvoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39022-39120-asnans_beauvoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39022-39120-asnans_beauvoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39022-39120-asnans_beauvoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39024-39700-audelange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39024-39700-audelange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39024-39700-audelange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39024-39700-audelange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39025-39190-augea/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39025-39190-augea/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39025-39190-augea/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39025-39190-augea/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39026-39380-augerans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39026-39380-augerans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39026-39380-augerans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39026-39380-augerans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39027-39270-augisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39027-39270-augisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39027-39270-augisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39027-39270-augisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39028-39800-aumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39028-39800-aumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39028-39800-aumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39028-39800-aumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39029-39410-aumur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39029-39410-aumur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39029-39410-aumur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39029-39410-aumur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39030-39100-authume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39030-39100-authume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39030-39100-authume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39030-39100-authume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39031-39700-auxange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39031-39700-auxange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39031-39700-auxange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39031-39700-auxange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39032-39200-avignon_les_saint_claude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39032-39200-avignon_les_saint_claude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39032-39200-avignon_les_saint_claude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39032-39200-avignon_les_saint_claude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39034-39120-balaiseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39034-39120-balaiseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39034-39120-balaiseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39034-39120-balaiseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39035-39160-balanod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39035-39160-balanod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39035-39160-balanod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39035-39160-balanod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39037-39380-bans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39037-39380-bans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39037-39380-bans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39037-39380-bans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39038-39130-baresia_sur_l_ain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39038-39130-baresia_sur_l_ain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39038-39130-baresia_sur_l_ain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39038-39130-baresia_sur_l_ain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39039-39700-la_barre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39039-39700-la_barre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39039-39700-la_barre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39039-39700-la_barre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39040-39800-barretaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39040-39800-barretaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39040-39800-barretaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39040-39800-barretaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39041-39210-baume_les_messieurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39041-39210-baume_les_messieurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39041-39210-baume_les_messieurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39041-39210-baume_les_messieurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39041-39570-baume_les_messieurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39041-39570-baume_les_messieurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39041-39570-baume_les_messieurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39041-39570-baume_les_messieurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39042-39100-baverans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39042-39100-baverans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39042-39100-baverans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39042-39100-baverans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39043-39190-beaufort_orbagna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39043-39190-beaufort_orbagna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39043-39190-beaufort_orbagna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39043-39190-beaufort_orbagna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39045-39270-beffia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39045-39270-beffia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39045-39270-beffia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39045-39270-beffia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39046-39310-bellecombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39046-39310-bellecombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39046-39310-bellecombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39046-39310-bellecombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39047-39400-bellefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39047-39400-bellefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39047-39400-bellefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39047-39400-bellefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39048-39380-belmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39048-39380-belmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39048-39380-belmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39048-39380-belmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39049-39800-bersaillin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39049-39800-bersaillin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39049-39800-bersaillin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39049-39800-bersaillin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39050-39800-besain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39050-39800-besain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39050-39800-besain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39050-39800-besain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39051-39290-biarne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39051-39290-biarne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39051-39290-biarne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39051-39290-biarne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39052-39150-bief_des_maisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39052-39150-bief_des_maisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39052-39150-bief_des_maisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39052-39150-bief_des_maisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39053-39250-bief_du_fourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39053-39250-bief_du_fourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39053-39250-bief_du_fourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39053-39250-bief_du_fourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39054-39800-biefmorin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39054-39800-biefmorin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39054-39800-biefmorin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39054-39800-biefmorin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39055-39250-billecul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39055-39250-billecul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39055-39250-billecul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39055-39250-billecul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39056-39140-bletterans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39056-39140-bletterans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39056-39140-bletterans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39056-39140-bletterans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39057-39210-blois_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39057-39210-blois_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39057-39210-blois_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39057-39210-blois_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39058-39130-blye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39058-39130-blye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39058-39130-blye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39058-39130-blye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39059-39220-bois_d_amont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39059-39220-bois_d_amont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39059-39220-bois_d_amont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39059-39220-bois_d_amont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39060-39230-bois_de_gand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39060-39230-bois_de_gand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39060-39230-bois_de_gand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39060-39230-bois_de_gand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39061-39130-boissia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39061-39130-boissia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39061-39130-boissia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39061-39130-boissia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39062-39240-la_boissiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39062-39240-la_boissiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39062-39240-la_boissiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39062-39240-la_boissiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39063-39130-bonlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39063-39130-bonlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39063-39130-bonlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39063-39130-bonlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39065-39800-bonnefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39065-39800-bonnefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39065-39800-bonnefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39065-39800-bonnefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39066-39570-bornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39066-39570-bornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39066-39570-bornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39066-39570-bornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39068-39370-les_bouchoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39068-39370-les_bouchoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39068-39370-les_bouchoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39068-39370-les_bouchoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39070-39300-bourg_de_sirod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39070-39300-bourg_de_sirod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39070-39300-bourg_de_sirod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39070-39300-bourg_de_sirod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39072-39110-bracon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39072-39110-bracon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39072-39110-bracon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39072-39110-bracon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39073-39800-brainans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39073-39800-brainans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39073-39800-brainans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39073-39800-brainans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39074-39290-brans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39074-39290-brans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39074-39290-brans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39074-39290-brans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39076-39700-la_breteniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39076-39700-la_breteniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39076-39700-la_breteniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39076-39700-la_breteniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39077-39120-bretenieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39077-39120-bretenieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39077-39120-bretenieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39077-39120-bretenieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39078-39100-brevans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39078-39100-brevans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39078-39100-brevans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39078-39100-brevans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39079-39570-briod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39079-39570-briod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39079-39570-briod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39079-39570-briod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39080-39320-broissia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39080-39320-broissia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39080-39320-broissia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39080-39320-broissia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39081-39800-buvilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39081-39800-buvilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39081-39800-buvilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39081-39800-buvilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39083-39250-censeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39083-39250-censeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39083-39250-censeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39083-39250-censeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39084-39110-cernans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39084-39110-cernans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39084-39110-cernans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39084-39110-cernans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39085-39250-cerniebaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39085-39250-cerniebaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39085-39250-cerniebaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39085-39250-cerniebaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39086-39240-cernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39086-39240-cernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39086-39240-cernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39086-39240-cernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39088-39570-cesancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39088-39570-cesancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39088-39570-cesancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39088-39570-cesancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39090-39120-chainee_des_coupis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39090-39120-chainee_des_coupis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39090-39120-chainee_des_coupis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39090-39120-chainee_des_coupis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39091-39150-les_chalesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39091-39150-les_chalesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39091-39150-les_chalesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39091-39150-les_chalesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39092-39270-chamberia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39092-39270-chamberia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39092-39270-chamberia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39092-39270-chamberia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39093-39380-chamblay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39093-39380-chamblay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39093-39380-chamblay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39093-39380-chamblay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39094-39800-chamole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39094-39800-chamole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39094-39800-chamole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39094-39800-chamole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39095-39600-champagne_sur_loue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39095-39600-champagne_sur_loue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39095-39600-champagne_sur_loue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39095-39600-champagne_sur_loue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39096-39290-champagney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39096-39290-champagney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39096-39290-champagney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39096-39290-champagney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39097-39300-champagnole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39097-39300-champagnole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39097-39300-champagnole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39097-39300-champagnole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39099-39500-champdivers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39099-39500-champdivers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39099-39500-champdivers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39099-39500-champdivers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39099-39120-champdivers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39099-39120-champdivers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39099-39120-champdivers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39099-39120-champdivers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39100-39230-champrougier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39100-39230-champrougier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39100-39230-champrougier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39100-39230-champrougier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39101-39100-champvans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39101-39100-champvans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39101-39100-champvans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39101-39100-champvans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39102-01590-chancia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39102-01590-chancia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39102-01590-chancia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39102-01590-chancia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39103-39110-la_chapelle_sur_furieuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39103-39110-la_chapelle_sur_furieuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39103-39110-la_chapelle_sur_furieuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39103-39110-la_chapelle_sur_furieuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39104-39140-chapelle_voland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39104-39140-chapelle_voland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39104-39140-chapelle_voland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39104-39140-chapelle_voland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39105-39300-chapois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39105-39300-chapois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39105-39300-chapois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39105-39300-chapois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39106-39260-charchilla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39106-39260-charchilla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39106-39260-charchilla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39106-39260-charchilla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39107-39130-charcier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39107-39130-charcier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39107-39130-charcier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39107-39130-charcier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39108-39250-charency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39108-39250-charency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39108-39250-charency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39108-39250-charency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39109-39130-charezier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39109-39130-charezier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39109-39130-charezier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39109-39130-charezier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39110-39230-la_charme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39110-39230-la_charme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39110-39230-la_charme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39110-39230-la_charme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39111-39240-charnod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39111-39240-charnod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39111-39240-charnod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39111-39240-charnod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39112-39230-la_chassagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39112-39230-la_chassagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39112-39230-la_chassagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39112-39230-la_chassagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39114-39210-chateau_chalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39114-39210-chateau_chalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39114-39210-chateau_chalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39114-39210-chateau_chalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39116-39600-la_chatelaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39116-39600-la_chatelaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39116-39600-la_chatelaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39116-39600-la_chatelaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39117-39380-chatelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39117-39380-chatelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39117-39380-chatelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39117-39380-chatelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39118-39130-chatel_de_joux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39118-39130-chatel_de_joux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39118-39130-chatel_de_joux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39118-39130-chatel_de_joux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39119-39230-le_chateley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39119-39230-le_chateley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39119-39230-le_chateley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39119-39230-le_chateley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39120-39300-chatelneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39120-39300-chatelneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39120-39300-chatelneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39120-39300-chatelneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39121-39700-chatenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39121-39700-chatenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39121-39700-chatenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39121-39700-chatenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39122-39130-chatillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39122-39130-chatillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39122-39130-chatillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39122-39130-chatillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39124-39230-chaumergy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39124-39230-chaumergy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39124-39230-chaumergy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39124-39230-chaumergy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39126-39150-la_chaumusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39126-39150-la_chaumusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39126-39150-la_chaumusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39126-39150-la_chaumusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39127-39800-chaussenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39127-39800-chaussenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39127-39800-chaussenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39127-39800-chaussenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39128-39120-chaussin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39128-39120-chaussin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39128-39120-chaussin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39128-39120-chaussin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39129-39150-chaux_des_crotenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39129-39150-chaux_des_crotenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39129-39150-chaux_des_crotenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39129-39150-chaux_des_crotenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39130-39150-nanchez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39130-39150-nanchez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39130-39150-nanchez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39130-39150-nanchez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39130-39200-nanchez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39130-39200-nanchez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39130-39200-nanchez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39130-39200-nanchez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39131-39150-la_chaux_du_dombief/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39131-39150-la_chaux_du_dombief/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39131-39150-la_chaux_du_dombief/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39131-39150-la_chaux_du_dombief/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39132-39230-la_chaux_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39132-39230-la_chaux_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39132-39230-la_chaux_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39132-39230-la_chaux_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39133-39110-chaux_champagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39133-39110-chaux_champagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39133-39110-chaux_champagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39133-39110-chaux_champagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39134-39270-chaveria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39134-39270-chaveria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39134-39270-chaveria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39134-39270-chaveria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39136-39230-chemenot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39136-39230-chemenot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39136-39230-chemenot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39136-39230-chemenot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39137-39240-saint_hymetiere_sur_valouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39137-39240-saint_hymetiere_sur_valouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39137-39240-saint_hymetiere_sur_valouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39137-39240-saint_hymetiere_sur_valouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39138-39120-chemin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39138-39120-chemin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39138-39120-chemin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39138-39120-chemin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39139-39120-chene_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39139-39120-chene_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39139-39120-chene_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39139-39120-chene_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39140-39230-chene_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39140-39230-chene_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39140-39230-chene_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39140-39230-chene_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39141-39290-chevigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39141-39290-chevigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39141-39290-chevigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39141-39290-chevigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39142-39190-chevreaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39142-39190-chevreaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39142-39190-chevreaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39142-39190-chevreaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39143-39130-chevrotaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39143-39130-chevrotaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39143-39130-chevrotaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39143-39130-chevrotaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39145-39570-chille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39145-39570-chille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39145-39570-chille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39145-39570-chille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39146-39570-chilly_le_vignoble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39146-39570-chilly_le_vignoble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39146-39570-chilly_le_vignoble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39146-39570-chilly_le_vignoble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39147-39110-chilly_sur_salins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39147-39110-chilly_sur_salins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39147-39110-chilly_sur_salins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39147-39110-chilly_sur_salins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39149-39380-chissey_sur_loue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39149-39380-chissey_sur_loue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39149-39380-chissey_sur_loue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39149-39380-chissey_sur_loue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39150-39100-choisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39150-39100-choisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39150-39100-choisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39150-39100-choisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39151-39370-choux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39151-39370-choux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39151-39370-choux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39151-39370-choux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39153-39300-cize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39153-39300-cize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39153-39300-cize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39153-39300-cize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39154-39130-clairvaux_les_lacs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39154-39130-clairvaux_les_lacs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39154-39130-clairvaux_les_lacs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39154-39130-clairvaux_les_lacs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39155-39110-clucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39155-39110-clucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39155-39110-clucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39155-39110-clucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39156-39130-cogna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39156-39130-cogna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39156-39130-cogna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39156-39130-cogna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39157-39200-coiserette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39157-39200-coiserette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39157-39200-coiserette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39157-39200-coiserette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39159-39800-colonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39159-39800-colonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39159-39800-colonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39159-39800-colonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39160-39140-commenailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39160-39140-commenailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39160-39140-commenailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39160-39140-commenailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39162-39570-condamine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39162-39570-condamine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39162-39570-condamine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39162-39570-condamine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39163-39240-condes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39163-39240-condes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39163-39240-condes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39163-39240-condes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39164-39570-conliege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39164-39570-conliege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39164-39570-conliege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39164-39570-conliege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39165-39300-conte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39165-39300-conte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39165-39300-conte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39165-39300-conte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39166-39240-cornod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39166-39240-cornod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39166-39240-cornod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39166-39240-cornod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39167-39140-cosges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39167-39140-cosges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39167-39140-cosges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39167-39140-cosges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39168-39570-courbette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39168-39570-courbette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39168-39570-courbette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39168-39570-courbette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39169-39570-courbouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39169-39570-courbouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39169-39570-courbouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39169-39570-courbouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39170-39570-courlans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39170-39570-courlans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39170-39570-courlans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39170-39570-courlans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39171-39570-courlaoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39171-39570-courlaoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39171-39570-courlaoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39171-39570-courlaoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39172-39700-courtefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39172-39700-courtefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39172-39700-courtefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39172-39700-courtefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39173-39190-cousance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39173-39190-cousance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39173-39190-cousance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39173-39190-cousance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39174-39200-coyriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39174-39200-coyriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39174-39200-coyriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39174-39200-coyriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39175-39260-coyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39175-39260-coyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39175-39260-coyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39175-39260-coyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39176-39600-cramans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39176-39600-cramans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39176-39600-cramans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39176-39600-cramans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39177-39570-hauteroche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39177-39570-hauteroche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39177-39570-hauteroche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39177-39570-hauteroche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39177-39210-hauteroche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39177-39210-hauteroche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39177-39210-hauteroche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39177-39210-hauteroche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39178-39300-crans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39178-39300-crans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39178-39300-crans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39178-39300-crans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39179-39260-crenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39179-39260-crenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39179-39260-crenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39179-39260-crenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39180-39270-cressia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39180-39270-cressia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39180-39270-cressia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39180-39270-cressia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39182-39100-crissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39182-39100-crissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39182-39100-crissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39182-39100-crissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39183-39300-crotenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39183-39300-crotenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39183-39300-crotenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39183-39300-crotenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39184-39260-les_crozets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39184-39260-les_crozets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39184-39260-les_crozets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39184-39260-les_crozets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39185-39190-cuisia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39185-39190-cuisia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39185-39190-cuisia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39185-39190-cuisia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39187-39250-cuvier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39187-39250-cuvier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39187-39250-cuvier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39187-39250-cuvier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39188-39290-dammartin_marpain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39188-39290-dammartin_marpain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39188-39290-dammartin_marpain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39188-39290-dammartin_marpain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39189-39500-damparis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39189-39500-damparis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39189-39500-damparis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39189-39500-damparis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39190-39700-dampierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39190-39700-dampierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39190-39700-dampierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39190-39700-dampierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39190-39350-dampierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39190-39350-dampierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39190-39350-dampierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39190-39350-dampierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39191-39230-darbonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39191-39230-darbonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39191-39230-darbonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39191-39230-darbonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39192-39130-denezieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39192-39130-denezieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39192-39130-denezieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39192-39130-denezieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39193-39120-le_deschaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39193-39120-le_deschaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39193-39120-le_deschaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39193-39120-le_deschaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39194-39140-desnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39194-39140-desnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39194-39140-desnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39194-39140-desnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39196-39230-les_deux_fays/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39196-39230-les_deux_fays/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39196-39230-les_deux_fays/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39196-39230-les_deux_fays/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39197-39190-digna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39197-39190-digna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39197-39190-digna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39197-39190-digna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39198-39100-dole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39198-39100-dole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39198-39100-dole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39198-39100-dole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39199-39210-domblans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39199-39210-domblans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39199-39210-domblans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39199-39210-domblans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39199-39230-domblans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39199-39230-domblans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39199-39230-domblans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39199-39230-domblans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39200-39270-dompierre_sur_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39200-39270-dompierre_sur_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39200-39270-dompierre_sur_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39200-39270-dompierre_sur_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39201-39130-doucier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39201-39130-doucier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39201-39130-doucier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39201-39130-doucier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39202-39110-dournon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39202-39110-dournon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39202-39110-dournon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39202-39110-dournon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39203-39250-doye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39203-39250-doye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39203-39250-doye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39203-39250-doye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39204-39240-dramelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39204-39240-dramelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39204-39240-dramelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39204-39240-dramelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39205-39700-eclans_nenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39205-39700-eclans_nenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39205-39700-eclans_nenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39205-39700-eclans_nenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39206-39600-ecleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39206-39600-ecleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39206-39600-ecleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39206-39600-ecleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39207-39270-ecrille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39207-39270-ecrille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39207-39270-ecrille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39207-39270-ecrille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39208-39150-entre_deux_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39208-39150-entre_deux_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39208-39150-entre_deux_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39208-39150-entre_deux_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39209-39160-val_d_epy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39209-39160-val_d_epy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39209-39160-val_d_epy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39209-39160-val_d_epy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39209-39320-val_d_epy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39209-39320-val_d_epy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39209-39320-val_d_epy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39209-39320-val_d_epy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39210-39300-equevillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39210-39300-equevillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39210-39300-equevillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39210-39300-equevillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39211-39120-les_essards_taignevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39211-39120-les_essards_taignevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39211-39120-les_essards_taignevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39211-39120-les_essards_taignevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39214-39250-esserval_tartre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39214-39250-esserval_tartre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39214-39250-esserval_tartre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39214-39250-esserval_tartre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39216-39130-etival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39216-39130-etival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39216-39130-etival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39216-39130-etival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39217-39570-l_etoile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39217-39570-l_etoile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39217-39570-l_etoile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39217-39570-l_etoile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39218-39700-etrepigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39218-39700-etrepigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39218-39700-etrepigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39218-39700-etrepigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39219-39700-evans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39219-39700-evans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39219-39700-evans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39219-39700-evans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39220-39700-falletans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39220-39700-falletans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39220-39700-falletans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39220-39700-falletans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39221-39250-la_faviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39221-39250-la_faviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39221-39250-la_faviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39221-39250-la_faviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39222-39800-fay_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39222-39800-fay_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39222-39800-fay_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39222-39800-fay_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39223-39600-la_ferte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39223-39600-la_ferte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39223-39600-la_ferte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39223-39600-la_ferte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39225-39800-le_fied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39225-39800-le_fied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39225-39800-le_fied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39225-39800-le_fied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39227-39520-foncine_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39227-39520-foncine_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39227-39520-foncine_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39227-39520-foncine_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39228-39460-foncine_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39228-39460-foncine_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39228-39460-foncine_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39228-39460-foncine_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39229-39140-fontainebrux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39229-39140-fontainebrux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39229-39140-fontainebrux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39229-39140-fontainebrux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39230-39130-fontenu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39230-39130-fontenu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39230-39130-fontenu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39230-39130-fontenu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39232-39150-fort_du_plasne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39232-39150-fort_du_plasne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39232-39150-fort_du_plasne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39232-39150-fort_du_plasne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39233-39100-foucherans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39233-39100-foucherans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39233-39100-foucherans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39233-39100-foucherans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39234-39230-foulenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39234-39230-foulenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39234-39230-foulenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39234-39230-foulenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39235-39700-fraisans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39235-39700-fraisans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39235-39700-fraisans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39235-39700-fraisans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39236-39230-francheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39236-39230-francheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39236-39230-francheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39236-39230-francheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39237-39250-fraroz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39237-39250-fraroz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39237-39250-fraroz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39237-39250-fraroz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39238-39290-frasne_les_meulieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39238-39290-frasne_les_meulieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39238-39290-frasne_les_meulieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39238-39290-frasne_les_meulieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39239-39130-la_frasnee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39239-39130-la_frasnee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39239-39130-la_frasnee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39239-39130-la_frasnee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39240-39130-le_frasnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39240-39130-le_frasnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39240-39130-le_frasnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39240-39130-le_frasnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39241-39570-frebuans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39241-39570-frebuans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39241-39570-frebuans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39241-39570-frebuans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39244-39210-frontenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39244-39210-frontenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39244-39210-frontenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39244-39210-frontenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39245-39120-gatey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39245-39120-gatey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39245-39120-gatey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39245-39120-gatey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39246-39350-gendrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39246-39350-gendrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39246-39350-gendrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39246-39350-gendrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39247-39240-genod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39247-39240-genod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39247-39240-genod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39247-39240-genod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39248-39110-geraise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39248-39110-geraise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39248-39110-geraise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39248-39110-geraise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39249-39380-germigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39249-39380-germigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39249-39380-germigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39249-39380-germigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39250-39570-geruge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39250-39570-geruge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39250-39570-geruge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39250-39570-geruge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39251-39570-gevingey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39251-39570-gevingey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39251-39570-gevingey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39251-39570-gevingey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39252-39100-gevry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39252-39100-gevry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39252-39100-gevry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39252-39100-gevry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39253-39320-gigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39253-39320-gigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39253-39320-gigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39253-39320-gigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39254-39250-gillois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39254-39250-gillois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39254-39250-gillois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39254-39250-gillois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39255-39190-gizia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39255-39190-gizia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39255-39190-gizia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39255-39190-gizia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39258-39150-grande_riviere_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39258-39150-grande_riviere_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39258-39150-grande_riviere_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39258-39150-grande_riviere_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39259-39600-grange_de_vaivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39259-39600-grange_de_vaivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39259-39600-grange_de_vaivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39259-39600-grange_de_vaivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39261-39320-graye_et_charnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39261-39320-graye_et_charnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39261-39320-graye_et_charnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39261-39320-graye_et_charnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39262-39290-gredisans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39262-39290-gredisans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39262-39290-gredisans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39262-39290-gredisans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39263-39800-grozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39263-39800-grozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39263-39800-grozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39263-39800-grozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39265-39130-hautecour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39265-39130-hautecour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39265-39130-hautecour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39265-39130-hautecour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39266-39120-les_hays/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39266-39120-les_hays/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39266-39120-les_hays/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39266-39120-les_hays/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39267-39110-ivory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39267-39110-ivory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39267-39110-ivory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39267-39110-ivory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39268-39110-ivrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39268-39110-ivrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39268-39110-ivrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39268-39110-ivrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39269-39360-jeurre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39269-39360-jeurre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39269-39360-jeurre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39269-39360-jeurre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39270-39100-jouhe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39270-39100-jouhe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39270-39100-jouhe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39270-39100-jouhe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39271-39150-lac_des_rouges_truites/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39271-39150-lac_des_rouges_truites/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39271-39150-lac_des_rouges_truites/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39271-39150-lac_des_rouges_truites/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39272-39210-ladoye_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39272-39210-ladoye_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39272-39210-ladoye_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39272-39210-ladoye_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39273-39320-montlainsia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39273-39320-montlainsia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39273-39320-montlainsia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39273-39320-montlainsia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39274-39310-lajoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39274-39310-lajoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39274-39310-lajoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39274-39310-lajoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39274-01410-lajoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39274-01410-lajoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39274-01410-lajoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39274-01410-lajoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39275-39310-lamoura/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39275-39310-lamoura/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39275-39310-lamoura/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39275-39310-lamoura/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39277-39300-le_larderet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39277-39300-le_larderet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39277-39300-le_larderet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39277-39300-le_larderet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39278-39130-largillay_marsonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39278-39130-largillay_marsonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39278-39130-largillay_marsonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39278-39130-largillay_marsonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39279-39140-larnaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39279-39140-larnaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39279-39140-larnaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39279-39140-larnaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39280-39360-larrivoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39280-39360-larrivoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39280-39360-larrivoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39280-39360-larrivoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39281-39300-le_latet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39281-39300-le_latet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39281-39300-le_latet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39281-39300-le_latet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39282-39250-la_latette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39282-39250-la_latette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39282-39250-la_latette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39282-39250-la_latette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39283-01590-lavancia_epercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39283-01590-lavancia_epercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39283-01590-lavancia_epercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39283-01590-lavancia_epercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39284-39700-lavangeot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39284-39700-lavangeot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39284-39700-lavangeot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39284-39700-lavangeot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39285-39700-lavans_les_dole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39285-39700-lavans_les_dole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39285-39700-lavans_les_dole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39285-39700-lavans_les_dole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39286-39170-lavans_les_saint_claude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39286-39170-lavans_les_saint_claude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39286-39170-lavans_les_saint_claude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39286-39170-lavans_les_saint_claude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39288-39210-lavigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39288-39210-lavigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39288-39210-lavigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39288-39210-lavigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39289-39260-lect/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39289-39260-lect/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39289-39260-lect/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39289-39260-lect/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39290-39240-valzin_en_petite_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39290-39240-valzin_en_petite_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39290-39240-valzin_en_petite_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39290-39240-valzin_en_petite_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39291-39110-lemuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39291-39110-lemuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39291-39110-lemuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39291-39110-lemuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39292-39300-lent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39292-39300-lent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39292-39300-lent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39292-39300-lent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39293-39170-lescheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39293-39170-lescheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39293-39170-lescheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39293-39170-lescheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39295-39320-loisia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39295-39320-loisia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39295-39320-loisia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39295-39320-loisia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39296-39230-lombard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39296-39230-lombard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39296-39230-lombard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39296-39230-lombard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39297-39400-longchaumois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39297-39400-longchaumois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39297-39400-longchaumois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39297-39400-longchaumois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39298-39250-longcochon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39298-39250-longcochon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39298-39250-longcochon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39298-39250-longcochon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39299-39120-longwy_sur_le_doubs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39299-39120-longwy_sur_le_doubs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39299-39120-longwy_sur_le_doubs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39299-39120-longwy_sur_le_doubs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39300-39000-lons_le_saunier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39300-39000-lons_le_saunier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39300-39000-lons_le_saunier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39300-39000-lons_le_saunier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39301-39300-loulle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39301-39300-loulle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39301-39300-loulle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39301-39300-loulle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39302-39350-louvatange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39302-39350-louvatange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39302-39350-louvatange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39302-39350-louvatange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39304-39210-le_louverot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39304-39210-le_louverot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39304-39210-le_louverot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39304-39210-le_louverot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39305-39380-la_loye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39305-39380-la_loye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39305-39380-la_loye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39305-39380-la_loye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39306-39570-macornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39306-39570-macornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39306-39570-macornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39306-39570-macornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39307-39260-maisod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39307-39260-maisod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39307-39260-maisod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39307-39260-maisod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39308-39700-malange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39308-39700-malange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39308-39700-malange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39308-39700-malange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39310-39230-mantry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39310-39230-mantry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39310-39230-mantry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39310-39230-mantry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39312-39240-marigna_sur_valouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39312-39240-marigna_sur_valouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39312-39240-marigna_sur_valouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39312-39240-marigna_sur_valouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39313-39130-marigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39313-39130-marigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39313-39130-marigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39313-39130-marigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39314-39270-marnezia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39314-39270-marnezia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39314-39270-marnezia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39314-39270-marnezia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39315-39110-marnoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39315-39110-marnoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39315-39110-marnoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39315-39110-marnoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39317-39210-la_marre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39317-39210-la_marre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39317-39210-la_marre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39317-39210-la_marre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39318-39260-martigna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39318-39260-martigna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39318-39260-martigna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39318-39260-martigna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39319-39600-mathenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39319-39600-mathenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39319-39600-mathenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39319-39600-mathenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39320-39190-maynal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39320-39190-maynal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39320-39190-maynal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39320-39190-maynal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39321-39210-menetru_le_vignoble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39321-39210-menetru_le_vignoble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39321-39210-menetru_le_vignoble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39321-39210-menetru_le_vignoble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39322-39130-menetrux_en_joux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39322-39130-menetrux_en_joux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39322-39130-menetrux_en_joux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39322-39130-menetrux_en_joux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39323-39290-menotey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39323-39290-menotey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39323-39290-menotey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39323-39290-menotey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39324-39270-merona/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39324-39270-merona/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39324-39270-merona/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39324-39270-merona/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39325-39600-mesnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39325-39600-mesnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39325-39600-mesnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39325-39600-mesnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39326-39130-mesnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39326-39130-mesnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39326-39130-mesnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39326-39130-mesnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39327-39570-messia_sur_sorne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39327-39570-messia_sur_sorne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39327-39570-messia_sur_sorne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39327-39570-messia_sur_sorne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39328-39260-meussia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39328-39260-meussia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39328-39260-meussia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39328-39260-meussia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39329-39250-mieges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39329-39250-mieges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39329-39250-mieges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39329-39250-mieges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39330-39800-miery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39330-39800-miery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39330-39800-miery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39330-39800-miery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39331-39250-mignovillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39331-39250-mignovillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39331-39250-mignovillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39331-39250-mignovillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39333-39260-moirans_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39333-39260-moirans_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39333-39260-moirans_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39333-39260-moirans_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39334-39570-moiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39334-39570-moiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39334-39570-moiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39334-39570-moiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39335-39290-moissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39335-39290-moissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39335-39290-moissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39335-39290-moissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39336-39800-molain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39336-39800-molain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39336-39800-molain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39336-39800-molain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39337-39600-molamboz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39337-39600-molamboz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39337-39600-molamboz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39337-39600-molamboz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39338-39500-molay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39338-39500-molay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39338-39500-molay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39338-39500-molay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39339-39360-chassal_molinges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39339-39360-chassal_molinges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39339-39360-chassal_molinges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39339-39360-chassal_molinges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39342-39230-monay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39342-39230-monay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39342-39230-monay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39342-39230-monay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39343-39320-monnetay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39343-39320-monnetay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39343-39320-monnetay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39343-39320-monnetay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39344-39300-monnet_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39344-39300-monnet_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39344-39300-monnet_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39344-39300-monnet_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39345-39100-monnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39345-39100-monnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39345-39100-monnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39345-39100-monnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39346-39160-montagna_le_reconduit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39346-39160-montagna_le_reconduit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39346-39160-montagna_le_reconduit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39346-39160-montagna_le_reconduit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39348-39570-montaigu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39348-39570-montaigu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39348-39570-montaigu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39348-39570-montaigu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39349-39210-montain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39349-39210-montain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39349-39210-montain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39349-39210-montain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39350-39380-montbarrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39350-39380-montbarrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39350-39380-montbarrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39350-39380-montbarrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39351-39260-montcusel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39351-39260-montcusel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39351-39260-montcusel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39351-39260-montcusel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39352-39700-monteplain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39352-39700-monteplain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39352-39700-monteplain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39352-39700-monteplain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39353-39320-montfleur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39353-39320-montfleur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39353-39320-montfleur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39353-39320-montfleur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39354-39800-montholier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39354-39800-montholier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39354-39800-montholier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39354-39800-montholier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39355-39600-montigny_les_arsures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39355-39600-montigny_les_arsures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39355-39600-montigny_les_arsures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39355-39600-montigny_les_arsures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39356-39300-montigny_sur_l_ain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39356-39300-montigny_sur_l_ain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39356-39300-montigny_sur_l_ain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39356-39300-montigny_sur_l_ain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39359-39110-montmarlon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39359-39110-montmarlon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39359-39110-montmarlon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39359-39110-montmarlon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39360-39290-montmirey_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39360-39290-montmirey_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39360-39290-montmirey_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39360-39290-montmirey_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39361-39290-montmirey_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39361-39290-montmirey_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39361-39290-montmirey_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39361-39290-montmirey_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39362-39570-montmorot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39362-39570-montmorot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39362-39570-montmorot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39362-39570-montmorot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39363-39320-montrevel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39363-39320-montrevel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39363-39320-montrevel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39363-39320-montrevel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39364-39300-montrond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39364-39300-montrond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39364-39300-montrond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39364-39300-montrond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39365-39380-mont_sous_vaudrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39365-39380-mont_sous_vaudrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39365-39380-mont_sous_vaudrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39365-39380-mont_sous_vaudrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39366-39300-mont_sur_monnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39366-39300-mont_sur_monnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39366-39300-mont_sur_monnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39366-39300-mont_sur_monnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39367-39400-morbier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39367-39400-morbier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39367-39400-morbier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39367-39400-morbier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39368-39400-hauts_de_bienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39368-39400-hauts_de_bienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39368-39400-hauts_de_bienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39368-39400-hauts_de_bienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39370-39330-mouchard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39370-39330-mouchard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39370-39330-mouchard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39370-39330-mouchard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39372-39250-mournans_charbonny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39372-39250-mournans_charbonny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39372-39250-mournans_charbonny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39372-39250-mournans_charbonny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39373-39310-les_moussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39373-39310-les_moussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39373-39310-les_moussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39373-39310-les_moussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39375-39270-moutonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39375-39270-moutonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39375-39270-moutonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39375-39270-moutonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39376-39300-moutoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39376-39300-moutoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39376-39300-moutoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39376-39300-moutoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39377-39290-mutigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39377-39290-mutigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39377-39290-mutigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39377-39290-mutigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39378-39160-les_trois_chateaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39378-39160-les_trois_chateaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39378-39160-les_trois_chateaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39378-39160-les_trois_chateaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39379-39140-nance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39379-39140-nance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39379-39140-nance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39379-39140-nance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39380-39270-nancuise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39380-39270-nancuise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39380-39270-nancuise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39380-39270-nancuise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39381-39300-les_nans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39381-39300-les_nans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39381-39300-les_nans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39381-39300-les_nans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39385-39120-neublans_abergement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39385-39120-neublans_abergement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39385-39120-neublans_abergement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39385-39120-neublans_abergement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39386-39800-neuvilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39386-39800-neuvilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39386-39800-neuvilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39386-39800-neuvilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39387-39380-nevy_les_dole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39387-39380-nevy_les_dole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39387-39380-nevy_les_dole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39387-39380-nevy_les_dole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39388-39210-nevy_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39388-39210-nevy_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39388-39210-nevy_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39388-39210-nevy_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39389-39300-ney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39389-39300-ney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39389-39300-ney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39389-39300-ney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39390-39570-nogna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39390-39570-nogna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39390-39570-nogna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39390-39570-nogna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39391-39250-nozeroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39391-39250-nozeroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39391-39250-nozeroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39391-39250-nozeroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39392-39290-offlanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39392-39290-offlanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39392-39290-offlanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39392-39290-offlanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39393-39250-onglieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39393-39250-onglieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39393-39250-onglieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39393-39250-onglieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39394-39270-onoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39394-39270-onoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39394-39270-onoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39394-39270-onoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39396-39700-orchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39396-39700-orchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39396-39700-orchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39396-39700-orchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39397-39270-orgelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39397-39270-orgelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39397-39270-orgelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39397-39270-orgelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39398-39350-ougney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39398-39350-ougney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39398-39350-ougney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39398-39350-ougney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39399-39380-ounans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39399-39380-ounans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39399-39380-ounans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39399-39380-ounans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39400-39700-our/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39400-39700-our/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39400-39700-our/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39400-39700-our/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39401-39800-oussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39401-39800-oussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39401-39800-oussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39401-39800-oussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39402-39350-pagney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39402-39350-pagney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39402-39350-pagney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39402-39350-pagney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39403-39330-pagnoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39403-39330-pagnoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39403-39330-pagnoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39403-39330-pagnoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39404-39570-pannessieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39404-39570-pannessieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39404-39570-pannessieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39404-39570-pannessieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39405-39100-parcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39405-39100-parcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39405-39100-parcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39405-39100-parcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39406-39300-le_pasquier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39406-39300-le_pasquier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39406-39300-le_pasquier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39406-39300-le_pasquier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39407-39230-passenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39407-39230-passenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39407-39230-passenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39407-39230-passenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39408-39130-patornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39408-39130-patornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39408-39130-patornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39408-39130-patornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39409-39290-peintre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39409-39290-peintre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39409-39290-peintre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39409-39290-peintre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39411-39570-perrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39411-39570-perrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39411-39570-perrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39411-39570-perrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39412-39120-peseux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39412-39120-peseux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39412-39120-peseux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39412-39120-peseux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39413-39370-la_pesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39413-39370-la_pesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39413-39370-la_pesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39413-39370-la_pesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39415-39120-petit_noir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39415-39120-petit_noir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39415-39120-petit_noir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39415-39120-petit_noir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39418-39800-picarreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39418-39800-picarreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39418-39800-picarreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39418-39800-picarreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39419-39300-pillemoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39419-39300-pillemoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39419-39300-pillemoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39419-39300-pillemoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39420-39270-pimorin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39420-39270-pimorin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39420-39270-pimorin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39420-39270-pimorin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39421-39210-le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39421-39210-le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39421-39210-le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39421-39210-le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39422-39210-plainoiseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39422-39210-plainoiseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39422-39210-plainoiseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39422-39210-plainoiseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39423-39270-plaisia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39423-39270-plaisia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39423-39270-plaisia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39423-39270-plaisia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39424-39150-les_planches_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39424-39150-les_planches_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39424-39150-les_planches_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39424-39150-les_planches_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39425-39600-les_planches_pres_arbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39425-39600-les_planches_pres_arbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39425-39600-les_planches_pres_arbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39425-39600-les_planches_pres_arbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39800-plasne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39800-plasne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39800-plasne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39800-plasne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39210-plasne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39210-plasne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39210-plasne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39210-plasne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39220-plasne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39220-plasne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39220-plasne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39426-39220-plasne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39427-39250-plenise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39427-39250-plenise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39427-39250-plenise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39427-39250-plenise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39428-39250-plenisette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39428-39250-plenisette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39428-39250-plenisette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39428-39250-plenisette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39429-39120-pleure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39429-39120-pleure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39429-39120-pleure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39429-39120-pleure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39430-39700-plumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39430-39700-plumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39430-39700-plumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39430-39700-plumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39431-39570-poids_de_fiole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39431-39570-poids_de_fiole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39431-39570-poids_de_fiole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39431-39570-poids_de_fiole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39432-39290-pointre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39432-39290-pointre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39432-39290-pointre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39432-39290-pointre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39434-39800-poligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39434-39800-poligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39434-39800-poligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39434-39800-poligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39435-39130-pont_de_poitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39435-39130-pont_de_poitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39435-39130-pont_de_poitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39435-39130-pont_de_poitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39436-39110-pont_d_hery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39436-39110-pont_d_hery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39436-39110-pont_d_hery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39436-39110-pont_d_hery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39437-39300-pont_du_navoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39437-39300-pont_du_navoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39437-39300-pont_du_navoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39437-39300-pont_du_navoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39439-39600-port_lesney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39439-39600-port_lesney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39439-39600-port_lesney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39439-39600-port_lesney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39441-39220-premanon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39441-39220-premanon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39441-39220-premanon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39441-39220-premanon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39441-39400-premanon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39441-39400-premanon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39441-39400-premanon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39441-39400-premanon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39443-39270-presilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39443-39270-presilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39443-39270-presilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39443-39270-presilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39444-39110-pretin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39444-39110-pretin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39444-39110-pretin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39444-39110-pretin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39445-39570-publy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39445-39570-publy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39445-39570-publy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39445-39570-publy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39446-39600-pupillin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39446-39600-pupillin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39446-39600-pupillin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39446-39600-pupillin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39447-39570-quintigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39447-39570-quintigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39447-39570-quintigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39447-39570-quintigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39448-39120-rahon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39448-39120-rahon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39448-39120-rahon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39448-39120-rahon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39449-39290-rainans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39449-39290-rainans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39449-39290-rainans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39449-39290-rainans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39451-39700-ranchot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39451-39700-ranchot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39451-39700-ranchot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39451-39700-ranchot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39452-39700-rans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39452-39700-rans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39452-39700-rans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39452-39700-rans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39453-39170-ravilloles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39453-39170-ravilloles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39453-39170-ravilloles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39453-39170-ravilloles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39454-39230-recanoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39454-39230-recanoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39454-39230-recanoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39454-39230-recanoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39455-39270-reithouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39455-39270-reithouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39455-39270-reithouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39455-39270-reithouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39456-39140-relans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39456-39140-relans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39456-39140-relans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39456-39140-relans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39457-39140-les_repots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39457-39140-les_repots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39457-39140-les_repots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39457-39140-les_repots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39458-39570-revigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39458-39570-revigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39458-39570-revigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39458-39570-revigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39460-39200-la_rixouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39460-39200-la_rixouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39460-39200-la_rixouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39460-39200-la_rixouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39461-39250-rix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39461-39250-rix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39461-39250-rix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39461-39250-rix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39462-39700-rochefort_sur_nenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39462-39700-rochefort_sur_nenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39462-39700-rochefort_sur_nenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39462-39700-rochefort_sur_nenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39463-39360-rogna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39463-39360-rogna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39463-39360-rogna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39463-39360-rogna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39464-39350-romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39464-39350-romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39464-39350-romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39464-39350-romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39465-39700-romange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39465-39700-romange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39465-39700-romange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39465-39700-romange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39466-39190-rosay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39466-39190-rosay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39466-39190-rosay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39466-39190-rosay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39467-39190-rotalier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39467-39190-rotalier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39467-39190-rotalier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39467-39190-rotalier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39468-39270-rothonay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39468-39270-rothonay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39468-39270-rothonay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39468-39270-rothonay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39469-39350-rouffange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39469-39350-rouffange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39469-39350-rouffange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39469-39350-rouffange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39470-39220-les_rousses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39470-39220-les_rousses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39470-39220-les_rousses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39470-39220-les_rousses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39470-39400-les_rousses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39470-39400-les_rousses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39470-39400-les_rousses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39470-39400-les_rousses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39471-39140-ruffey_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39471-39140-ruffey_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39471-39140-ruffey_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39471-39140-ruffey_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39472-39230-rye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39472-39230-rye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39472-39230-rye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39472-39230-rye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39473-39130-saffloz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39473-39130-saffloz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39473-39130-saffloz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39473-39130-saffloz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39474-39190-sainte_agnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39474-39190-sainte_agnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39474-39190-sainte_agnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39474-39190-sainte_agnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39475-39160-saint_amour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39475-39160-saint_amour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39475-39160-saint_amour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39475-39160-saint_amour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39476-39410-saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39476-39410-saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39476-39410-saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39476-39410-saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39477-39120-saint_baraing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39477-39120-saint_baraing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39477-39120-saint_baraing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39477-39120-saint_baraing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39478-39200-saint_claude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39478-39200-saint_claude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39478-39200-saint_claude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39478-39200-saint_claude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39479-39600-saint_cyr_montmalin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39479-39600-saint_cyr_montmalin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39479-39600-saint_cyr_montmalin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39479-39600-saint_cyr_montmalin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39480-39570-saint_didier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39480-39570-saint_didier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39480-39570-saint_didier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39480-39570-saint_didier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39481-39300-saint_germain_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39481-39300-saint_germain_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39481-39300-saint_germain_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39481-39300-saint_germain_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39485-39320-val_suran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39485-39320-val_suran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39485-39320-val_suran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39485-39320-val_suran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39486-39230-saint_lamain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39486-39230-saint_lamain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39486-39230-saint_lamain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39486-39230-saint_lamain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39487-39150-saint_laurent_en_grandvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39487-39150-saint_laurent_en_grandvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39487-39150-saint_laurent_en_grandvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39487-39150-saint_laurent_en_grandvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39489-39230-saint_lothain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39489-39230-saint_lothain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39489-39230-saint_lothain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39489-39230-saint_lothain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39490-39120-saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39490-39120-saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39490-39120-saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39490-39120-saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39491-39170-coteaux_du_lizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39491-39170-coteaux_du_lizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39491-39170-coteaux_du_lizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39491-39170-coteaux_du_lizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39492-39570-saint_maur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39492-39570-saint_maur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39492-39570-saint_maur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39492-39570-saint_maur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39493-39130-saint_maurice_crillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39493-39130-saint_maurice_crillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39493-39130-saint_maurice_crillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39493-39130-saint_maurice_crillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39494-39150-saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39494-39150-saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39494-39150-saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39494-39150-saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39495-39110-saint_thiebaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39495-39110-saint_thiebaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39495-39110-saint_thiebaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39495-39110-saint_thiebaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39497-39110-saizenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39497-39110-saizenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39497-39110-saizenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39497-39110-saizenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39498-39700-salans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39498-39700-salans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39498-39700-salans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39498-39700-salans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39499-39350-saligney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39499-39350-saligney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39499-39350-saligney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39499-39350-saligney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39500-39110-salins_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39500-39110-salins_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39500-39110-salins_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39500-39110-salins_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39501-39100-sampans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39501-39100-sampans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39501-39100-sampans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39501-39100-sampans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39502-39380-santans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39502-39380-santans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39502-39380-santans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39502-39380-santans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39503-39300-sapois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39503-39300-sapois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39503-39300-sapois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39503-39300-sapois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39504-39270-sarrogna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39504-39270-sarrogna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39504-39270-sarrogna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39504-39270-sarrogna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39505-39130-saugeot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39505-39130-saugeot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39505-39130-saugeot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39505-39130-saugeot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39507-39120-seligney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39507-39120-seligney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39507-39120-seligney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39507-39120-seligney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39508-39230-sellieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39508-39230-sellieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39508-39230-sellieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39508-39230-sellieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39510-39310-septmoncel_les_molunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39510-39310-septmoncel_les_molunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39510-39310-septmoncel_les_molunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39510-39310-septmoncel_les_molunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39510-39200-septmoncel_les_molunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39510-39200-septmoncel_les_molunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39510-39200-septmoncel_les_molunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39510-39200-septmoncel_les_molunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39511-39230-sergenaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39511-39230-sergenaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39511-39230-sergenaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39511-39230-sergenaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39512-39120-sergenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39512-39120-sergenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39512-39120-sergenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39512-39120-sergenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39513-39700-sermange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39513-39700-sermange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39513-39700-sermange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39513-39700-sermange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39514-39700-serre_les_moulieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39514-39700-serre_les_moulieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39514-39700-serre_les_moulieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39514-39700-serre_les_moulieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39517-39300-sirod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39517-39300-sirod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39517-39300-sirod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39517-39300-sirod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39518-39130-songeson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39518-39130-songeson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39518-39130-songeson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39518-39130-songeson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39519-39130-soucia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39519-39130-soucia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39519-39130-soucia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39519-39130-soucia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39520-39380-souvans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39520-39380-souvans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39520-39380-souvans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39520-39380-souvans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39522-39300-supt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39522-39300-supt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39522-39300-supt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39522-39300-supt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39523-39300-syam/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39523-39300-syam/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39523-39300-syam/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39523-39300-syam/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39525-39120-tassenieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39525-39120-tassenieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39525-39120-tassenieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39525-39120-tassenieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39526-39500-tavaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39526-39500-tavaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39526-39500-tavaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39526-39500-tavaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39527-39350-taxenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39527-39350-taxenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39527-39350-taxenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39527-39350-taxenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39528-39290-thervay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39528-39290-thervay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39528-39290-thervay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39528-39290-thervay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39529-39110-thesy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39529-39110-thesy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39529-39110-thesy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39529-39110-thesy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39530-39240-thoirette_coisia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39530-39240-thoirette_coisia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39530-39240-thoirette_coisia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39530-39240-thoirette_coisia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39531-39130-thoiria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39531-39130-thoiria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39531-39130-thoiria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39531-39130-thoiria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39532-39160-thoissia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39532-39160-thoissia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39532-39160-thoissia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39532-39160-thoissia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39533-39230-toulouse_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39533-39230-toulouse_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39533-39230-toulouse_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39533-39230-toulouse_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39534-39270-la_tour_du_meix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39534-39270-la_tour_du_meix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39534-39270-la_tour_du_meix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39534-39270-la_tour_du_meix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39535-39800-tourmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39535-39800-tourmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39535-39800-tourmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39535-39800-tourmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39537-39570-trenal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39537-39570-trenal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39537-39570-trenal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39537-39570-trenal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39537-39190-trenal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39537-39190-trenal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39537-39190-trenal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39537-39190-trenal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39538-39130-uxelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39538-39130-uxelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39538-39130-uxelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39538-39130-uxelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39539-39600-vadans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39539-39600-vadans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39539-39600-vadans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39539-39600-vadans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39540-39300-valempoulieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39540-39300-valempoulieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39540-39300-valempoulieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39540-39300-valempoulieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39543-39300-vannoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39543-39300-vannoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39543-39300-vannoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39543-39300-vannoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39545-39300-le_vaudioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39545-39300-le_vaudioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39545-39300-le_vaudioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39545-39300-le_vaudioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39546-39380-vaudrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39546-39380-vaudrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39546-39380-vaudrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39546-39380-vaudrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39547-39360-vaux_les_saint_claude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39547-39360-vaux_les_saint_claude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39547-39360-vaux_les_saint_claude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39547-39360-vaux_les_saint_claude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39548-39800-vaux_sur_poligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39548-39800-vaux_sur_poligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39548-39800-vaux_sur_poligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39548-39800-vaux_sur_poligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39550-39570-verges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39550-39570-verges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39550-39570-verges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39550-39570-verges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39551-39160-veria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39551-39160-veria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39551-39160-veria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39551-39160-veria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39552-39570-vernantois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39552-39570-vernantois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39552-39570-vernantois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39552-39570-vernantois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39553-39210-le_vernois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39553-39210-le_vernois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39553-39210-le_vernois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39553-39210-le_vernois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39554-39300-vers_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39554-39300-vers_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39554-39300-vers_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39554-39300-vers_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39555-39230-vers_sous_sellieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39555-39230-vers_sous_sellieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39555-39230-vers_sous_sellieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39555-39230-vers_sous_sellieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39556-39130-vertamboz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39556-39130-vertamboz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39556-39130-vertamboz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39556-39130-vertamboz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39557-39240-vescles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39557-39240-vescles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39557-39240-vescles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39557-39240-vescles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39558-39570-vevy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39558-39570-vevy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39558-39570-vevy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39558-39570-vevy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39559-39380-la_vieille_loye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39559-39380-la_vieille_loye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39559-39380-la_vieille_loye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39559-39380-la_vieille_loye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39560-39200-villard_saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39560-39200-villard_saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39560-39200-villard_saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39560-39200-villard_saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39561-39260-villards_d_heria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39561-39260-villards_d_heria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39561-39260-villards_d_heria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39561-39260-villards_d_heria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39565-39600-villeneuve_d_aval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39565-39600-villeneuve_d_aval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39565-39600-villeneuve_d_aval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39565-39600-villeneuve_d_aval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39567-39570-villeneuve_sous_pymont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39567-39570-villeneuve_sous_pymont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39567-39570-villeneuve_sous_pymont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39567-39570-villeneuve_sous_pymont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39568-39800-villerserine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39568-39800-villerserine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39568-39800-villerserine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39568-39800-villerserine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39569-39600-villers_farlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39569-39600-villers_farlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39569-39600-villers_farlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39569-39600-villers_farlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39570-39800-villers_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39570-39800-villers_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39570-39800-villers_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39570-39800-villers_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39570-39120-villers_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39570-39120-villers_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39570-39120-villers_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39570-39120-villers_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39571-39120-villers_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39571-39120-villers_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39571-39120-villers_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39571-39120-villers_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39572-39600-villette_les_arbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39572-39600-villette_les_arbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39572-39600-villette_les_arbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39572-39600-villette_les_arbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39573-39100-villette_les_dole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39573-39100-villette_les_dole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39573-39100-villette_les_dole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39573-39100-villette_les_dole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39574-39140-villevieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39574-39140-villevieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39574-39140-villevieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39574-39140-villevieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39575-39230-le_villey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39575-39230-le_villey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39575-39230-le_villey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39575-39230-le_villey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39576-39190-val_sonnette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39576-39190-val_sonnette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39576-39190-val_sonnette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39576-39190-val_sonnette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39577-39230-vincent_froideville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39577-39230-vincent_froideville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39577-39230-vincent_froideville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39577-39230-vincent_froideville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39579-39360-viry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39579-39360-viry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39579-39360-viry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39579-39360-viry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39581-39350-vitreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39581-39350-vitreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39581-39350-vitreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39581-39350-vitreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39582-39210-voiteur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39582-39210-voiteur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39582-39210-voiteur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39582-39210-voiteur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39583-39240-vosbles_valfin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39583-39240-vosbles_valfin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39583-39240-vosbles_valfin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39583-39240-vosbles_valfin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39584-39700-vriange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39584-39700-vriange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39584-39700-vriange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39584-39700-vriange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39585-39360-vulvoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39585-39360-vulvoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39585-39360-vulvoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39585-39360-vulvoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39586-39110-aresches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39586-39110-aresches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39586-39110-aresches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt39-jura/commune39586-39110-aresches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-40.xml
+++ b/public/sitemaps/sitemap-40.xml
@@ -5,660 +5,1316 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40001-40800-aire_sur_l_adour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40001-40800-aire_sur_l_adour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40001-40800-aire_sur_l_adour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40001-40800-aire_sur_l_adour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40002-40330-amou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40002-40330-amou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40002-40330-amou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40002-40330-amou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40003-40990-angoume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40003-40990-angoume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40003-40990-angoume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40003-40990-angoume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40004-40150-angresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40004-40150-angresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40004-40150-angresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40004-40150-angresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40005-40320-arboucave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40005-40320-arboucave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40005-40320-arboucave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40005-40320-arboucave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40006-40110-arengosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40006-40110-arengosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40006-40110-arengosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40006-40110-arengosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40007-40700-argelos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40007-40700-argelos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40007-40700-argelos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40007-40700-argelos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40008-40430-argelouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40008-40430-argelouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40008-40430-argelouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40008-40430-argelouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40011-40330-arsague/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40011-40330-arsague/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40011-40330-arsague/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40011-40330-arsague/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40012-40090-artassenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40012-40090-artassenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40012-40090-artassenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40012-40090-artassenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40013-40190-arthez_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40013-40190-arthez_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40013-40190-arthez_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40013-40190-arthez_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40014-40120-arue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40014-40120-arue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40014-40120-arue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40014-40120-arue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40015-40310-arx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40015-40310-arx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40015-40310-arx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40015-40310-arx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40016-40700-aubagnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40016-40700-aubagnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40016-40700-aubagnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40016-40700-aubagnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40017-40500-audignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40017-40500-audignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40017-40500-audignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40017-40500-audignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40018-40400-audon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40018-40400-audon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40018-40400-audon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40018-40400-audon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40019-40200-aureilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40019-40200-aureilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40019-40200-aureilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40019-40200-aureilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40020-40500-aurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40020-40500-aurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40020-40500-aurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40020-40500-aurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40021-40140-azur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40021-40140-azur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40021-40140-azur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40021-40140-azur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40022-40320-bahus_soubiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40022-40320-bahus_soubiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40022-40320-bahus_soubiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40022-40320-bahus_soubiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40023-40380-baigts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40023-40380-baigts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40023-40380-baigts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40023-40380-baigts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40024-40500-banos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40024-40500-banos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40024-40500-banos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40024-40500-banos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40025-40090-bascons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40025-40090-bascons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40025-40090-bascons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40025-40090-bascons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40026-40500-bas_mauco/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40026-40500-bas_mauco/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40026-40500-bas_mauco/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40026-40500-bas_mauco/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40027-40700-bassercles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40027-40700-bassercles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40027-40700-bassercles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40027-40700-bassercles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40028-40360-bastennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40028-40360-bastennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40028-40360-bastennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40028-40360-bastennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40029-40320-bats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40029-40320-bats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40029-40320-bats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40029-40320-bats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40030-40310-baudignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40030-40310-baudignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40030-40310-baudignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40030-40310-baudignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40031-40400-begaar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40031-40400-begaar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40031-40400-begaar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40031-40400-begaar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40032-40410-belhade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40032-40410-belhade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40032-40410-belhade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40032-40410-belhade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40033-40120-belis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40033-40120-belis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40033-40120-belis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40033-40120-belis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40034-40300-belus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40034-40300-belus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40034-40300-belus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40034-40300-belus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40035-40180-benesse_les_dax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40035-40180-benesse_les_dax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40035-40180-benesse_les_dax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40035-40180-benesse_les_dax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40036-40230-benesse_maremne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40036-40230-benesse_maremne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40036-40230-benesse_maremne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40036-40230-benesse_maremne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40037-40280-benquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40037-40280-benquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40037-40280-benquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40037-40280-benquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40038-40250-bergouey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40038-40250-bergouey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40038-40250-bergouey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40038-40250-bergouey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40039-40240-betbezer_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40039-40240-betbezer_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40039-40240-betbezer_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40039-40240-betbezer_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40040-40370-beylongue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40040-40370-beylongue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40040-40370-beylongue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40040-40370-beylongue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40041-40700-beyries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40041-40700-beyries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40041-40700-beyries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40041-40700-beyries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40042-40390-biarrotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40042-40390-biarrotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40042-40390-biarrotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40042-40390-biarrotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40043-40170-bias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40043-40170-bias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40043-40170-bias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40043-40170-bias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40044-40390-biaudos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40044-40390-biaudos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40044-40390-biaudos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40044-40390-biaudos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40046-40600-biscarrosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40046-40600-biscarrosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40046-40600-biscarrosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40046-40600-biscarrosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40047-40330-bonnegarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40047-40330-bonnegarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40047-40330-bonnegarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40047-40330-bonnegarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40049-40270-borderes_et_lamensans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40049-40270-borderes_et_lamensans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40049-40270-borderes_et_lamensans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40049-40270-borderes_et_lamensans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40050-40090-bostens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40050-40090-bostens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40050-40090-bostens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40050-40090-bostens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40051-40090-bougue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40051-40090-bougue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40051-40090-bougue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40051-40090-bougue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40052-40190-bourdalat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40052-40190-bourdalat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40052-40190-bourdalat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40052-40190-bourdalat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40053-40120-bourriot_bergonce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40053-40120-bourriot_bergonce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40053-40120-bourriot_bergonce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40053-40120-bourriot_bergonce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40054-40330-brassempouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40054-40330-brassempouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40054-40330-brassempouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40054-40330-brassempouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40055-40280-bretagne_de_marsan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40055-40280-bretagne_de_marsan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40055-40280-bretagne_de_marsan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40055-40280-bretagne_de_marsan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40056-40420-brocas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40056-40420-brocas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40056-40420-brocas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40056-40420-brocas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40057-40320-buanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40057-40320-buanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40057-40320-buanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40057-40320-buanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40058-40120-cachen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40058-40120-cachen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40058-40120-cachen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40058-40120-cachen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40059-40300-cagnotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40059-40300-cagnotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40059-40300-cagnotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40059-40300-cagnotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40060-40430-callen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40060-40430-callen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40060-40430-callen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40060-40430-callen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40061-40090-campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40061-40090-campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40061-40090-campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40061-40090-campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40062-40090-campet_et_lamolere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40062-40090-campet_et_lamolere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40062-40090-campet_et_lamolere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40062-40090-campet_et_lamolere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40063-40180-candresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40063-40180-candresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40063-40180-candresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40063-40180-candresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40064-40090-canenx_et_reaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40064-40090-canenx_et_reaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40064-40090-canenx_et_reaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40064-40090-canenx_et_reaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40065-40130-capbreton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40065-40130-capbreton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40065-40130-capbreton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40065-40130-capbreton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40066-40400-carcares_sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40066-40400-carcares_sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40066-40400-carcares_sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40066-40400-carcares_sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40067-40400-carcen_ponson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40067-40400-carcen_ponson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40067-40400-carcen_ponson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40067-40400-carcen_ponson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40068-40380-cassen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40068-40380-cassen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40068-40380-cassen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40068-40380-cassen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40069-40700-castaignos_souslens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40069-40700-castaignos_souslens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40069-40700-castaignos_souslens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40069-40700-castaignos_souslens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40070-40270-castandet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40070-40270-castandet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40070-40270-castandet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40070-40270-castandet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40071-40360-castelnau_chalosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40071-40360-castelnau_chalosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40071-40360-castelnau_chalosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40071-40360-castelnau_chalosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40072-40320-castelnau_tursan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40072-40320-castelnau_tursan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40072-40320-castelnau_tursan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40072-40320-castelnau_tursan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40073-40700-castelner/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40073-40700-castelner/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40073-40700-castelner/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40073-40700-castelner/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40074-40330-castel_sarrazin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40074-40330-castel_sarrazin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40074-40330-castel_sarrazin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40074-40330-castel_sarrazin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40075-40260-castets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40075-40260-castets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40075-40260-castets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40075-40260-castets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40076-40500-cauna/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40076-40500-cauna/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40076-40500-cauna/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40076-40500-cauna/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40077-40300-cauneille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40077-40300-cauneille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40077-40300-cauneille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40077-40300-cauneille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40078-40250-caupenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40078-40250-caupenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40078-40250-caupenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40078-40250-caupenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40079-40700-cazalis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40079-40700-cazalis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40079-40700-cazalis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40079-40700-cazalis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40080-40270-cazeres_sur_l_adour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40080-40270-cazeres_sur_l_adour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40080-40270-cazeres_sur_l_adour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40080-40270-cazeres_sur_l_adour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40081-40090-cere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40081-40090-cere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40081-40090-cere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40081-40090-cere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40082-40320-classun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40082-40320-classun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40082-40320-classun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40082-40320-classun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40083-40320-cledes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40083-40320-cledes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40083-40320-cledes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40083-40320-cledes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40084-40180-clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40084-40180-clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40084-40180-clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40084-40180-clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40085-40210-commensacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40085-40210-commensacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40085-40210-commensacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40085-40210-commensacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40086-40500-coudures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40086-40500-coudures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40086-40500-coudures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40086-40500-coudures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40087-40240-creon_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40087-40240-creon_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40087-40240-creon_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40087-40240-creon_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40088-40100-dax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40088-40100-dax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40088-40100-dax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40088-40100-dax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40089-40700-doazit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40089-40700-doazit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40089-40700-doazit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40089-40700-doazit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40090-40360-donzacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40090-40360-donzacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40090-40360-donzacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40090-40360-donzacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40091-40800-duhort_bachen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40091-40800-duhort_bachen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40091-40800-duhort_bachen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40091-40800-duhort_bachen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40092-40500-dumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40092-40500-dumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40092-40500-dumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40092-40500-dumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40093-40310-escalans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40093-40310-escalans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40093-40310-escalans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40093-40310-escalans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40094-40210-escource/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40094-40210-escource/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40094-40210-escource/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40094-40210-escource/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40095-40290-estibeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40095-40290-estibeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40095-40290-estibeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40095-40290-estibeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40096-40240-estigarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40096-40240-estigarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40096-40240-estigarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40096-40240-estigarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40097-40320-eugenie_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40097-40320-eugenie_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40097-40320-eugenie_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40097-40320-eugenie_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40098-40500-eyres_moncube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40098-40500-eyres_moncube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40098-40500-eyres_moncube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40098-40500-eyres_moncube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40099-40500-fargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40099-40500-fargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40099-40500-fargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40099-40500-fargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40100-40190-le_freche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40100-40190-le_freche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40100-40190-le_freche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40100-40190-le_freche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40101-40350-gaas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40101-40350-gaas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40101-40350-gaas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40101-40350-gaas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40102-40310-gabarret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40102-40310-gabarret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40102-40310-gabarret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40102-40310-gabarret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40103-40090-gailleres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40103-40090-gailleres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40103-40090-gailleres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40103-40090-gailleres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40104-40380-gamarde_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40104-40380-gamarde_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40104-40380-gamarde_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40104-40380-gamarde_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40105-40420-garein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40105-40420-garein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40105-40420-garein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40105-40420-garein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40106-40180-garrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40106-40180-garrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40106-40180-garrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40106-40180-garrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40108-40160-gastes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40108-40160-gastes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40108-40160-gastes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40108-40160-gastes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40109-40330-gaujacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40109-40330-gaujacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40109-40330-gaujacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40109-40330-gaujacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40110-40320-geaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40110-40320-geaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40110-40320-geaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40110-40320-geaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40111-40090-geloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40111-40090-geloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40111-40090-geloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40111-40090-geloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40112-40380-gibret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40112-40380-gibret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40112-40380-gibret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40112-40380-gibret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40113-40180-goos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40113-40180-goos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40113-40180-goos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40113-40180-goos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40114-40990-gourbera/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40114-40990-gourbera/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40114-40990-gourbera/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40114-40990-gourbera/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40115-40465-gousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40115-40465-gousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40115-40465-gousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40115-40465-gousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40116-40400-gouts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40116-40400-gouts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40116-40400-gouts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40116-40400-gouts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40117-40270-grenade_sur_l_adour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40117-40270-grenade_sur_l_adour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40117-40270-grenade_sur_l_adour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40117-40270-grenade_sur_l_adour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40118-40290-habas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40118-40290-habas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40118-40290-habas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40118-40290-habas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40119-40700-hagetmau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40119-40700-hagetmau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40119-40700-hagetmau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40119-40700-hagetmau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40120-40300-hastingues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40120-40300-hastingues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40120-40300-hastingues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40120-40300-hastingues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40121-40250-hauriet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40121-40250-hauriet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40121-40250-hauriet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40121-40250-hauriet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40122-40280-haut_mauco/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40122-40280-haut_mauco/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40122-40280-haut_mauco/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40122-40280-haut_mauco/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40123-40990-herm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40123-40990-herm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40123-40990-herm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40123-40990-herm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40124-40310-herre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40124-40310-herre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40124-40310-herre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40124-40310-herre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40125-40180-heugas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40125-40180-heugas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40125-40180-heugas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40125-40180-heugas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40126-40180-hinx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40126-40180-hinx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40126-40180-hinx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40126-40180-hinx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40127-40190-hontanx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40127-40190-hontanx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40127-40190-hontanx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40127-40190-hontanx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40128-40700-horsarrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40128-40700-horsarrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40128-40700-horsarrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40128-40700-horsarrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40129-40230-josse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40129-40230-josse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40129-40230-josse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40129-40230-josse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40130-40700-labastide_chalosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40130-40700-labastide_chalosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40130-40700-labastide_chalosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40130-40700-labastide_chalosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40131-40240-labastide_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40131-40240-labastide_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40131-40240-labastide_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40131-40240-labastide_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40132-40300-labatut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40132-40300-labatut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40132-40300-labatut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40132-40300-labatut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40133-40530-labenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40133-40530-labenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40133-40530-labenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40133-40530-labenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40134-40210-labouheyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40134-40210-labouheyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40134-40210-labouheyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40134-40210-labouheyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40135-40420-labrit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40135-40420-labrit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40135-40420-labrit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40135-40420-labrit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40136-40320-lacajunte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40136-40320-lacajunte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40136-40320-lacajunte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40136-40320-lacajunte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40137-40120-lacquy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40137-40120-lacquy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40137-40120-lacquy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40137-40120-lacquy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40138-40700-lacrabe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40138-40700-lacrabe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40138-40700-lacrabe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40138-40700-lacrabe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40139-40090-laglorieuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40139-40090-laglorieuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40139-40090-laglorieuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40139-40090-laglorieuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40140-40240-lagrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40140-40240-lagrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40140-40240-lagrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40140-40240-lagrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40141-40250-lahosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40141-40250-lahosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40141-40250-lahosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40141-40250-lahosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40142-40465-laluque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40142-40465-laluque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40142-40465-laluque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40142-40465-laluque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40143-40250-lamothe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40143-40250-lamothe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40143-40250-lamothe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40143-40250-lamothe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40144-40250-larbey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40144-40250-larbey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40144-40250-larbey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40144-40250-larbey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40145-40270-larriviere_saint_savin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40145-40270-larriviere_saint_savin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40145-40270-larriviere_saint_savin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40145-40270-larriviere_saint_savin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40146-40800-latrille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40146-40800-latrille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40146-40800-latrille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40146-40800-latrille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40147-40250-laurede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40147-40250-laurede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40147-40250-laurede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40147-40250-laurede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40148-40320-lauret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40148-40320-lauret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40148-40320-lauret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40148-40320-lauret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40149-40120-lencouacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40149-40120-lencouacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40149-40120-lencouacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40149-40120-lencouacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40150-40550-leon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40150-40550-leon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40150-40550-leon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40150-40550-leon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40151-40400-lesgor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40151-40400-lesgor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40151-40400-lesgor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40151-40400-lesgor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40152-40260-lesperon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40152-40260-lesperon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40152-40260-lesperon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40152-40260-lesperon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40153-40250-le_leuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40153-40250-le_leuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40153-40250-le_leuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40153-40250-le_leuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40154-40170-levignacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40154-40170-levignacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40154-40170-levignacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40154-40170-levignacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40155-40260-linxe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40155-40260-linxe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40155-40260-linxe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40155-40260-linxe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40156-40410-liposthey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40156-40410-liposthey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40156-40410-liposthey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40156-40410-liposthey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40157-40170-lit_et_mixe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40157-40170-lit_et_mixe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40157-40170-lit_et_mixe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40157-40170-lit_et_mixe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40158-40240-losse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40158-40240-losse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40158-40240-losse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40158-40240-losse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40159-40380-louer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40159-40380-louer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40159-40380-louer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40159-40380-louer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40160-40250-lourquen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40160-40250-lourquen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40160-40250-lourquen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40160-40250-lourquen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40161-40240-lubbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40161-40240-lubbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40161-40240-lubbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40161-40240-lubbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40162-40090-lucbardez_et_bargues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40162-40090-lucbardez_et_bargues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40162-40090-lucbardez_et_bargues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40162-40090-lucbardez_et_bargues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40163-40210-lue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40163-40210-lue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40163-40210-lue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40163-40210-lue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40164-40120-retjons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40164-40120-retjons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40164-40120-retjons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40164-40120-retjons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40165-40630-luglon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40165-40630-luglon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40165-40630-luglon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40165-40630-luglon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40166-40270-lussagnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40166-40270-lussagnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40166-40270-lussagnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40166-40270-lussagnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40167-40430-luxey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40167-40430-luxey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40167-40430-luxey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40167-40430-luxey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40168-40140-magescq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40168-40140-magescq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40168-40140-magescq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40168-40140-magescq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40169-40120-maillas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40169-40120-maillas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40169-40120-maillas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40169-40120-maillas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40170-40120-mailleres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40170-40120-mailleres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40170-40120-mailleres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40170-40120-mailleres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40171-40410-mano/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40171-40410-mano/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40171-40410-mano/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40171-40410-mano/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40172-40700-mant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40172-40700-mant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40172-40700-mant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40172-40700-mant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40173-40330-marpaps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40173-40330-marpaps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40173-40330-marpaps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40173-40330-marpaps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40174-40320-mauries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40174-40320-mauries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40174-40320-mauries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40174-40320-mauries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40175-40270-maurrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40175-40270-maurrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40175-40270-maurrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40175-40270-maurrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40176-40240-mauvezin_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40176-40240-mauvezin_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40176-40240-mauvezin_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40176-40240-mauvezin_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40177-40250-maylis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40177-40250-maylis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40177-40250-maylis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40177-40250-maylis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40178-40090-mazerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40178-40090-mazerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40178-40090-mazerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40178-40090-mazerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40179-40990-mees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40179-40990-mees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40179-40990-mees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40179-40990-mees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40180-40400-meilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40180-40400-meilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40180-40400-meilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40180-40400-meilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40181-40660-messanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40181-40660-messanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40181-40660-messanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40181-40660-messanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40182-40170-mezos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40182-40170-mezos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40182-40170-mezos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40182-40170-mezos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40183-40350-mimbaste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40183-40350-mimbaste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40183-40350-mimbaste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40183-40350-mimbaste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40184-40200-mimizan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40184-40200-mimizan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40184-40200-mimizan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40184-40200-mimizan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40185-40320-miramont_sensacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40185-40320-miramont_sensacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40185-40320-miramont_sensacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40185-40320-miramont_sensacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40186-40290-misson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40186-40290-misson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40186-40290-misson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40186-40290-misson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40187-40660-moliets_et_maa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40187-40660-moliets_et_maa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40187-40660-moliets_et_maa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40187-40660-moliets_et_maa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40188-40700-momuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40188-40700-momuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40188-40700-momuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40188-40700-momuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40189-40700-monget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40189-40700-monget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40189-40700-monget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40189-40700-monget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40190-40700-monsegur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40190-40700-monsegur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40190-40700-monsegur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40190-40700-monsegur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40191-40500-montaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40191-40500-montaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40191-40500-montaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40191-40500-montaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40192-40000-mont_de_marsan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40192-40000-mont_de_marsan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40192-40000-mont_de_marsan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40192-40000-mont_de_marsan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40193-40190-montegut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40193-40190-montegut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40193-40190-montegut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40193-40190-montegut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40194-40380-montfort_en_chalosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40194-40380-montfort_en_chalosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40194-40380-montfort_en_chalosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40194-40380-montfort_en_chalosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40195-40500-montgaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40195-40500-montgaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40195-40500-montgaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40195-40500-montgaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40196-40500-montsoue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40196-40500-montsoue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40196-40500-montsoue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40196-40500-montsoue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40197-40110-morcenx_la_nouvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40197-40110-morcenx_la_nouvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40197-40110-morcenx_la_nouvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40197-40110-morcenx_la_nouvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40198-40700-morganx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40198-40700-morganx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40198-40700-morganx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40198-40700-morganx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40199-40290-mouscardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40199-40290-mouscardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40199-40290-mouscardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40199-40290-mouscardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40200-40410-moustey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40200-40410-moustey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40200-40410-moustey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40200-40410-moustey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40201-40250-mugron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40201-40250-mugron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40201-40250-mugron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40201-40250-mugron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40202-40180-narrosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40202-40180-narrosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40202-40180-narrosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40202-40180-narrosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40203-40330-nassiet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40203-40330-nassiet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40203-40330-nassiet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40203-40330-nassiet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40204-40250-nerbis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40204-40250-nerbis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40204-40250-nerbis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40204-40250-nerbis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40205-40380-nousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40205-40380-nousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40205-40380-nousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40205-40380-nousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40206-40300-oeyregave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40206-40300-oeyregave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40206-40300-oeyregave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40206-40300-oeyregave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40207-40180-oeyreluy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40207-40180-oeyreluy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40207-40180-oeyreluy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40207-40180-oeyreluy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40208-40380-onard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40208-40380-onard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40208-40380-onard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40208-40380-onard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40209-40440-ondres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40209-40440-ondres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40209-40440-ondres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40209-40440-ondres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40210-40110-onesse_laharie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40210-40110-onesse_laharie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40210-40110-onesse_laharie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40210-40110-onesse_laharie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40211-40300-orist/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40211-40300-orist/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40211-40300-orist/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40211-40300-orist/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40212-40300-orthevielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40212-40300-orthevielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40212-40300-orthevielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40212-40300-orthevielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40213-40230-orx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40213-40230-orx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40213-40230-orx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40213-40230-orx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40214-40290-ossages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40214-40290-ossages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40214-40290-ossages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40214-40290-ossages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40215-40110-ousse_suzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40215-40110-ousse_suzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40215-40110-ousse_suzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40215-40110-ousse_suzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40216-40380-ozourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40216-40380-ozourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40216-40380-ozourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40216-40380-ozourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40217-40160-parentis_en_born/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40217-40160-parentis_en_born/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40217-40160-parentis_en_born/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40217-40160-parentis_en_born/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40218-40310-parleboscq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40218-40310-parleboscq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40218-40310-parleboscq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40218-40310-parleboscq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40219-40320-payros_cazautets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40219-40320-payros_cazautets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40219-40320-payros_cazautets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40219-40320-payros_cazautets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40220-40320-pecorade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40220-40320-pecorade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40220-40320-pecorade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40220-40320-pecorade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40221-40190-perquie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40221-40190-perquie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40221-40190-perquie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40221-40190-perquie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40222-40300-pey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40222-40300-pey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40222-40300-pey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40222-40300-pey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40223-40700-peyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40223-40700-peyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40223-40700-peyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40223-40700-peyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40224-40300-peyrehorade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40224-40300-peyrehorade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40224-40300-peyrehorade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40224-40300-peyrehorade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40225-40320-philondenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40225-40320-philondenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40225-40320-philondenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40225-40320-philondenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40226-40320-pimbo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40226-40320-pimbo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40226-40320-pimbo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40226-40320-pimbo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40227-40410-pissos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40227-40410-pissos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40227-40410-pissos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40227-40410-pissos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40228-40360-pomarez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40228-40360-pomarez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40228-40360-pomarez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40228-40360-pomarez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40229-40200-pontenx_les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40229-40200-pontenx_les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40229-40200-pontenx_les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40229-40200-pontenx_les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40230-40465-pontonx_sur_l_adour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40230-40465-pontonx_sur_l_adour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40230-40465-pontonx_sur_l_adour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40230-40465-pontonx_sur_l_adour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40231-40300-port_de_lanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40231-40300-port_de_lanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40231-40300-port_de_lanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40231-40300-port_de_lanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40232-40700-poudenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40232-40700-poudenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40232-40700-poudenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40232-40700-poudenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40233-40350-pouillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40233-40350-pouillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40233-40350-pouillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40233-40350-pouillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40234-40120-pouydesseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40234-40120-pouydesseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40234-40120-pouydesseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40234-40120-pouydesseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40235-40380-poyanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40235-40380-poyanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40235-40380-poyanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40235-40380-poyanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40236-40380-poyartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40236-40380-poyartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40236-40380-poyartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40236-40380-poyartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40237-40465-prechacq_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40237-40465-prechacq_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40237-40465-prechacq_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40237-40465-prechacq_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40238-40190-pujo_le_plan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40238-40190-pujo_le_plan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40238-40190-pujo_le_plan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40238-40190-pujo_le_plan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40239-40320-puyol_cazalet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40239-40320-puyol_cazalet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40239-40320-puyol_cazalet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40239-40320-puyol_cazalet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40240-40270-renung/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40240-40270-renung/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40240-40270-renung/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40240-40270-renung/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40242-40310-rimbez_et_baudiets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40242-40310-rimbez_et_baudiets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40242-40310-rimbez_et_baudiets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40242-40310-rimbez_et_baudiets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40243-40370-rion_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40243-40370-rion_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40243-40370-rion_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40243-40370-rion_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40244-40180-riviere_saas_et_gourby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40244-40180-riviere_saas_et_gourby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40244-40180-riviere_saas_et_gourby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40244-40180-riviere_saas_et_gourby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40245-40120-roquefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40245-40120-roquefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40245-40120-roquefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40245-40120-roquefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40246-40630-sabres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40246-40630-sabres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40246-40630-sabres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40246-40630-sabres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40247-40800-saint_agnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40247-40800-saint_agnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40247-40800-saint_agnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40247-40800-saint_agnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40248-40390-saint_andre_de_seignanx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40248-40390-saint_andre_de_seignanx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40248-40390-saint_andre_de_seignanx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40248-40390-saint_andre_de_seignanx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40249-40250-saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40249-40250-saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40249-40250-saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40249-40250-saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40250-40090-saint_avit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40250-40090-saint_avit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40250-40090-saint_avit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40250-40090-saint_avit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40251-40390-saint_barthelemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40251-40390-saint_barthelemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40251-40390-saint_barthelemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40251-40390-saint_barthelemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40252-40700-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40252-40700-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40252-40700-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40252-40700-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40253-40700-saint_cricq_chalosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40253-40700-saint_cricq_chalosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40253-40700-saint_cricq_chalosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40253-40700-saint_cricq_chalosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40254-40300-saint_cricq_du_gave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40254-40300-saint_cricq_du_gave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40254-40300-saint_cricq_du_gave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40254-40300-saint_cricq_du_gave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40255-40190-saint_cricq_villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40255-40190-saint_cricq_villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40255-40190-saint_cricq_villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40255-40190-saint_cricq_villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40256-40300-saint_etienne_d_orthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40256-40300-saint_etienne_d_orthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40256-40300-saint_etienne_d_orthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40256-40300-saint_etienne_d_orthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40257-40200-sainte_eulalie_en_born/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40257-40200-sainte_eulalie_en_born/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40257-40200-sainte_eulalie_en_born/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40257-40200-sainte_eulalie_en_born/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40258-40190-sainte_foy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40258-40190-sainte_foy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40258-40190-sainte_foy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40258-40190-sainte_foy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40259-40190-saint_gein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40259-40190-saint_gein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40259-40190-saint_gein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40259-40190-saint_gein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40260-40380-saint_geours_d_auribat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40260-40380-saint_geours_d_auribat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40260-40380-saint_geours_d_auribat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40260-40380-saint_geours_d_auribat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40261-40230-saint_geours_de_maremne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40261-40230-saint_geours_de_maremne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40261-40230-saint_geours_de_maremne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40261-40230-saint_geours_de_maremne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40262-40120-saint_gor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40262-40120-saint_gor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40262-40120-saint_gor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40262-40120-saint_gor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40263-40380-saint_jean_de_lier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40263-40380-saint_jean_de_lier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40263-40380-saint_jean_de_lier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40263-40380-saint_jean_de_lier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40264-40230-saint_jean_de_marsacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40264-40230-saint_jean_de_marsacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40264-40230-saint_jean_de_marsacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40264-40230-saint_jean_de_marsacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40265-40240-saint_julien_d_armagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40265-40240-saint_julien_d_armagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40265-40240-saint_julien_d_armagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40265-40240-saint_julien_d_armagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40266-40170-saint_julien_en_born/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40266-40170-saint_julien_en_born/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40266-40170-saint_julien_en_born/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40266-40170-saint_julien_en_born/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40267-40240-saint_justin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40267-40240-saint_justin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40267-40240-saint_justin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40267-40240-saint_justin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40268-40390-saint_laurent_de_gosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40268-40390-saint_laurent_de_gosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40268-40390-saint_laurent_de_gosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40268-40390-saint_laurent_de_gosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40269-40300-saint_lon_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40269-40300-saint_lon_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40269-40300-saint_lon_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40269-40300-saint_lon_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40270-40320-saint_loubouer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40270-40320-saint_loubouer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40270-40320-saint_loubouer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40270-40320-saint_loubouer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40271-40390-sainte_marie_de_gosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40271-40390-sainte_marie_de_gosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40271-40390-sainte_marie_de_gosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40271-40390-sainte_marie_de_gosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40272-40390-saint_martin_de_hinx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40272-40390-saint_martin_de_hinx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40272-40390-saint_martin_de_hinx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40272-40390-saint_martin_de_hinx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40273-40390-saint_martin_de_seignanx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40273-40390-saint_martin_de_seignanx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40273-40390-saint_martin_de_seignanx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40273-40390-saint_martin_de_seignanx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40274-40090-saint_martin_d_oney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40274-40090-saint_martin_d_oney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40274-40090-saint_martin_d_oney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40274-40090-saint_martin_d_oney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40275-40270-saint_maurice_sur_adour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40275-40270-saint_maurice_sur_adour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40275-40270-saint_maurice_sur_adour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40275-40270-saint_maurice_sur_adour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40276-40550-saint_michel_escalus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40276-40550-saint_michel_escalus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40276-40550-saint_michel_escalus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40276-40550-saint_michel_escalus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40277-40180-saint_pandelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40277-40180-saint_pandelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40277-40180-saint_pandelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40277-40180-saint_pandelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40278-40200-saint_paul_en_born/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40278-40200-saint_paul_en_born/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40278-40200-saint_paul_en_born/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40278-40200-saint_paul_en_born/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40279-40990-saint_paul_les_dax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40279-40990-saint_paul_les_dax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40279-40990-saint_paul_les_dax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40279-40990-saint_paul_les_dax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40280-40090-saint_perdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40280-40090-saint_perdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40280-40090-saint_perdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40280-40090-saint_perdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40281-40280-saint_pierre_du_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40281-40280-saint_pierre_du_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40281-40280-saint_pierre_du_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40281-40280-saint_pierre_du_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40282-40500-saint_sever/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40282-40500-saint_sever/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40282-40500-saint_sever/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40282-40500-saint_sever/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40283-40990-saint_vincent_de_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40283-40990-saint_vincent_de_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40283-40990-saint_vincent_de_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40283-40990-saint_vincent_de_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40284-40230-saint_vincent_de_tyrosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40284-40230-saint_vincent_de_tyrosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40284-40230-saint_vincent_de_tyrosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40284-40230-saint_vincent_de_tyrosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40285-40400-saint_yaguen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40285-40400-saint_yaguen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40285-40400-saint_yaguen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40285-40400-saint_yaguen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40286-40320-samadet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40286-40320-samadet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40286-40320-samadet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40286-40320-samadet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40287-40460-sanguinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40287-40460-sanguinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40287-40460-sanguinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40287-40460-sanguinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40288-40120-sarbazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40288-40120-sarbazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40288-40120-sarbazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40288-40120-sarbazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40289-40500-sarraziet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40289-40500-sarraziet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40289-40500-sarraziet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40289-40500-sarraziet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40290-40800-sarron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40290-40800-sarron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40290-40800-sarron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40290-40800-sarron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40291-40230-saubion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40291-40230-saubion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40291-40230-saubion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40291-40230-saubion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40292-40230-saubrigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40292-40230-saubrigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40292-40230-saubrigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40292-40230-saubrigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40293-40180-saubusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40293-40180-saubusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40293-40180-saubusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40293-40180-saubusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40294-40180-saugnac_et_cambran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40294-40180-saugnac_et_cambran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40294-40180-saugnac_et_cambran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40294-40180-saugnac_et_cambran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40295-40410-saugnacq_et_muret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40295-40410-saugnacq_et_muret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40295-40410-saugnacq_et_muret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40295-40410-saugnacq_et_muret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40296-40510-seignosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40296-40510-seignosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40296-40510-seignosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40296-40510-seignosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40297-40420-le_sen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40297-40420-le_sen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40297-40420-le_sen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40297-40420-le_sen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40298-40700-serres_gaston/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40298-40700-serres_gaston/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40298-40700-serres_gaston/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40298-40700-serres_gaston/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40299-40700-serreslous_et_arribans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40299-40700-serreslous_et_arribans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40299-40700-serreslous_et_arribans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40299-40700-serreslous_et_arribans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40300-40180-seyresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40300-40180-seyresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40300-40180-seyresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40300-40180-seyresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40301-40180-siest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40301-40180-siest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40301-40180-siest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40301-40180-siest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40303-40210-solferino/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40303-40210-solferino/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40303-40210-solferino/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40303-40210-solferino/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40304-40150-soorts_hossegor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40304-40150-soorts_hossegor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40304-40150-soorts_hossegor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40304-40150-soorts_hossegor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40305-40320-sorbets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40305-40320-sorbets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40305-40320-sorbets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40305-40320-sorbets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40306-40300-sorde_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40306-40300-sorde_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40306-40300-sorde_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40306-40300-sorde_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40307-40430-sore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40307-40430-sore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40307-40430-sore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40307-40430-sore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40308-40180-sort_en_chalosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40308-40180-sort_en_chalosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40308-40180-sort_en_chalosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40308-40180-sort_en_chalosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40309-40250-souprosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40309-40250-souprosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40309-40250-souprosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40309-40250-souprosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40310-40140-soustons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40310-40140-soustons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40310-40140-soustons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40310-40140-soustons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40311-40260-taller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40311-40260-taller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40311-40260-taller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40311-40260-taller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40312-40220-tarnos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40312-40220-tarnos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40312-40220-tarnos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40312-40220-tarnos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40313-40400-tartas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40313-40400-tartas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40313-40400-tartas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40313-40400-tartas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40314-40180-tercis_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40314-40180-tercis_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40314-40180-tercis_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40314-40180-tercis_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40315-40990-tethieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40315-40990-tethieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40315-40990-tethieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40315-40990-tethieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40316-40360-tilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40316-40360-tilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40316-40360-tilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40316-40360-tilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40317-40230-tosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40317-40230-tosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40317-40230-tosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40317-40230-tosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40318-40250-toulouzette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40318-40250-toulouzette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40318-40250-toulouzette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40318-40250-toulouzette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40319-40630-trensacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40319-40630-trensacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40319-40630-trensacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40319-40630-trensacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40320-40090-uchacq_et_parentis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40320-40090-uchacq_et_parentis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40320-40090-uchacq_et_parentis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40320-40090-uchacq_et_parentis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40321-40320-urgons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40321-40320-urgons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40321-40320-urgons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40321-40320-urgons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40322-40170-uza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40322-40170-uza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40322-40170-uza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40322-40170-uza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40323-40420-vert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40323-40420-vert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40323-40420-vert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40323-40420-vert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40324-40380-vicq_d_auribat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40324-40380-vicq_d_auribat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40324-40380-vicq_d_auribat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40324-40380-vicq_d_auribat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40325-40320-vielle_tursan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40325-40320-vielle_tursan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40325-40320-vielle_tursan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40325-40320-vielle_tursan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40326-40560-vielle_saint_girons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40326-40560-vielle_saint_girons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40326-40560-vielle_saint_girons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40326-40560-vielle_saint_girons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40327-40240-vielle_soubiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40327-40240-vielle_soubiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40327-40240-vielle_soubiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40327-40240-vielle_soubiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40328-40480-vieux_boucau_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40328-40480-vieux_boucau_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40328-40480-vieux_boucau_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40328-40480-vieux_boucau_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40329-40270-le_vignau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40329-40270-le_vignau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40329-40270-le_vignau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40329-40270-le_vignau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40330-40110-villenave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40330-40110-villenave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40330-40110-villenave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40330-40110-villenave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40331-40190-villeneuve_de_marsan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40331-40190-villeneuve_de_marsan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40331-40190-villeneuve_de_marsan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40331-40190-villeneuve_de_marsan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40332-40160-ychoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40332-40160-ychoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40332-40160-ychoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40332-40160-ychoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40333-40110-ygos_saint_saturnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40333-40110-ygos_saint_saturnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40333-40110-ygos_saint_saturnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40333-40110-ygos_saint_saturnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40334-40180-yzosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40334-40180-yzosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40334-40180-yzosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt40-landes/commune40334-40180-yzosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-41.xml
+++ b/public/sitemaps/sitemap-41.xml
@@ -5,546 +5,1088 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41001-41310-ambloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41001-41310-ambloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41001-41310-ambloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41001-41310-ambloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41002-41400-ange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41002-41400-ange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41002-41400-ange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41002-41400-ange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41003-41100-areines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41003-41100-areines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41003-41100-areines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41003-41100-areines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41004-41800-artins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41004-41800-artins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41004-41800-artins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41004-41800-artins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41006-41240-autainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41006-41240-autainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41006-41240-autainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41006-41240-autainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41007-41310-authon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41007-41310-authon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41007-41310-authon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41007-41310-authon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41008-41500-avaray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41008-41500-avaray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41008-41500-avaray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41008-41500-avaray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41009-41330-averdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41009-41330-averdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41009-41330-averdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41009-41330-averdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41010-41100-aze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41010-41100-aze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41010-41100-aze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41010-41100-aze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41012-41170-baillou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41012-41170-baillou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41012-41170-baillou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41012-41170-baillou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41013-41250-bauzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41013-41250-bauzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41013-41250-bauzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41013-41250-bauzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41014-41170-beauchene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41014-41170-beauchene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41014-41170-beauchene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41014-41170-beauchene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41016-41130-billy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41016-41130-billy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41016-41130-billy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41016-41130-billy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41017-41240-binas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41017-41240-binas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41017-41240-binas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41017-41240-binas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41018-41000-blois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41018-41000-blois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41018-41000-blois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41018-41000-blois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41019-41290-boisseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41019-41290-boisseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41019-41290-boisseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41019-41290-boisseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41020-41800-bonneveau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41020-41800-bonneveau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41020-41800-bonneveau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41020-41800-bonneveau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41022-41270-bouffry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41022-41270-bouffry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41022-41270-bouffry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41022-41270-bouffry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41024-41270-boursay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41024-41270-boursay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41024-41270-boursay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41024-41270-boursay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41025-41250-bracieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41025-41250-bracieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41025-41250-bracieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41025-41250-bracieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41026-41160-brevainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41026-41160-brevainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41026-41160-brevainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41026-41160-brevainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41027-41370-briou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41027-41370-briou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41027-41370-briou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41027-41370-briou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41028-41160-busloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41028-41160-busloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41028-41160-busloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41028-41160-busloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41029-41120-cande_sur_beuvron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41029-41120-cande_sur_beuvron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41029-41120-cande_sur_beuvron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41029-41120-cande_sur_beuvron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41030-41360-celle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41030-41360-celle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41030-41360-celle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41030-41360-celle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41031-41120-cellettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41031-41120-cellettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41031-41120-cellettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41031-41120-cellettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41032-41120-chailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41032-41120-chailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41032-41120-chailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41032-41120-chailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41034-41250-chambord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41034-41250-chambord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41034-41250-chambord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41034-41250-chambord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41035-41330-champigny_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41035-41330-champigny_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41035-41330-champigny_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41035-41330-champigny_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41036-41600-chaon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41036-41600-chaon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41036-41600-chaon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41036-41600-chaon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41037-41290-la_chapelle_encherie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41037-41290-la_chapelle_encherie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41037-41290-la_chapelle_encherie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41037-41290-la_chapelle_encherie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41038-41320-la_chapelle_montmartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41038-41320-la_chapelle_montmartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41038-41320-la_chapelle_montmartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41038-41320-la_chapelle_montmartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41039-41500-la_chapelle_saint_martin_en_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41039-41500-la_chapelle_saint_martin_en_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41039-41500-la_chapelle_saint_martin_en_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41039-41500-la_chapelle_saint_martin_en_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41040-41330-la_chapelle_vendomoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41040-41330-la_chapelle_vendomoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41040-41330-la_chapelle_vendomoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41040-41330-la_chapelle_vendomoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41041-41270-la_chapelle_vicomtesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41041-41270-la_chapelle_vicomtesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41041-41270-la_chapelle_vicomtesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41041-41270-la_chapelle_vicomtesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41042-41110-chateauvieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41042-41110-chateauvieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41042-41110-chateauvieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41042-41110-chateauvieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41043-41130-chatillon_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41043-41130-chatillon_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41043-41130-chatillon_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41043-41130-chatillon_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41044-41320-chatres_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41044-41320-chatres_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41044-41320-chatres_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41044-41320-chatres_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41045-41150-chaumont_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41045-41150-chaumont_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41045-41150-chaumont_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41045-41150-chaumont_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41046-41600-chaumont_sur_tharonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41046-41600-chaumont_sur_tharonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41046-41600-chaumont_sur_tharonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41046-41600-chaumont_sur_tharonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41047-41260-la_chaussee_saint_victor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41047-41260-la_chaussee_saint_victor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41047-41260-la_chaussee_saint_victor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41047-41260-la_chaussee_saint_victor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41048-41270-chauvigny_du_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41048-41270-chauvigny_du_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41048-41270-chauvigny_du_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41048-41270-chauvigny_du_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41049-41700-chemery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41049-41700-chemery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41049-41700-chemery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41049-41700-chemery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41050-41700-cheverny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41050-41700-cheverny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41050-41700-cheverny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41050-41700-cheverny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41051-41400-chissay_en_touraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41051-41400-chissay_en_touraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41051-41400-chissay_en_touraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41051-41400-chissay_en_touraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41052-41120-chitenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41052-41120-chitenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41052-41120-chitenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41052-41120-chitenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41053-41170-choue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41053-41170-choue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41053-41170-choue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41053-41170-choue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41054-41700-choussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41054-41700-choussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41054-41700-choussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41054-41700-choussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41055-41150-valloire_sur_cisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41055-41150-valloire_sur_cisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41055-41150-valloire_sur_cisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41055-41150-valloire_sur_cisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41057-41290-conan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41057-41290-conan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41057-41290-conan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41057-41290-conan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41058-41370-concriers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41058-41370-concriers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41058-41370-concriers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41058-41370-concriers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41700-le_controis_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41700-le_controis_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41700-le_controis_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41700-le_controis_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41120-le_controis_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41120-le_controis_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41120-le_controis_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41120-le_controis_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41400-le_controis_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41400-le_controis_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41400-le_controis_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41059-41400-le_controis_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41060-41170-cormenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41060-41170-cormenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41060-41170-cormenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41060-41170-cormenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41061-41120-cormeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41061-41120-cormeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41061-41120-cormeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41061-41120-cormeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41062-41700-couddes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41062-41700-couddes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41062-41700-couddes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41062-41700-couddes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41063-41110-couffy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41063-41110-couffy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41063-41110-couffy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41063-41110-couffy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41065-41100-coulommiers_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41065-41100-coulommiers_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41065-41100-coulommiers_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41065-41100-coulommiers_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41066-41500-courbouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41066-41500-courbouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41066-41500-courbouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41066-41500-courbouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41067-41700-cour_cheverny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41067-41700-cour_cheverny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41067-41700-cour_cheverny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41067-41700-cour_cheverny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41068-41230-courmemin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41068-41230-courmemin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41068-41230-courmemin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41068-41230-courmemin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41069-41500-cour_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41069-41500-cour_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41069-41500-cour_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41069-41500-cour_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41070-41800-vallee_de_ronsard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41070-41800-vallee_de_ronsard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41070-41800-vallee_de_ronsard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41070-41800-vallee_de_ronsard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41071-41220-crouy_sur_cosson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41071-41220-crouy_sur_cosson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41071-41220-crouy_sur_cosson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41071-41220-crouy_sur_cosson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41072-41100-crucheray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41072-41100-crucheray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41072-41100-crucheray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41072-41100-crucheray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41073-41160-danze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41073-41160-danze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41073-41160-danze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41073-41160-danze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41074-41220-dhuizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41074-41220-dhuizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41074-41220-dhuizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41074-41220-dhuizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41075-41270-droue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41075-41270-droue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41075-41270-droue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41075-41270-droue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41077-41290-epiais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41077-41290-epiais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41077-41290-epiais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41077-41290-epiais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41078-41360-epuisay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41078-41360-epuisay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41078-41360-epuisay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41078-41360-epuisay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41079-41800-les_essarts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41079-41800-les_essarts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41079-41800-les_essarts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41079-41800-les_essarts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41080-41400-faverolles_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41080-41400-faverolles_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41080-41400-faverolles_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41080-41400-faverolles_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41081-41100-faye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41081-41100-faye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41081-41100-faye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41081-41100-faye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41083-41210-la_ferte_beauharnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41083-41210-la_ferte_beauharnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41083-41210-la_ferte_beauharnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41083-41210-la_ferte_beauharnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41084-41300-la_ferte_imbault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41084-41300-la_ferte_imbault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41084-41300-la_ferte_imbault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41084-41300-la_ferte_imbault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41085-41220-la_ferte_saint_cyr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41085-41220-la_ferte_saint_cyr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41085-41220-la_ferte_saint_cyr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41085-41220-la_ferte_saint_cyr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41086-41250-fontaines_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41086-41250-fontaines_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41086-41250-fontaines_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41086-41250-fontaines_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41087-41800-fontaine_les_coteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41087-41800-fontaine_les_coteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41087-41800-fontaine_les_coteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41087-41800-fontaine_les_coteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41088-41270-fontaine_raoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41088-41270-fontaine_raoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41088-41270-fontaine_raoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41088-41270-fontaine_raoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41089-41270-la_fontenelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41089-41270-la_fontenelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41089-41270-la_fontenelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41089-41270-la_fontenelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41090-41360-fortan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41090-41360-fortan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41090-41360-fortan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41090-41360-fortan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41091-41330-fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41091-41330-fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41091-41330-fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41091-41330-fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41093-41190-francay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41093-41190-francay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41093-41190-francay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41093-41190-francay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41094-41700-fresnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41094-41700-fresnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41094-41700-fresnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41094-41700-fresnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41095-41160-freteval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41095-41160-freteval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41095-41160-freteval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41095-41160-freteval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41096-41270-le_gault_du_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41096-41270-le_gault_du_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41096-41270-le_gault_du_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41096-41270-le_gault_du_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41097-41130-gievres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41097-41130-gievres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41097-41130-gievres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41097-41130-gievres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41098-41310-gombergean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41098-41310-gombergean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41098-41310-gombergean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41098-41310-gombergean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41099-41230-gy_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41099-41230-gy_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41099-41230-gy_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41099-41230-gy_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41100-41800-les_hayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41100-41800-les_hayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41100-41800-les_hayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41100-41800-les_hayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41101-41190-herbault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41101-41190-herbault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41101-41190-herbault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41101-41190-herbault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41102-41800-houssay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41102-41800-houssay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41102-41800-houssay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41102-41800-houssay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41103-41310-huisseau_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41103-41310-huisseau_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41103-41310-huisseau_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41103-41310-huisseau_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41104-41350-huisseau_sur_cosson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41104-41350-huisseau_sur_cosson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41104-41350-huisseau_sur_cosson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41104-41350-huisseau_sur_cosson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41105-41370-josnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41105-41370-josnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41105-41370-josnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41105-41370-josnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41106-41600-lamotte_beuvron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41106-41600-lamotte_beuvron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41106-41600-lamotte_beuvron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41106-41600-lamotte_beuvron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41107-41310-lance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41107-41310-lance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41107-41310-lance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41107-41310-lance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41108-41190-lancome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41108-41190-lancome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41108-41190-lancome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41108-41190-lancome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41109-41190-landes_le_gaulois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41109-41190-landes_le_gaulois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41109-41190-landes_le_gaulois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41109-41190-landes_le_gaulois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41110-41320-langon_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41110-41320-langon_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41110-41320-langon_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41110-41320-langon_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41112-41230-lassay_sur_croisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41112-41230-lassay_sur_croisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41112-41230-lassay_sur_croisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41112-41230-lassay_sur_croisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41113-41800-lavardin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41113-41800-lavardin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41113-41800-lavardin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41113-41800-lavardin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41114-41500-lestiou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41114-41500-lestiou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41114-41500-lestiou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41114-41500-lestiou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41115-41160-lignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41115-41160-lignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41115-41160-lignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41115-41160-lignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41116-41100-lisle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41116-41100-lisle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41116-41100-lisle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41116-41100-lisle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41118-41200-loreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41118-41200-loreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41118-41200-loreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41118-41200-loreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41119-41370-lorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41119-41370-lorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41119-41370-lorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41119-41370-lorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41120-41360-lunay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41120-41360-lunay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41120-41360-lunay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41120-41360-lunay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41121-41370-la_madeleine_villefrouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41121-41370-la_madeleine_villefrouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41121-41370-la_madeleine_villefrouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41121-41370-la_madeleine_villefrouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41122-41320-maray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41122-41320-maray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41122-41320-maray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41122-41320-maray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41123-41370-marchenoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41123-41370-marchenoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41123-41370-marchenoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41123-41370-marchenoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41124-41100-marcilly_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41124-41100-marcilly_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41124-41100-marcilly_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41124-41100-marcilly_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41125-41210-marcilly_en_gault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41125-41210-marcilly_en_gault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41125-41210-marcilly_en_gault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41125-41210-marcilly_en_gault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41126-41110-mareuil_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41126-41110-mareuil_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41126-41110-mareuil_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41126-41110-mareuil_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41127-41210-la_marolle_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41127-41210-la_marolle_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41127-41210-la_marolle_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41127-41210-la_marolle_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41128-41330-marolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41128-41330-marolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41128-41330-marolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41128-41330-marolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41129-41250-maslives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41129-41250-maslives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41129-41250-maslives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41129-41250-maslives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41130-41500-maves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41130-41500-maves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41130-41500-maves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41130-41500-maves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41131-41100-mazange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41131-41100-mazange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41131-41100-mazange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41131-41100-mazange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41132-41140-mehers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41132-41140-mehers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41132-41140-mehers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41132-41140-mehers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41134-41500-menars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41134-41500-menars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41134-41500-menars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41134-41500-menars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41135-41320-mennetou_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41135-41320-mennetou_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41135-41320-mennetou_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41135-41320-mennetou_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41136-41500-mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41136-41500-mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41136-41500-mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41136-41500-mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41137-41150-mesland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41137-41150-mesland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41137-41150-mesland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41137-41150-mesland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41138-41100-meslay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41138-41100-meslay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41138-41100-meslay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41138-41100-meslay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41139-41130-meusnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41139-41130-meusnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41139-41130-meusnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41139-41130-meusnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41140-41200-millancay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41140-41200-millancay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41140-41200-millancay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41140-41200-millancay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41141-41160-moisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41141-41160-moisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41141-41160-moisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41141-41160-moisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41142-41190-valencisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41142-41190-valencisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41142-41190-valencisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41142-41190-valencisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41143-41170-mondoubleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41143-41170-mondoubleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41143-41170-mondoubleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41143-41170-mondoubleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41144-41150-monteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41144-41150-monteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41144-41150-monteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41144-41150-monteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41145-41120-monthou_sur_bievre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41145-41120-monthou_sur_bievre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41145-41120-monthou_sur_bievre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41145-41120-monthou_sur_bievre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41146-41400-monthou_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41146-41400-monthou_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41146-41400-monthou_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41146-41400-monthou_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41147-41120-les_montils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41147-41120-les_montils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41147-41120-les_montils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41147-41120-les_montils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41148-41350-montlivault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41148-41350-montlivault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41148-41350-montlivault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41148-41350-montlivault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41149-41800-montoire_sur_le_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41149-41800-montoire_sur_le_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41149-41800-montoire_sur_le_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41149-41800-montoire_sur_le_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41150-41250-mont_pres_chambord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41150-41250-mont_pres_chambord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41150-41250-mont_pres_chambord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41150-41250-mont_pres_chambord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41151-41400-montrichard_val_de_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41151-41400-montrichard_val_de_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41151-41400-montrichard_val_de_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41151-41400-montrichard_val_de_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41152-41210-montrieux_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41152-41210-montrieux_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41152-41210-montrieux_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41152-41210-montrieux_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41153-41800-montrouveau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41153-41800-montrouveau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41153-41800-montrouveau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41153-41800-montrouveau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41154-41160-moree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41154-41160-moree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41154-41160-moree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41154-41160-moree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41155-41500-muides_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41155-41500-muides_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41155-41500-muides_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41155-41500-muides_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41156-41500-mulsans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41156-41500-mulsans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41156-41500-mulsans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41156-41500-mulsans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41157-41230-mur_de_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41157-41230-mur_de_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41157-41230-mur_de_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41157-41230-mur_de_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41158-41100-naveil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41158-41100-naveil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41158-41100-naveil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41158-41100-naveil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41159-41210-neung_sur_beuvron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41159-41210-neung_sur_beuvron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41159-41210-neung_sur_beuvron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41159-41210-neung_sur_beuvron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41160-41250-neuvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41160-41250-neuvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41160-41250-neuvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41160-41250-neuvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41161-41600-nouan_le_fuzelier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41161-41600-nouan_le_fuzelier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41161-41600-nouan_le_fuzelier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41161-41600-nouan_le_fuzelier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41163-41310-nourray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41163-41310-nourray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41163-41310-nourray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41163-41310-nourray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41164-41140-noyers_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41164-41140-noyers_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41164-41140-noyers_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41164-41140-noyers_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41166-41700-oisly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41166-41700-oisly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41166-41700-oisly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41166-41700-oisly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41167-41150-veuzain_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41167-41150-veuzain_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41167-41150-veuzain_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41167-41150-veuzain_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41168-41300-orcay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41168-41300-orcay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41168-41300-orcay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41168-41300-orcay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41171-41290-oucques_la_nouvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41171-41290-oucques_la_nouvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41171-41290-oucques_la_nouvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41171-41290-oucques_la_nouvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41172-41160-ouzouer_le_doyen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41172-41160-ouzouer_le_doyen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41172-41160-ouzouer_le_doyen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41172-41160-ouzouer_le_doyen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41173-41240-beauce_la_romaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41173-41240-beauce_la_romaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41173-41240-beauce_la_romaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41173-41240-beauce_la_romaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41173-41160-beauce_la_romaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41173-41160-beauce_la_romaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41173-41160-beauce_la_romaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41173-41160-beauce_la_romaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41174-41100-perigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41174-41100-perigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41174-41100-perigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41174-41100-perigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41175-41100-pezou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41175-41100-pezou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41175-41100-pezou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41175-41100-pezou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41176-41300-pierrefitte_sur_sauldre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41176-41300-pierrefitte_sur_sauldre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41176-41300-pierrefitte_sur_sauldre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41176-41300-pierrefitte_sur_sauldre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41177-41170-le_plessis_dorin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41177-41170-le_plessis_dorin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41177-41170-le_plessis_dorin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41177-41170-le_plessis_dorin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41178-41370-le_plessis_l_echelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41178-41370-le_plessis_l_echelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41178-41370-le_plessis_l_echelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41178-41370-le_plessis_l_echelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41179-41270-le_poislay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41179-41270-le_poislay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41179-41270-le_poislay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41179-41270-le_poislay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41180-41400-pontlevoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41180-41400-pontlevoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41180-41400-pontlevoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41180-41400-pontlevoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41181-41110-pouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41181-41110-pouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41181-41110-pouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41181-41110-pouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41182-41190-pray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41182-41190-pray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41182-41190-pray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41182-41190-pray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41184-41310-prunay_cassereau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41184-41310-prunay_cassereau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41184-41310-prunay_cassereau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41184-41310-prunay_cassereau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41185-41200-pruniers_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41185-41200-pruniers_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41185-41200-pruniers_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41185-41200-pruniers_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41186-41160-rahart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41186-41160-rahart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41186-41160-rahart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41186-41160-rahart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41187-41100-renay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41187-41100-renay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41187-41100-renay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41187-41100-renay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41188-41290-rhodon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41188-41290-rhodon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41188-41290-rhodon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41188-41290-rhodon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41189-41150-rilly_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41189-41150-rilly_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41189-41150-rilly_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41189-41150-rilly_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41190-41100-roce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41190-41100-roce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41190-41100-roce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41190-41100-roce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41191-41370-roches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41191-41370-roches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41191-41370-roches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41191-41370-roches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41192-41800-les_roches_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41192-41800-les_roches_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41192-41800-les_roches_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41192-41800-les_roches_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41193-41270-romilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41193-41270-romilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41193-41270-romilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41193-41270-romilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41194-41200-romorantin_lanthenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41194-41200-romorantin_lanthenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41194-41200-romorantin_lanthenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41194-41200-romorantin_lanthenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41195-41230-rougeou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41195-41230-rougeou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41195-41230-rougeou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41195-41230-rougeou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41196-41270-ruan_sur_egvonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41196-41270-ruan_sur_egvonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41196-41270-ruan_sur_egvonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41196-41270-ruan_sur_egvonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41198-41110-saint_aignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41198-41110-saint_aignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41198-41110-saint_aignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41198-41110-saint_aignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41199-41310-saint_amand_longpre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41199-41310-saint_amand_longpre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41199-41310-saint_amand_longpre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41199-41310-saint_amand_longpre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41200-41100-sainte_anne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41200-41100-sainte_anne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41200-41100-sainte_anne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41200-41100-sainte_anne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41201-41800-saint_arnoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41201-41800-saint_arnoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41201-41800-saint_arnoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41201-41800-saint_arnoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41203-41330-saint_bohaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41203-41330-saint_bohaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41203-41330-saint_bohaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41203-41330-saint_bohaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41204-41350-saint_claude_de_diray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41204-41350-saint_claude_de_diray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41204-41350-saint_claude_de_diray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41204-41350-saint_claude_de_diray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41205-41190-saint_cyr_du_gault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41205-41190-saint_cyr_du_gault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41205-41190-saint_cyr_du_gault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41205-41190-saint_cyr_du_gault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41206-41000-saint_denis_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41206-41000-saint_denis_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41206-41000-saint_denis_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41206-41000-saint_denis_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41207-41500-saint_dye_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41207-41500-saint_dye_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41207-41500-saint_dye_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41207-41500-saint_dye_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41208-41190-saint_etienne_des_guerets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41208-41190-saint_etienne_des_guerets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41208-41190-saint_etienne_des_guerets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41208-41190-saint_etienne_des_guerets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41209-41100-saint_firmin_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41209-41100-saint_firmin_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41209-41100-saint_firmin_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41209-41100-saint_firmin_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41211-41400-saint_georges_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41211-41400-saint_georges_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41211-41400-saint_georges_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41211-41400-saint_georges_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41212-41350-saint_gervais_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41212-41350-saint_gervais_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41212-41350-saint_gervais_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41212-41350-saint_gervais_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41213-41310-saint_gourgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41213-41310-saint_gourgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41213-41310-saint_gourgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41213-41310-saint_gourgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41214-41160-saint_hilaire_la_gravelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41214-41160-saint_hilaire_la_gravelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41214-41160-saint_hilaire_la_gravelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41214-41160-saint_hilaire_la_gravelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41215-41800-saint_jacques_des_guerets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41215-41800-saint_jacques_des_guerets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41215-41800-saint_jacques_des_guerets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41215-41800-saint_jacques_des_guerets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41216-41160-saint_jean_froidmentel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41216-41160-saint_jean_froidmentel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41216-41160-saint_jean_froidmentel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41216-41160-saint_jean_froidmentel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41217-41400-saint_julien_de_chedon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41217-41400-saint_julien_de_chedon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41217-41400-saint_julien_de_chedon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41217-41400-saint_julien_de_chedon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41218-41320-saint_julien_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41218-41320-saint_julien_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41218-41320-saint_julien_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41218-41320-saint_julien_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41219-41240-saint_laurent_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41219-41240-saint_laurent_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41219-41240-saint_laurent_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41219-41240-saint_laurent_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41220-41220-saint_laurent_nouan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41220-41220-saint_laurent_nouan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41220-41220-saint_laurent_nouan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41220-41220-saint_laurent_nouan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41221-41370-saint_leonard_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41221-41370-saint_leonard_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41221-41370-saint_leonard_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41221-41370-saint_leonard_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41222-41320-saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41222-41320-saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41222-41320-saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41222-41320-saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41223-41190-saint_lubin_en_vergonnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41223-41190-saint_lubin_en_vergonnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41223-41190-saint_lubin_en_vergonnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41223-41190-saint_lubin_en_vergonnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41224-41170-saint_marc_du_cor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41224-41170-saint_marc_du_cor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41224-41170-saint_marc_du_cor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41224-41170-saint_marc_du_cor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41225-41800-saint_martin_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41225-41800-saint_martin_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41225-41800-saint_martin_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41225-41800-saint_martin_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41226-41100-saint_ouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41226-41100-saint_ouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41226-41100-saint_ouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41226-41100-saint_ouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41228-41800-saint_rimay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41228-41800-saint_rimay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41228-41800-saint_rimay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41228-41800-saint_rimay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41229-41140-saint_romain_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41229-41140-saint_romain_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41229-41140-saint_romain_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41229-41140-saint_romain_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41230-41000-saint_sulpice_de_pommeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41230-41000-saint_sulpice_de_pommeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41230-41000-saint_sulpice_de_pommeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41230-41000-saint_sulpice_de_pommeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41231-41210-saint_viatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41231-41210-saint_viatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41231-41210-saint_viatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41231-41210-saint_viatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41232-41300-salbris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41232-41300-salbris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41232-41300-salbris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41232-41300-salbris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41233-41120-sambin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41233-41120-sambin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41233-41120-sambin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41233-41120-sambin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41234-41190-santenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41234-41190-santenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41234-41190-santenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41234-41190-santenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41235-41170-sarge_sur_braye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41235-41170-sarge_sur_braye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41235-41170-sarge_sur_braye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41235-41170-sarge_sur_braye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41236-41310-sasnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41236-41310-sasnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41236-41310-sasnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41236-41310-sasnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41237-41700-sassay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41237-41700-sassay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41237-41700-sassay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41237-41700-sassay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41238-41360-savigny_sur_braye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41238-41360-savigny_sur_braye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41238-41360-savigny_sur_braye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41238-41360-savigny_sur_braye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41239-41110-seigy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41239-41110-seigy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41239-41110-seigy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41239-41110-seigy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41241-41300-selles_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41241-41300-selles_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41241-41300-selles_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41241-41300-selles_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41242-41130-selles_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41242-41130-selles_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41242-41130-selles_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41242-41130-selles_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41243-41100-selommes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41243-41100-selommes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41243-41100-selommes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41243-41100-selommes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41245-41500-seris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41245-41500-seris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41245-41500-seris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41245-41500-seris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41246-41120-seur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41246-41120-seur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41246-41120-seur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41246-41120-seur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41247-41230-soings_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41247-41230-soings_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41247-41230-soings_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41247-41230-soings_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41248-41170-couetron_au_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41248-41170-couetron_au_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41248-41170-couetron_au_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41248-41170-couetron_au_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41249-41300-souesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41249-41300-souesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41249-41300-souesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41249-41300-souesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41250-41800-souge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41250-41800-souge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41250-41800-souge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41250-41800-souge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41251-41600-souvigny_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41251-41600-souvigny_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41251-41600-souvigny_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41251-41600-souvigny_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41252-41500-suevres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41252-41500-suevres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41252-41500-suevres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41252-41500-suevres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41253-41370-talcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41253-41370-talcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41253-41370-talcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41253-41370-talcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41254-41170-le_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41254-41170-le_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41254-41170-le_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41254-41170-le_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41255-41800-ternay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41255-41800-ternay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41255-41800-ternay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41255-41800-ternay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41256-41300-theillay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41256-41300-theillay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41256-41300-theillay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41256-41300-theillay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41258-41140-thesee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41258-41140-thesee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41258-41140-thesee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41258-41140-thesee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41259-41100-thore_la_rochette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41259-41100-thore_la_rochette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41259-41100-thore_la_rochette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41259-41100-thore_la_rochette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41260-41220-thoury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41260-41220-thoury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41260-41220-thoury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41260-41220-thoury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41261-41190-tourailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41261-41190-tourailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41261-41190-tourailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41261-41190-tourailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41262-41250-tour_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41262-41250-tour_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41262-41250-tour_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41262-41250-tour_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41265-41800-troo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41265-41800-troo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41265-41800-troo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41265-41800-troo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41266-41120-valaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41266-41120-valaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41266-41120-valaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41266-41120-valaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41267-41400-vallieres_les_grandes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41267-41400-vallieres_les_grandes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41267-41400-vallieres_les_grandes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41267-41400-vallieres_les_grandes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41268-41230-veilleins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41268-41230-veilleins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41268-41230-veilleins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41268-41230-veilleins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41269-41100-vendome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41269-41100-vendome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41269-41100-vendome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41269-41100-vendome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41271-41230-vernou_en_sologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41271-41230-vernou_en_sologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41271-41230-vernou_en_sologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41271-41230-vernou_en_sologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41273-41290-vievy_le_raye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41273-41290-vievy_le_raye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41273-41290-vievy_le_raye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41273-41290-vievy_le_raye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41274-41800-villavard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41274-41800-villavard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41274-41800-villavard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41274-41800-villavard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41275-41160-la_ville_aux_clercs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41275-41160-la_ville_aux_clercs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41275-41160-la_ville_aux_clercs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41275-41160-la_ville_aux_clercs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41276-41000-villebarou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41276-41000-villebarou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41276-41000-villebarou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41276-41000-villebarou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41277-41270-villebout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41277-41270-villebout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41277-41270-villebout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41277-41270-villebout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41278-41310-villechauve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41278-41310-villechauve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41278-41310-villechauve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41278-41310-villechauve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41279-41800-villedieu_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41279-41800-villedieu_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41279-41800-villedieu_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41279-41800-villedieu_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41280-41200-villefranche_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41280-41200-villefranche_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41280-41200-villefranche_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41280-41200-villefranche_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41281-41330-villefrancoeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41281-41330-villefrancoeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41281-41330-villefrancoeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41281-41330-villefrancoeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41282-41200-villeherviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41282-41200-villeherviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41282-41200-villeherviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41282-41200-villeherviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41283-41100-villemardy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41283-41100-villemardy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41283-41100-villemardy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41283-41100-villemardy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41284-41290-villeneuve_frouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41284-41290-villeneuve_frouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41284-41290-villeneuve_frouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41284-41290-villeneuve_frouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41285-41220-villeny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41285-41220-villeny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41285-41220-villeny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41285-41220-villeny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41286-41310-villeporcher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41286-41310-villeporcher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41286-41310-villeporcher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41286-41310-villeporcher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41287-41100-villerable/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41287-41100-villerable/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41287-41100-villerable/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41287-41100-villerable/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41288-41000-villerbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41288-41000-villerbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41288-41000-villerbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41288-41000-villerbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41289-41240-villermain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41289-41240-villermain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41289-41240-villermain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41289-41240-villermain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41290-41100-villeromain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41290-41100-villeromain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41290-41100-villeromain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41290-41100-villeromain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41291-41100-villetrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41291-41100-villetrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41291-41100-villetrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41291-41100-villetrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41292-41500-villexanton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41292-41500-villexanton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41292-41500-villexanton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41292-41500-villexanton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41293-41100-villiersfaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41293-41100-villiersfaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41293-41100-villiersfaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41293-41100-villiersfaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41294-41100-villiers_sur_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41294-41100-villiers_sur_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41294-41100-villiers_sur_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41294-41100-villiers_sur_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41295-41350-vineuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41295-41350-vineuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41295-41350-vineuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41295-41350-vineuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41296-41600-vouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41296-41600-vouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41296-41600-vouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41296-41600-vouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41297-41600-yvoy_le_marron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41297-41600-yvoy_le_marron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41297-41600-yvoy_le_marron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt41-loir_et_cher/commune41297-41600-yvoy_le_marron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-42.xml
+++ b/public/sitemaps/sitemap-42.xml
@@ -5,662 +5,1320 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42001-42380-aboen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42001-42380-aboen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42001-42380-aboen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42001-42380-aboen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42002-42130-ailleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42002-42130-ailleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42002-42130-ailleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42002-42130-ailleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42003-42820-ambierle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42003-42820-ambierle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42003-42820-ambierle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42003-42820-ambierle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42005-42160-andrezieux_boutheon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42005-42160-andrezieux_boutheon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42005-42160-andrezieux_boutheon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42005-42160-andrezieux_boutheon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42006-42550-apinac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42006-42550-apinac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42006-42550-apinac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42006-42550-apinac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42007-42460-arcinges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42007-42460-arcinges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42007-42460-arcinges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42007-42460-arcinges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42008-42370-arcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42008-42370-arcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42008-42370-arcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42008-42370-arcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42009-42130-arthun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42009-42130-arthun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42009-42130-arthun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42009-42130-arthun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42010-42330-aveizieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42010-42330-aveizieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42010-42330-aveizieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42010-42330-aveizieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42011-42510-balbigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42011-42510-balbigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42011-42510-balbigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42011-42510-balbigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42012-42600-bard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42012-42600-bard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42012-42600-bard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42012-42600-bard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42013-42210-bellegarde_en_forez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42013-42210-bellegarde_en_forez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42013-42210-bellegarde_en_forez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42013-42210-bellegarde_en_forez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42014-42670-belleroche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42014-42670-belleroche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42014-42670-belleroche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42014-42670-belleroche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42015-42670-belmont_de_la_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42015-42670-belmont_de_la_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42015-42670-belmont_de_la_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42015-42670-belmont_de_la_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42016-42720-la_benisson_dieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42016-42720-la_benisson_dieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42016-42720-la_benisson_dieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42016-42720-la_benisson_dieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42017-42660-le_bessat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42017-42660-le_bessat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42017-42660-le_bessat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42017-42660-le_bessat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42018-42520-bessey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42018-42520-bessey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42018-42520-bessey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42018-42520-bessey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42019-42130-boen_sur_lignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42019-42130-boen_sur_lignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42019-42130-boen_sur_lignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42019-42130-boen_sur_lignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42020-42210-boisset_les_montrond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42020-42210-boisset_les_montrond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42020-42210-boisset_les_montrond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42020-42210-boisset_les_montrond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42021-42560-boisset_saint_priest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42021-42560-boisset_saint_priest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42021-42560-boisset_saint_priest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42021-42560-boisset_saint_priest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42022-42160-bonson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42022-42160-bonson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42022-42160-bonson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42022-42160-bonson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42023-42220-bourg_argental/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42023-42220-bourg_argental/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42023-42220-bourg_argental/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42023-42220-bourg_argental/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42025-42460-boyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42025-42460-boyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42025-42460-boyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42025-42460-boyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42026-42720-briennon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42026-42720-briennon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42026-42720-briennon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42026-42720-briennon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42027-42260-bully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42027-42260-bully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42027-42260-bully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42027-42260-bully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42028-42220-burdignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42028-42220-burdignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42028-42220-burdignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42028-42220-burdignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42029-42510-bussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42029-42510-bussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42029-42510-bussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42029-42510-bussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42030-42260-bussy_albieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42030-42260-bussy_albieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42030-42260-bussy_albieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42030-42260-bussy_albieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42031-42240-caloire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42031-42240-caloire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42031-42240-caloire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42031-42240-caloire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42032-42320-cellieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42032-42320-cellieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42032-42320-cellieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42032-42320-cellieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42033-42460-le_cergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42033-42460-le_cergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42033-42460-le_cergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42033-42460-le_cergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42034-42440-cervieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42034-42440-cervieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42034-42440-cervieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42034-42440-cervieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42035-42130-cezay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42035-42130-cezay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42035-42130-cezay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42035-42130-cezay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42036-42800-chagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42036-42800-chagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42036-42800-chagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42036-42800-chagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42037-42600-chalain_d_uzore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42037-42600-chalain_d_uzore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42037-42600-chalain_d_uzore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42037-42600-chalain_d_uzore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42038-42600-chalain_le_comtal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42038-42600-chalain_le_comtal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42038-42600-chalain_le_comtal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42038-42600-chalain_le_comtal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42039-42920-chalmazel_jeansagniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42039-42920-chalmazel_jeansagniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42039-42920-chalmazel_jeansagniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42039-42920-chalmazel_jeansagniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42040-42440-la_chamba/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42040-42440-la_chamba/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42040-42440-la_chamba/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42040-42440-la_chamba/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42041-42110-chambeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42041-42110-chambeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42041-42110-chambeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42041-42110-chambeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42042-42170-chambles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42042-42170-chambles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42042-42170-chambles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42042-42170-chambles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42043-42330-chamboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42043-42330-chamboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42043-42330-chamboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42043-42330-chamboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42044-42500-le_chambon_feugerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42044-42500-le_chambon_feugerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42044-42500-le_chambon_feugerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42044-42500-le_chambon_feugerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42045-42440-la_chambonie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42045-42440-la_chambonie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42045-42440-la_chambonie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42045-42440-la_chambonie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42046-42600-champdieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42046-42600-champdieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42046-42600-champdieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42046-42600-champdieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42047-42430-champoly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42047-42430-champoly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42047-42430-champoly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42047-42430-champoly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42048-42190-chandon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42048-42190-chandon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42048-42190-chandon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42048-42190-chandon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42049-42310-changy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42049-42310-changy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42049-42310-changy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42049-42310-changy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42050-42380-la_chapelle_en_lafaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42050-42380-la_chapelle_en_lafaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42050-42380-la_chapelle_en_lafaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42050-42380-la_chapelle_en_lafaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42051-42410-la_chapelle_villars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42051-42410-la_chapelle_villars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42051-42410-la_chapelle_villars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42051-42410-la_chapelle_villars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42052-42190-charlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42052-42190-charlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42052-42190-charlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42052-42190-charlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42053-42800-chateauneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42053-42800-chateauneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42053-42800-chateauneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42053-42800-chateauneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42054-42940-chatelneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42054-42940-chatelneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42054-42940-chatelneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42054-42940-chatelneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42055-42140-chatelus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42055-42140-chatelus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42055-42140-chatelus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42055-42140-chatelus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42056-42410-chavanay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42056-42410-chavanay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42056-42410-chavanay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42056-42410-chavanay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42058-42560-chazelles_sur_lavieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42058-42560-chazelles_sur_lavieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42058-42560-chazelles_sur_lavieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42058-42560-chazelles_sur_lavieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42059-42140-chazelles_sur_lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42059-42140-chazelles_sur_lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42059-42140-chazelles_sur_lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42059-42140-chazelles_sur_lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42060-42560-chenereilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42060-42560-chenereilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42060-42560-chenereilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42060-42560-chenereilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42061-42430-cherier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42061-42430-cherier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42061-42430-cherier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42061-42430-cherier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42062-42140-chevrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42062-42140-chevrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42062-42140-chevrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42062-42140-chevrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42063-42114-chirassimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42063-42114-chirassimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42063-42114-chirassimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42063-42114-chirassimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42064-42410-chuyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42064-42410-chuyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42064-42410-chuyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42064-42410-chuyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42065-42110-civens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42065-42110-civens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42065-42110-civens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42065-42110-civens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42066-42110-cleppe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42066-42110-cleppe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42066-42110-cleppe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42066-42110-cleppe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42067-42220-colombier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42067-42220-colombier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42067-42220-colombier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42067-42220-colombier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42068-42840-combre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42068-42840-combre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42068-42840-combre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42068-42840-combre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42069-42120-commelle_vernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42069-42120-commelle_vernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42069-42120-commelle_vernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42069-42120-commelle_vernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42070-42123-cordelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42070-42123-cordelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42070-42123-cordelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42070-42123-cordelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42071-42120-le_coteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42071-42120-le_coteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42071-42120-le_coteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42071-42120-le_coteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42072-42111-la_cote_en_couzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42072-42111-la_cote_en_couzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42072-42111-la_cote_en_couzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42072-42111-la_cote_en_couzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42073-42360-cottance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42073-42360-cottance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42073-42360-cottance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42073-42360-cottance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42074-42460-coutouvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42074-42460-coutouvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42074-42460-coutouvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42074-42460-coutouvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42075-42210-craintilleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42075-42210-craintilleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42075-42210-craintilleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42075-42210-craintilleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42076-42260-cremeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42076-42260-cremeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42076-42260-cremeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42076-42260-cremeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42077-42540-croizet_sur_gand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42077-42540-croizet_sur_gand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42077-42540-croizet_sur_gand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42077-42540-croizet_sur_gand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42078-42310-le_crozet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42078-42310-le_crozet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42078-42310-le_crozet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42078-42310-le_crozet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42079-42460-cuinzier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42079-42460-cuinzier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42079-42460-cuinzier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42079-42460-cuinzier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42081-42330-cuzieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42081-42330-cuzieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42081-42330-cuzieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42081-42330-cuzieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42083-42800-dargoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42083-42800-dargoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42083-42800-dargoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42083-42800-dargoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42084-42130-debats_riviere_d_orpra/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42084-42130-debats_riviere_d_orpra/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42084-42130-debats_riviere_d_orpra/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42084-42130-debats_riviere_d_orpra/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42085-42740-doizieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42085-42740-doizieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42085-42740-doizieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42085-42740-doizieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42086-42670-ecoche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42086-42670-ecoche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42086-42670-ecoche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42086-42670-ecoche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42087-42600-ecotay_l_olme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42087-42600-ecotay_l_olme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42087-42600-ecotay_l_olme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42087-42600-ecotay_l_olme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42088-42110-epercieux_saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42088-42110-epercieux_saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42088-42110-epercieux_saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42088-42110-epercieux_saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42089-42600-essertines_en_chatelneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42089-42600-essertines_en_chatelneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42089-42600-essertines_en_chatelneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42089-42600-essertines_en_chatelneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42090-42360-essertines_en_donzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42090-42360-essertines_en_donzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42090-42360-essertines_en_donzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42090-42360-essertines_en_donzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42091-42380-estivareilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42091-42380-estivareilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42091-42380-estivareilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42091-42380-estivareilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42092-42580-l_etrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42092-42580-l_etrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42092-42580-l_etrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42092-42580-l_etrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42093-42320-farnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42093-42320-farnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42093-42320-farnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42093-42320-farnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42094-42110-feurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42094-42110-feurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42094-42110-feurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42094-42110-feurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42095-42700-firminy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42095-42700-firminy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42095-42700-firminy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42095-42700-firminy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42096-42140-fontanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42096-42140-fontanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42096-42140-fontanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42096-42140-fontanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42097-42480-la_fouillouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42097-42480-la_fouillouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42097-42480-la_fouillouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42097-42480-la_fouillouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42098-42470-fourneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42098-42470-fourneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42098-42470-fourneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42098-42470-fourneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42099-42490-fraisses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42099-42490-fraisses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42099-42490-fraisses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42099-42490-fraisses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42100-42140-la_gimond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42100-42140-la_gimond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42100-42140-la_gimond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42100-42140-la_gimond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42101-42220-graix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42101-42220-graix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42101-42220-graix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42101-42220-graix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42102-42140-grammond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42102-42140-grammond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42102-42140-grammond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42102-42140-grammond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42103-42320-la_grand_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42103-42320-la_grand_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42103-42320-la_grand_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42103-42320-la_grand_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42104-42460-la_gresle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42104-42460-la_gresle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42104-42460-la_gresle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42104-42460-la_gresle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42105-42600-grezieux_le_fromental/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42105-42600-grezieux_le_fromental/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42105-42600-grezieux_le_fromental/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42105-42600-grezieux_le_fromental/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42106-42260-grezolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42106-42260-grezolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42106-42260-grezolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42106-42260-grezolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42107-42560-gumieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42107-42560-gumieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42107-42560-gumieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42107-42560-gumieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42108-42210-l_hopital_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42108-42210-l_hopital_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42108-42210-l_hopital_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42108-42210-l_hopital_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42109-42130-l_hopital_sous_rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42109-42130-l_hopital_sous_rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42109-42130-l_hopital_sous_rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42109-42130-l_hopital_sous_rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42110-42152-l_horme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42110-42152-l_horme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42110-42152-l_horme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42110-42152-l_horme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42112-42460-jarnosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42112-42460-jarnosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42112-42460-jarnosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42112-42460-jarnosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42113-42110-jas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42113-42110-jas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42113-42110-jas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42113-42110-jas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42115-42660-jonzieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42115-42660-jonzieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42115-42660-jonzieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42115-42660-jonzieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42116-42430-jure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42116-42430-jure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42116-42430-jure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42116-42430-jure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42117-42560-lavieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42117-42560-lavieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42117-42560-lavieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42117-42560-lavieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42118-42470-lay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42118-42470-lay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42118-42470-lay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42118-42470-lay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42119-42130-leigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42119-42130-leigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42119-42130-leigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42119-42130-leigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42120-42155-lentigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42120-42155-lentigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42120-42155-lentigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42120-42155-lentigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42121-42600-lerigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42121-42600-lerigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42121-42600-lerigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42121-42600-lerigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42122-42600-lezigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42122-42600-lezigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42122-42600-lezigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42122-42600-lezigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42123-42420-lorette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42123-42420-lorette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42123-42420-lorette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42123-42420-lorette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42124-42520-lupe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42124-42520-lupe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42124-42520-lupe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42124-42520-lupe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42125-42260-lure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42125-42260-lure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42125-42260-lure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42125-42260-lure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42126-42380-luriecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42126-42380-luriecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42126-42380-luriecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42126-42380-luriecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42127-42300-mably/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42127-42300-mably/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42127-42300-mably/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42127-42300-mably/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42128-42114-machezal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42128-42114-machezal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42128-42114-machezal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42128-42114-machezal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42129-42520-maclas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42129-42520-maclas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42129-42520-maclas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42129-42520-maclas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42130-42600-magneux_haute_rive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42130-42600-magneux_haute_rive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42130-42600-magneux_haute_rive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42130-42600-magneux_haute_rive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42131-42750-maizilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42131-42750-maizilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42131-42750-maizilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42131-42750-maizilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42132-42520-malleval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42132-42520-malleval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42132-42520-malleval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42132-42520-malleval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42133-42140-marcenod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42133-42140-marcenod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42133-42140-marcenod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42133-42140-marcenod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42134-42130-marcilly_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42134-42130-marcilly_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42134-42130-marcilly_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42134-42130-marcilly_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42135-42210-marclopt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42135-42210-marclopt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42135-42210-marclopt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42135-42210-marclopt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42136-42130-marcoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42136-42130-marcoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42136-42130-marcoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42136-42130-marcoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42137-42560-margerie_chantagret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42137-42560-margerie_chantagret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42137-42560-margerie_chantagret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42137-42560-margerie_chantagret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42138-42140-maringes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42138-42140-maringes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42138-42140-maringes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42138-42140-maringes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42139-42660-marlhes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42139-42660-marlhes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42139-42660-marlhes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42139-42660-marlhes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42140-42560-marols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42140-42560-marols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42140-42560-marols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42140-42560-marols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42141-42750-mars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42141-42750-mars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42141-42750-mars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42141-42750-mars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42142-42380-merle_leignec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42142-42380-merle_leignec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42142-42380-merle_leignec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42142-42380-merle_leignec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42143-42110-mizerieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42143-42110-mizerieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42143-42110-mizerieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42143-42110-mizerieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42145-42840-montagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42145-42840-montagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42145-42840-montagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42145-42840-montagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42146-42380-montarcher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42146-42380-montarcher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42146-42380-montarcher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42146-42380-montarcher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42147-42600-montbrison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42147-42600-montbrison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42147-42600-montbrison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42147-42600-montbrison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42148-42360-montchal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42148-42360-montchal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42148-42360-montchal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42148-42360-montchal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42149-42210-montrond_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42149-42210-montrond_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42149-42210-montrond_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42149-42210-montrond_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42150-42130-montverdun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42150-42130-montverdun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42150-42130-montverdun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42150-42130-montverdun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42151-42600-mornand_en_forez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42151-42600-mornand_en_forez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42151-42600-mornand_en_forez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42151-42600-mornand_en_forez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42152-42720-nandax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42152-42720-nandax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42152-42720-nandax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42152-42720-nandax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42153-42470-neaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42153-42470-neaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42153-42470-neaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42153-42470-neaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42154-42510-neronde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42154-42510-neronde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42154-42510-neronde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42154-42510-neronde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42155-42510-nervieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42155-42510-nervieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42155-42510-nervieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42155-42510-nervieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42156-42590-neulise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42156-42590-neulise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42156-42590-neulise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42156-42590-neulise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42157-42640-noailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42157-42640-noailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42157-42640-noailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42157-42640-noailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42158-42370-les_noes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42158-42370-les_noes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42158-42370-les_noes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42158-42370-les_noes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42159-42440-noiretable/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42159-42440-noiretable/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42159-42440-noiretable/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42159-42440-noiretable/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42160-42260-nollieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42160-42260-nollieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42160-42260-nollieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42160-42260-nollieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42161-42120-notre_dame_de_boisset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42161-42120-notre_dame_de_boisset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42161-42120-notre_dame_de_boisset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42161-42120-notre_dame_de_boisset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42162-42155-ouches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42162-42155-ouches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42162-42155-ouches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42162-42155-ouches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42163-42310-la_pacaudiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42163-42310-la_pacaudiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42163-42310-la_pacaudiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42163-42310-la_pacaudiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42164-42990-palogneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42164-42990-palogneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42164-42990-palogneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42164-42990-palogneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42165-42360-panissieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42165-42360-panissieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42165-42360-panissieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42165-42360-panissieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42166-42120-parigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42166-42120-parigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42166-42120-parigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42166-42120-parigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42167-42410-pavezin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42167-42410-pavezin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42167-42410-pavezin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42167-42410-pavezin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42168-42410-pelussin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42168-42410-pelussin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42168-42410-pelussin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42168-42410-pelussin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42169-42380-perigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42169-42380-perigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42169-42380-perigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42169-42380-perigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42170-42120-perreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42170-42120-perreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42170-42120-perreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42170-42120-perreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42171-42590-pinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42171-42590-pinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42171-42590-pinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42171-42590-pinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42172-42660-planfoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42172-42660-planfoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42172-42660-planfoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42172-42660-planfoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42173-42260-pommiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42173-42260-pommiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42173-42260-pommiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42173-42260-pommiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42174-42110-poncins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42174-42110-poncins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42174-42110-poncins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42174-42110-poncins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42175-42110-pouilly_les_feurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42175-42110-pouilly_les_feurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42175-42110-pouilly_les_feurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42175-42110-pouilly_les_feurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42176-42155-pouilly_les_nonains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42176-42155-pouilly_les_nonains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42176-42155-pouilly_les_nonains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42176-42155-pouilly_les_nonains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42177-42720-pouilly_sous_charlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42177-42720-pouilly_sous_charlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42177-42720-pouilly_sous_charlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42177-42720-pouilly_sous_charlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42178-42630-pradines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42178-42630-pradines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42178-42630-pradines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42178-42630-pradines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42179-42600-pralong/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42179-42600-pralong/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42179-42600-pralong/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42179-42600-pralong/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42180-42600-precieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42180-42600-precieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42180-42600-precieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42180-42600-precieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42181-42630-regny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42181-42630-regny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42181-42630-regny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42181-42630-regny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42182-42370-renaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42182-42370-renaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42182-42370-renaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42182-42370-renaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42183-42150-la_ricamarie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42183-42150-la_ricamarie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42183-42150-la_ricamarie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42183-42150-la_ricamarie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42184-42153-riorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42184-42153-riorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42184-42153-riorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42184-42153-riorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42185-42340-rivas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42185-42340-rivas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42185-42340-rivas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42185-42340-rivas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42186-42800-rive_de_gier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42186-42800-rive_de_gier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42186-42800-rive_de_gier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42186-42800-rive_de_gier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42187-42300-roanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42187-42300-roanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42187-42300-roanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42187-42300-roanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42188-42600-roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42188-42600-roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42188-42600-roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42188-42600-roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42189-42230-roche_la_moliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42189-42230-roche_la_moliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42189-42230-roche_la_moliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42189-42230-roche_la_moliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42191-42520-roisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42191-42520-roisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42191-42520-roisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42191-42520-roisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42192-42380-rozier_cotes_d_aurec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42192-42380-rozier_cotes_d_aurec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42192-42380-rozier_cotes_d_aurec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42192-42380-rozier_cotes_d_aurec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42193-42810-rozier_en_donzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42193-42810-rozier_en_donzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42193-42810-rozier_en_donzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42193-42810-rozier_en_donzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42194-42310-sail_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42194-42310-sail_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42194-42310-sail_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42194-42310-sail_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42195-42890-sail_sous_couzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42195-42890-sail_sous_couzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42195-42890-sail_sous_couzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42195-42890-sail_sous_couzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42196-42510-sainte_agathe_en_donzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42196-42510-sainte_agathe_en_donzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42196-42510-sainte_agathe_en_donzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42196-42510-sainte_agathe_en_donzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42197-42130-sainte_agathe_la_bouteresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42197-42130-sainte_agathe_la_bouteresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42197-42130-sainte_agathe_la_bouteresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42197-42130-sainte_agathe_la_bouteresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42198-42370-saint_alban_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42198-42370-saint_alban_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42198-42370-saint_alban_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42198-42370-saint_alban_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42199-42370-saint_andre_d_apchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42199-42370-saint_andre_d_apchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42199-42370-saint_andre_d_apchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42199-42370-saint_andre_d_apchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42200-42210-saint_andre_le_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42200-42210-saint_andre_le_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42200-42210-saint_andre_le_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42200-42210-saint_andre_le_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42201-42520-saint_appolinard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42201-42520-saint_appolinard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42201-42520-saint_appolinard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42201-42520-saint_appolinard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42202-42110-saint_barthelemy_lestra/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42202-42110-saint_barthelemy_lestra/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42202-42110-saint_barthelemy_lestra/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42202-42110-saint_barthelemy_lestra/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42203-42310-saint_bonnet_des_quarts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42203-42310-saint_bonnet_des_quarts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42203-42310-saint_bonnet_des_quarts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42203-42310-saint_bonnet_des_quarts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42204-42380-saint_bonnet_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42204-42380-saint_bonnet_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42204-42380-saint_bonnet_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42204-42380-saint_bonnet_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42205-42940-saint_bonnet_le_courreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42205-42940-saint_bonnet_le_courreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42205-42940-saint_bonnet_le_courreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42205-42940-saint_bonnet_le_courreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42206-42330-saint_bonnet_les_oules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42206-42330-saint_bonnet_les_oules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42206-42330-saint_bonnet_les_oules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42206-42330-saint_bonnet_les_oules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42207-42400-saint_chamond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42207-42400-saint_chamond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42207-42400-saint_chamond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42207-42400-saint_chamond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42208-42320-saint_christo_en_jarez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42208-42320-saint_christo_en_jarez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42208-42320-saint_christo_en_jarez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42208-42320-saint_christo_en_jarez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42209-42540-sainte_colombe_sur_gand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42209-42540-sainte_colombe_sur_gand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42209-42540-sainte_colombe_sur_gand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42209-42540-sainte_colombe_sur_gand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42210-42800-sainte_croix_en_jarez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42210-42800-sainte_croix_en_jarez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42210-42800-sainte_croix_en_jarez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42210-42800-sainte_croix_en_jarez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42211-42160-saint_cyprien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42211-42160-saint_cyprien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42211-42160-saint_cyprien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42211-42160-saint_cyprien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42212-42123-saint_cyr_de_favieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42212-42123-saint_cyr_de_favieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42212-42123-saint_cyr_de_favieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42212-42123-saint_cyr_de_favieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42213-42114-saint_cyr_de_valorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42213-42114-saint_cyr_de_valorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42213-42114-saint_cyr_de_valorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42213-42114-saint_cyr_de_valorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42214-42210-saint_cyr_les_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42214-42210-saint_cyr_les_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42214-42210-saint_cyr_les_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42214-42210-saint_cyr_les_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42215-42750-saint_denis_de_cabanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42215-42750-saint_denis_de_cabanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42215-42750-saint_denis_de_cabanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42215-42750-saint_denis_de_cabanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42216-42140-saint_denis_sur_coise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42216-42140-saint_denis_sur_coise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42216-42140-saint_denis_sur_coise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42216-42140-saint_denis_sur_coise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42217-42111-saint_didier_sur_rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42217-42111-saint_didier_sur_rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42217-42111-saint_didier_sur_rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42217-42111-saint_didier_sur_rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42000-saint_etienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42000-saint_etienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42000-saint_etienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42000-saint_etienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42100-saint_etienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42100-saint_etienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42100-saint_etienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42100-saint_etienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42230-saint_etienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42230-saint_etienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42230-saint_etienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42218-42230-saint_etienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42219-42130-saint_etienne_le_molard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42219-42130-saint_etienne_le_molard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42219-42130-saint_etienne_le_molard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42219-42130-saint_etienne_le_molard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42220-42640-saint_forgeux_lespinasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42220-42640-saint_forgeux_lespinasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42220-42640-saint_forgeux_lespinasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42220-42640-saint_forgeux_lespinasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42221-42110-sainte_foy_saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42221-42110-sainte_foy_saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42221-42110-sainte_foy_saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42221-42110-sainte_foy_saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42222-42330-saint_galmier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42222-42330-saint_galmier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42222-42330-saint_galmier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42222-42330-saint_galmier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42223-42530-saint_genest_lerpt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42223-42530-saint_genest_lerpt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42223-42530-saint_genest_lerpt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42223-42530-saint_genest_lerpt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42224-42660-saint_genest_malifaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42224-42660-saint_genest_malifaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42224-42660-saint_genest_malifaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42224-42660-saint_genest_malifaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42225-42800-genilac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42225-42800-genilac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42225-42800-genilac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42225-42800-genilac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42226-42510-saint_georges_de_baroille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42226-42510-saint_georges_de_baroille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42226-42510-saint_georges_de_baroille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42226-42510-saint_georges_de_baroille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42227-42990-saint_georges_en_couzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42227-42990-saint_georges_en_couzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42227-42990-saint_georges_en_couzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42227-42990-saint_georges_en_couzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42228-42610-saint_georges_haute_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42228-42610-saint_georges_haute_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42228-42610-saint_georges_haute_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42228-42610-saint_georges_haute_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42229-42670-saint_germain_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42229-42670-saint_germain_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42229-42670-saint_germain_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42229-42670-saint_germain_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42230-42260-saint_germain_laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42230-42260-saint_germain_laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42230-42260-saint_germain_laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42230-42260-saint_germain_laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42231-42640-saint_germain_lespinasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42231-42640-saint_germain_lespinasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42231-42640-saint_germain_lespinasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42231-42640-saint_germain_lespinasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42232-42370-saint_haon_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42232-42370-saint_haon_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42232-42370-saint_haon_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42232-42370-saint_haon_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42233-42370-saint_haon_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42233-42370-saint_haon_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42233-42370-saint_haon_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42233-42370-saint_haon_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42234-42570-saint_heand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42234-42570-saint_heand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42234-42570-saint_heand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42234-42570-saint_heand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42235-42380-saint_hilaire_cusson_la_valmitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42235-42380-saint_hilaire_cusson_la_valmitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42235-42380-saint_hilaire_cusson_la_valmitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42235-42380-saint_hilaire_cusson_la_valmitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42236-42190-saint_hilaire_sous_charlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42236-42190-saint_hilaire_sous_charlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42236-42190-saint_hilaire_sous_charlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42236-42190-saint_hilaire_sous_charlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42237-42650-saint_jean_bonnefonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42237-42650-saint_jean_bonnefonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42237-42650-saint_jean_bonnefonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42237-42650-saint_jean_bonnefonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42238-42440-saint_jean_la_vetre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42238-42440-saint_jean_la_vetre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42238-42440-saint_jean_la_vetre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42238-42440-saint_jean_la_vetre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42239-42155-saint_jean_saint_maurice_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42239-42155-saint_jean_saint_maurice_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42239-42155-saint_jean_saint_maurice_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42239-42155-saint_jean_saint_maurice_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42240-42560-saint_jean_soleymieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42240-42560-saint_jean_soleymieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42240-42560-saint_jean_soleymieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42240-42560-saint_jean_soleymieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42241-42590-saint_jodard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42241-42590-saint_jodard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42241-42590-saint_jodard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42241-42590-saint_jodard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42242-42800-saint_joseph/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42242-42800-saint_joseph/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42242-42800-saint_joseph/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42242-42800-saint_joseph/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42243-42260-saint_julien_d_oddes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42243-42260-saint_julien_d_oddes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42243-42260-saint_julien_d_oddes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42243-42260-saint_julien_d_oddes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42245-42440-vetre_sur_anzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42245-42440-vetre_sur_anzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42245-42440-vetre_sur_anzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42245-42440-vetre_sur_anzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42245-42111-vetre_sur_anzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42245-42111-vetre_sur_anzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42245-42111-vetre_sur_anzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42245-42111-vetre_sur_anzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42246-42220-saint_julien_molin_molette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42246-42220-saint_julien_molin_molette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42246-42220-saint_julien_molin_molette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42246-42220-saint_julien_molin_molette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42247-42990-saint_just_en_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42247-42990-saint_just_en_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42247-42990-saint_just_en_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42247-42990-saint_just_en_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42248-42430-saint_just_en_chevalet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42248-42430-saint_just_en_chevalet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42248-42430-saint_just_en_chevalet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42248-42430-saint_just_en_chevalet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42249-42540-saint_just_la_pendue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42249-42540-saint_just_la_pendue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42249-42540-saint_just_la_pendue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42249-42540-saint_just_la_pendue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42251-42210-saint_laurent_la_conche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42251-42210-saint_laurent_la_conche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42251-42210-saint_laurent_la_conche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42251-42210-saint_laurent_la_conche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42252-42130-saint_laurent_rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42252-42130-saint_laurent_rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42252-42130-saint_laurent_rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42252-42130-saint_laurent_rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42253-42155-saint_leger_sur_roanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42253-42155-saint_leger_sur_roanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42253-42155-saint_leger_sur_roanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42253-42155-saint_leger_sur_roanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42254-42122-saint_marcel_de_felines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42254-42122-saint_marcel_de_felines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42254-42122-saint_marcel_de_felines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42254-42122-saint_marcel_de_felines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42255-42430-saint_marcel_d_urfe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42255-42430-saint_marcel_d_urfe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42255-42430-saint_marcel_d_urfe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42255-42430-saint_marcel_d_urfe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42256-42680-saint_marcellin_en_forez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42256-42680-saint_marcellin_en_forez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42256-42680-saint_marcellin_en_forez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42256-42680-saint_marcellin_en_forez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42257-42620-saint_martin_d_estreaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42257-42620-saint_martin_d_estreaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42257-42620-saint_martin_d_estreaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42257-42620-saint_martin_d_estreaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42259-42800-saint_martin_la_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42259-42800-saint_martin_la_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42259-42800-saint_martin_la_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42259-42800-saint_martin_la_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42260-42260-saint_martin_la_sauvete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42260-42260-saint_martin_la_sauvete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42260-42260-saint_martin_la_sauvete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42260-42260-saint_martin_la_sauvete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42261-42110-saint_martin_lestra/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42261-42110-saint_martin_lestra/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42261-42110-saint_martin_lestra/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42261-42110-saint_martin_lestra/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42262-42240-saint_maurice_en_gourgois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42262-42240-saint_maurice_en_gourgois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42262-42240-saint_maurice_en_gourgois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42262-42240-saint_maurice_en_gourgois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42264-42330-saint_medard_en_forez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42264-42330-saint_medard_en_forez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42264-42330-saint_medard_en_forez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42264-42330-saint_medard_en_forez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42265-42410-saint_michel_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42265-42410-saint_michel_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42265-42410-saint_michel_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42265-42410-saint_michel_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42266-42380-saint_nizier_de_fornas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42266-42380-saint_nizier_de_fornas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42266-42380-saint_nizier_de_fornas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42266-42380-saint_nizier_de_fornas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42267-42190-saint_nizier_sous_charlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42267-42190-saint_nizier_sous_charlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42267-42190-saint_nizier_sous_charlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42267-42190-saint_nizier_sous_charlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42268-42590-vezelin_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42268-42590-vezelin_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42268-42590-vezelin_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42268-42590-vezelin_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42268-42260-vezelin_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42268-42260-vezelin_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42268-42260-vezelin_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42268-42260-vezelin_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42269-42600-saint_paul_d_uzore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42269-42600-saint_paul_d_uzore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42269-42600-saint_paul_d_uzore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42269-42600-saint_paul_d_uzore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42270-42240-saint_paul_en_cornillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42270-42240-saint_paul_en_cornillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42270-42240-saint_paul_en_cornillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42270-42240-saint_paul_en_cornillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42271-42740-saint_paul_en_jarez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42271-42740-saint_paul_en_jarez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42271-42740-saint_paul_en_jarez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42271-42740-saint_paul_en_jarez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42272-42520-saint_pierre_de_boeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42272-42520-saint_pierre_de_boeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42272-42520-saint_pierre_de_boeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42272-42520-saint_pierre_de_boeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42273-42190-saint_pierre_la_noaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42273-42190-saint_pierre_la_noaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42273-42190-saint_pierre_la_noaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42273-42190-saint_pierre_la_noaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42274-42260-saint_polgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42274-42260-saint_polgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42274-42260-saint_polgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42274-42260-saint_polgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42275-42270-saint_priest_en_jarez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42275-42270-saint_priest_en_jarez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42275-42270-saint_priest_en_jarez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42275-42270-saint_priest_en_jarez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42276-42830-saint_priest_la_prugne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42276-42830-saint_priest_la_prugne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42276-42830-saint_priest_la_prugne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42276-42830-saint_priest_la_prugne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42277-42590-saint_priest_la_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42277-42590-saint_priest_la_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42277-42590-saint_priest_la_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42277-42590-saint_priest_la_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42278-42440-saint_priest_la_vetre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42278-42440-saint_priest_la_vetre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42278-42440-saint_priest_la_vetre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42278-42440-saint_priest_la_vetre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42279-42170-saint_just_saint_rambert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42279-42170-saint_just_saint_rambert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42279-42170-saint_just_saint_rambert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42279-42170-saint_just_saint_rambert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42280-42660-saint_regis_du_coin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42280-42660-saint_regis_du_coin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42280-42660-saint_regis_du_coin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42280-42660-saint_regis_du_coin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42281-42370-saint_rirand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42281-42370-saint_rirand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42281-42370-saint_rirand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42281-42370-saint_rirand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42282-42430-saint_romain_d_urfe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42282-42430-saint_romain_d_urfe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42282-42430-saint_romain_d_urfe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42282-42430-saint_romain_d_urfe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42283-42800-saint_romain_en_jarez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42283-42800-saint_romain_en_jarez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42283-42800-saint_romain_en_jarez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42283-42800-saint_romain_en_jarez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42284-42640-saint_romain_la_motte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42284-42640-saint_romain_la_motte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42284-42640-saint_romain_la_motte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42284-42640-saint_romain_la_motte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42285-42610-saint_romain_le_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42285-42610-saint_romain_le_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42285-42610-saint_romain_le_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42285-42610-saint_romain_le_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42286-42660-saint_romain_les_atheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42286-42660-saint_romain_les_atheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42286-42660-saint_romain_les_atheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42286-42660-saint_romain_les_atheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42286-42500-saint_romain_les_atheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42286-42500-saint_romain_les_atheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42286-42500-saint_romain_les_atheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42286-42500-saint_romain_les_atheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42287-42220-saint_sauveur_en_rue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42287-42220-saint_sauveur_en_rue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42287-42220-saint_sauveur_en_rue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42287-42220-saint_sauveur_en_rue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42288-42130-saint_sixte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42288-42130-saint_sixte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42288-42130-saint_sixte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42288-42130-saint_sixte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42289-42470-saint_symphorien_de_lay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42289-42470-saint_symphorien_de_lay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42289-42470-saint_symphorien_de_lay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42289-42470-saint_symphorien_de_lay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42290-42600-saint_thomas_la_garde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42290-42600-saint_thomas_la_garde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42290-42600-saint_thomas_la_garde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42290-42600-saint_thomas_la_garde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42293-42630-saint_victor_sur_rhins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42293-42630-saint_victor_sur_rhins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42293-42630-saint_victor_sur_rhins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42293-42630-saint_victor_sur_rhins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42294-42120-saint_vincent_de_boisset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42294-42120-saint_vincent_de_boisset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42294-42120-saint_vincent_de_boisset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42294-42120-saint_vincent_de_boisset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42295-42440-les_salles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42295-42440-les_salles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42295-42440-les_salles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42295-42440-les_salles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42296-42110-salt_en_donzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42296-42110-salt_en_donzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42296-42110-salt_en_donzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42296-42110-salt_en_donzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42297-42110-salvizinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42297-42110-salvizinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42297-42110-salvizinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42297-42110-salvizinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42298-42990-sauvain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42298-42990-sauvain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42298-42990-sauvain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42298-42990-sauvain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42299-42600-savigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42299-42600-savigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42299-42600-savigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42299-42600-savigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42300-42460-sevelinges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42300-42460-sevelinges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42300-42460-sevelinges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42300-42460-sevelinges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42301-42560-soleymieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42301-42560-soleymieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42301-42560-soleymieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42301-42560-soleymieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42302-42290-sorbiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42302-42290-sorbiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42302-42290-sorbiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42302-42290-sorbiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42303-42260-souternon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42303-42260-souternon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42303-42260-souternon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42303-42260-souternon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42304-42450-sury_le_comtal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42304-42450-sury_le_comtal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42304-42450-sury_le_comtal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42304-42450-sury_le_comtal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42305-42350-la_talaudiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42305-42350-la_talaudiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42305-42350-la_talaudiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42305-42350-la_talaudiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42306-42660-tarentaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42306-42660-tarentaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42306-42660-tarentaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42306-42660-tarentaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42307-42800-tartaras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42307-42800-tartaras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42307-42800-tartaras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42307-42800-tartaras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42308-42740-la_terrasse_sur_dorlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42308-42740-la_terrasse_sur_dorlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42308-42740-la_terrasse_sur_dorlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42308-42740-la_terrasse_sur_dorlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42310-42220-thelis_la_combe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42310-42220-thelis_la_combe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42310-42220-thelis_la_combe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42310-42220-thelis_la_combe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42311-42580-la_tour_en_jarez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42311-42580-la_tour_en_jarez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42311-42580-la_tour_en_jarez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42311-42580-la_tour_en_jarez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42312-42380-la_tourette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42312-42380-la_tourette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42312-42380-la_tourette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42312-42380-la_tourette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42313-42130-trelins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42313-42130-trelins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42313-42130-trelins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42313-42130-trelins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42314-42830-la_tuiliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42314-42830-la_tuiliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42314-42830-la_tuiliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42314-42830-la_tuiliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42315-42210-unias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42315-42210-unias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42315-42210-unias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42315-42210-unias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42316-42240-unieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42316-42240-unieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42316-42240-unieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42316-42240-unieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42317-42310-urbise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42317-42310-urbise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42317-42310-urbise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42317-42310-urbise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42318-42550-usson_en_forez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42318-42550-usson_en_forez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42318-42550-usson_en_forez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42318-42550-usson_en_forez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42319-42110-valeille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42319-42110-valeille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42319-42110-valeille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42319-42110-valeille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42320-42320-valfleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42320-42320-valfleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42320-42320-valfleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42320-42320-valfleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42321-42111-la_valla_sur_rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42321-42111-la_valla_sur_rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42321-42111-la_valla_sur_rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42321-42111-la_valla_sur_rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42322-42131-la_valla_en_gier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42322-42131-la_valla_en_gier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42322-42131-la_valla_en_gier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42322-42131-la_valla_en_gier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42323-42340-veauche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42323-42340-veauche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42323-42340-veauche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42323-42340-veauche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42324-42340-veauchette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42324-42340-veauchette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42324-42340-veauchette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42324-42340-veauchette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42325-42590-vendranges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42325-42590-vendranges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42325-42590-vendranges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42325-42590-vendranges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42326-42520-veranne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42326-42520-veranne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42326-42520-veranne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42326-42520-veranne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42327-42410-verin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42327-42410-verin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42327-42410-verin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42327-42410-verin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42328-42600-verrieres_en_forez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42328-42600-verrieres_en_forez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42328-42600-verrieres_en_forez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42328-42600-verrieres_en_forez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42329-42220-la_versanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42329-42220-la_versanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42329-42220-la_versanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42329-42220-la_versanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42330-42390-villars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42330-42390-villars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42330-42390-villars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42330-42390-villars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42331-42155-villemontais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42331-42155-villemontais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42331-42155-villemontais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42331-42155-villemontais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42332-42300-villerest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42332-42300-villerest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42332-42300-villerest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42332-42300-villerest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42333-42460-villers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42333-42460-villers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42333-42460-villers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42333-42460-villers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42334-42780-violay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42334-42780-violay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42334-42780-violay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42334-42780-violay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42335-42140-viricelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42335-42140-viricelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42335-42140-viricelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42335-42140-viricelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42336-42140-virigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42336-42140-virigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42336-42140-virigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42336-42140-virigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42337-42310-vivans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42337-42310-vivans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42337-42310-vivans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42337-42310-vivans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42338-42720-vougy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42338-42720-vougy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42338-42720-vougy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42338-42720-vougy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42339-42430-chausseterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42339-42430-chausseterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42339-42430-chausseterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt42-loire/commune42339-42430-chausseterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-43.xml
+++ b/public/sitemaps/sitemap-43.xml
@@ -5,532 +5,1060 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43001-43100-agnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43001-43100-agnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43001-43100-agnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43001-43100-agnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43002-43000-aiguilhe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43002-43000-aiguilhe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43002-43000-aiguilhe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43002-43000-aiguilhe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43003-43270-allegre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43003-43270-allegre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43003-43270-allegre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43003-43270-allegre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43004-43150-alleyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43004-43150-alleyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43004-43150-alleyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43004-43150-alleyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43005-43580-alleyras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43005-43580-alleyras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43005-43580-alleyras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43005-43580-alleyras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43006-43380-ally/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43006-43380-ally/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43006-43380-ally/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43006-43380-ally/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43007-43200-araules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43007-43200-araules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43007-43200-araules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43007-43200-araules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43008-43490-arlempdes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43008-43490-arlempdes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43008-43490-arlempdes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43008-43490-arlempdes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43009-43380-arlet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43009-43380-arlet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43009-43380-arlet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43009-43380-arlet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43010-43700-arsac_en_velay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43010-43700-arsac_en_velay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43010-43700-arsac_en_velay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43010-43700-arsac_en_velay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43011-43380-aubazat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43011-43380-aubazat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43011-43380-aubazat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43011-43380-aubazat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43012-43110-aurec_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43012-43110-aurec_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43012-43110-aurec_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43012-43110-aurec_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43013-43300-vissac_auteyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43013-43300-vissac_auteyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43013-43300-vissac_auteyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43013-43300-vissac_auteyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43014-43450-autrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43014-43450-autrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43014-43450-autrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43014-43450-autrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43015-43300-auvers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43015-43300-auvers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43015-43300-auvers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43015-43300-auvers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43016-43390-auzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43016-43390-auzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43016-43390-auzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43016-43390-auzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43017-43390-azerat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43017-43390-azerat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43017-43390-azerat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43017-43390-azerat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43018-43370-bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43018-43370-bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43018-43370-bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43018-43370-bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43019-43340-barges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43019-43340-barges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43019-43340-barges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43019-43340-barges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43020-43210-bas_en_basset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43020-43210-bas_en_basset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43020-43210-bas_en_basset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43020-43210-bas_en_basset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43021-43800-beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43021-43800-beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43021-43800-beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43021-43800-beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43022-43100-beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43022-43100-beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43022-43100-beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43022-43100-beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43023-43500-beaune_sur_arzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43023-43500-beaune_sur_arzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43023-43500-beaune_sur_arzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43023-43500-beaune_sur_arzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43024-43200-beaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43024-43200-beaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43024-43200-beaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43024-43200-beaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43025-43590-beauzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43025-43590-beauzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43025-43590-beauzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43025-43590-beauzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43026-43350-bellevue_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43026-43350-bellevue_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43026-43350-bellevue_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43026-43350-bellevue_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43027-43160-berbezit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43027-43160-berbezit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43027-43160-berbezit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43027-43160-berbezit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43028-43200-bessamorel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43028-43200-bessamorel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43028-43200-bessamorel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43028-43200-bessamorel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43029-43170-la_besseyre_saint_mary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43029-43170-la_besseyre_saint_mary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43029-43170-la_besseyre_saint_mary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43029-43170-la_besseyre_saint_mary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43030-43350-blanzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43030-43350-blanzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43030-43350-blanzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43030-43350-blanzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43031-43380-blassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43031-43380-blassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43031-43380-blassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43031-43380-blassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43032-43700-blavozy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43032-43700-blavozy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43032-43700-blavozy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43032-43700-blavozy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43033-43450-blesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43033-43450-blesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43033-43450-blesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43033-43450-blesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43034-43500-boisset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43034-43500-boisset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43034-43500-boisset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43034-43500-boisset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43035-43160-bonneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43035-43160-bonneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43035-43160-bonneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43035-43160-bonneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43036-43350-borne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43036-43350-borne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43036-43350-borne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43036-43350-borne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43037-43510-le_bouchet_saint_nicolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43037-43510-le_bouchet_saint_nicolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43037-43510-le_bouchet_saint_nicolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43037-43510-le_bouchet_saint_nicolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43038-43360-bournoncle_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43038-43360-bournoncle_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43038-43360-bournoncle_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43038-43360-bournoncle_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43039-43370-le_brignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43039-43370-le_brignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43039-43370-le_brignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43039-43370-le_brignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43039-43150-le_brignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43039-43150-le_brignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43039-43150-le_brignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43039-43150-le_brignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43040-43100-brioude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43040-43100-brioude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43040-43100-brioude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43040-43100-brioude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43041-43700-brives_charensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43041-43700-brives_charensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43041-43700-brives_charensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43041-43700-brives_charensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43042-43510-cayres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43042-43510-cayres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43042-43510-cayres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43042-43510-cayres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43043-43270-ceaux_d_allegre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43043-43270-ceaux_d_allegre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43043-43270-ceaux_d_allegre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43043-43270-ceaux_d_allegre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43044-43380-cerzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43044-43380-cerzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43044-43380-cerzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43044-43380-cerzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43045-43000-ceyssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43045-43000-ceyssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43045-43000-ceyssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43045-43000-ceyssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43046-43770-chadrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43046-43770-chadrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43046-43770-chadrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43046-43770-chadrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43047-43150-chadron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43047-43150-chadron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43047-43150-chadron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43047-43150-chadron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43048-43160-la_chaise_dieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43048-43160-la_chaise_dieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43048-43160-la_chaise_dieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43048-43160-la_chaise_dieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43049-43800-chamalieres_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43049-43800-chamalieres_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43049-43800-chamalieres_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43049-43800-chamalieres_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43050-43410-chambezon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43050-43410-chambezon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43050-43410-chambezon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43050-43410-chambezon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43051-43400-le_chambon_sur_lignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43051-43400-le_chambon_sur_lignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43051-43400-le_chambon_sur_lignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43051-43400-le_chambon_sur_lignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43052-43440-champagnac_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43052-43440-champagnac_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43052-43440-champagnac_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43052-43440-champagnac_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43430-champclause/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43430-champclause/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43430-champclause/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43430-champclause/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43260-champclause/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43260-champclause/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43260-champclause/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43260-champclause/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43000-champclause/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43000-champclause/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43000-champclause/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43053-43000-champclause/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43054-43170-chanaleilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43054-43170-chanaleilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43054-43170-chanaleilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43054-43170-chanaleilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43055-43100-chaniat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43055-43100-chaniat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43055-43100-chaniat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43055-43100-chaniat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43056-43300-chanteuges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43056-43300-chanteuges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43056-43300-chanteuges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43056-43300-chanteuges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43057-43270-la_chapelle_bertin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43057-43270-la_chapelle_bertin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43057-43270-la_chapelle_bertin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43057-43270-la_chapelle_bertin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43058-43120-la_chapelle_d_aurec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43058-43120-la_chapelle_d_aurec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43058-43120-la_chapelle_d_aurec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43058-43120-la_chapelle_d_aurec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43059-43160-la_chapelle_geneste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43059-43160-la_chapelle_geneste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43059-43160-la_chapelle_geneste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43059-43160-la_chapelle_geneste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43060-43300-charraix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43060-43300-charraix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43060-43300-charraix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43060-43300-charraix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43061-43700-chaspinhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43061-43700-chaspinhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43061-43700-chaspinhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43061-43700-chaspinhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43062-43320-chaspuzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43062-43320-chaspuzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43062-43320-chaspuzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43062-43320-chaspuzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43063-43230-chassagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43063-43230-chassagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43063-43230-chassagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43063-43230-chassagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43064-43440-chassignolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43064-43440-chassignolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43064-43440-chassignolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43064-43440-chassignolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43065-43300-chastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43065-43300-chastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43065-43300-chastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43065-43300-chastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43066-43430-chaudeyrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43066-43430-chaudeyrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43066-43430-chaudeyrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43066-43430-chaudeyrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43067-43230-chavaniac_lafayette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43067-43230-chavaniac_lafayette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43067-43230-chavaniac_lafayette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43067-43230-chavaniac_lafayette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43068-43300-chazelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43068-43300-chazelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43068-43300-chazelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43068-43300-chazelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43069-43190-chenereilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43069-43190-chenereilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43069-43190-chenereilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43069-43190-chenereilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43070-43380-chilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43070-43380-chilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43070-43380-chilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43070-43380-chilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43071-43500-chomelix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43071-43500-chomelix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43071-43500-chomelix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43071-43500-chomelix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43072-43230-la_chomette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43072-43230-la_chomette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43072-43230-la_chomette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43072-43230-la_chomette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43073-43160-cistrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43073-43160-cistrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43073-43160-cistrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43073-43160-cistrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43074-43100-cohade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43074-43100-cohade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43074-43100-cohade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43074-43100-cohade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43075-43230-collat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43075-43230-collat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43075-43230-collat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43075-43230-collat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43076-43160-connangles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43076-43160-connangles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43076-43160-connangles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43076-43160-connangles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43077-43490-costaros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43077-43490-costaros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43077-43490-costaros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43077-43490-costaros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43078-43700-coubon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43078-43700-coubon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43078-43700-coubon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43078-43700-coubon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43079-43230-couteuges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43079-43230-couteuges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43079-43230-couteuges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43079-43230-couteuges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43080-43500-craponne_sur_arzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43080-43500-craponne_sur_arzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43080-43500-craponne_sur_arzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43080-43500-craponne_sur_arzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43082-43300-cronce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43082-43300-cronce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43082-43300-cronce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43082-43300-cronce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43083-43170-cubelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43083-43170-cubelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43083-43170-cubelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43083-43170-cubelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43084-43370-cussac_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43084-43370-cussac_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43084-43370-cussac_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43084-43370-cussac_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43085-43300-desges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43085-43300-desges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43085-43300-desges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43085-43300-desges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43086-43230-domeyrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43086-43230-domeyrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43086-43230-domeyrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43086-43230-domeyrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43087-43220-dunieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43087-43220-dunieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43087-43220-dunieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43087-43220-dunieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43088-43450-espalem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43088-43450-espalem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43088-43450-espalem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43088-43450-espalem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43089-43000-espaly_saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43089-43000-espaly_saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43089-43000-espaly_saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43089-43000-espaly_saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43090-43170-esplantas_vazeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43090-43170-esplantas_vazeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43090-43170-esplantas_vazeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43090-43170-esplantas_vazeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43091-43150-les_estables/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43091-43150-les_estables/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43091-43150-les_estables/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43091-43150-les_estables/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43092-43430-fay_sur_lignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43092-43430-fay_sur_lignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43092-43430-fay_sur_lignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43092-43430-fay_sur_lignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43093-43160-felines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43093-43160-felines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43093-43160-felines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43093-43160-felines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43094-43300-ferrussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43094-43300-ferrussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43094-43300-ferrussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43094-43300-ferrussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43095-43320-fix_saint_geneys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43095-43320-fix_saint_geneys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43095-43320-fix_saint_geneys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43095-43320-fix_saint_geneys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43096-43100-fontannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43096-43100-fontannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43096-43100-fontannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43096-43100-fontannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43097-43150-freycenet_la_cuche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43097-43150-freycenet_la_cuche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43097-43150-freycenet_la_cuche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43097-43150-freycenet_la_cuche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43098-43150-freycenet_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43098-43150-freycenet_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43098-43150-freycenet_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43098-43150-freycenet_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43099-43250-frugeres_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43099-43250-frugeres_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43099-43250-frugeres_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43099-43250-frugeres_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43100-43230-frugieres_le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43100-43230-frugieres_le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43100-43230-frugieres_le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43100-43230-frugieres_le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43101-43150-goudet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43101-43150-goudet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43101-43150-goudet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43101-43150-goudet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43102-43200-grazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43102-43200-grazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43102-43200-grazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43102-43200-grazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43103-43450-grenier_montgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43103-43450-grenier_montgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43103-43450-grenier_montgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43103-43450-grenier_montgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43104-43170-grezes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43104-43170-grezes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43104-43170-grezes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43104-43170-grezes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43105-43100-javaugues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43105-43100-javaugues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43105-43100-javaugues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43105-43100-javaugues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43106-43230-jax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43106-43230-jax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43106-43230-jax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43106-43230-jax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43107-43230-josat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43107-43230-josat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43107-43230-josat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43107-43230-josat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43108-43500-jullianges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43108-43500-jullianges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43108-43500-jullianges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43108-43500-jullianges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43109-43490-lafarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43109-43490-lafarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43109-43490-lafarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43109-43490-lafarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43110-43100-lamothe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43110-43100-lamothe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43110-43100-lamothe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43110-43100-lamothe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43111-43340-landos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43111-43340-landos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43111-43340-landos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43111-43340-landos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43112-43300-langeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43112-43300-langeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43112-43300-langeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43112-43300-langeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43113-43260-lantriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43113-43260-lantriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43113-43260-lantriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43113-43260-lantriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43114-43200-lapte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43114-43200-lapte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43114-43200-lapte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43114-43200-lapte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43115-43150-laussonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43115-43150-laussonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43115-43150-laussonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43115-43150-laussonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43116-43440-laval_sur_doulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43116-43440-laval_sur_doulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43116-43440-laval_sur_doulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43116-43440-laval_sur_doulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43117-43100-lavaudieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43117-43100-lavaudieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43117-43100-lavaudieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43117-43100-lavaudieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43118-43380-lavoute_chilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43118-43380-lavoute_chilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43118-43380-lavoute_chilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43118-43380-lavoute_chilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43119-43800-lavoute_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43119-43800-lavoute_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43119-43800-lavoute_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43119-43800-lavoute_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43120-43410-lempdes_sur_allagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43120-43410-lempdes_sur_allagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43120-43410-lempdes_sur_allagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43120-43410-lempdes_sur_allagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43121-43410-leotoing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43121-43410-leotoing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43121-43410-leotoing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43121-43410-leotoing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43122-43350-lissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43122-43350-lissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43122-43350-lissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43122-43350-lissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43123-43360-lorlanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43123-43360-lorlanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43123-43360-lorlanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43123-43360-lorlanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43124-43320-loudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43124-43320-loudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43124-43320-loudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43124-43320-loudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43125-43100-lubilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43125-43100-lubilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43125-43100-lubilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43125-43100-lubilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43126-43800-malrevers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43126-43800-malrevers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43126-43800-malrevers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43126-43800-malrevers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43127-43210-malvalette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43127-43210-malvalette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43127-43210-malvalette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43127-43210-malvalette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43128-43160-malvieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43128-43160-malvieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43128-43160-malvieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43128-43160-malvieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43129-43190-le_mas_de_tence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43129-43190-le_mas_de_tence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43129-43190-le_mas_de_tence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43129-43190-le_mas_de_tence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43130-43520-mazet_saint_voy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43130-43520-mazet_saint_voy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43130-43520-mazet_saint_voy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43130-43520-mazet_saint_voy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43131-43230-mazerat_aurouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43131-43230-mazerat_aurouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43131-43230-mazerat_aurouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43131-43230-mazerat_aurouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43132-43300-mazeyrat_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43132-43300-mazeyrat_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43132-43300-mazeyrat_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43132-43300-mazeyrat_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43133-43100-mercoeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43133-43100-mercoeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43133-43100-mercoeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43133-43100-mercoeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43134-43800-mezeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43134-43800-mezeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43134-43800-mezeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43134-43800-mezeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43135-43150-le_monastier_sur_gazeille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43135-43150-le_monastier_sur_gazeille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43135-43150-le_monastier_sur_gazeille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43135-43150-le_monastier_sur_gazeille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43136-43580-monistrol_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43136-43580-monistrol_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43136-43580-monistrol_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43136-43580-monistrol_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43137-43120-monistrol_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43137-43120-monistrol_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43137-43120-monistrol_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43137-43120-monistrol_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43138-43270-monlet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43138-43270-monlet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43138-43270-monlet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43138-43270-monlet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43139-43230-montclard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43139-43230-montclard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43139-43230-montclard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43139-43230-montclard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43140-43700-le_monteil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43140-43700-le_monteil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43140-43700-le_monteil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43140-43700-le_monteil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43141-43290-montfaucon_en_velay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43141-43290-montfaucon_en_velay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43141-43290-montfaucon_en_velay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43141-43290-montfaucon_en_velay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43142-43290-montregard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43142-43290-montregard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43142-43290-montregard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43142-43290-montregard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43143-43260-montusclat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43143-43260-montusclat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43143-43260-montusclat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43143-43260-montusclat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43144-43150-moudeyres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43144-43150-moudeyres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43144-43150-moudeyres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43144-43150-moudeyres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43145-43510-ouides/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43145-43510-ouides/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43145-43510-ouides/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43145-43510-ouides/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43147-43100-paulhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43147-43100-paulhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43147-43100-paulhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43147-43100-paulhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43148-43230-paulhaguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43148-43230-paulhaguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43148-43230-paulhaguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43148-43230-paulhaguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43149-43300-pebrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43149-43300-pebrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43149-43300-pebrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43149-43300-pebrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43150-43200-le_pertuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43150-43200-le_pertuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43150-43200-le_pertuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43150-43200-le_pertuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43151-43300-pinols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43151-43300-pinols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43151-43300-pinols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43151-43300-pinols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43152-43000-polignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43152-43000-polignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43152-43000-polignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43152-43000-polignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43153-43330-pont_salomon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43153-43330-pont_salomon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43153-43330-pont_salomon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43153-43330-pont_salomon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43154-43420-pradelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43154-43420-pradelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43154-43420-pradelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43154-43420-pradelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43155-43300-prades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43155-43300-prades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43155-43300-prades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43155-43300-prades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43156-43150-presailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43156-43150-presailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43156-43150-presailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43156-43150-presailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43157-43000-le_puy_en_velay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43157-43000-le_puy_en_velay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43157-43000-le_puy_en_velay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43157-43000-le_puy_en_velay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43157-43750-le_puy_en_velay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43157-43750-le_puy_en_velay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43157-43750-le_puy_en_velay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43157-43750-le_puy_en_velay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43158-43260-queyrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43158-43260-queyrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43158-43260-queyrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43158-43260-queyrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43159-43290-raucoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43159-43290-raucoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43159-43290-raucoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43159-43290-raucoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43160-43340-rauret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43160-43340-rauret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43160-43340-rauret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43160-43340-rauret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43162-43130-retournac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43162-43130-retournac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43162-43130-retournac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43162-43130-retournac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43163-43220-riotord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43163-43220-riotord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43163-43220-riotord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43163-43220-riotord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43164-43810-roche_en_regnier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43164-43810-roche_en_regnier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43164-43810-roche_en_regnier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43164-43810-roche_en_regnier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43165-43800-rosieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43165-43800-rosieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43165-43800-rosieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43165-43800-rosieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43166-43130-saint_andre_de_chalencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43166-43130-saint_andre_de_chalencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43166-43130-saint_andre_de_chalencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43166-43130-saint_andre_de_chalencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43167-43300-saint_arcons_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43167-43300-saint_arcons_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43167-43300-saint_arcons_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43167-43300-saint_arcons_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43168-43420-saint_arcons_de_barges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43168-43420-saint_arcons_de_barges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43168-43420-saint_arcons_de_barges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43168-43420-saint_arcons_de_barges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43169-43380-saint_austremoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43169-43380-saint_austremoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43169-43380-saint_austremoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43169-43380-saint_austremoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43170-43100-saint_beauzire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43170-43100-saint_beauzire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43170-43100-saint_beauzire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43170-43100-saint_beauzire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43171-43300-saint_berain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43171-43300-saint_berain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43171-43300-saint_berain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43171-43300-saint_berain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43172-43290-saint_bonnet_le_froid/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43172-43290-saint_bonnet_le_froid/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43172-43290-saint_bonnet_le_froid/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43172-43290-saint_bonnet_le_froid/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43173-43340-saint_christophe_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43173-43340-saint_christophe_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43173-43340-saint_christophe_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43173-43340-saint_christophe_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43174-43370-saint_christophe_sur_dolaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43174-43370-saint_christophe_sur_dolaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43174-43370-saint_christophe_sur_dolaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43174-43370-saint_christophe_sur_dolaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43175-43380-saint_cirgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43175-43380-saint_cirgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43175-43380-saint_cirgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43175-43380-saint_cirgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43177-43140-saint_didier_en_velay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43177-43140-saint_didier_en_velay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43177-43140-saint_didier_en_velay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43177-43140-saint_didier_en_velay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43178-43440-saint_didier_sur_doulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43178-43440-saint_didier_sur_doulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43178-43440-saint_didier_sur_doulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43178-43440-saint_didier_sur_doulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43180-43420-saint_etienne_du_vigan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43180-43420-saint_etienne_du_vigan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43180-43420-saint_etienne_du_vigan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43180-43420-saint_etienne_du_vigan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43181-43260-saint_etienne_lardeyrol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43181-43260-saint_etienne_lardeyrol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43181-43260-saint_etienne_lardeyrol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43181-43260-saint_etienne_lardeyrol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43182-43450-saint_etienne_sur_blesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43182-43450-saint_etienne_sur_blesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43182-43450-saint_etienne_sur_blesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43182-43450-saint_etienne_sur_blesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43183-43230-sainte_eugenie_de_villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43183-43230-sainte_eugenie_de_villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43183-43230-sainte_eugenie_de_villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43183-43230-sainte_eugenie_de_villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43184-43330-saint_ferreol_d_auroure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43184-43330-saint_ferreol_d_auroure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43184-43330-saint_ferreol_d_auroure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43184-43330-saint_ferreol_d_auroure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43185-43250-sainte_florine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43185-43250-sainte_florine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43185-43250-sainte_florine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43185-43250-sainte_florine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43186-43550-saint_front/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43186-43550-saint_front/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43186-43550-saint_front/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43186-43550-saint_front/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43187-43350-saint_geneys_pres_saint_paulien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43187-43350-saint_geneys_pres_saint_paulien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43187-43350-saint_geneys_pres_saint_paulien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43187-43350-saint_geneys_pres_saint_paulien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43188-43230-saint_georges_d_aurac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43188-43230-saint_georges_d_aurac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43188-43230-saint_georges_d_aurac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43188-43230-saint_georges_d_aurac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43189-43500-saint_georges_lagricol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43189-43500-saint_georges_lagricol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43189-43500-saint_georges_lagricol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43189-43500-saint_georges_lagricol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43190-43700-saint_germain_laprade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43190-43700-saint_germain_laprade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43190-43700-saint_germain_laprade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43190-43700-saint_germain_laprade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43191-43360-saint_geron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43191-43360-saint_geron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43191-43360-saint_geron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43191-43360-saint_geron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43192-43340-saint_haon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43192-43340-saint_haon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43192-43340-saint_haon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43192-43340-saint_haon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43193-43390-saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43193-43390-saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43193-43390-saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43193-43390-saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43194-43260-saint_hostien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43194-43260-saint_hostien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43194-43260-saint_hostien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43194-43260-saint_hostien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43195-43380-saint_ilpize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43195-43380-saint_ilpize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43195-43380-saint_ilpize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43195-43380-saint_ilpize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43196-43500-saint_jean_d_aubrigoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43196-43500-saint_jean_d_aubrigoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43196-43500-saint_jean_d_aubrigoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43196-43500-saint_jean_d_aubrigoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43197-43320-saint_jean_de_nay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43197-43320-saint_jean_de_nay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43197-43320-saint_jean_de_nay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43197-43320-saint_jean_de_nay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43198-43510-saint_jean_lachalm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43198-43510-saint_jean_lachalm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43198-43510-saint_jean_lachalm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43198-43510-saint_jean_lachalm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43199-43200-saint_jeures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43199-43200-saint_jeures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43199-43200-saint_jeures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43199-43200-saint_jeures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43200-43260-saint_julien_chapteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43200-43260-saint_julien_chapteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43200-43260-saint_julien_chapteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43200-43260-saint_julien_chapteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43201-43500-saint_julien_d_ance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43201-43500-saint_julien_d_ance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43201-43500-saint_julien_d_ance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43201-43500-saint_julien_d_ance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43202-43300-saint_julien_des_chazes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43202-43300-saint_julien_des_chazes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43202-43300-saint_julien_des_chazes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43202-43300-saint_julien_des_chazes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43203-43200-saint_julien_du_pinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43203-43200-saint_julien_du_pinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43203-43200-saint_julien_du_pinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43203-43200-saint_julien_du_pinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43204-43220-saint_julien_molhesabate/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43204-43220-saint_julien_molhesabate/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43204-43220-saint_julien_molhesabate/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43204-43220-saint_julien_molhesabate/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43205-43240-saint_just_malmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43205-43240-saint_just_malmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43205-43240-saint_just_malmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43205-43240-saint_just_malmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43206-43100-saint_just_pres_brioude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43206-43100-saint_just_pres_brioude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43206-43100-saint_just_pres_brioude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43206-43100-saint_just_pres_brioude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43207-43100-saint_laurent_chabreuges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43207-43100-saint_laurent_chabreuges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43207-43100-saint_laurent_chabreuges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43207-43100-saint_laurent_chabreuges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43208-43230-sainte_marguerite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43208-43230-sainte_marguerite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43208-43230-sainte_marguerite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43208-43230-sainte_marguerite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43210-43150-saint_martin_de_fugeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43210-43150-saint_martin_de_fugeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43210-43150-saint_martin_de_fugeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43210-43150-saint_martin_de_fugeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43211-43200-saint_maurice_de_lignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43211-43200-saint_maurice_de_lignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43211-43200-saint_maurice_de_lignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43211-43200-saint_maurice_de_lignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43211-43120-saint_maurice_de_lignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43211-43120-saint_maurice_de_lignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43211-43120-saint_maurice_de_lignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43211-43120-saint_maurice_de_lignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43212-43500-saint_pal_de_chalencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43212-43500-saint_pal_de_chalencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43212-43500-saint_pal_de_chalencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43212-43500-saint_pal_de_chalencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43213-43620-saint_pal_de_mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43213-43620-saint_pal_de_mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43213-43620-saint_pal_de_mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43213-43620-saint_pal_de_mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43214-43160-saint_pal_de_senouire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43214-43160-saint_pal_de_senouire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43214-43160-saint_pal_de_senouire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43214-43160-saint_pal_de_senouire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43215-43420-saint_paul_de_tartas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43215-43420-saint_paul_de_tartas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43215-43420-saint_paul_de_tartas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43215-43420-saint_paul_de_tartas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43216-43350-saint_paulien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43216-43350-saint_paulien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43216-43350-saint_paulien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43216-43350-saint_paulien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43217-43810-saint_pierre_du_champ/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43217-43810-saint_pierre_du_champ/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43217-43810-saint_pierre_du_champ/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43217-43810-saint_pierre_du_champ/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43218-43260-saint_pierre_eynac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43218-43260-saint_pierre_eynac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43218-43260-saint_pierre_eynac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43218-43260-saint_pierre_eynac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43219-43230-saint_prejet_armandon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43219-43230-saint_prejet_armandon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43219-43230-saint_prejet_armandon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43219-43230-saint_prejet_armandon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43220-43580-saint_prejet_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43220-43580-saint_prejet_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43220-43580-saint_prejet_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43220-43580-saint_prejet_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43221-43580-saint_privat_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43221-43580-saint_privat_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43221-43580-saint_privat_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43221-43580-saint_privat_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43222-43380-saint_privat_du_dragon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43222-43380-saint_privat_du_dragon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43222-43380-saint_privat_du_dragon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43222-43380-saint_privat_du_dragon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43223-43620-saint_romain_lachalm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43223-43620-saint_romain_lachalm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43223-43620-saint_romain_lachalm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43223-43620-saint_romain_lachalm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43224-43600-sainte_sigolene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43224-43600-sainte_sigolene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43224-43600-sainte_sigolene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43224-43600-sainte_sigolene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43225-43580-saint_venerand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43225-43580-saint_venerand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43225-43580-saint_venerand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43225-43580-saint_venerand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43226-43440-saint_vert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43226-43440-saint_vert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43226-43440-saint_vert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43226-43440-saint_vert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43227-43140-saint_victor_malescours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43227-43140-saint_victor_malescours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43227-43140-saint_victor_malescours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43227-43140-saint_victor_malescours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43228-43500-saint_victor_sur_arlanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43228-43500-saint_victor_sur_arlanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43228-43500-saint_victor_sur_arlanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43228-43500-saint_victor_sur_arlanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43229-43320-saint_vidal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43229-43320-saint_vidal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43229-43320-saint_vidal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43229-43320-saint_vidal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43230-43800-saint_vincent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43230-43800-saint_vincent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43230-43800-saint_vincent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43230-43800-saint_vincent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43231-43150-salettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43231-43150-salettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43231-43150-salettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43231-43150-salettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43232-43230-salzuit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43232-43230-salzuit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43232-43230-salzuit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43232-43230-salzuit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43233-43320-sanssac_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43233-43320-sanssac_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43233-43320-sanssac_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43233-43320-sanssac_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43234-43170-saugues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43234-43170-saugues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43234-43170-saugues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43234-43170-saugues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43236-43140-la_seauve_sur_semene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43236-43140-la_seauve_sur_semene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43236-43140-la_seauve_sur_semene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43236-43140-la_seauve_sur_semene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43237-43160-sembadel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43237-43160-sembadel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43237-43160-sembadel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43237-43160-sembadel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43238-43510-seneujols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43238-43510-seneujols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43238-43510-seneujols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43238-43510-seneujols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43239-43300-siaugues_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43239-43300-siaugues_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43239-43300-siaugues_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43239-43300-siaugues_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43240-43130-solignac_sous_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43240-43130-solignac_sous_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43240-43130-solignac_sous_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43240-43130-solignac_sous_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43241-43370-solignac_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43241-43370-solignac_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43241-43370-solignac_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43241-43370-solignac_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43242-43300-tailhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43242-43300-tailhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43242-43300-tailhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43242-43300-tailhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43244-43190-tence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43244-43190-tence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43244-43190-tence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43244-43190-tence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43245-43170-thoras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43245-43170-thoras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43245-43170-thoras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43245-43170-thoras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43246-43530-tiranges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43246-43530-tiranges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43246-43530-tiranges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43246-43530-tiranges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43247-43450-torsiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43247-43450-torsiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43247-43450-torsiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43247-43450-torsiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43249-43210-valprivas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43249-43210-valprivas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43249-43210-valprivas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43249-43210-valprivas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43250-43230-vals_le_chastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43250-43230-vals_le_chastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43250-43230-vals_le_chastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43250-43230-vals_le_chastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43251-43750-vals_pres_le_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43251-43750-vals_pres_le_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43251-43750-vals_pres_le_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43251-43750-vals_pres_le_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43251-43000-vals_pres_le_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43251-43000-vals_pres_le_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43251-43000-vals_pres_le_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43251-43000-vals_pres_le_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43252-43270-varennes_saint_honorat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43252-43270-varennes_saint_honorat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43252-43270-varennes_saint_honorat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43252-43270-varennes_saint_honorat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43253-43430-les_vastres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43253-43430-les_vastres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43253-43430-les_vastres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43253-43430-les_vastres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43254-43320-vazeilles_limandre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43254-43320-vazeilles_limandre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43254-43320-vazeilles_limandre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43254-43320-vazeilles_limandre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43256-43170-venteuges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43256-43170-venteuges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43256-43170-venteuges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43256-43170-venteuges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43257-43320-vergezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43257-43320-vergezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43257-43320-vergezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43257-43320-vergezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43258-43360-vergongheon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43258-43360-vergongheon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43258-43360-vergongheon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43258-43360-vergongheon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43259-43270-vernassal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43259-43270-vernassal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43259-43270-vernassal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43259-43270-vernassal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43260-43320-le_vernet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43260-43320-le_vernet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43260-43320-le_vernet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43260-43320-le_vernet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43261-43390-vezezoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43261-43390-vezezoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43261-43390-vezezoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43261-43390-vezezoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43262-43100-vieille_brioude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43262-43100-vieille_brioude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43262-43100-vieille_brioude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43262-43100-vieille_brioude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43263-43490-vielprat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43263-43490-vielprat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43263-43490-vielprat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43263-43490-vielprat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43264-43380-villeneuve_d_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43264-43380-villeneuve_d_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43264-43380-villeneuve_d_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43264-43380-villeneuve_d_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43265-43600-les_villettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43265-43600-les_villettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43265-43600-les_villettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43265-43600-les_villettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43267-43800-vorey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43267-43800-vorey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43267-43800-vorey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43267-43800-vorey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43268-43200-yssingeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43268-43200-yssingeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43268-43200-yssingeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt43-haute_loire/commune43268-43200-yssingeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-44.xml
+++ b/public/sitemaps/sitemap-44.xml
@@ -5,428 +5,852 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44001-44170-abbaretz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44001-44170-abbaretz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44001-44170-abbaretz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44001-44170-abbaretz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44002-44140-aigrefeuille_sur_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44002-44140-aigrefeuille_sur_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44002-44140-aigrefeuille_sur_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44002-44140-aigrefeuille_sur_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44003-44150-ancenis_saint_gereon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44003-44150-ancenis_saint_gereon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44003-44150-ancenis_saint_gereon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44003-44150-ancenis_saint_gereon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44005-44320-chaumes_en_retz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44005-44320-chaumes_en_retz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44005-44320-chaumes_en_retz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44005-44320-chaumes_en_retz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44005-44680-chaumes_en_retz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44005-44680-chaumes_en_retz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44005-44680-chaumes_en_retz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44005-44680-chaumes_en_retz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44006-44410-asserac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44006-44410-asserac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44006-44410-asserac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44006-44410-asserac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44007-44460-avessac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44007-44460-avessac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44007-44460-avessac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44007-44460-avessac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44009-44115-basse_goulaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44009-44115-basse_goulaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44009-44115-basse_goulaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44009-44115-basse_goulaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44010-44740-batz_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44010-44740-batz_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44010-44740-batz_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44010-44740-batz_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44012-44760-la_bernerie_en_retz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44012-44760-la_bernerie_en_retz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44012-44760-la_bernerie_en_retz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44012-44760-la_bernerie_en_retz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44013-44160-besne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44013-44160-besne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44013-44160-besne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44013-44160-besne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44014-44140-le_bignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44014-44140-le_bignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44014-44140-le_bignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44014-44140-le_bignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44015-44130-blain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44015-44130-blain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44015-44130-blain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44015-44130-blain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44016-44430-la_boissiere_du_dore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44016-44430-la_boissiere_du_dore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44016-44430-la_boissiere_du_dore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44016-44430-la_boissiere_du_dore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44018-44830-bouaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44018-44830-bouaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44018-44830-bouaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44018-44830-bouaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44019-44260-bouee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44019-44260-bouee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44019-44260-bouee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44019-44260-bouee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44020-44340-bouguenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44020-44340-bouguenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44020-44340-bouguenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44020-44340-bouguenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44021-44580-villeneuve_en_retz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44021-44580-villeneuve_en_retz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44021-44580-villeneuve_en_retz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44021-44580-villeneuve_en_retz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44022-44190-boussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44022-44190-boussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44022-44190-boussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44022-44190-boussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44023-44130-bouvron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44023-44130-bouvron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44023-44130-bouvron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44023-44130-bouvron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44024-44830-brains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44024-44830-brains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44024-44830-brains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44024-44830-brains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44025-44750-campbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44025-44750-campbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44025-44750-campbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44025-44750-campbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44026-44470-carquefou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44026-44470-carquefou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44026-44470-carquefou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44026-44470-carquefou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44027-44390-casson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44027-44390-casson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44027-44390-casson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44027-44390-casson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44028-44850-le_cellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44028-44850-le_cellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44028-44850-le_cellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44028-44850-le_cellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44029-44450-divatte_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44029-44450-divatte_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44029-44450-divatte_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44029-44450-divatte_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44030-44410-la_chapelle_des_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44030-44410-la_chapelle_des_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44030-44410-la_chapelle_des_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44030-44410-la_chapelle_des_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44031-44670-la_chapelle_glain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44031-44670-la_chapelle_glain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44031-44670-la_chapelle_glain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44031-44670-la_chapelle_glain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44032-44330-la_chapelle_heulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44032-44330-la_chapelle_heulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44032-44330-la_chapelle_heulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44032-44330-la_chapelle_heulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44033-44260-la_chapelle_launay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44033-44260-la_chapelle_launay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44033-44260-la_chapelle_launay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44033-44260-la_chapelle_launay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44035-44240-la_chapelle_sur_erdre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44035-44240-la_chapelle_sur_erdre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44035-44240-la_chapelle_sur_erdre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44035-44240-la_chapelle_sur_erdre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44036-44110-chateaubriant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44036-44110-chateaubriant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44036-44110-chateaubriant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44036-44110-chateaubriant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44037-44690-chateau_thebaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44037-44690-chateau_thebaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44037-44690-chateau_thebaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44037-44690-chateau_thebaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44038-44320-chauve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44038-44320-chauve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44038-44320-chauve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44038-44320-chauve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44039-44640-cheix_en_retz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44039-44640-cheix_en_retz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44039-44640-cheix_en_retz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44039-44640-cheix_en_retz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44041-44118-la_chevroliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44041-44118-la_chevroliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44041-44118-la_chevroliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44041-44118-la_chevroliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44043-44190-clisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44043-44190-clisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44043-44190-clisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44043-44190-clisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44044-44290-conquereuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44044-44290-conquereuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44044-44290-conquereuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44044-44290-conquereuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44045-44360-cordemais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44045-44360-cordemais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44045-44360-cordemais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44045-44360-cordemais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44046-44560-corsept/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44046-44560-corsept/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44046-44560-corsept/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44046-44560-corsept/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44047-44220-coueron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44047-44220-coueron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44047-44220-coueron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44047-44220-coueron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44048-44521-couffe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44048-44521-couffe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44048-44521-couffe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44048-44521-couffe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44049-44490-le_croisic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44049-44490-le_croisic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44049-44490-le_croisic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44049-44490-le_croisic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44050-44160-crossac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44050-44160-crossac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44050-44160-crossac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44050-44160-crossac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44051-44590-derval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44051-44590-derval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44051-44590-derval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44051-44590-derval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44052-44480-donges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44052-44480-donges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44052-44480-donges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44052-44480-donges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44053-44530-dreffeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44053-44530-dreffeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44053-44530-dreffeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44053-44530-dreffeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44054-44110-erbray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44054-44110-erbray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44054-44110-erbray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44054-44110-erbray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44055-44500-la_baule_escoublac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44055-44500-la_baule_escoublac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44055-44500-la_baule_escoublac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44055-44500-la_baule_escoublac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44056-44130-fay_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44056-44130-fay_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44056-44130-fay_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44056-44130-fay_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44057-44460-fegreac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44057-44460-fegreac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44057-44460-fegreac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44057-44460-fegreac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44058-44660-ferce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44058-44660-ferce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44058-44660-ferce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44058-44660-ferce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44061-44320-frossay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44061-44320-frossay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44061-44320-frossay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44061-44320-frossay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44062-44130-le_gavre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44062-44130-le_gavre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44062-44130-le_gavre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44062-44130-le_gavre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44063-44190-getigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44063-44190-getigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44063-44190-getigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44063-44190-getigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44064-44190-gorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44064-44190-gorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44064-44190-gorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44064-44190-gorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44065-44520-grand_auverne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44065-44520-grand_auverne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44065-44520-grand_auverne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44065-44520-grand_auverne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44066-44119-grandchamps_des_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44066-44119-grandchamps_des_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44066-44119-grandchamps_des_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44066-44119-grandchamps_des_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44067-44290-guemene_penfao/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44067-44290-guemene_penfao/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44067-44290-guemene_penfao/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44067-44290-guemene_penfao/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44068-44530-guenrouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44068-44530-guenrouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44068-44530-guenrouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44068-44530-guenrouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44069-44350-guerande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44069-44350-guerande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44069-44350-guerande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44069-44350-guerande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44070-44690-la_haie_fouassiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44070-44690-la_haie_fouassiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44070-44690-la_haie_fouassiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44070-44690-la_haie_fouassiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44071-44115-haute_goulaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44071-44115-haute_goulaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44071-44115-haute_goulaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44071-44115-haute_goulaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44072-44410-herbignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44072-44410-herbignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44072-44410-herbignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44072-44410-herbignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44073-44810-heric/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44073-44810-heric/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44073-44810-heric/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44073-44810-heric/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44074-44610-indre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44074-44610-indre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44074-44610-indre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44074-44610-indre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44075-44520-isse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44075-44520-isse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44075-44520-isse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44075-44520-isse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44076-44170-jans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44076-44170-jans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44076-44170-jans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44076-44170-jans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44077-44440-joue_sur_erdre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44077-44440-joue_sur_erdre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44077-44440-joue_sur_erdre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44077-44440-joue_sur_erdre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44078-44670-juigne_des_moutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44078-44670-juigne_des_moutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44078-44670-juigne_des_moutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44078-44670-juigne_des_moutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44079-44430-le_landreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44079-44430-le_landreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44079-44430-le_landreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44079-44430-le_landreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44080-44260-lavau_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44080-44260-lavau_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44080-44260-lavau_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44080-44260-lavau_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44081-44650-lege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44081-44650-lege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44081-44650-lege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44081-44650-lege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44082-44850-ligne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44082-44850-ligne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44082-44850-ligne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44082-44850-ligne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44083-44310-la_limouziniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44083-44310-la_limouziniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44083-44310-la_limouziniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44083-44310-la_limouziniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44084-44430-le_loroux_bottereau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44084-44430-le_loroux_bottereau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44084-44430-le_loroux_bottereau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44084-44430-le_loroux_bottereau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44085-44110-louisfert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44085-44110-louisfert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44085-44110-louisfert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44085-44110-louisfert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44086-44590-lusanger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44086-44590-lusanger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44086-44590-lusanger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44086-44590-lusanger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44087-44270-machecoul_saint_meme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44087-44270-machecoul_saint_meme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44087-44270-machecoul_saint_meme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44087-44270-machecoul_saint_meme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44088-44690-maisdon_sur_sevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44088-44690-maisdon_sur_sevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44088-44690-maisdon_sur_sevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44088-44690-maisdon_sur_sevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44089-44260-malville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44089-44260-malville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44089-44260-malville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44089-44260-malville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44090-44270-la_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44090-44270-la_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44090-44270-la_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44090-44270-la_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44091-44170-marsac_sur_don/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44091-44170-marsac_sur_don/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44091-44170-marsac_sur_don/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44091-44170-marsac_sur_don/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44092-44290-masserac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44092-44290-masserac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44092-44290-masserac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44092-44290-masserac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44094-44470-mauves_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44094-44470-mauves_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44094-44470-mauves_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44094-44470-mauves_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44095-44520-la_meilleraye_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44095-44520-la_meilleraye_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44095-44520-la_meilleraye_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44095-44520-la_meilleraye_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44096-44522-mesanger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44096-44522-mesanger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44096-44522-mesanger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44096-44522-mesanger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44097-44420-mesquer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44097-44420-mesquer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44097-44420-mesquer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44097-44420-mesquer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44098-44780-missillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44098-44780-missillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44098-44780-missillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44098-44780-missillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44099-44520-moisdon_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44099-44520-moisdon_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44099-44520-moisdon_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44099-44520-moisdon_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44100-44690-monnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44100-44690-monnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44100-44690-monnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44100-44690-monnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44101-44620-la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44101-44620-la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44101-44620-la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44101-44620-la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44102-44140-montbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44102-44140-montbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44102-44140-montbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44102-44140-montbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44103-44550-montoir_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44103-44550-montoir_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44103-44550-montoir_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44103-44550-montoir_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44104-44370-montrelais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44104-44370-montrelais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44104-44370-montrelais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44104-44370-montrelais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44105-44590-mouais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44105-44590-mouais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44105-44590-mouais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44105-44590-mouais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44106-44760-les_moutiers_en_retz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44106-44760-les_moutiers_en_retz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44106-44760-les_moutiers_en_retz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44106-44760-les_moutiers_en_retz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44107-44850-mouzeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44107-44850-mouzeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44107-44850-mouzeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44107-44850-mouzeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44108-44330-mouzillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44108-44330-mouzillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44108-44330-mouzillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44108-44330-mouzillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44100-nantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44100-nantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44100-nantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44100-nantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44000-nantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44000-nantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44000-nantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44000-nantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44300-nantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44300-nantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44300-nantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44300-nantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44200-nantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44200-nantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44200-nantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44109-44200-nantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44110-44390-nort_sur_erdre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44110-44390-nort_sur_erdre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44110-44390-nort_sur_erdre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44110-44390-nort_sur_erdre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44111-44130-notre_dame_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44111-44130-notre_dame_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44111-44130-notre_dame_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44111-44130-notre_dame_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44112-44110-noyal_sur_brutz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44112-44110-noyal_sur_brutz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44112-44110-noyal_sur_brutz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44112-44110-noyal_sur_brutz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44113-44170-nozay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44113-44170-nozay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44113-44170-nozay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44113-44170-nozay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44114-44700-orvault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44114-44700-orvault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44114-44700-orvault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44114-44700-orvault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44115-44521-oudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44115-44521-oudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44115-44521-oudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44115-44521-oudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44116-44560-paimboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44116-44560-paimboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44116-44560-paimboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44116-44560-paimboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44117-44330-le_pallet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44117-44330-le_pallet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44117-44330-le_pallet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44117-44330-le_pallet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44118-44440-pannece/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44118-44440-pannece/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44118-44440-pannece/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44118-44440-pannece/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44119-44270-paulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44119-44270-paulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44119-44270-paulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44119-44270-paulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44120-44640-le_pellerin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44120-44640-le_pellerin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44120-44640-le_pellerin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44120-44640-le_pellerin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44121-44670-petit_auverne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44121-44670-petit_auverne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44121-44670-petit_auverne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44121-44670-petit_auverne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44122-44390-petit_mars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44122-44390-petit_mars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44122-44390-petit_mars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44122-44390-petit_mars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44123-44290-pierric/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44123-44290-pierric/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44123-44290-pierric/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44123-44290-pierric/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44124-44540-le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44124-44540-le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44124-44540-le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44124-44540-le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44125-44420-piriac_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44125-44420-piriac_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44125-44420-piriac_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44125-44420-piriac_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44126-44770-la_plaine_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44126-44770-la_plaine_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44126-44770-la_plaine_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44126-44770-la_plaine_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44127-44140-la_planche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44127-44140-la_planche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44127-44140-la_planche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44127-44140-la_planche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44128-44630-plesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44128-44630-plesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44128-44630-plesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44128-44630-plesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44129-44160-pontchateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44129-44160-pontchateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44129-44160-pontchateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44129-44160-pontchateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44130-44860-pont_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44130-44860-pont_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44130-44860-pont_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44130-44860-pont_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44131-44210-pornic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44131-44210-pornic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44131-44210-pornic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44131-44210-pornic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44132-44380-pornichet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44132-44380-pornichet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44132-44380-pornichet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44132-44380-pornichet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44133-44710-port_saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44133-44710-port_saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44133-44710-port_saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44133-44710-port_saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44134-44522-pouille_les_coteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44134-44522-pouille_les_coteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44134-44522-pouille_les_coteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44134-44522-pouille_les_coteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44135-44510-le_pouliguen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44135-44510-le_pouliguen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44135-44510-le_pouliguen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44135-44510-le_pouliguen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44136-44770-prefailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44136-44770-prefailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44136-44770-prefailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44136-44770-prefailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44137-44260-prinquiau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44137-44260-prinquiau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44137-44260-prinquiau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44137-44260-prinquiau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44138-44390-puceul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44138-44390-puceul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44138-44390-puceul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44138-44390-puceul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44139-44750-quilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44139-44750-quilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44139-44750-quilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44139-44750-quilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44140-44330-la_regrippiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44140-44330-la_regrippiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44140-44330-la_regrippiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44140-44330-la_regrippiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44141-44430-la_remaudiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44141-44430-la_remaudiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44141-44430-la_remaudiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44141-44430-la_remaudiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44142-44140-remouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44142-44140-remouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44142-44140-remouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44142-44140-remouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44143-44400-reze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44143-44400-reze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44143-44400-reze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44143-44400-reze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44144-44440-riaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44144-44440-riaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44144-44440-riaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44144-44440-riaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44145-44640-rouans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44145-44640-rouans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44145-44640-rouans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44145-44640-rouans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44146-44660-rouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44146-44660-rouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44146-44660-rouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44146-44660-rouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44148-44660-ruffigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44148-44660-ruffigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44148-44660-ruffigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44148-44660-ruffigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44149-44390-saffre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44149-44390-saffre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44149-44390-saffre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44149-44390-saffre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44150-44860-saint_aignan_grandlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44150-44860-saint_aignan_grandlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44150-44860-saint_aignan_grandlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44150-44860-saint_aignan_grandlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44151-44117-saint_andre_des_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44151-44117-saint_andre_des_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44151-44117-saint_andre_des_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44151-44117-saint_andre_des_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44152-44160-sainte_anne_sur_brivet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44152-44160-sainte_anne_sur_brivet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44152-44160-sainte_anne_sur_brivet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44152-44160-sainte_anne_sur_brivet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44153-44110-saint_aubin_des_chateaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44153-44110-saint_aubin_des_chateaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44153-44110-saint_aubin_des_chateaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44153-44110-saint_aubin_des_chateaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44154-44250-saint_brevin_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44154-44250-saint_brevin_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44154-44250-saint_brevin_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44154-44250-saint_brevin_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44155-44310-saint_colomban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44155-44310-saint_colomban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44155-44310-saint_colomban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44155-44310-saint_colomban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44156-44650-corcoue_sur_logne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44156-44650-corcoue_sur_logne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44156-44650-corcoue_sur_logne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44156-44650-corcoue_sur_logne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44157-44270-saint_etienne_de_mer_morte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44157-44270-saint_etienne_de_mer_morte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44157-44270-saint_etienne_de_mer_morte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44157-44270-saint_etienne_de_mer_morte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44158-44360-saint_etienne_de_montluc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44158-44360-saint_etienne_de_montluc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44158-44360-saint_etienne_de_montluc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44158-44360-saint_etienne_de_montluc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44159-44690-saint_fiacre_sur_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44159-44690-saint_fiacre_sur_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44159-44690-saint_fiacre_sur_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44159-44690-saint_fiacre_sur_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44161-44530-saint_gildas_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44161-44530-saint_gildas_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44161-44530-saint_gildas_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44161-44530-saint_gildas_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44162-44800-saint_herblain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44162-44800-saint_herblain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44162-44800-saint_herblain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44162-44800-saint_herblain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44163-44150-vair_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44163-44150-vair_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44163-44150-vair_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44163-44150-vair_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44164-44680-saint_hilaire_de_chaleons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44164-44680-saint_hilaire_de_chaleons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44164-44680-saint_hilaire_de_chaleons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44164-44680-saint_hilaire_de_chaleons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44165-44190-saint_hilaire_de_clisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44165-44190-saint_hilaire_de_clisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44165-44190-saint_hilaire_de_clisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44165-44190-saint_hilaire_de_clisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44166-44640-saint_jean_de_boiseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44166-44640-saint_jean_de_boiseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44166-44640-saint_jean_de_boiseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44166-44640-saint_jean_de_boiseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44168-44720-saint_joachim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44168-44720-saint_joachim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44168-44720-saint_joachim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44168-44720-saint_joachim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44169-44450-saint_julien_de_concelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44169-44450-saint_julien_de_concelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44169-44450-saint_julien_de_concelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44169-44450-saint_julien_de_concelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44170-44670-saint_julien_de_vouvantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44170-44670-saint_julien_de_vouvantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44170-44670-saint_julien_de_vouvantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44170-44670-saint_julien_de_vouvantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44171-44710-saint_leger_les_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44171-44710-saint_leger_les_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44171-44710-saint_leger_les_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44171-44710-saint_leger_les_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44172-44980-sainte_luce_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44172-44980-sainte_luce_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44172-44980-sainte_luce_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44172-44980-sainte_luce_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44173-44190-saint_lumine_de_clisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44173-44190-saint_lumine_de_clisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44173-44190-saint_lumine_de_clisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44173-44190-saint_lumine_de_clisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44174-44310-saint_lumine_de_coutais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44174-44310-saint_lumine_de_coutais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44174-44310-saint_lumine_de_coutais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44174-44310-saint_lumine_de_coutais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44175-44410-saint_lyphard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44175-44410-saint_lyphard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44175-44410-saint_lyphard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44175-44410-saint_lyphard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44176-44550-saint_malo_de_guersac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44176-44550-saint_malo_de_guersac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44176-44550-saint_malo_de_guersac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44176-44550-saint_malo_de_guersac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44178-44680-saint_mars_de_coutais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44178-44680-saint_mars_de_coutais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44178-44680-saint_mars_de_coutais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44178-44680-saint_mars_de_coutais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44179-44850-saint_mars_du_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44179-44850-saint_mars_du_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44179-44850-saint_mars_du_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44179-44850-saint_mars_du_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44180-44540-vallons_de_l_erdre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44180-44540-vallons_de_l_erdre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44180-44540-vallons_de_l_erdre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44180-44540-vallons_de_l_erdre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44182-44730-saint_michel_chef_chef/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44182-44730-saint_michel_chef_chef/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44182-44730-saint_michel_chef_chef/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44182-44730-saint_michel_chef_chef/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44183-44350-saint_molf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44183-44350-saint_molf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44183-44350-saint_molf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44183-44350-saint_molf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44184-44600-saint_nazaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44184-44600-saint_nazaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44184-44600-saint_nazaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44184-44600-saint_nazaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44185-44460-saint_nicolas_de_redon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44185-44460-saint_nicolas_de_redon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44185-44460-saint_nicolas_de_redon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44185-44460-saint_nicolas_de_redon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44186-44680-sainte_pazanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44186-44680-sainte_pazanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44186-44680-sainte_pazanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44186-44680-sainte_pazanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44187-44320-saint_pere_en_retz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44187-44320-saint_pere_en_retz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44187-44320-saint_pere_en_retz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44187-44320-saint_pere_en_retz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44188-44310-saint_philbert_de_grand_lieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44188-44310-saint_philbert_de_grand_lieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44188-44310-saint_philbert_de_grand_lieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44188-44310-saint_philbert_de_grand_lieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44189-44160-sainte_reine_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44189-44160-sainte_reine_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44189-44160-sainte_reine_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44189-44160-sainte_reine_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44190-44230-saint_sebastien_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44190-44230-saint_sebastien_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44190-44230-saint_sebastien_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44190-44230-saint_sebastien_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44192-44320-saint_viaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44192-44320-saint_viaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44192-44320-saint_viaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44192-44320-saint_viaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44193-44590-saint_vincent_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44193-44590-saint_vincent_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44193-44590-saint_vincent_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44193-44590-saint_vincent_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44194-44880-sautron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44194-44880-sautron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44194-44880-sautron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44194-44880-sautron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44195-44260-savenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44195-44260-savenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44195-44260-savenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44195-44260-savenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44196-44530-severac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44196-44530-severac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44196-44530-severac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44196-44530-severac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44197-44590-sion_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44197-44590-sion_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44197-44590-sion_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44197-44590-sion_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44198-44840-les_sorinieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44198-44840-les_sorinieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44198-44840-les_sorinieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44198-44840-les_sorinieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44199-44110-soudan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44199-44110-soudan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44199-44110-soudan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44199-44110-soudan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44200-44660-soulvache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44200-44660-soulvache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44200-44660-soulvache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44200-44660-soulvache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44201-44240-suce_sur_erdre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44201-44240-suce_sur_erdre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44201-44240-suce_sur_erdre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44201-44240-suce_sur_erdre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44202-44440-teille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44202-44440-teille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44202-44440-teille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44202-44440-teille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44203-44360-le_temple_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44203-44360-le_temple_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44203-44360-le_temple_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44203-44360-le_temple_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44204-44470-thouare_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44204-44470-thouare_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44204-44470-thouare_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44204-44470-thouare_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44205-44390-les_touches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44205-44390-les_touches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44205-44390-les_touches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44205-44390-les_touches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44206-44650-touvois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44206-44650-touvois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44206-44650-touvois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44206-44650-touvois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44207-44440-trans_sur_erdre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44207-44440-trans_sur_erdre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44207-44440-trans_sur_erdre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44207-44440-trans_sur_erdre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44208-44170-treffieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44208-44170-treffieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44208-44170-treffieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44208-44170-treffieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44209-44119-treillieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44209-44119-treillieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44209-44119-treillieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44209-44119-treillieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44210-44570-trignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44210-44570-trignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44210-44570-trignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44210-44570-trignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44211-44420-la_turballe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44211-44420-la_turballe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44211-44420-la_turballe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44211-44420-la_turballe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44212-44330-vallet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44212-44330-vallet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44212-44330-vallet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44212-44330-vallet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44213-44370-loireauxence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44213-44370-loireauxence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44213-44370-loireauxence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44213-44370-loireauxence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44214-44170-vay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44214-44170-vay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44214-44170-vay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44214-44170-vay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44215-44120-vertou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44215-44120-vertou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44215-44120-vertou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44215-44120-vertou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44216-44116-vieillevigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44216-44116-vieillevigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44216-44116-vieillevigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44216-44116-vieillevigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44217-44360-vigneux_de_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44217-44360-vigneux_de_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44217-44360-vigneux_de_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44217-44360-vigneux_de_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44218-44110-villepot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44218-44110-villepot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44218-44110-villepot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44218-44110-villepot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44220-44640-vue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44220-44640-vue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44220-44640-vue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44220-44640-vue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44221-44810-la_chevallerais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44221-44810-la_chevallerais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44221-44810-la_chevallerais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44221-44810-la_chevallerais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44222-44522-la_roche_blanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44222-44522-la_roche_blanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44222-44522-la_roche_blanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44222-44522-la_roche_blanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44223-44140-geneston/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44223-44140-geneston/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44223-44140-geneston/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44223-44140-geneston/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44224-44170-la_grigonnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44224-44170-la_grigonnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44224-44170-la_grigonnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt44-loire_atlantique/commune44224-44170-la_grigonnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-45.xml
+++ b/public/sitemaps/sitemap-45.xml
@@ -5,662 +5,1320 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45001-45230-adon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45001-45230-adon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45001-45230-adon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45001-45230-adon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45002-45230-aillant_sur_milleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45002-45230-aillant_sur_milleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45002-45230-aillant_sur_milleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45002-45230-aillant_sur_milleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45004-45200-amilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45004-45200-amilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45004-45200-amilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45004-45200-amilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45005-45480-andonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45005-45480-andonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45005-45480-andonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45005-45480-andonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45006-45160-ardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45006-45160-ardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45006-45160-ardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45006-45160-ardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45008-45410-artenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45008-45410-artenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45008-45410-artenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45008-45410-artenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45009-45170-ascheres_le_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45009-45170-ascheres_le_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45009-45170-ascheres_le_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45009-45170-ascheres_le_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45010-45300-ascoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45010-45300-ascoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45010-45300-ascoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45010-45300-ascoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45011-45170-attray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45011-45170-attray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45011-45170-attray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45011-45170-attray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45012-45300-audeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45012-45300-audeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45012-45300-audeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45012-45300-audeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45013-45330-augerville_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45013-45330-augerville_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45013-45330-augerville_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45013-45330-augerville_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45014-45390-aulnay_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45014-45390-aulnay_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45014-45390-aulnay_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45014-45390-aulnay_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45015-45480-autruy_sur_juine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45015-45480-autruy_sur_juine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45015-45480-autruy_sur_juine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45015-45480-autruy_sur_juine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45016-45500-autry_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45016-45500-autry_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45016-45500-autry_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45016-45500-autry_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45017-45270-auvilliers_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45017-45270-auvilliers_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45017-45270-auvilliers_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45017-45270-auvilliers_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45018-45340-auxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45018-45340-auxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45018-45340-auxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45018-45340-auxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45019-45130-baccon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45019-45130-baccon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45019-45130-baccon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45019-45130-baccon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45020-45130-le_bardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45020-45130-le_bardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45020-45130-le_bardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45020-45130-le_bardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45021-45340-barville_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45021-45340-barville_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45021-45340-barville_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45021-45340-barville_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45022-45340-batilly_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45022-45340-batilly_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45022-45340-batilly_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45022-45340-batilly_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45023-45420-batilly_en_puisaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45023-45420-batilly_en_puisaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45023-45420-batilly_en_puisaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45023-45420-batilly_en_puisaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45024-45130-baule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45024-45130-baule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45024-45130-baule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45024-45130-baule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45025-45480-bazoches_les_gallerandes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45025-45480-bazoches_les_gallerandes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45025-45480-bazoches_les_gallerandes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45025-45480-bazoches_les_gallerandes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45026-45210-bazoches_sur_le_betz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45026-45210-bazoches_sur_le_betz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45026-45210-bazoches_sur_le_betz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45026-45210-bazoches_sur_le_betz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45027-45270-beauchamps_sur_huillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45027-45270-beauchamps_sur_huillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45027-45270-beauchamps_sur_huillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45027-45270-beauchamps_sur_huillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45028-45190-beaugency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45028-45190-beaugency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45028-45190-beaugency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45028-45190-beaugency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45029-45630-beaulieu_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45029-45630-beaulieu_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45029-45630-beaulieu_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45029-45630-beaulieu_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45030-45340-beaune_la_rolande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45030-45340-beaune_la_rolande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45030-45340-beaune_la_rolande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45030-45340-beaune_la_rolande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45031-45270-bellegarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45031-45270-bellegarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45031-45270-bellegarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45031-45270-bellegarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45032-45210-le_bignon_mirabeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45032-45210-le_bignon_mirabeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45032-45210-le_bignon_mirabeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45032-45210-le_bignon_mirabeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45033-45390-boesses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45033-45390-boesses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45033-45390-boesses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45033-45390-boesses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45034-45760-boigny_sur_bionne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45034-45760-boigny_sur_bionne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45034-45760-boigny_sur_bionne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45034-45760-boigny_sur_bionne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45035-45340-boiscommun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45035-45340-boiscommun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45035-45340-boiscommun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45035-45340-boiscommun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45036-45290-boismorand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45036-45290-boismorand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45036-45290-boismorand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45036-45290-boismorand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45037-45480-boisseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45037-45480-boisseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45037-45480-boisseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45037-45480-boisseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45038-45300-bondaroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45038-45300-bondaroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45038-45300-bondaroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45038-45300-bondaroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45039-45460-bonnee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45039-45460-bonnee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45039-45460-bonnee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45039-45460-bonnee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45040-45420-bonny_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45040-45420-bonny_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45040-45420-bonny_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45040-45420-bonny_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45041-45340-bordeaux_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45041-45340-bordeaux_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45041-45340-bordeaux_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45041-45340-bordeaux_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45042-45460-les_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45042-45460-les_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45042-45460-les_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45042-45460-les_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45043-45430-bou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45043-45430-bou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45043-45430-bou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45043-45430-bou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45044-45170-bougy_lez_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45044-45170-bougy_lez_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45044-45170-bougy_lez_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45044-45170-bougy_lez_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45045-45300-bouilly_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45045-45300-bouilly_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45045-45300-bouilly_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45045-45300-bouilly_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45046-45140-boulay_les_barres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45046-45140-boulay_les_barres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45046-45140-boulay_les_barres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45046-45140-boulay_les_barres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45047-45300-bouzonville_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45047-45300-bouzonville_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45047-45300-bouzonville_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45047-45300-bouzonville_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45049-45460-bouzy_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45049-45460-bouzy_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45049-45460-bouzy_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45049-45460-bouzy_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45050-45300-boynes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45050-45300-boynes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45050-45300-boynes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45050-45300-boynes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45051-45460-bray_saint_aignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45051-45460-bray_saint_aignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45051-45460-bray_saint_aignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45051-45460-bray_saint_aignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45052-45250-breteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45052-45250-breteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45052-45250-breteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45052-45250-breteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45053-45250-briare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45053-45250-briare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45053-45250-briare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45053-45250-briare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45054-45390-briarres_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45054-45390-briarres_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45054-45390-briarres_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45054-45390-briarres_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45055-45310-bricy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45055-45310-bricy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45055-45310-bricy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45055-45310-bricy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45056-45390-bromeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45056-45390-bromeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45056-45390-bromeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45056-45390-bromeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45058-45410-bucy_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45058-45410-bucy_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45058-45410-bucy_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45058-45410-bucy_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45059-45140-bucy_saint_liphard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45059-45140-bucy_saint_liphard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45059-45140-bucy_saint_liphard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45059-45140-bucy_saint_liphard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45060-45230-la_bussiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45060-45230-la_bussiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45060-45230-la_bussiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45060-45230-la_bussiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45061-45120-cepoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45061-45120-cepoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45061-45120-cepoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45061-45120-cepoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45062-45520-cercottes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45062-45520-cercottes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45062-45520-cercottes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45062-45520-cercottes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45063-45620-cerdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45063-45620-cerdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45063-45620-cerdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45063-45620-cerdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45064-45360-cernoy_en_berry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45064-45360-cernoy_en_berry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45064-45360-cernoy_en_berry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45064-45360-cernoy_en_berry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45065-45300-cesarville_dossainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45065-45300-cesarville_dossainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45065-45300-cesarville_dossainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45065-45300-cesarville_dossainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45066-45260-chailly_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45066-45260-chailly_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45066-45260-chailly_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45066-45260-chailly_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45067-45380-chaingy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45067-45380-chaingy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45067-45380-chaingy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45067-45380-chaingy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45068-45120-chalette_sur_loing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45068-45120-chalette_sur_loing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45068-45120-chalette_sur_loing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45068-45120-chalette_sur_loing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45069-45340-chambon_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45069-45340-chambon_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45069-45340-chambon_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45069-45340-chambon_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45070-45420-champoulet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45070-45420-champoulet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45070-45420-champoulet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45070-45420-champoulet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45072-45400-chanteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45072-45400-chanteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45072-45400-chanteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45072-45400-chanteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45073-45320-chantecoq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45073-45320-chantecoq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45073-45320-chantecoq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45073-45320-chantecoq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45074-45310-la_chapelle_onzerain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45074-45310-la_chapelle_onzerain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45074-45310-la_chapelle_onzerain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45074-45310-la_chapelle_onzerain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45075-45380-la_chapelle_saint_mesmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45075-45380-la_chapelle_saint_mesmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45075-45380-la_chapelle_saint_mesmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45075-45380-la_chapelle_saint_mesmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45076-45210-la_chapelle_saint_sepulcre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45076-45210-la_chapelle_saint_sepulcre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45076-45210-la_chapelle_saint_sepulcre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45076-45210-la_chapelle_saint_sepulcre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45077-45230-la_chapelle_sur_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45077-45230-la_chapelle_sur_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45077-45230-la_chapelle_sur_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45077-45230-la_chapelle_sur_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45078-45270-chapelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45078-45270-chapelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45078-45270-chapelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45078-45270-chapelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45079-45230-le_charme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45079-45230-le_charme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45079-45230-le_charme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45079-45230-le_charme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45080-45480-charmont_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45080-45480-charmont_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45080-45480-charmont_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45080-45480-charmont_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45081-45130-charsonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45081-45130-charsonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45081-45130-charsonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45081-45130-charsonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45082-45110-chateauneuf_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45082-45110-chateauneuf_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45082-45110-chateauneuf_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45082-45110-chateauneuf_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45083-45220-chateau_renard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45083-45220-chateau_renard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45083-45220-chateau_renard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45083-45220-chateau_renard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45084-45260-chatenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45084-45260-chatenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45084-45260-chatenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45084-45260-chatenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45085-45230-chatillon_coligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45085-45230-chatillon_coligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45085-45230-chatillon_coligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45085-45230-chatillon_coligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45086-45480-chatillon_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45086-45480-chatillon_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45086-45480-chatillon_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45086-45480-chatillon_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45087-45360-chatillon_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45087-45360-chatillon_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45087-45360-chatillon_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45087-45360-chatillon_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45088-45480-chaussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45088-45480-chaussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45088-45480-chaussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45088-45480-chaussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45089-45430-checy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45089-45430-checy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45089-45430-checy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45089-45430-checy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45091-45210-chevannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45091-45210-chevannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45091-45210-chevannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45091-45210-chevannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45092-45700-chevillon_sur_huillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45092-45700-chevillon_sur_huillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45092-45700-chevillon_sur_huillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45092-45700-chevillon_sur_huillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45093-45520-chevilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45093-45520-chevilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45093-45520-chevilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45093-45520-chevilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45094-45210-chevry_sous_le_bignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45094-45210-chevry_sous_le_bignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45094-45210-chevry_sous_le_bignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45094-45210-chevry_sous_le_bignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45095-45170-chilleurs_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45095-45170-chilleurs_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45095-45170-chilleurs_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45095-45170-chilleurs_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45096-45290-les_choux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45096-45290-les_choux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45096-45290-les_choux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45096-45290-les_choux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45097-45220-chuelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45097-45220-chuelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45097-45220-chuelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45097-45220-chuelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45098-45370-clery_saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45098-45370-clery_saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45098-45370-clery_saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45098-45370-clery_saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45099-45310-coinces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45099-45310-coinces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45099-45310-coinces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45099-45310-coinces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45100-45800-combleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45100-45800-combleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45100-45800-combleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45100-45800-combleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45101-45530-combreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45101-45530-combreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45101-45530-combreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45101-45530-combreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45102-45700-conflans_sur_loing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45102-45700-conflans_sur_loing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45102-45700-conflans_sur_loing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45102-45700-conflans_sur_loing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45103-45490-corbeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45103-45490-corbeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45103-45490-corbeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45103-45490-corbeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45104-45120-corquilleroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45104-45120-corquilleroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45104-45120-corquilleroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45104-45120-corquilleroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45105-45700-cortrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45105-45700-cortrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45105-45700-cortrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45105-45700-cortrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45107-45260-coudroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45107-45260-coudroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45107-45260-coudroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45107-45260-coudroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45108-45720-coullons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45108-45720-coullons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45108-45720-coullons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45108-45720-coullons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45109-45130-coulmiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45109-45130-coulmiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45109-45130-coulmiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45109-45130-coulmiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45110-45300-courcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45110-45300-courcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45110-45300-courcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45110-45300-courcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45111-45300-courcy_aux_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45111-45300-courcy_aux_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45111-45300-courcy_aux_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45111-45300-courcy_aux_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45112-45260-la_cour_marigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45112-45260-la_cour_marigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45112-45260-la_cour_marigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45112-45260-la_cour_marigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45113-45320-courtemaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45113-45320-courtemaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45113-45320-courtemaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45113-45320-courtemaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45114-45490-courtempierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45114-45490-courtempierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45114-45490-courtempierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45114-45490-courtempierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45115-45320-courtenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45115-45320-courtenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45115-45320-courtenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45115-45320-courtenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45116-45190-cravant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45116-45190-cravant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45116-45190-cravant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45116-45190-cravant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45118-45170-crottes_en_pithiverais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45118-45170-crottes_en_pithiverais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45118-45170-crottes_en_pithiverais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45118-45170-crottes_en_pithiverais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45119-45300-dadonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45119-45300-dadonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45119-45300-dadonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45119-45300-dadonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45120-45420-dammarie_en_puisaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45120-45420-dammarie_en_puisaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45120-45420-dammarie_en_puisaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45120-45420-dammarie_en_puisaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45121-45230-dammarie_sur_loing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45121-45230-dammarie_sur_loing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45121-45230-dammarie_sur_loing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45121-45230-dammarie_sur_loing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45122-45570-dampierre_en_burly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45122-45570-dampierre_en_burly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45122-45570-dampierre_en_burly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45122-45570-dampierre_en_burly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45123-45150-darvoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45123-45150-darvoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45123-45150-darvoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45123-45150-darvoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45124-45390-desmonts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45124-45390-desmonts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45124-45390-desmonts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45124-45390-desmonts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45125-45390-dimancheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45125-45390-dimancheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45125-45390-dimancheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45125-45390-dimancheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45126-45450-donnery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45126-45450-donnery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45126-45450-donnery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45126-45450-donnery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45127-45680-dordives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45127-45680-dordives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45127-45680-dordives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45127-45680-dordives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45129-45220-douchy_montcorbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45129-45220-douchy_montcorbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45129-45220-douchy_montcorbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45129-45220-douchy_montcorbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45130-45370-dry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45130-45370-dry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45130-45370-dry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45130-45370-dry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45131-45390-echilleuses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45131-45390-echilleuses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45131-45390-echilleuses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45131-45390-echilleuses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45132-45340-egry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45132-45340-egry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45132-45340-egry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45132-45340-egry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45133-45300-engenville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45133-45300-engenville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45133-45300-engenville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45133-45300-engenville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45134-45130-epieds_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45134-45130-epieds_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45134-45130-epieds_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45134-45130-epieds_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45135-45480-erceville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45135-45480-erceville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45135-45480-erceville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45135-45480-erceville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45136-45320-ervauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45136-45320-ervauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45136-45320-ervauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45136-45320-ervauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45137-45300-escrennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45137-45300-escrennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45137-45300-escrennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45137-45300-escrennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45138-45250-escrignelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45138-45250-escrignelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45138-45250-escrignelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45138-45250-escrignelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45139-45300-estouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45139-45300-estouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45139-45300-estouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45139-45300-estouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45141-45420-faverelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45141-45420-faverelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45141-45420-faverelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45141-45420-faverelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45142-45450-fay_aux_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45142-45450-fay_aux_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45142-45450-fay_aux_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45142-45450-fay_aux_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45143-45230-feins_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45143-45230-feins_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45143-45230-feins_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45143-45230-feins_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45144-45150-ferolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45144-45150-ferolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45144-45150-ferolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45144-45150-ferolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45145-45210-ferrieres_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45145-45210-ferrieres_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45145-45210-ferrieres_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45145-45210-ferrieres_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45146-45240-la_ferte_saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45146-45240-la_ferte_saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45146-45240-la_ferte_saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45146-45240-la_ferte_saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45147-45400-fleury_les_aubrais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45147-45400-fleury_les_aubrais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45147-45400-fleury_les_aubrais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45147-45400-fleury_les_aubrais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45148-45210-fontenay_sur_loing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45148-45210-fontenay_sur_loing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45148-45210-fontenay_sur_loing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45148-45210-fontenay_sur_loing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45149-45320-foucherolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45149-45320-foucherolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45149-45320-foucherolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45149-45320-foucherolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45150-45270-freville_du_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45150-45270-freville_du_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45150-45270-freville_du_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45150-45270-freville_du_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45151-45340-gaubertin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45151-45340-gaubertin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45151-45340-gaubertin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45151-45340-gaubertin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45152-45310-gemigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45152-45310-gemigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45152-45310-gemigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45152-45310-gemigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45153-45110-germigny_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45153-45110-germigny_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45153-45110-germigny_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45153-45110-germigny_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45154-45520-gidy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45154-45520-gidy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45154-45520-gidy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45154-45520-gidy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45155-45500-gien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45155-45500-gien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45155-45500-gien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45155-45500-gien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45156-45120-girolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45156-45120-girolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45156-45120-girolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45156-45120-girolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45157-45300-givraines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45157-45300-givraines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45157-45300-givraines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45157-45300-givraines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45158-45490-gondreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45158-45490-gondreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45158-45490-gondreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45158-45490-gondreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45159-45390-grangermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45159-45390-grangermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45159-45390-grangermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45159-45390-grangermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45160-45480-greneville_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45160-45480-greneville_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45160-45480-greneville_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45160-45480-greneville_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45161-45210-griselles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45161-45210-griselles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45161-45210-griselles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45161-45210-griselles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45162-45300-guigneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45162-45300-guigneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45162-45300-guigneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45162-45300-guigneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45164-45600-guilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45164-45600-guilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45164-45600-guilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45164-45600-guilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45165-45220-gy_les_nonains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45165-45220-gy_les_nonains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45165-45220-gy_les_nonains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45165-45220-gy_les_nonains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45166-45520-huetre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45166-45520-huetre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45166-45520-huetre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45166-45520-huetre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45167-45130-huisseau_sur_mauves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45167-45130-huisseau_sur_mauves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45167-45130-huisseau_sur_mauves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45167-45130-huisseau_sur_mauves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45168-45450-ingrannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45168-45450-ingrannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45168-45450-ingrannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45168-45450-ingrannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45169-45140-ingre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45169-45140-ingre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45169-45140-ingre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45169-45140-ingre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45170-45300-intville_la_guetard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45170-45300-intville_la_guetard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45170-45300-intville_la_guetard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45170-45300-intville_la_guetard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45171-45620-isdes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45171-45620-isdes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45171-45620-isdes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45171-45620-isdes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45173-45150-jargeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45173-45150-jargeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45173-45150-jargeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45173-45150-jargeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45174-45480-jouy_en_pithiverais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45174-45480-jouy_en_pithiverais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45174-45480-jouy_en_pithiverais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45174-45480-jouy_en_pithiverais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45175-45370-jouy_le_potier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45175-45370-jouy_le_potier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45175-45370-jouy_le_potier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45175-45370-jouy_le_potier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45176-45340-juranville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45176-45340-juranville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45176-45340-juranville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45176-45340-juranville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45177-45300-laas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45177-45300-laas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45177-45300-laas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45177-45300-laas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45178-45270-ladon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45178-45270-ladon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45178-45270-ladon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45178-45270-ladon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45179-45740-lailly_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45179-45740-lailly_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45179-45740-lailly_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45179-45740-lailly_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45180-45290-langesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45180-45290-langesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45180-45290-langesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45180-45290-langesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45181-45480-leouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45181-45480-leouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45181-45480-leouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45181-45480-leouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45182-45240-ligny_le_ribault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45182-45240-ligny_le_ribault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45182-45240-ligny_le_ribault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45182-45240-ligny_le_ribault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45183-45410-lion_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45183-45410-lion_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45183-45410-lion_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45183-45410-lion_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45184-45600-lion_en_sullias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45184-45600-lion_en_sullias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45184-45600-lion_en_sullias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45184-45600-lion_en_sullias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45185-45700-lombreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45185-45700-lombreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45185-45700-lombreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45185-45700-lombreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45186-45490-lorcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45186-45490-lorcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45186-45490-lorcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45186-45490-lorcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45187-45260-lorris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45187-45260-lorris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45187-45260-lorris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45187-45260-lorris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45188-45470-loury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45188-45470-loury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45188-45470-loury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45188-45470-loury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45189-45210-louzouer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45189-45210-louzouer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45189-45210-louzouer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45189-45210-louzouer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45191-45330-le_malesherbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45191-45330-le_malesherbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45191-45330-le_malesherbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45191-45330-le_malesherbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45191-45300-le_malesherbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45191-45300-le_malesherbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45191-45300-le_malesherbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45191-45300-le_malesherbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45193-45240-marcilly_en_villette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45193-45240-marcilly_en_villette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45193-45240-marcilly_en_villette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45193-45240-marcilly_en_villette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45194-45430-mardie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45194-45430-mardie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45194-45430-mardie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45194-45430-mardie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45195-45300-mareau_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45195-45300-mareau_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45195-45300-mareau_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45195-45300-mareau_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45196-45370-mareau_aux_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45196-45370-mareau_aux_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45196-45370-mareau_aux_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45196-45370-mareau_aux_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45197-45760-marigny_les_usages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45197-45760-marigny_les_usages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45197-45760-marigny_les_usages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45197-45760-marigny_les_usages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45198-45300-marsainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45198-45300-marsainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45198-45300-marsainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45198-45300-marsainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45199-45220-melleroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45199-45220-melleroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45199-45220-melleroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45199-45220-melleroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45200-45240-menestreau_en_villette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45200-45240-menestreau_en_villette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45200-45240-menestreau_en_villette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45200-45240-menestreau_en_villette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45201-45210-merinville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45201-45210-merinville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45201-45210-merinville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45201-45210-merinville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45202-45190-messas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45202-45190-messas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45202-45190-messas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45202-45190-messas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45203-45130-meung_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45203-45130-meung_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45203-45130-meung_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45203-45130-meung_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45204-45370-mezieres_lez_clery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45204-45370-mezieres_lez_clery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45204-45370-mezieres_lez_clery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45204-45370-mezieres_lez_clery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45205-45270-mezieres_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45205-45270-mezieres_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45205-45270-mezieres_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45205-45270-mezieres_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45206-45490-migneres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45206-45490-migneres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45206-45490-migneres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45206-45490-migneres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45207-45490-mignerette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45207-45490-mignerette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45207-45490-mignerette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45207-45490-mignerette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45208-45200-montargis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45208-45200-montargis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45208-45200-montargis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45208-45200-montargis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45209-45340-montbarrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45209-45340-montbarrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45209-45340-montbarrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45209-45340-montbarrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45210-45230-montbouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45210-45230-montbouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45210-45230-montbouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45210-45230-montbouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45212-45700-montcresson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45212-45700-montcresson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45212-45700-montcresson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45212-45700-montcresson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45213-45260-montereau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45213-45260-montereau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45213-45260-montereau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45213-45260-montereau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45214-45170-montigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45214-45170-montigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45214-45170-montigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45214-45170-montigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45215-45340-montliard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45215-45340-montliard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45215-45340-montliard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45215-45340-montliard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45216-45700-mormant_sur_vernisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45216-45700-mormant_sur_vernisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45216-45700-mormant_sur_vernisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45216-45700-mormant_sur_vernisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45217-45300-morville_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45217-45300-morville_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45217-45300-morville_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45217-45300-morville_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45218-45290-le_moulinet_sur_solin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45218-45290-le_moulinet_sur_solin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45218-45290-le_moulinet_sur_solin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45218-45290-le_moulinet_sur_solin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45219-45270-moulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45219-45270-moulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45219-45270-moulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45219-45270-moulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45220-45340-nancray_sur_rimarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45220-45340-nancray_sur_rimarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45220-45340-nancray_sur_rimarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45220-45340-nancray_sur_rimarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45222-45210-nargis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45222-45210-nargis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45222-45210-nargis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45222-45210-nargis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45223-45270-nesploy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45223-45270-nesploy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45223-45270-nesploy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45223-45270-nesploy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45224-45170-neuville_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45224-45170-neuville_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45224-45170-neuville_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45224-45170-neuville_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45225-45390-la_neuville_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45225-45390-la_neuville_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45225-45390-la_neuville_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45225-45390-la_neuville_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45226-45510-neuvy_en_sullias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45226-45510-neuvy_en_sullias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45226-45510-neuvy_en_sullias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45226-45510-neuvy_en_sullias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45227-45500-nevoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45227-45500-nevoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45227-45500-nevoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45227-45500-nevoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45228-45340-nibelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45228-45340-nibelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45228-45340-nibelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45228-45340-nibelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45229-45290-nogent_sur_vernisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45229-45290-nogent_sur_vernisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45229-45290-nogent_sur_vernisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45229-45290-nogent_sur_vernisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45230-45260-noyers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45230-45260-noyers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45230-45260-noyers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45230-45260-noyers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45231-45170-oison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45231-45170-oison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45231-45170-oison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45231-45170-oison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45232-45160-olivet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45232-45160-olivet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45232-45160-olivet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45232-45160-olivet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45233-45390-ondreville_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45233-45390-ondreville_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45233-45390-ondreville_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45233-45390-ondreville_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45234-45000-orleans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45234-45000-orleans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45234-45000-orleans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45234-45000-orleans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45234-45100-orleans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45234-45100-orleans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45234-45100-orleans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45234-45100-orleans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45235-45140-ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45235-45140-ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45235-45140-ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45235-45140-ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45237-45390-orville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45237-45390-orville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45237-45390-orville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45237-45390-orville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45238-45250-ousson_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45238-45250-ousson_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45238-45250-ousson_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45238-45250-ousson_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45239-45290-oussoy_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45239-45290-oussoy_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45239-45290-oussoy_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45239-45290-oussoy_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45240-45480-outarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45240-45480-outarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45240-45480-outarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45240-45480-outarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45241-45150-ouvrouer_les_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45241-45150-ouvrouer_les_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45241-45150-ouvrouer_les_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45241-45150-ouvrouer_les_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45242-45290-ouzouer_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45242-45290-ouzouer_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45242-45290-ouzouer_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45242-45290-ouzouer_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45243-45270-ouzouer_sous_bellegarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45243-45270-ouzouer_sous_bellegarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45243-45270-ouzouer_sous_bellegarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45243-45270-ouzouer_sous_bellegarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45244-45570-ouzouer_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45244-45570-ouzouer_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45244-45570-ouzouer_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45244-45570-ouzouer_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45245-45250-ouzouer_sur_trezee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45245-45250-ouzouer_sur_trezee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45245-45250-ouzouer_sur_trezee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45245-45250-ouzouer_sur_trezee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45246-45300-pannecieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45246-45300-pannecieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45246-45300-pannecieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45246-45300-pannecieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45247-45700-pannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45247-45700-pannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45247-45700-pannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45247-45700-pannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45248-45310-patay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45248-45310-patay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45248-45310-patay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45248-45310-patay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45249-45200-paucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45249-45200-paucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45249-45200-paucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45249-45200-paucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45250-45210-pers_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45250-45210-pers_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45250-45210-pers_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45250-45210-pers_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45251-45360-pierrefitte_es_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45251-45360-pierrefitte_es_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45251-45360-pierrefitte_es_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45251-45360-pierrefitte_es_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45252-45300-pithiviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45252-45300-pithiviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45252-45300-pithiviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45252-45300-pithiviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45253-45300-pithiviers_le_vieil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45253-45300-pithiviers_le_vieil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45253-45300-pithiviers_le_vieil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45253-45300-pithiviers_le_vieil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45254-45500-poilly_lez_gien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45254-45500-poilly_lez_gien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45254-45500-poilly_lez_gien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45254-45500-poilly_lez_gien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45255-45490-prefontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45255-45490-prefontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45255-45490-prefontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45255-45490-prefontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45256-45260-presnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45256-45260-presnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45256-45260-presnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45256-45260-presnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45257-45290-pressigny_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45257-45290-pressigny_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45257-45290-pressigny_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45257-45290-pressigny_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45258-45390-puiseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45258-45390-puiseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45258-45390-puiseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45258-45390-puiseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45259-45270-quiers_sur_bezonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45259-45270-quiers_sur_bezonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45259-45270-quiers_sur_bezonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45259-45270-quiers_sur_bezonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45260-45300-ramoulu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45260-45300-ramoulu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45260-45300-ramoulu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45260-45300-ramoulu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45261-45470-rebrechien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45261-45470-rebrechien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45261-45470-rebrechien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45261-45470-rebrechien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45262-45310-rouvray_sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45262-45310-rouvray_sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45262-45310-rouvray_sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45262-45310-rouvray_sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45263-45300-rouvres_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45263-45300-rouvres_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45263-45300-rouvres_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45263-45300-rouvres_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45264-45130-rozieres_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45264-45130-rozieres_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45264-45130-rozieres_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45264-45130-rozieres_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45265-45210-rozoy_le_vieil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45265-45210-rozoy_le_vieil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45265-45210-rozoy_le_vieil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45265-45210-rozoy_le_vieil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45266-45410-ruan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45266-45410-ruan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45266-45410-ruan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45266-45410-ruan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45268-45600-saint_aignan_le_jaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45268-45600-saint_aignan_le_jaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45268-45600-saint_aignan_le_jaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45268-45600-saint_aignan_le_jaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45269-45130-saint_ay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45269-45130-saint_ay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45269-45130-saint_ay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45269-45130-saint_ay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45270-45730-saint_benoit_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45270-45730-saint_benoit_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45270-45730-saint_benoit_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45270-45730-saint_benoit_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45271-45500-saint_brisson_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45271-45500-saint_brisson_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45271-45500-saint_brisson_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45271-45500-saint_brisson_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45272-45590-saint_cyr_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45272-45590-saint_cyr_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45272-45590-saint_cyr_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45272-45590-saint_cyr_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45273-45550-saint_denis_de_l_hotel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45273-45550-saint_denis_de_l_hotel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45273-45550-saint_denis_de_l_hotel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45273-45550-saint_denis_de_l_hotel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45274-45560-saint_denis_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45274-45560-saint_denis_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45274-45560-saint_denis_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45274-45560-saint_denis_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45275-45220-saint_firmin_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45275-45220-saint_firmin_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45275-45220-saint_firmin_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45275-45220-saint_firmin_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45276-45360-saint_firmin_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45276-45360-saint_firmin_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45276-45360-saint_firmin_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45276-45360-saint_firmin_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45277-45600-saint_florent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45277-45600-saint_florent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45277-45600-saint_florent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45277-45600-saint_florent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45278-45230-sainte_genevieve_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45278-45230-sainte_genevieve_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45278-45230-sainte_genevieve_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45278-45230-sainte_genevieve_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45279-45220-saint_germain_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45279-45220-saint_germain_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45279-45220-saint_germain_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45279-45220-saint_germain_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45280-45500-saint_gondon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45280-45500-saint_gondon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45280-45500-saint_gondon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45280-45500-saint_gondon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45281-45320-saint_hilaire_les_andresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45281-45320-saint_hilaire_les_andresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45281-45320-saint_hilaire_les_andresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45281-45320-saint_hilaire_les_andresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45282-45160-saint_hilaire_saint_mesmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45282-45160-saint_hilaire_saint_mesmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45282-45160-saint_hilaire_saint_mesmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45282-45160-saint_hilaire_saint_mesmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45283-45700-saint_hilaire_sur_puiseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45283-45700-saint_hilaire_sur_puiseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45283-45700-saint_hilaire_sur_puiseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45283-45700-saint_hilaire_sur_puiseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45284-45800-saint_jean_de_braye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45284-45800-saint_jean_de_braye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45284-45800-saint_jean_de_braye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45284-45800-saint_jean_de_braye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45285-45140-saint_jean_de_la_ruelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45285-45140-saint_jean_de_la_ruelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45285-45140-saint_jean_de_la_ruelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45285-45140-saint_jean_de_la_ruelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45286-45650-saint_jean_le_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45286-45650-saint_jean_le_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45286-45650-saint_jean_le_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45286-45650-saint_jean_le_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45287-45210-saint_loup_de_gonois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45287-45210-saint_loup_de_gonois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45287-45210-saint_loup_de_gonois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45287-45210-saint_loup_de_gonois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45288-45340-saint_loup_des_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45288-45340-saint_loup_des_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45288-45340-saint_loup_des_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45288-45340-saint_loup_des_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45289-45170-saint_lye_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45289-45170-saint_lye_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45289-45170-saint_lye_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45289-45170-saint_lye_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45290-45110-saint_martin_d_abbat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45290-45110-saint_martin_d_abbat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45290-45110-saint_martin_d_abbat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45290-45110-saint_martin_d_abbat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45291-45500-saint_martin_sur_ocre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45291-45500-saint_martin_sur_ocre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45291-45500-saint_martin_sur_ocre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45291-45500-saint_martin_sur_ocre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45292-45230-saint_maurice_sur_aveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45292-45230-saint_maurice_sur_aveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45292-45230-saint_maurice_sur_aveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45292-45230-saint_maurice_sur_aveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45293-45700-saint_maurice_sur_fessard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45293-45700-saint_maurice_sur_fessard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45293-45700-saint_maurice_sur_fessard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45293-45700-saint_maurice_sur_fessard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45294-45340-saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45294-45340-saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45294-45340-saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45294-45340-saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45296-45310-saint_peravy_la_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45296-45310-saint_peravy_la_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45296-45310-saint_peravy_la_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45296-45310-saint_peravy_la_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45297-45600-saint_pere_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45297-45600-saint_pere_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45297-45600-saint_pere_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45297-45600-saint_pere_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45298-45750-saint_pryve_saint_mesmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45298-45750-saint_pryve_saint_mesmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45298-45750-saint_pryve_saint_mesmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45298-45750-saint_pryve_saint_mesmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45299-45310-saint_sigismond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45299-45310-saint_sigismond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45299-45310-saint_sigismond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45299-45310-saint_sigismond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45300-45640-sandillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45300-45640-sandillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45300-45640-sandillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45300-45640-sandillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45301-45170-santeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45301-45170-santeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45301-45170-santeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45301-45170-santeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45302-45770-saran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45302-45770-saran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45302-45770-saran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45302-45770-saran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45303-45490-sceaux_du_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45303-45490-sceaux_du_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45303-45490-sceaux_du_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45303-45490-sceaux_du_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45305-45530-seichebrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45305-45530-seichebrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45305-45530-seichebrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45305-45530-seichebrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45306-45210-la_selle_en_hermoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45306-45210-la_selle_en_hermoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45306-45210-la_selle_en_hermoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45306-45210-la_selle_en_hermoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45307-45210-la_selle_sur_le_bied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45307-45210-la_selle_sur_le_bied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45307-45210-la_selle_sur_le_bied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45307-45210-la_selle_sur_le_bied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45308-45400-semoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45308-45400-semoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45308-45400-semoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45308-45400-semoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45309-45240-sennely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45309-45240-sennely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45309-45240-sennely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45309-45240-sennely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45310-45300-sermaises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45310-45300-sermaises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45310-45300-sermaises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45310-45300-sermaises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45311-45110-sigloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45311-45110-sigloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45311-45110-sigloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45311-45110-sigloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45312-45700-solterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45312-45700-solterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45312-45700-solterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45312-45700-solterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45313-45410-sougy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45313-45410-sougy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45313-45410-sougy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45313-45410-sougy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45314-45450-sully_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45314-45450-sully_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45314-45450-sully_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45314-45450-sully_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45315-45600-sully_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45315-45600-sully_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45315-45600-sully_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45315-45600-sully_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45316-45530-sury_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45316-45530-sury_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45316-45530-sury_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45316-45530-sury_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45317-45190-tavers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45317-45190-tavers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45317-45190-tavers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45317-45190-tavers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45320-45300-thignonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45320-45300-thignonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45320-45300-thignonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45320-45300-thignonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45321-45260-thimory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45321-45260-thimory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45321-45260-thimory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45321-45260-thimory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45322-45210-thorailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45322-45210-thorailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45322-45210-thorailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45322-45210-thorailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45323-45420-thou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45323-45420-thou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45323-45420-thou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45323-45420-thou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45324-45510-tigy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45324-45510-tigy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45324-45510-tigy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45324-45510-tigy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45325-45170-tivernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45325-45170-tivernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45325-45170-tivernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45325-45170-tivernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45326-45310-tournoisis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45326-45310-tournoisis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45326-45310-tournoisis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45326-45310-tournoisis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45327-45470-trainou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45327-45470-trainou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45327-45470-trainou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45327-45470-trainou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45328-45490-treilles_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45328-45490-treilles_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45328-45490-treilles_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45328-45490-treilles_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45329-45220-trigueres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45329-45220-trigueres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45329-45220-trigueres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45329-45220-trigueres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45330-45410-trinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45330-45410-trinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45330-45410-trinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45330-45410-trinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45331-45510-vannes_sur_cosson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45331-45510-vannes_sur_cosson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45331-45510-vannes_sur_cosson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45331-45510-vannes_sur_cosson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45332-45290-varennes_changy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45332-45290-varennes_changy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45332-45290-varennes_changy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45332-45290-varennes_changy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45333-45760-vennecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45333-45760-vennecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45333-45760-vennecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45333-45760-vennecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45334-45260-vieilles_maisons_sur_joudry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45334-45260-vieilles_maisons_sur_joudry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45334-45260-vieilles_maisons_sur_joudry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45334-45260-vieilles_maisons_sur_joudry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45335-45510-vienne_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45335-45510-vienne_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45335-45510-vienne_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45335-45510-vienne_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45336-45600-viglain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45336-45600-viglain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45336-45600-viglain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45336-45600-viglain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45337-45310-villamblain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45337-45310-villamblain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45337-45310-villamblain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45337-45310-villamblain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45338-45700-villemandeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45338-45700-villemandeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45338-45700-villemandeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45338-45700-villemandeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45339-45270-villemoutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45339-45270-villemoutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45339-45270-villemoutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45339-45270-villemoutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45340-45600-villemurlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45340-45600-villemurlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45340-45600-villemurlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45340-45600-villemurlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45341-45310-villeneuve_sur_conie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45341-45310-villeneuve_sur_conie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45341-45310-villeneuve_sur_conie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45341-45310-villeneuve_sur_conie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45342-45170-villereau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45342-45170-villereau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45342-45170-villereau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45342-45170-villereau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45343-45700-villevoques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45343-45700-villevoques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45343-45700-villevoques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45343-45700-villevoques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45344-45190-villorceau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45344-45190-villorceau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45344-45190-villorceau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45344-45190-villorceau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45345-45700-vimory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45345-45700-vimory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45345-45700-vimory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45345-45700-vimory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45346-45530-vitry_aux_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45346-45530-vitry_aux_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45346-45530-vitry_aux_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45346-45530-vitry_aux_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45347-45300-vrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45347-45300-vrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45347-45300-vrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45347-45300-vrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45348-45300-yevre_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45348-45300-yevre_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45348-45300-yevre_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt45-loiret/commune45348-45300-yevre_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-46.xml
+++ b/public/sitemaps/sitemap-46.xml
@@ -5,636 +5,1268 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46001-46140-albas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46001-46140-albas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46001-46140-albas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46001-46140-albas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46002-46500-albiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46002-46500-albiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46002-46500-albiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46002-46500-albiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46003-46500-alvignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46003-46500-alvignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46003-46500-alvignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46003-46500-alvignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46004-46120-anglars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46004-46120-anglars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46004-46120-anglars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46004-46120-anglars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46005-46140-anglars_juillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46005-46140-anglars_juillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46005-46140-anglars_juillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46005-46140-anglars_juillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46006-46300-anglars_nozac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46006-46300-anglars_nozac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46006-46300-anglars_nozac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46006-46300-anglars_nozac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46007-46090-arcambal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46007-46090-arcambal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46007-46090-arcambal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46007-46090-arcambal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46008-46250-les_arques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46008-46250-les_arques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46008-46250-les_arques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46008-46250-les_arques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46009-46320-assier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46009-46320-assier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46009-46320-assier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46009-46320-assier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46010-46090-aujols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46010-46090-aujols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46010-46090-aujols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46010-46090-aujols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46011-46400-autoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46011-46400-autoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46011-46400-autoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46011-46400-autoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46012-46120-aynac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46012-46120-aynac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46012-46120-aynac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46012-46120-aynac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46013-46230-bach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46013-46230-bach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46013-46230-bach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46013-46230-bach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46015-46270-bagnac_sur_cele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46015-46270-bagnac_sur_cele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46015-46270-bagnac_sur_cele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46015-46270-bagnac_sur_cele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46016-46600-baladou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46016-46600-baladou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46016-46600-baladou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46016-46600-baladou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46017-46400-bannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46017-46400-bannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46017-46400-bannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46017-46400-bannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46018-46500-le_bastit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46018-46500-le_bastit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46018-46500-le_bastit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46018-46500-le_bastit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46020-46260-beauregard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46020-46260-beauregard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46020-46260-beauregard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46020-46260-beauregard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46021-46100-beduer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46021-46100-beduer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46021-46100-beduer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46021-46100-beduer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46022-46140-belaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46022-46140-belaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46022-46140-belaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46022-46140-belaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46023-46230-belfort_du_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46023-46230-belfort_du_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46023-46230-belfort_du_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46023-46230-belfort_du_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46024-46130-belmont_bretenoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46024-46130-belmont_bretenoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46024-46130-belmont_bretenoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46024-46130-belmont_bretenoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46026-46230-belmont_sainte_foi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46026-46230-belmont_sainte_foi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46026-46230-belmont_sainte_foi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46026-46230-belmont_sainte_foi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46027-46090-berganty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46027-46090-berganty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46027-46090-berganty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46027-46090-berganty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46028-46110-betaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46028-46110-betaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46028-46110-betaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46028-46110-betaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46029-46130-biars_sur_cere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46029-46130-biars_sur_cere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46029-46130-biars_sur_cere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46029-46130-biars_sur_cere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46030-46500-bio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46030-46500-bio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46030-46500-bio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46030-46500-bio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46031-46330-blars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46031-46330-blars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46031-46330-blars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46031-46330-blars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46032-46150-boissieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46032-46150-boissieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46032-46150-boissieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46032-46150-boissieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46033-46800-porte_du_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46033-46800-porte_du_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46033-46800-porte_du_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46033-46800-porte_du_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46034-46120-le_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46034-46120-le_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46034-46120-le_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46034-46120-le_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46035-46100-boussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46035-46100-boussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46035-46100-boussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46035-46100-boussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46036-46120-le_bouyssou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46036-46120-le_bouyssou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46036-46120-le_bouyssou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46036-46120-le_bouyssou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46037-46330-bouzies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46037-46330-bouzies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46037-46330-bouzies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46037-46330-bouzies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46038-46130-bretenoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46038-46130-bretenoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46038-46130-bretenoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46038-46130-bretenoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46039-46320-brengues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46039-46320-brengues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46039-46320-brengues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46039-46320-brengues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46040-46330-cabrerets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46040-46330-cabrerets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46040-46330-cabrerets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46040-46330-cabrerets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46041-46160-cadrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46041-46160-cadrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46041-46160-cadrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46041-46160-cadrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46042-46000-cahors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46042-46000-cahors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46042-46000-cahors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46042-46000-cahors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46043-46130-cahus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46043-46130-cahus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46043-46130-cahus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46043-46130-cahus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46044-46140-caillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46044-46140-caillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46044-46140-caillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46044-46140-caillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46045-46160-cajarc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46045-46160-cajarc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46045-46160-cajarc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46045-46160-cajarc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46046-46150-calamane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46046-46150-calamane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46046-46150-calamane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46046-46150-calamane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46047-46350-cales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46047-46350-cales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46047-46350-cales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46047-46350-cales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46049-46160-calvignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46049-46160-calvignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46049-46160-calvignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46049-46160-calvignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46050-46140-cambayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46050-46140-cambayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46050-46140-cambayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46050-46140-cambayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46051-46100-cambes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46051-46100-cambes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46051-46100-cambes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46051-46100-cambes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46052-46100-camboulit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46052-46100-camboulit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46052-46100-camboulit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46052-46100-camboulit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46053-46100-camburat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46053-46100-camburat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46053-46100-camburat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46053-46100-camburat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46054-46240-caniac_du_causse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46054-46240-caniac_du_causse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46054-46240-caniac_du_causse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46054-46240-caniac_du_causse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46055-46100-capdenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46055-46100-capdenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46055-46100-capdenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46055-46100-capdenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46056-46160-carayac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46056-46160-carayac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46056-46160-carayac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46056-46160-carayac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46057-46100-cardaillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46057-46100-cardaillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46057-46100-cardaillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46057-46100-cardaillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46058-46110-carennac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46058-46110-carennac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46058-46110-carennac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46058-46110-carennac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46059-46500-carlucet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46059-46500-carlucet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46059-46500-carlucet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46059-46500-carlucet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46060-46140-carnac_rouffiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46060-46140-carnac_rouffiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46060-46140-carnac_rouffiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46060-46140-carnac_rouffiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46061-46700-cassagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46061-46700-cassagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46061-46700-cassagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46061-46700-cassagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46062-46140-castelfranc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46062-46140-castelfranc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46062-46140-castelfranc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46062-46140-castelfranc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46063-46170-castelnau_montratier_sainte_alauzie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46063-46170-castelnau_montratier_sainte_alauzie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46063-46170-castelnau_montratier_sainte_alauzie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46063-46170-castelnau_montratier_sainte_alauzie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46064-46150-catus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46064-46150-catus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46064-46150-catus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46064-46150-catus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46065-46110-cavagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46065-46110-cavagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46065-46110-cavagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46065-46110-cavagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46066-46250-cazals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46066-46250-cazals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46066-46250-cazals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46066-46250-cazals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46068-46330-cenevieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46068-46330-cenevieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46068-46330-cenevieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46068-46330-cenevieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46069-46170-cezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46069-46170-cezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46069-46170-cezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46069-46170-cezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46070-46230-cieurac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46070-46230-cieurac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46070-46230-cieurac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46070-46230-cieurac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46072-46310-concores/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46072-46310-concores/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46072-46310-concores/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46072-46310-concores/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46073-46260-concots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46073-46260-concots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46073-46260-concots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46073-46260-concots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46074-46110-condat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46074-46110-condat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46074-46110-condat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46074-46110-condat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46075-46100-corn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46075-46100-corn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46075-46100-corn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46075-46100-corn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46076-46130-cornac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46076-46130-cornac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46076-46130-cornac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46076-46130-cornac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46078-46500-couzou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46078-46500-couzou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46078-46500-couzou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46078-46500-couzou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46079-46360-cras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46079-46360-cras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46079-46360-cras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46079-46360-cras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46080-46150-crayssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46080-46150-crayssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46080-46150-crayssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46080-46150-crayssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46081-46330-cregols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46081-46330-cregols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46081-46330-cregols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46081-46330-cregols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46082-46230-cremps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46082-46230-cremps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46082-46230-cremps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46082-46230-cremps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46083-46600-cressensac_sarrazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46083-46600-cressensac_sarrazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46083-46600-cressensac_sarrazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46083-46600-cressensac_sarrazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46084-46600-creysse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46084-46600-creysse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46084-46600-creysse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46084-46600-creysse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46085-46270-cuzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46085-46270-cuzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46085-46270-cuzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46085-46270-cuzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46086-46600-cuzance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46086-46600-cuzance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46086-46600-cuzance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46086-46600-cuzance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46087-46340-degagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46087-46340-degagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46087-46340-degagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46087-46340-degagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46088-46140-douelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46088-46140-douelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46088-46140-douelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46088-46140-douelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46089-46700-duravel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46089-46700-duravel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46089-46700-duravel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46089-46700-duravel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46090-46320-durbans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46090-46320-durbans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46090-46320-durbans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46090-46320-durbans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46091-46230-escamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46091-46230-escamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46091-46230-escamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46091-46230-escamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46092-46090-esclauzels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46092-46090-esclauzels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46092-46090-esclauzels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46092-46090-esclauzels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46093-46320-espagnac_sainte_eulalie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46093-46320-espagnac_sainte_eulalie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46093-46320-espagnac_sainte_eulalie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46093-46320-espagnac_sainte_eulalie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46094-46320-espedaillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46094-46320-espedaillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46094-46320-espedaillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46094-46320-espedaillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46095-46090-espere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46095-46090-espere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46095-46090-espere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46095-46090-espere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46096-46120-espeyroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46096-46120-espeyroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46096-46120-espeyroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46096-46120-espeyroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46097-46130-estal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46097-46130-estal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46097-46130-estal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46097-46130-estal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46098-46300-fajoles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46098-46300-fajoles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46098-46300-fajoles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46098-46300-fajoles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46100-46100-faycelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46100-46100-faycelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46100-46100-faycelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46100-46100-faycelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46101-46270-felzins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46101-46270-felzins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46101-46270-felzins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46101-46270-felzins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46102-46100-figeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46102-46100-figeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46102-46100-figeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46102-46100-figeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46103-46170-saint_paul_flaugnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46103-46170-saint_paul_flaugnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46103-46170-saint_paul_flaugnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46103-46170-saint_paul_flaugnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46104-46320-flaujac_gare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46104-46320-flaujac_gare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46104-46320-flaujac_gare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46104-46320-flaujac_gare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46105-46090-flaujac_poujols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46105-46090-flaujac_poujols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46105-46090-flaujac_poujols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46105-46090-flaujac_poujols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46106-46600-floirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46106-46600-floirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46106-46600-floirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46106-46600-floirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46107-46700-floressas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46107-46700-floressas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46107-46700-floressas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46107-46700-floressas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46108-46100-fons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46108-46100-fons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46108-46100-fons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46108-46100-fons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46109-46230-fontanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46109-46230-fontanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46109-46230-fontanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46109-46230-fontanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46111-46100-fourmagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46111-46100-fourmagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46111-46100-fourmagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46111-46100-fourmagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46112-46090-francoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46112-46090-francoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46112-46090-francoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46112-46090-francoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46113-46310-frayssinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46113-46310-frayssinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46113-46310-frayssinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46113-46310-frayssinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46114-46250-frayssinet_le_gelat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46114-46250-frayssinet_le_gelat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46114-46250-frayssinet_le_gelat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46114-46250-frayssinet_le_gelat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46115-46400-frayssinhes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46115-46400-frayssinhes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46115-46400-frayssinhes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46115-46400-frayssinhes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46116-46160-frontenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46116-46160-frontenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46116-46160-frontenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46116-46160-frontenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46117-46130-gagnac_sur_cere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46117-46130-gagnac_sur_cere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46117-46130-gagnac_sur_cere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46117-46130-gagnac_sur_cere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46118-46600-gignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46118-46600-gignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46118-46600-gignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46118-46600-gignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46119-46150-gigouzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46119-46150-gigouzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46119-46150-gigouzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46119-46150-gigouzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46120-46250-gindou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46120-46250-gindou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46120-46250-gindou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46120-46250-gindou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46121-46300-ginouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46121-46300-ginouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46121-46300-ginouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46121-46300-ginouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46122-46130-gintrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46122-46130-gintrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46122-46130-gintrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46122-46130-gintrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46123-46130-girac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46123-46130-girac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46123-46130-girac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46123-46130-girac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46124-46130-glanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46124-46130-glanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46124-46130-glanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46124-46130-glanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46125-46210-gorses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46125-46210-gorses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46125-46210-gorses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46125-46210-gorses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46126-46250-goujounac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46126-46250-goujounac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46126-46250-goujounac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46126-46250-goujounac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46127-46300-gourdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46127-46300-gourdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46127-46300-gourdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46127-46300-gourdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46128-46500-gramat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46128-46500-gramat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46128-46500-gramat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46128-46500-gramat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46129-46160-grealou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46129-46160-grealou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46129-46160-grealou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46129-46160-grealou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46130-46700-grezels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46130-46700-grezels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46130-46700-grezels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46130-46700-grezels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46131-46320-grezes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46131-46320-grezes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46131-46320-grezes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46131-46320-grezes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46132-46500-issendolus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46132-46500-issendolus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46132-46500-issendolus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46132-46500-issendolus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46133-46320-issepts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46133-46320-issepts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46133-46320-issepts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46133-46320-issepts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46134-46150-les_junies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46134-46150-les_junies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46134-46150-les_junies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46134-46150-les_junies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46135-46210-labastide_du_haut_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46135-46210-labastide_du_haut_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46135-46210-labastide_du_haut_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46135-46210-labastide_du_haut_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46136-46150-labastide_du_vert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46136-46150-labastide_du_vert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46136-46150-labastide_du_vert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46136-46150-labastide_du_vert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46137-46090-labastide_marnhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46137-46090-labastide_marnhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46137-46090-labastide_marnhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46137-46090-labastide_marnhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46138-46240-coeur_de_causse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46138-46240-coeur_de_causse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46138-46240-coeur_de_causse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46138-46240-coeur_de_causse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46139-46120-labathude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46139-46120-labathude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46139-46120-labathude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46139-46120-labathude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46140-46230-laburgade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46140-46230-laburgade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46140-46230-laburgade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46140-46230-laburgade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46142-46700-lacapelle_cabanac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46142-46700-lacapelle_cabanac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46142-46700-lacapelle_cabanac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46142-46700-lacapelle_cabanac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46143-46120-lacapelle_marival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46143-46120-lacapelle_marival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46143-46120-lacapelle_marival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46143-46120-lacapelle_marival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46144-46200-lacave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46144-46200-lacave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46144-46200-lacave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46144-46200-lacave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46145-46200-lachapelle_auzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46145-46200-lachapelle_auzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46145-46200-lachapelle_auzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46145-46200-lachapelle_auzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46146-46400-ladirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46146-46400-ladirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46146-46400-ladirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46146-46400-ladirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46147-46220-lagardelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46147-46220-lagardelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46147-46220-lagardelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46147-46220-lagardelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46148-46230-lalbenque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46148-46230-lalbenque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46148-46230-lalbenque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46148-46230-lalbenque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46149-46090-lamagdelaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46149-46090-lamagdelaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46149-46090-lamagdelaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46149-46090-lamagdelaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46151-46240-lamothe_cassel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46151-46240-lamothe_cassel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46151-46240-lamothe_cassel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46151-46240-lamothe_cassel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46152-46350-lamothe_fenelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46152-46350-lamothe_fenelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46152-46350-lamothe_fenelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46152-46350-lamothe_fenelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46153-46200-lanzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46153-46200-lanzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46153-46200-lanzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46153-46200-lanzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46154-46260-laramiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46154-46260-laramiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46154-46260-laramiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46154-46260-laramiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46155-46160-larnagol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46155-46160-larnagol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46155-46160-larnagol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46155-46160-larnagol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46156-46090-bellefont_la_rauze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46156-46090-bellefont_la_rauze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46156-46090-bellefont_la_rauze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46156-46090-bellefont_la_rauze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46157-46160-larroque_toirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46157-46160-larroque_toirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46157-46160-larroque_toirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46157-46160-larroque_toirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46159-46400-latouille_lentillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46159-46400-latouille_lentillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46159-46400-latouille_lentillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46159-46400-latouille_lentillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46160-46210-latronquiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46160-46210-latronquiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46160-46210-latronquiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46160-46210-latronquiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46161-46210-lauresses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46161-46210-lauresses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46161-46210-lauresses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46161-46210-lauresses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46162-46360-lauzes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46162-46360-lauzes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46162-46360-lauzes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46162-46360-lauzes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46163-46130-laval_de_cere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46163-46130-laval_de_cere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46163-46130-laval_de_cere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46163-46130-laval_de_cere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46164-46340-lavercantiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46164-46340-lavercantiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46164-46340-lavercantiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46164-46340-lavercantiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46165-46500-lavergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46165-46500-lavergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46165-46500-lavergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46165-46500-lavergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46167-46330-lentillac_du_causse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46167-46330-lentillac_du_causse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46167-46330-lentillac_du_causse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46167-46330-lentillac_du_causse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46168-46100-lentillac_saint_blaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46168-46100-lentillac_saint_blaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46168-46100-lentillac_saint_blaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46168-46100-lentillac_saint_blaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46169-46300-leobard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46169-46300-leobard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46169-46300-leobard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46169-46300-leobard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46170-46120-leyme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46170-46120-leyme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46170-46120-leyme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46170-46120-leyme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46171-46150-lherm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46171-46150-lherm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46171-46150-lherm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46171-46150-lherm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46172-46170-lhospitalet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46172-46170-lhospitalet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46172-46170-lhospitalet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46172-46170-lhospitalet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46173-46260-limogne_en_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46173-46260-limogne_en_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46173-46260-limogne_en_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46173-46260-limogne_en_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46174-46270-linac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46174-46270-linac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46174-46270-linac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46174-46270-linac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46175-46100-lissac_et_mouret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46175-46100-lissac_et_mouret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46175-46100-lissac_et_mouret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46175-46100-lissac_et_mouret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46176-46320-livernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46176-46320-livernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46176-46320-livernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46176-46320-livernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46177-46130-loubressac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46177-46130-loubressac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46177-46130-loubressac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46177-46130-loubressac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46178-46350-loupiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46178-46350-loupiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46178-46350-loupiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46178-46350-loupiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46179-46260-lugagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46179-46260-lugagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46179-46260-lugagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46179-46260-lugagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46180-46100-lunan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46180-46100-lunan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46180-46100-lunan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46180-46100-lunan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46181-46240-lunegarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46181-46240-lunegarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46181-46240-lunegarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46181-46240-lunegarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46182-46140-luzech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46182-46140-luzech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46182-46140-luzech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46182-46140-luzech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46183-46160-marcilhac_sur_cele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46183-46160-marcilhac_sur_cele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46183-46160-marcilhac_sur_cele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46183-46160-marcilhac_sur_cele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46184-46250-marminiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46184-46250-marminiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46184-46250-marminiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46184-46250-marminiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46185-46600-martel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46185-46600-martel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46185-46600-martel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46185-46600-martel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46186-46350-masclat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46186-46350-masclat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46186-46350-masclat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46186-46350-masclat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46187-46700-mauroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46187-46700-mauroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46187-46700-mauroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46187-46700-mauroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46188-46090-maxou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46188-46090-maxou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46188-46090-maxou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46188-46090-maxou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46189-46500-mayrinhac_lentour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46189-46500-mayrinhac_lentour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46189-46500-mayrinhac_lentour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46189-46500-mayrinhac_lentour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46190-46150-mechmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46190-46150-mechmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46190-46150-mechmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46190-46150-mechmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46191-46090-mercues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46191-46090-mercues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46191-46090-mercues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46191-46090-mercues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46192-46200-meyronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46192-46200-meyronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46192-46200-meyronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46192-46200-meyronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46193-46500-miers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46193-46500-miers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46193-46500-miers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46193-46500-miers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46194-46300-milhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46194-46300-milhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46194-46300-milhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46194-46300-milhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46195-46120-molieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46195-46120-molieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46195-46120-molieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46195-46120-molieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46196-46310-montamel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46196-46310-montamel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46196-46310-montamel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46196-46310-montamel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46197-46090-le_montat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46197-46090-le_montat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46197-46090-le_montat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46197-46090-le_montat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46198-46160-montbrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46198-46160-montbrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46198-46160-montbrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46198-46160-montbrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46199-46700-montcabrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46199-46700-montcabrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46199-46700-montcabrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46199-46700-montcabrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46200-46250-montclera/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46200-46250-montclera/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46200-46250-montclera/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46200-46250-montclera/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46201-46800-montcuq_en_quercy_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46201-46800-montcuq_en_quercy_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46201-46800-montcuq_en_quercy_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46201-46800-montcuq_en_quercy_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46202-46230-montdoumerc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46202-46230-montdoumerc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46202-46230-montdoumerc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46202-46230-montdoumerc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46203-46210-montet_et_bouxal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46203-46210-montet_et_bouxal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46203-46210-montet_et_bouxal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46203-46210-montet_et_bouxal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46204-46240-montfaucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46204-46240-montfaucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46204-46240-montfaucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46204-46240-montfaucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46205-46150-montgesty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46205-46150-montgesty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46205-46150-montgesty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46205-46150-montgesty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46206-46800-montlauzun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46206-46800-montlauzun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46206-46800-montlauzun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46206-46800-montlauzun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46207-46270-montredon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46207-46270-montredon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46207-46270-montredon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46207-46270-montredon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46208-46600-montvalent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46208-46600-montvalent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46208-46600-montvalent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46208-46600-montvalent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46209-46350-nadaillac_de_rouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46209-46350-nadaillac_de_rouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46209-46350-nadaillac_de_rouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46209-46350-nadaillac_de_rouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46210-46360-nadillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46210-46360-nadillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46210-46360-nadillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46210-46360-nadillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46211-46150-nuzejouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46211-46150-nuzejouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46211-46150-nuzejouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46211-46150-nuzejouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46212-46330-orniac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46212-46330-orniac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46212-46330-orniac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46212-46330-orniac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46213-46500-padirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46213-46500-padirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46213-46500-padirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46213-46500-padirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46214-46140-parnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46214-46140-parnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46214-46140-parnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46214-46140-parnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46215-46350-payrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46215-46350-payrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46215-46350-payrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46215-46350-payrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46216-46300-payrignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46216-46300-payrignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46216-46300-payrignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46216-46300-payrignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46217-46170-pern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46217-46170-pern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46217-46170-pern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46217-46170-pern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46218-46220-pescadoires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46218-46220-pescadoires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46218-46220-pescadoires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46218-46220-pescadoires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46219-46310-peyrilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46219-46310-peyrilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46219-46310-peyrilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46219-46310-peyrilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46220-46200-pinsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46220-46200-pinsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46220-46200-pinsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46220-46200-pinsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46221-46100-planioles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46221-46100-planioles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46221-46100-planioles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46221-46100-planioles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46222-46250-pomarede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46222-46250-pomarede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46222-46250-pomarede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46222-46250-pomarede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46223-46150-pontcirq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46223-46150-pontcirq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46223-46150-pontcirq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46223-46150-pontcirq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46224-46090-pradines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46224-46090-pradines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46224-46090-pradines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46224-46090-pradines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46225-46220-prayssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46225-46220-prayssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46225-46220-prayssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46225-46220-prayssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46226-46270-prendeignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46226-46270-prendeignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46226-46270-prendeignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46226-46270-prendeignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46227-46260-promilhanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46227-46260-promilhanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46227-46260-promilhanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46227-46260-promilhanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46228-46130-prudhomat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46228-46130-prudhomat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46228-46130-prudhomat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46228-46130-prudhomat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46229-46130-puybrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46229-46130-puybrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46229-46130-puybrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46229-46130-puybrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46230-46260-puyjourdes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46230-46260-puyjourdes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46230-46260-puyjourdes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46230-46260-puyjourdes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46231-46700-puy_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46231-46700-puy_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46231-46700-puy_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46231-46700-puy_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46232-46110-le_vignon_en_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46232-46110-le_vignon_en_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46232-46110-le_vignon_en_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46232-46110-le_vignon_en_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46232-46600-le_vignon_en_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46232-46600-le_vignon_en_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46232-46600-le_vignon_en_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46232-46600-le_vignon_en_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46233-46320-quissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46233-46320-quissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46233-46320-quissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46233-46320-quissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46234-46340-rampoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46234-46340-rampoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46234-46340-rampoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46234-46340-rampoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46235-46500-reilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46235-46500-reilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46235-46500-reilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46235-46500-reilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46236-46350-reilhaguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46236-46350-reilhaguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46236-46350-reilhaguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46236-46350-reilhaguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46237-46320-reyrevignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46237-46320-reyrevignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46237-46320-reyrevignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46237-46320-reyrevignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46238-46500-rignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46238-46500-rignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46238-46500-rignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46238-46500-rignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46239-46200-le_roc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46239-46200-le_roc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46239-46200-le_roc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46239-46200-le_roc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46240-46500-rocamadour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46240-46500-rocamadour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46240-46500-rocamadour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46240-46500-rocamadour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46241-46300-rouffilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46241-46300-rouffilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46241-46300-rouffilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46241-46300-rouffilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46242-46120-rudelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46242-46120-rudelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46242-46120-rudelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46242-46120-rudelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46243-46120-rueyres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46243-46120-rueyres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46243-46120-rueyres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46243-46120-rueyres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46244-46210-sabadel_latronquiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46244-46210-sabadel_latronquiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46244-46210-sabadel_latronquiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46244-46210-sabadel_latronquiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46245-46360-sabadel_lauzes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46245-46360-sabadel_lauzes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46245-46360-sabadel_lauzes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46245-46360-sabadel_lauzes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46246-46500-saignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46246-46500-saignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46246-46500-saignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46246-46500-saignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46247-46260-saillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46247-46260-saillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46247-46260-saillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46247-46260-saillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46249-46120-saint_bressou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46249-46120-saint_bressou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46249-46120-saint_bressou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46249-46120-saint_bressou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46250-46250-saint_caprais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46250-46250-saint_caprais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46250-46250-saint_caprais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46250-46250-saint_caprais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46251-46400-saint_cere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46251-46400-saint_cere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46251-46400-saint_cere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46251-46400-saint_cere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46252-46360-les_pechs_du_vers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46252-46360-les_pechs_du_vers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46252-46360-les_pechs_du_vers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46252-46360-les_pechs_du_vers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46253-46310-saint_chamarand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46253-46310-saint_chamarand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46253-46310-saint_chamarand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46253-46310-saint_chamarand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46254-46160-saint_chels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46254-46160-saint_chels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46254-46160-saint_chels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46254-46160-saint_chels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46255-46210-saint_cirgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46255-46210-saint_cirgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46255-46210-saint_cirgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46255-46210-saint_cirgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46256-46330-saint_cirq_lapopie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46256-46330-saint_cirq_lapopie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46256-46330-saint_cirq_lapopie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46256-46330-saint_cirq_lapopie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46257-46300-saint_cirq_madelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46257-46300-saint_cirq_madelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46257-46300-saint_cirq_madelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46257-46300-saint_cirq_madelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46258-46300-saint_cirq_souillaguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46258-46300-saint_cirq_souillaguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46258-46300-saint_cirq_souillaguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46258-46300-saint_cirq_souillaguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46259-46300-saint_clair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46259-46300-saint_clair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46259-46300-saint_clair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46259-46300-saint_clair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46260-46120-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46260-46120-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46260-46120-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46260-46120-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46262-46800-lendou_en_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46262-46800-lendou_en_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46262-46800-lendou_en_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46262-46800-lendou_en_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46263-46800-barguelonne_en_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46263-46800-barguelonne_en_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46263-46800-barguelonne_en_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46263-46800-barguelonne_en_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46264-46150-saint_denis_catus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46264-46150-saint_denis_catus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46264-46150-saint_denis_catus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46264-46150-saint_denis_catus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46265-46600-saint_denis_les_martel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46265-46600-saint_denis_les_martel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46265-46600-saint_denis_les_martel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46265-46600-saint_denis_les_martel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46266-46100-saint_felix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46266-46100-saint_felix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46266-46100-saint_felix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46266-46100-saint_felix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46267-46310-saint_germain_du_bel_air/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46267-46310-saint_germain_du_bel_air/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46267-46310-saint_germain_du_bel_air/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46267-46310-saint_germain_du_bel_air/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46268-46330-saint_gery_vers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46268-46330-saint_gery_vers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46268-46330-saint_gery_vers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46268-46330-saint_gery_vers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46268-46090-saint_gery_vers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46268-46090-saint_gery_vers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46268-46090-saint_gery_vers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46268-46090-saint_gery_vers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46269-46210-saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46269-46210-saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46269-46210-saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46269-46210-saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46270-46260-saint_jean_de_laur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46270-46260-saint_jean_de_laur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46270-46260-saint_jean_de_laur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46270-46260-saint_jean_de_laur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46271-46400-saint_jean_lespinasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46271-46400-saint_jean_lespinasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46271-46400-saint_jean_lespinasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46271-46400-saint_jean_lespinasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46272-46270-saint_jean_mirabel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46272-46270-saint_jean_mirabel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46272-46270-saint_jean_mirabel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46272-46270-saint_jean_mirabel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46273-46400-saint_laurent_les_tours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46273-46400-saint_laurent_les_tours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46273-46400-saint_laurent_les_tours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46273-46400-saint_laurent_les_tours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46276-46330-saint_martin_labouval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46276-46330-saint_martin_labouval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46276-46330-saint_martin_labouval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46276-46330-saint_martin_labouval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46277-46700-saint_martin_le_redon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46277-46700-saint_martin_le_redon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46277-46700-saint_martin_le_redon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46277-46700-saint_martin_le_redon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46279-46120-saint_maurice_en_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46279-46120-saint_maurice_en_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46279-46120-saint_maurice_en_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46279-46120-saint_maurice_en_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46280-46150-saint_medard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46280-46150-saint_medard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46280-46150-saint_medard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46280-46150-saint_medard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46281-46400-saint_medard_de_presque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46281-46400-saint_medard_de_presque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46281-46400-saint_medard_de_presque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46281-46400-saint_medard_de_presque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46282-46210-saint_medard_nicourby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46282-46210-saint_medard_nicourby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46282-46210-saint_medard_nicourby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46282-46210-saint_medard_nicourby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46283-46110-saint_michel_de_bannieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46283-46110-saint_michel_de_bannieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46283-46110-saint_michel_de_bannieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46283-46110-saint_michel_de_bannieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46284-46130-saint_michel_loubejou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46284-46130-saint_michel_loubejou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46284-46130-saint_michel_loubejou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46284-46130-saint_michel_loubejou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46286-46400-saint_paul_de_vern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46286-46400-saint_paul_de_vern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46286-46400-saint_paul_de_vern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46286-46400-saint_paul_de_vern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46288-46100-saint_perdoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46288-46100-saint_perdoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46288-46100-saint_perdoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46288-46100-saint_perdoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46289-46160-saint_pierre_toirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46289-46160-saint_pierre_toirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46289-46160-saint_pierre_toirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46289-46160-saint_pierre_toirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46290-46300-saint_projet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46290-46300-saint_projet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46290-46300-saint_projet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46290-46300-saint_projet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46292-46320-saint_simon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46292-46320-saint_simon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46292-46320-saint_simon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46292-46320-saint_simon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46293-46200-saint_sozy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46293-46200-saint_sozy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46293-46200-saint_sozy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46293-46200-saint_sozy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46294-46160-saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46294-46160-saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46294-46160-saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46294-46160-saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46295-46400-saint_vincent_du_pendit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46295-46400-saint_vincent_du_pendit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46295-46400-saint_vincent_du_pendit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46295-46400-saint_vincent_du_pendit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46296-46140-saint_vincent_rive_d_olt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46296-46140-saint_vincent_rive_d_olt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46296-46140-saint_vincent_rive_d_olt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46296-46140-saint_vincent_rive_d_olt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46297-46340-salviac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46297-46340-salviac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46297-46340-salviac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46297-46340-salviac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46299-46330-sauliac_sur_cele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46299-46330-sauliac_sur_cele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46299-46330-sauliac_sur_cele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46299-46330-sauliac_sur_cele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46301-46140-sauzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46301-46140-sauzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46301-46140-sauzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46301-46140-sauzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46302-46210-senaillac_latronquiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46302-46210-senaillac_latronquiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46302-46210-senaillac_latronquiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46302-46210-senaillac_latronquiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46303-46360-senaillac_lauzes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46303-46360-senaillac_lauzes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46303-46360-senaillac_lauzes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46303-46360-senaillac_lauzes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46304-46240-seniergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46304-46240-seniergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46304-46240-seniergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46304-46240-seniergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46305-46700-serignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46305-46700-serignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46305-46700-serignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46305-46700-serignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46306-46320-sonac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46306-46320-sonac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46306-46320-sonac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46306-46320-sonac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46307-46700-soturac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46307-46700-soturac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46307-46700-soturac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46307-46700-soturac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46308-46300-soucirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46308-46300-soucirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46308-46300-soucirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46308-46300-soucirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46309-46200-souillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46309-46200-souillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46309-46200-souillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46309-46200-souillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46310-46240-soulomes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46310-46240-soulomes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46310-46240-soulomes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46310-46240-soulomes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46311-46190-sousceyrac_en_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46311-46190-sousceyrac_en_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46311-46190-sousceyrac_en_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46311-46190-sousceyrac_en_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46312-46110-strenquels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46312-46110-strenquels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46312-46110-strenquels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46312-46110-strenquels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46313-46130-tauriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46313-46130-tauriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46313-46130-tauriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46313-46130-tauriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46314-46120-terrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46314-46120-terrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46314-46120-terrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46314-46120-terrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46315-46190-teyssieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46315-46190-teyssieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46315-46190-teyssieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46315-46190-teyssieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46316-46150-thedirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46316-46150-thedirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46316-46150-thedirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46316-46150-thedirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46317-46500-thegra/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46317-46500-thegra/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46317-46500-thegra/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46317-46500-thegra/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46318-46120-themines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46318-46120-themines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46318-46120-themines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46318-46120-themines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46319-46120-theminettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46319-46120-theminettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46319-46120-theminettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46319-46120-theminettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46320-46330-tour_de_faure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46320-46330-tour_de_faure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46320-46330-tour_de_faure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46320-46330-tour_de_faure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46321-46700-touzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46321-46700-touzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46321-46700-touzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46321-46700-touzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46322-46090-trespoux_rassiels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46322-46090-trespoux_rassiels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46322-46090-trespoux_rassiels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46322-46090-trespoux_rassiels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46323-46240-ussel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46323-46240-ussel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46323-46240-ussel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46323-46240-ussel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46324-46310-uzech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46324-46310-uzech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46324-46310-uzech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46324-46310-uzech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46328-46260-varaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46328-46260-varaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46328-46260-varaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46328-46260-varaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46329-46230-vaylats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46329-46230-vaylats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46329-46230-vaylats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46329-46230-vaylats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46330-46110-vayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46330-46110-vayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46330-46110-vayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46330-46110-vayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46332-46100-viazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46332-46100-viazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46332-46100-viazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46332-46100-viazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46333-46260-vidaillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46333-46260-vidaillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46333-46260-vidaillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46333-46260-vidaillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46334-46300-le_vigan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46334-46300-le_vigan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46334-46300-le_vigan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46334-46300-le_vigan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46335-46090-villeseque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46335-46090-villeseque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46335-46090-villeseque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46335-46090-villeseque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46336-46700-vire_sur_lot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46336-46700-vire_sur_lot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46336-46700-vire_sur_lot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46336-46700-vire_sur_lot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46337-46200-mayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46337-46200-mayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46337-46200-mayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46337-46200-mayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46338-46210-bessonies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46338-46210-bessonies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46338-46210-bessonies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46338-46210-bessonies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46339-46400-saint_jean_lagineste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46339-46400-saint_jean_lagineste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46339-46400-saint_jean_lagineste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46339-46400-saint_jean_lagineste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46340-46090-saint_pierre_lafeuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46340-46090-saint_pierre_lafeuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46340-46090-saint_pierre_lafeuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt46-lot/commune46340-46090-saint_pierre_lafeuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-47.xml
+++ b/public/sitemaps/sitemap-47.xml
@@ -5,644 +5,1284 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47001-47000-agen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47001-47000-agen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47001-47000-agen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47001-47000-agen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47002-47350-agme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47002-47350-agme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47002-47350-agme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47002-47350-agme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47003-47800-agnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47003-47800-agnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47003-47800-agnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47003-47800-agnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47004-47190-aiguillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47004-47190-aiguillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47004-47190-aiguillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47004-47190-aiguillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47005-47800-allemans_du_dropt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47005-47800-allemans_du_dropt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47005-47800-allemans_du_dropt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47005-47800-allemans_du_dropt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47006-47110-allez_et_cazeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47006-47110-allez_et_cazeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47006-47110-allez_et_cazeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47006-47110-allez_et_cazeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47007-47420-allons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47007-47420-allons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47007-47420-allons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47007-47420-allons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47008-47160-ambrus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47008-47160-ambrus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47008-47160-ambrus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47008-47160-ambrus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47009-47170-andiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47009-47170-andiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47009-47170-andiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47009-47170-andiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47010-47700-antagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47010-47700-antagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47010-47700-antagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47010-47700-antagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47011-47370-anthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47011-47370-anthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47011-47370-anthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47011-47370-anthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47012-47700-anzex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47012-47700-anzex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47012-47700-anzex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47012-47700-anzex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47013-47250-argenton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47013-47250-argenton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47013-47250-argenton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47013-47250-argenton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47014-47800-armillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47014-47800-armillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47014-47800-armillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47014-47800-armillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47015-47220-astaffort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47015-47220-astaffort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47015-47220-astaffort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47015-47220-astaffort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47016-47310-aubiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47016-47310-aubiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47016-47310-aubiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47016-47310-aubiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47017-47140-auradou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47017-47140-auradou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47017-47140-auradou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47017-47140-auradou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47018-47120-auriac_sur_dropt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47018-47120-auriac_sur_dropt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47018-47120-auriac_sur_dropt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47018-47120-auriac_sur_dropt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47019-47480-bajamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47019-47480-bajamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47019-47480-bajamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47019-47480-bajamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47020-47120-baleyssagues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47020-47120-baleyssagues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47020-47120-baleyssagues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47020-47120-baleyssagues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47021-47230-barbaste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47021-47230-barbaste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47021-47230-barbaste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47021-47230-barbaste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47022-47130-bazens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47022-47130-bazens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47022-47130-bazens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47022-47130-bazens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47023-47290-beaugas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47023-47290-beaugas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47023-47290-beaugas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47023-47290-beaugas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47024-47200-beaupuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47024-47200-beaupuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47024-47200-beaupuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47024-47200-beaupuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47025-47470-beauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47025-47470-beauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47025-47470-beauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47025-47470-beauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47026-47700-beauziac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47026-47700-beauziac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47026-47700-beauziac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47026-47700-beauziac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47027-47300-bias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47027-47300-bias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47027-47300-bias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47027-47300-bias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47028-47200-birac_sur_trec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47028-47200-birac_sur_trec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47028-47200-birac_sur_trec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47028-47200-birac_sur_trec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47029-47500-blanquefort_sur_briolance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47029-47500-blanquefort_sur_briolance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47029-47500-blanquefort_sur_briolance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47029-47500-blanquefort_sur_briolance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47030-47470-blaymont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47030-47470-blaymont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47030-47470-blaymont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47030-47470-blaymont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47031-47550-boe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47031-47550-boe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47031-47550-boe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47031-47550-boe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47032-47240-bon_encontre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47032-47240-bon_encontre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47032-47240-bon_encontre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47032-47240-bon_encontre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47033-47290-boudy_de_beauregard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47033-47290-boudy_de_beauregard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47033-47290-boudy_de_beauregard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47033-47290-boudy_de_beauregard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47034-47250-bouglon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47034-47250-bouglon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47034-47250-bouglon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47034-47250-bouglon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47035-47410-bourgougnague/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47035-47410-bourgougnague/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47035-47410-bourgougnague/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47035-47410-bourgougnague/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47036-47370-bourlens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47036-47370-bourlens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47036-47370-bourlens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47036-47370-bourlens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47037-47210-bournel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47037-47210-bournel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47037-47210-bournel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47037-47210-bournel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47038-47320-bourran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47038-47320-bourran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47038-47320-bourran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47038-47320-bourran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47039-47420-bousses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47039-47420-bousses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47039-47420-bousses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47039-47420-bousses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47040-47310-brax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47040-47310-brax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47040-47310-brax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47040-47310-brax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47041-47130-bruch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47041-47130-bruch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47041-47130-bruch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47041-47130-bruch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47042-47260-brugnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47042-47260-brugnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47042-47260-brugnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47042-47260-brugnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47043-47160-buzet_sur_baise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47043-47160-buzet_sur_baise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47043-47160-buzet_sur_baise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47043-47160-buzet_sur_baise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47044-47330-cahuzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47044-47330-cahuzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47044-47330-cahuzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47044-47330-cahuzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47045-47600-calignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47045-47600-calignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47045-47600-calignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47045-47600-calignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47046-47430-calonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47046-47430-calonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47046-47430-calonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47046-47430-calonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47047-47350-cambes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47047-47350-cambes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47047-47350-cambes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47047-47350-cambes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47048-47290-cancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47048-47290-cancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47048-47290-cancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47048-47290-cancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47049-47440-casseneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47049-47440-casseneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47049-47440-casseneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47049-47440-casseneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47050-47340-cassignas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47050-47340-cassignas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47050-47340-cassignas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47050-47340-cassignas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47051-47240-castelculier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47051-47240-castelculier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47051-47240-castelculier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47051-47240-castelculier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47052-47700-casteljaloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47052-47700-casteljaloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47052-47700-casteljaloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47052-47700-casteljaloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47053-47340-castella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47053-47340-castella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47053-47340-castella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47053-47340-castella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47054-47260-castelmoron_sur_lot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47054-47260-castelmoron_sur_lot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47054-47260-castelmoron_sur_lot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47054-47260-castelmoron_sur_lot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47055-47290-castelnaud_de_gratecambe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47055-47290-castelnaud_de_gratecambe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47055-47290-castelnaud_de_gratecambe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47055-47290-castelnaud_de_gratecambe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47056-47180-castelnau_sur_gupie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47056-47180-castelnau_sur_gupie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47056-47180-castelnau_sur_gupie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47056-47180-castelnau_sur_gupie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47057-47330-castillonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47057-47330-castillonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47057-47330-castillonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47057-47330-castillonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47058-47160-caubeyres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47058-47160-caubeyres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47058-47160-caubeyres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47058-47160-caubeyres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47059-47120-caubon_saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47059-47120-caubon_saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47059-47120-caubon_saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47059-47120-caubon_saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47060-47220-caudecoste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47060-47220-caudecoste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47060-47220-caudecoste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47060-47220-caudecoste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47061-47430-caumont_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47061-47430-caumont_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47061-47430-caumont_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47061-47430-caumont_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47062-47470-cauzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47062-47470-cauzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47062-47470-cauzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47062-47470-cauzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47063-47330-cavarc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47063-47330-cavarc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47063-47330-cavarc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47063-47330-cavarc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47064-47370-cazideroque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47064-47370-cazideroque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47064-47370-cazideroque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47064-47370-cazideroque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47065-47320-clairac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47065-47320-clairac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47065-47320-clairac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47065-47320-clairac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47066-47130-clermont_dessous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47066-47130-clermont_dessous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47066-47130-clermont_dessous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47066-47130-clermont_dessous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47067-47270-clermont_soubiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47067-47270-clermont_soubiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47067-47270-clermont_soubiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47067-47270-clermont_soubiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47068-47250-cocumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47068-47250-cocumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47068-47250-cocumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47068-47250-cocumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47069-47450-colayrac_saint_cirq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47069-47450-colayrac_saint_cirq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47069-47450-colayrac_saint_cirq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47069-47450-colayrac_saint_cirq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47070-47500-condezaygues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47070-47500-condezaygues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47070-47500-condezaygues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47070-47500-condezaygues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47071-47260-coulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47071-47260-coulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47071-47260-coulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47071-47260-coulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47072-47370-courbiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47072-47370-courbiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47072-47370-courbiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47072-47370-courbiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47073-47360-cours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47073-47360-cours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47073-47360-cours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47073-47360-cours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47074-47180-couthures_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47074-47180-couthures_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47074-47180-couthures_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47074-47180-couthures_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47075-47340-la_croix_blanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47075-47340-la_croix_blanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47075-47340-la_croix_blanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47075-47340-la_croix_blanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47076-47220-cuq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47076-47220-cuq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47076-47220-cuq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47076-47220-cuq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47077-47500-cuzorn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47077-47500-cuzorn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47077-47500-cuzorn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47077-47500-cuzorn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47078-47160-damazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47078-47160-damazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47078-47160-damazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47078-47160-damazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47079-47140-dausse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47079-47140-dausse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47079-47140-dausse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47079-47140-dausse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47080-47210-devillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47080-47210-devillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47080-47210-devillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47080-47210-devillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47081-47110-dolmayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47081-47110-dolmayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47081-47110-dolmayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47081-47110-dolmayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47082-47470-dondas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47082-47470-dondas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47082-47470-dondas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47082-47470-dondas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47083-47210-doudrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47083-47210-doudrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47083-47210-doudrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47083-47210-doudrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47084-47330-douzains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47084-47330-douzains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47084-47330-douzains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47084-47330-douzains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47085-47420-durance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47085-47420-durance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47085-47420-durance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47085-47420-durance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47086-47120-duras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47086-47120-duras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47086-47120-duras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47086-47120-duras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47087-47470-engayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47087-47470-engayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47087-47470-engayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47087-47470-engayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47088-47350-escassefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47088-47350-escassefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47088-47350-escassefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47088-47350-escassefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47089-47120-esclottes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47089-47120-esclottes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47089-47120-esclottes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47089-47120-esclottes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47090-47600-espiens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47090-47600-espiens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47090-47600-espiens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47090-47600-espiens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47091-47310-estillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47091-47310-estillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47091-47310-estillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47091-47310-estillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47092-47220-fals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47092-47220-fals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47092-47220-fals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47092-47220-fals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47093-47700-fargues_sur_ourbise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47093-47700-fargues_sur_ourbise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47093-47700-fargues_sur_ourbise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47093-47700-fargues_sur_ourbise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47094-47400-fauguerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47094-47400-fauguerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47094-47400-fauguerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47094-47400-fauguerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47095-47400-fauillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47095-47400-fauillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47095-47400-fauillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47095-47400-fauillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47096-47330-ferrensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47096-47330-ferrensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47096-47330-ferrensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47096-47330-ferrensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47097-47230-feugarolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47097-47230-feugarolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47097-47230-feugarolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47097-47230-feugarolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47098-47600-fieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47098-47600-fieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47098-47600-fieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47098-47600-fieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47099-47260-fongrave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47099-47260-fongrave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47099-47260-fongrave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47099-47260-fongrave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47100-47510-foulayronnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47100-47510-foulayronnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47100-47510-foulayronnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47100-47510-foulayronnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47101-47200-fourques_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47101-47200-fourques_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47101-47200-fourques_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47101-47200-fourques_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47102-47600-francescas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47102-47600-francescas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47102-47600-francescas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47102-47600-francescas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47103-47600-frechou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47103-47600-frechou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47103-47600-frechou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47103-47600-frechou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47104-47360-fregimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47104-47360-fregimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47104-47360-fregimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47104-47360-fregimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47105-47140-frespech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47105-47140-frespech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47105-47140-frespech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47105-47140-frespech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47106-47500-fumel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47106-47500-fumel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47106-47500-fumel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47106-47500-fumel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47107-47190-galapian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47107-47190-galapian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47107-47190-galapian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47107-47190-galapian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47108-47200-gaujac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47108-47200-gaujac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47108-47200-gaujac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47108-47200-gaujac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47109-47150-gavaudun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47109-47150-gavaudun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47109-47150-gavaudun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47109-47150-gavaudun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47110-47400-gontaud_de_nogaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47110-47400-gontaud_de_nogaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47110-47400-gontaud_de_nogaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47110-47400-gontaud_de_nogaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47111-47260-granges_sur_lot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47111-47260-granges_sur_lot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47111-47260-granges_sur_lot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47111-47260-granges_sur_lot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47112-47400-grateloup_saint_gayrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47112-47400-grateloup_saint_gayrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47112-47400-grateloup_saint_gayrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47112-47400-grateloup_saint_gayrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47113-47270-grayssas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47113-47270-grayssas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47113-47270-grayssas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47113-47270-grayssas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47114-47250-grezet_cavagnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47114-47250-grezet_cavagnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47114-47250-grezet_cavagnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47114-47250-grezet_cavagnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47115-47250-guerin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47115-47250-guerin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47115-47250-guerin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47115-47250-guerin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47117-47340-hautefage_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47117-47340-hautefage_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47117-47340-hautefage_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47117-47340-hautefage_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47118-47400-hautesvignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47118-47400-hautesvignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47118-47400-hautesvignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47118-47400-hautesvignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47119-47420-houeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47119-47420-houeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47119-47420-houeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47119-47420-houeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47120-47180-jusix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47120-47180-jusix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47120-47180-jusix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47120-47180-jusix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47121-47250-labastide_castel_amouroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47121-47250-labastide_castel_amouroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47121-47250-labastide_castel_amouroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47121-47250-labastide_castel_amouroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47122-47350-labretonie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47122-47350-labretonie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47122-47350-labretonie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47122-47350-labretonie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47123-47150-lacapelle_biron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47123-47150-lacapelle_biron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47123-47150-lacapelle_biron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47123-47150-lacapelle_biron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47124-47150-lacaussade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47124-47150-lacaussade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47124-47150-lacaussade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47124-47150-lacaussade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47125-47360-lacepede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47125-47360-lacepede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47125-47360-lacepede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47125-47360-lacepede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47126-47350-lachapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47126-47350-lachapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47126-47350-lachapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47126-47350-lachapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47127-47320-lafitte_sur_lot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47127-47320-lafitte_sur_lot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47127-47320-lafitte_sur_lot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47127-47320-lafitte_sur_lot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47128-47240-lafox/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47128-47240-lafox/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47128-47240-lafox/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47128-47240-lafox/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47129-47190-lagarrigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47129-47190-lagarrigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47129-47190-lagarrigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47129-47190-lagarrigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47130-47400-lagruere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47130-47400-lagruere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47130-47400-lagruere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47130-47400-lagruere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47131-47180-lagupie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47131-47180-lagupie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47131-47180-lagupie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47131-47180-lagupie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47132-47330-lalandusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47132-47330-lalandusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47132-47330-lalandusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47132-47330-lalandusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47133-47310-lamontjoie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47133-47310-lamontjoie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47133-47310-lamontjoie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47133-47310-lamontjoie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47134-47170-lannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47134-47170-lannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47134-47170-lannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47134-47170-lannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47135-47260-laparade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47135-47260-laparade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47135-47260-laparade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47135-47260-laparade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47136-47800-laperche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47136-47800-laperche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47136-47800-laperche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47136-47800-laperche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47137-47310-laplume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47137-47310-laplume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47137-47310-laplume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47137-47310-laplume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47138-47340-laroque_timbaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47138-47340-laroque_timbaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47138-47340-laroque_timbaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47138-47340-laroque_timbaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47139-47600-lasserre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47139-47600-lasserre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47139-47600-lasserre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47139-47600-lasserre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47140-47360-laugnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47140-47360-laugnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47140-47360-laugnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47140-47360-laugnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47141-47150-laussou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47141-47150-laussou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47141-47150-laussou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47141-47150-laussou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47142-47410-lauzun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47142-47410-lauzun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47142-47410-lauzun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47142-47410-lauzun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47143-47230-lavardac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47143-47230-lavardac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47143-47230-lavardac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47143-47230-lavardac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47144-47800-lavergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47144-47800-lavergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47144-47800-lavergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47144-47800-lavergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47145-47390-layrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47145-47390-layrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47145-47390-layrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47145-47390-layrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47146-47300-ledat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47146-47300-ledat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47146-47300-ledat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47146-47300-ledat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47147-47120-levignac_de_guyenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47147-47120-levignac_de_guyenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47147-47120-levignac_de_guyenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47147-47120-levignac_de_guyenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47148-47700-leyritz_moncassin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47148-47700-leyritz_moncassin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47148-47700-leyritz_moncassin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47148-47700-leyritz_moncassin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47150-47200-longueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47150-47200-longueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47150-47200-longueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47150-47200-longueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47151-47120-loubes_bernac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47151-47120-loubes_bernac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47151-47120-loubes_bernac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47151-47120-loubes_bernac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47152-47290-lougratte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47152-47290-lougratte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47152-47290-lougratte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47152-47290-lougratte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47154-47360-lusignan_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47154-47360-lusignan_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47154-47360-lusignan_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47154-47360-lusignan_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47155-47360-madaillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47155-47360-madaillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47155-47360-madaillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47155-47360-madaillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47156-47200-marcellus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47156-47200-marcellus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47156-47200-marcellus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47156-47200-marcellus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47157-47200-marmande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47157-47200-marmande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47157-47200-marmande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47157-47200-marmande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47158-47220-marmont_pachas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47158-47220-marmont_pachas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47158-47220-marmont_pachas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47158-47220-marmont_pachas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47159-47430-le_mas_d_agenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47159-47430-le_mas_d_agenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47159-47430-le_mas_d_agenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47159-47430-le_mas_d_agenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47160-47370-masquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47160-47370-masquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47160-47370-masquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47160-47370-masquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47161-47140-massels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47161-47140-massels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47161-47140-massels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47161-47140-massels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47162-47140-massoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47162-47140-massoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47162-47140-massoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47162-47140-massoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47163-47200-mauvezin_sur_gupie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47163-47200-mauvezin_sur_gupie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47163-47200-mauvezin_sur_gupie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47163-47200-mauvezin_sur_gupie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47164-47210-mazieres_naresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47164-47210-mazieres_naresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47164-47210-mazieres_naresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47164-47210-mazieres_naresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47165-47180-meilhan_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47165-47180-meilhan_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47165-47180-meilhan_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47165-47180-meilhan_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47167-47170-mezin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47167-47170-mezin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47167-47170-mezin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47167-47170-mezin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47168-47800-miramont_de_guyenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47168-47800-miramont_de_guyenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47168-47800-miramont_de_guyenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47168-47800-miramont_de_guyenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47169-47310-moirax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47169-47310-moirax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47169-47310-moirax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47169-47310-moirax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47170-47290-monbahus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47170-47290-monbahus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47170-47290-monbahus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47170-47290-monbahus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47171-47340-monbalen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47171-47340-monbalen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47171-47340-monbalen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47171-47340-monbalen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47172-47310-moncaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47172-47310-moncaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47172-47310-moncaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47172-47310-moncaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47173-47380-monclar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47173-47380-monclar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47173-47380-monclar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47173-47380-monclar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47174-47600-moncrabeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47174-47600-moncrabeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47174-47600-moncrabeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47174-47600-moncrabeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47175-47150-monflanquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47175-47150-monflanquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47175-47150-monflanquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47175-47150-monflanquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47176-47230-mongaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47176-47230-mongaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47176-47230-mongaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47176-47230-mongaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47177-47160-monheurt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47177-47160-monheurt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47177-47160-monheurt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47177-47160-monheurt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47178-47150-monsegur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47178-47150-monsegur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47178-47150-monsegur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47178-47150-monsegur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47179-47500-monsempron_libos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47179-47500-monsempron_libos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47179-47500-monsempron_libos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47179-47500-monsempron_libos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47180-47600-montagnac_sur_auvignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47180-47600-montagnac_sur_auvignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47180-47600-montagnac_sur_auvignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47180-47600-montagnac_sur_auvignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47181-47150-montagnac_sur_lede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47181-47150-montagnac_sur_lede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47181-47150-montagnac_sur_lede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47181-47150-montagnac_sur_lede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47182-47380-montastruc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47182-47380-montastruc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47182-47380-montastruc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47182-47380-montastruc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47183-47330-montauriol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47183-47330-montauriol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47183-47330-montauriol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47183-47330-montauriol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47184-47210-montaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47184-47210-montaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47184-47210-montaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47184-47210-montaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47185-47500-montayral/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47185-47500-montayral/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47185-47500-montayral/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47185-47500-montayral/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47186-47130-montesquieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47186-47130-montesquieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47186-47130-montesquieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47186-47130-montesquieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47187-47120-monteton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47187-47120-monteton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47187-47120-monteton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47187-47120-monteton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47188-47800-montignac_de_lauzun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47188-47800-montignac_de_lauzun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47188-47800-montignac_de_lauzun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47188-47800-montignac_de_lauzun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47189-47350-montignac_toupinerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47189-47350-montignac_toupinerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47189-47350-montignac_toupinerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47189-47350-montignac_toupinerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47190-47360-montpezat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47190-47360-montpezat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47190-47360-montpezat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47190-47360-montpezat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47191-47200-montpouillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47191-47200-montpouillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47191-47200-montpouillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47191-47200-montpouillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47192-47290-monviel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47192-47290-monviel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47192-47290-monviel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47192-47290-monviel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47193-47290-moulinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47193-47290-moulinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47193-47290-moulinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47193-47290-moulinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47194-47800-moustier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47194-47800-moustier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47194-47800-moustier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47194-47800-moustier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47195-47600-nerac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47195-47600-nerac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47195-47600-nerac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47195-47600-nerac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47196-47190-nicole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47196-47190-nicole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47196-47190-nicole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47196-47190-nicole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47197-47600-nomdieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47197-47600-nomdieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47197-47600-nomdieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47197-47600-nomdieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47198-47440-pailloles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47198-47440-pailloles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47198-47440-pailloles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47198-47440-pailloles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47199-47120-pardaillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47199-47120-pardaillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47199-47120-pardaillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47199-47120-pardaillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47200-47210-parranquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47200-47210-parranquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47200-47210-parranquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47200-47210-parranquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47201-47520-le_passage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47201-47520-le_passage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47201-47520-le_passage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47201-47520-le_passage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47202-47150-paulhiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47202-47150-paulhiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47202-47150-paulhiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47202-47150-paulhiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47203-47140-penne_d_agenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47203-47140-penne_d_agenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47203-47140-penne_d_agenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47203-47140-penne_d_agenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47204-47350-peyriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47204-47350-peyriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47204-47350-peyriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47204-47350-peyriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47205-47700-pinderes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47205-47700-pinderes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47205-47700-pinderes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47205-47700-pinderes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47206-47380-pinel_hauterive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47206-47380-pinel_hauterive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47206-47380-pinel_hauterive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47206-47380-pinel_hauterive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47207-47230-pompiey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47207-47230-pompiey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47207-47230-pompiey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47207-47230-pompiey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47208-47420-pompogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47208-47420-pompogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47208-47420-pompogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47208-47420-pompogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47209-47480-pont_du_casse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47209-47480-pont_du_casse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47209-47480-pont_du_casse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47209-47480-pont_du_casse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47210-47130-port_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47210-47130-port_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47210-47130-port_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47210-47130-port_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47211-47170-poudenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47211-47170-poudenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47211-47170-poudenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47211-47170-poudenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47212-47700-poussignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47212-47700-poussignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47212-47700-poussignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47212-47700-poussignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47213-47360-prayssas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47213-47360-prayssas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47213-47360-prayssas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47213-47360-prayssas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47214-47160-puch_d_agenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47214-47160-puch_d_agenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47214-47160-puch_d_agenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47214-47160-puch_d_agenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47215-47300-pujols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47215-47300-pujols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47215-47300-pujols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47215-47300-pujols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47216-47350-puymiclan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47216-47350-puymiclan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47216-47350-puymiclan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47216-47350-puymiclan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47217-47270-puymirol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47217-47270-puymirol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47217-47270-puymirol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47217-47270-puymirol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47218-47800-puysserampion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47218-47800-puysserampion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47218-47800-puysserampion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47218-47800-puysserampion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47219-47210-rayet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47219-47210-rayet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47219-47210-rayet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47219-47210-rayet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47220-47160-razimet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47220-47160-razimet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47220-47160-razimet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47220-47160-razimet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47221-47170-reaup_lisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47221-47170-reaup_lisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47221-47170-reaup_lisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47221-47170-reaup_lisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47222-47700-la_reunion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47222-47700-la_reunion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47222-47700-la_reunion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47222-47700-la_reunion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47223-47210-rives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47223-47210-rives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47223-47210-rives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47223-47210-rives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47224-47250-romestaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47224-47250-romestaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47224-47250-romestaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47224-47250-romestaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47225-47310-roquefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47225-47310-roquefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47225-47310-roquefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47225-47310-roquefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47226-47800-roumagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47226-47800-roumagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47226-47800-roumagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47226-47800-roumagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47227-47700-ruffiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47227-47700-ruffiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47227-47700-ruffiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47227-47700-ruffiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47228-47340-saint_antoine_de_ficalba/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47228-47340-saint_antoine_de_ficalba/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47228-47340-saint_antoine_de_ficalba/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47228-47340-saint_antoine_de_ficalba/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47229-47120-saint_astier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47229-47120-saint_astier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47229-47120-saint_astier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47229-47120-saint_astier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47230-47150-saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47230-47150-saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47230-47150-saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47230-47150-saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47231-47350-saint_avit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47231-47350-saint_avit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47231-47350-saint_avit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47231-47350-saint_avit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47232-47350-saint_barthelemy_d_agenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47232-47350-saint_barthelemy_d_agenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47232-47350-saint_barthelemy_d_agenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47232-47350-saint_barthelemy_d_agenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47233-47180-sainte_bazeille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47233-47180-sainte_bazeille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47233-47180-sainte_bazeille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47233-47180-sainte_bazeille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47234-47270-saint_caprais_de_lerm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47234-47270-saint_caprais_de_lerm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47234-47270-saint_caprais_de_lerm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47234-47270-saint_caprais_de_lerm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47235-47410-saint_colomb_de_lauzun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47235-47410-saint_colomb_de_lauzun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47235-47410-saint_colomb_de_lauzun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47235-47410-saint_colomb_de_lauzun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47236-47120-sainte_colombe_de_duras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47236-47120-sainte_colombe_de_duras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47236-47120-sainte_colombe_de_duras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47236-47120-sainte_colombe_de_duras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47237-47300-sainte_colombe_de_villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47237-47300-sainte_colombe_de_villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47237-47300-sainte_colombe_de_villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47237-47300-sainte_colombe_de_villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47238-47310-sainte_colombe_en_bruilhois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47238-47310-sainte_colombe_en_bruilhois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47238-47310-sainte_colombe_en_bruilhois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47238-47310-sainte_colombe_en_bruilhois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47239-47380-saint_etienne_de_fougeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47239-47380-saint_etienne_de_fougeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47239-47380-saint_etienne_de_fougeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47239-47380-saint_etienne_de_fougeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47240-47210-saint_etienne_de_villereal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47240-47210-saint_etienne_de_villereal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47240-47210-saint_etienne_de_villereal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47240-47210-saint_etienne_de_villereal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47241-47210-saint_eutrope_de_born/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47241-47210-saint_eutrope_de_born/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47241-47210-saint_eutrope_de_born/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47241-47210-saint_eutrope_de_born/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47242-47500-saint_front_sur_lemance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47242-47500-saint_front_sur_lemance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47242-47500-saint_front_sur_lemance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47242-47500-saint_front_sur_lemance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47244-47250-sainte_gemme_martaillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47244-47250-sainte_gemme_martaillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47244-47250-sainte_gemme_martaillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47244-47250-sainte_gemme_martaillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47245-47120-saint_geraud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47245-47120-saint_geraud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47245-47120-saint_geraud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47245-47120-saint_geraud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47246-47450-saint_hilaire_de_lusignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47246-47450-saint_hilaire_de_lusignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47246-47450-saint_hilaire_de_lusignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47246-47450-saint_hilaire_de_lusignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47247-47120-saint_jean_de_duras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47247-47120-saint_jean_de_duras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47247-47120-saint_jean_de_duras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47247-47120-saint_jean_de_duras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47248-47270-saint_jean_de_thurac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47248-47270-saint_jean_de_thurac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47248-47270-saint_jean_de_thurac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47248-47270-saint_jean_de_thurac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47249-47130-saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47249-47130-saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47249-47130-saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47249-47130-saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47250-47160-saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47250-47160-saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47250-47160-saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47250-47160-saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47251-47160-saint_leon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47251-47160-saint_leon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47251-47160-saint_leon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47251-47160-saint_leon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47252-47110-sainte_livrade_sur_lot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47252-47110-sainte_livrade_sur_lot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47252-47110-sainte_livrade_sur_lot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47252-47110-sainte_livrade_sur_lot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47253-47430-sainte_marthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47253-47430-sainte_marthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47253-47430-sainte_marthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47253-47430-sainte_marthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47254-47700-saint_martin_curton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47254-47700-saint_martin_curton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47254-47700-saint_martin_curton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47254-47700-saint_martin_curton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47255-47270-saint_martin_de_beauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47255-47270-saint_martin_de_beauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47255-47270-saint_martin_de_beauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47255-47270-saint_martin_de_beauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47256-47210-saint_martin_de_villereal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47256-47210-saint_martin_de_villereal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47256-47210-saint_martin_de_villereal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47256-47210-saint_martin_de_villereal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47257-47180-saint_martin_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47257-47180-saint_martin_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47257-47180-saint_martin_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47257-47180-saint_martin_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47258-47170-sainte_maure_de_peyriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47258-47170-sainte_maure_de_peyriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47258-47170-sainte_maure_de_peyriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47258-47170-sainte_maure_de_peyriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47259-47290-saint_maurice_de_lestapel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47259-47290-saint_maurice_de_lestapel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47259-47290-saint_maurice_de_lestapel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47259-47290-saint_maurice_de_lestapel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47260-47270-saint_maurin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47260-47270-saint_maurin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47260-47270-saint_maurin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47260-47270-saint_maurin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47262-47220-saint_nicolas_de_la_balerme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47262-47220-saint_nicolas_de_la_balerme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47262-47220-saint_nicolas_de_la_balerme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47262-47220-saint_nicolas_de_la_balerme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47263-47200-saint_pardoux_du_breuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47263-47200-saint_pardoux_du_breuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47263-47200-saint_pardoux_du_breuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47263-47200-saint_pardoux_du_breuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47264-47800-saint_pardoux_isaac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47264-47800-saint_pardoux_isaac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47264-47800-saint_pardoux_isaac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47264-47800-saint_pardoux_isaac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47265-47290-saint_pastour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47265-47290-saint_pastour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47265-47290-saint_pastour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47265-47290-saint_pastour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47266-47170-saint_pe_saint_simon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47266-47170-saint_pe_saint_simon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47266-47170-saint_pe_saint_simon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47266-47170-saint_pe_saint_simon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47267-47160-saint_pierre_de_buzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47267-47160-saint_pierre_de_buzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47267-47160-saint_pierre_de_buzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47267-47160-saint_pierre_de_buzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47269-47270-saint_pierre_de_clairac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47269-47270-saint_pierre_de_clairac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47269-47270-saint_pierre_de_clairac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47269-47270-saint_pierre_de_clairac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47271-47120-saint_pierre_sur_dropt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47271-47120-saint_pierre_sur_dropt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47271-47120-saint_pierre_sur_dropt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47271-47120-saint_pierre_sur_dropt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47272-47330-saint_quentin_du_dropt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47272-47330-saint_quentin_du_dropt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47272-47330-saint_quentin_du_dropt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47272-47330-saint_quentin_du_dropt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47273-47340-saint_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47273-47340-saint_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47273-47340-saint_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47273-47340-saint_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47274-47270-saint_romain_le_noble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47274-47270-saint_romain_le_noble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47274-47270-saint_romain_le_noble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47274-47270-saint_romain_le_noble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47275-47360-saint_salvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47275-47360-saint_salvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47275-47360-saint_salvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47275-47360-saint_salvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47276-47360-saint_sardos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47276-47360-saint_sardos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47276-47360-saint_sardos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47276-47360-saint_sardos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47277-47180-saint_sauveur_de_meilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47277-47180-saint_sauveur_de_meilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47277-47180-saint_sauveur_de_meilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47277-47180-saint_sauveur_de_meilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47278-47120-saint_sernin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47278-47120-saint_sernin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47278-47120-saint_sernin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47278-47120-saint_sernin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47279-47220-saint_sixte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47279-47220-saint_sixte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47279-47220-saint_sixte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47279-47220-saint_sixte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47280-47140-saint_sylvestre_sur_lot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47280-47140-saint_sylvestre_sur_lot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47280-47140-saint_sylvestre_sur_lot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47280-47140-saint_sylvestre_sur_lot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47281-47270-saint_urcisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47281-47270-saint_urcisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47281-47270-saint_urcisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47281-47270-saint_urcisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47282-47310-saint_vincent_de_lamontjoie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47282-47310-saint_vincent_de_lamontjoie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47282-47310-saint_vincent_de_lamontjoie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47282-47310-saint_vincent_de_lamontjoie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47283-47500-saint_vite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47283-47500-saint_vite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47283-47500-saint_vite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47283-47500-saint_vite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47284-47150-salles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47284-47150-salles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47284-47150-salles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47284-47150-salles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47285-47250-samazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47285-47250-samazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47285-47250-samazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47285-47250-samazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47286-47420-saumejan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47286-47420-saumejan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47286-47420-saumejan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47286-47420-saumejan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47287-47600-saumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47287-47600-saumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47287-47600-saumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47287-47600-saumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47288-47340-sauvagnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47288-47340-sauvagnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47288-47340-sauvagnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47288-47340-sauvagnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47289-47270-la_sauvetat_de_saveres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47289-47270-la_sauvetat_de_saveres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47289-47270-la_sauvetat_de_saveres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47289-47270-la_sauvetat_de_saveres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47290-47800-la_sauvetat_du_dropt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47290-47800-la_sauvetat_du_dropt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47290-47800-la_sauvetat_du_dropt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47290-47800-la_sauvetat_du_dropt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47291-47150-la_sauvetat_sur_lede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47291-47150-la_sauvetat_sur_lede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47291-47150-la_sauvetat_sur_lede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47291-47150-la_sauvetat_sur_lede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47292-47500-sauveterre_la_lemance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47292-47500-sauveterre_la_lemance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47292-47500-sauveterre_la_lemance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47292-47500-sauveterre_la_lemance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47293-47220-sauveterre_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47293-47220-sauveterre_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47293-47220-sauveterre_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47293-47220-sauveterre_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47294-47120-savignac_de_duras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47294-47120-savignac_de_duras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47294-47120-savignac_de_duras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47294-47120-savignac_de_duras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47295-47150-savignac_sur_leyze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47295-47150-savignac_sur_leyze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47295-47150-savignac_sur_leyze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47295-47150-savignac_sur_leyze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47296-47410-segalas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47296-47410-segalas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47296-47410-segalas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47296-47410-segalas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47297-47360-sembas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47297-47360-sembas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47297-47360-sembas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47297-47360-sembas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47298-47430-senestis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47298-47430-senestis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47298-47430-senestis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47298-47430-senestis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47299-47410-serignac_peboudou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47299-47410-serignac_peboudou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47299-47410-serignac_peboudou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47299-47410-serignac_peboudou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47300-47310-serignac_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47300-47310-serignac_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47300-47310-serignac_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47300-47310-serignac_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47301-47350-seyches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47301-47350-seyches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47301-47350-seyches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47301-47350-seyches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47302-47170-sos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47302-47170-sos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47302-47170-sos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47302-47170-sos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47303-47120-soumensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47303-47120-soumensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47303-47120-soumensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47303-47120-soumensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47304-47200-taillebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47304-47200-taillebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47304-47200-taillebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47304-47200-taillebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47305-47270-tayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47305-47270-tayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47305-47270-tayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47305-47270-tayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47306-47110-le_temple_sur_lot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47306-47110-le_temple_sur_lot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47306-47110-le_temple_sur_lot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47306-47110-le_temple_sur_lot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47307-47370-thezac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47307-47370-thezac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47307-47370-thezac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47307-47370-thezac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47308-47230-thouars_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47308-47230-thouars_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47308-47230-thouars_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47308-47230-thouars_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47309-47380-tombeboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47309-47380-tombeboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47309-47380-tombeboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47309-47380-tombeboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47310-47400-tonneins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47310-47400-tonneins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47310-47400-tonneins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47310-47400-tonneins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47311-47210-tourliac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47311-47210-tourliac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47311-47210-tourliac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47311-47210-tourliac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47312-47370-tournon_d_agenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47312-47370-tournon_d_agenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47312-47370-tournon_d_agenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47312-47370-tournon_d_agenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47313-47380-tourtres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47313-47380-tourtres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47313-47380-tourtres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47313-47380-tourtres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47314-47140-tremons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47314-47140-tremons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47314-47140-tremons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47314-47140-tremons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47315-47140-trentels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47315-47140-trentels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47315-47140-trentels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47315-47140-trentels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47316-47400-vares/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47316-47400-vares/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47316-47400-vares/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47316-47400-vares/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47317-47260-verteuil_d_agenais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47317-47260-verteuil_d_agenais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47317-47260-verteuil_d_agenais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47317-47260-verteuil_d_agenais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47318-47230-vianne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47318-47230-vianne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47318-47230-vianne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47318-47230-vianne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47319-47380-villebramar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47319-47380-villebramar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47319-47380-villebramar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47319-47380-villebramar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47320-47160-villefranche_du_queyran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47320-47160-villefranche_du_queyran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47320-47160-villefranche_du_queyran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47320-47160-villefranche_du_queyran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47321-47120-villeneuve_de_duras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47321-47120-villeneuve_de_duras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47321-47120-villeneuve_de_duras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47321-47120-villeneuve_de_duras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47323-47300-villeneuve_sur_lot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47323-47300-villeneuve_sur_lot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47323-47300-villeneuve_sur_lot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47323-47300-villeneuve_sur_lot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47324-47210-villereal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47324-47210-villereal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47324-47210-villereal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47324-47210-villereal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47325-47400-villeton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47325-47400-villeton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47325-47400-villeton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47325-47400-villeton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47326-47200-virazeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47326-47200-virazeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47326-47200-virazeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47326-47200-virazeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47327-47230-xaintrailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47327-47230-xaintrailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47327-47230-xaintrailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47327-47230-xaintrailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47328-47370-saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47328-47370-saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47328-47370-saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt47-lot_et_garonne/commune47328-47370-saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-48.xml
+++ b/public/sitemaps/sitemap-48.xml
@@ -5,334 +5,664 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48001-48310-albaret_le_comtal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48001-48310-albaret_le_comtal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48001-48310-albaret_le_comtal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48001-48310-albaret_le_comtal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48002-48200-albaret_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48002-48200-albaret_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48002-48200-albaret_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48002-48200-albaret_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48003-48190-allenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48003-48190-allenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48003-48190-allenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48003-48190-allenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48004-48800-altier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48004-48800-altier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48004-48800-altier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48004-48800-altier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48005-48100-antrenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48005-48100-antrenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48005-48100-antrenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48005-48100-antrenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48007-48310-arzenc_d_apcher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48007-48310-arzenc_d_apcher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48007-48310-arzenc_d_apcher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48007-48310-arzenc_d_apcher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48008-48170-arzenc_de_randon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48008-48170-arzenc_de_randon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48008-48170-arzenc_de_randon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48008-48170-arzenc_de_randon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48009-48130-peyre_en_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48009-48130-peyre_en_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48009-48130-peyre_en_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48009-48130-peyre_en_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48009-48100-peyre_en_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48009-48100-peyre_en_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48009-48100-peyre_en_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48009-48100-peyre_en_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48010-48600-auroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48010-48600-auroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48010-48600-auroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48010-48600-auroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48012-48200-les_monts_verts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48012-48200-les_monts_verts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48012-48200-les_monts_verts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48012-48200-les_monts_verts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48013-48000-badaroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48013-48000-badaroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48013-48000-badaroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48013-48000-badaroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48015-48800-pied_de_borne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48015-48800-pied_de_borne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48015-48800-pied_de_borne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48015-48800-pied_de_borne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48016-48000-balsieges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48016-48000-balsieges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48016-48000-balsieges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48016-48000-balsieges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48017-48500-banassac_canilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48017-48500-banassac_canilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48017-48500-banassac_canilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48017-48500-banassac_canilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48018-48000-barjac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48018-48000-barjac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48018-48000-barjac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48018-48000-barjac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48019-48400-barre_des_cevennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48019-48400-barre_des_cevennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48019-48400-barre_des_cevennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48019-48400-barre_des_cevennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48020-48400-bassurels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48020-48400-bassurels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48020-48400-bassurels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48020-48400-bassurels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48021-48250-la_bastide_puylaurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48021-48250-la_bastide_puylaurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48021-48250-la_bastide_puylaurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48021-48250-la_bastide_puylaurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48025-48200-les_bessons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48025-48200-les_bessons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48025-48200-les_bessons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48025-48200-les_bessons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48026-48200-blavignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48026-48200-blavignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48026-48200-blavignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48026-48200-blavignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48190-mont_lozere_et_goulet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48190-mont_lozere_et_goulet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48190-mont_lozere_et_goulet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48190-mont_lozere_et_goulet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48250-mont_lozere_et_goulet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48250-mont_lozere_et_goulet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48250-mont_lozere_et_goulet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48250-mont_lozere_et_goulet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48170-mont_lozere_et_goulet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48170-mont_lozere_et_goulet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48170-mont_lozere_et_goulet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48027-48170-mont_lozere_et_goulet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48028-48400-les_bondons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48028-48400-les_bondons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48028-48400-les_bondons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48028-48400-les_bondons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48029-48000-le_born/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48029-48000-le_born/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48029-48000-le_born/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48029-48000-le_born/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48030-48000-brenoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48030-48000-brenoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48030-48000-brenoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48030-48000-brenoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48031-48310-brion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48031-48310-brion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48031-48310-brion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48031-48310-brion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48032-48100-le_buisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48032-48100-le_buisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48032-48100-le_buisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48032-48100-le_buisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48034-48500-la_canourgue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48034-48500-la_canourgue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48034-48500-la_canourgue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48034-48500-la_canourgue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48036-48400-cassagnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48036-48400-cassagnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48036-48400-cassagnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48036-48400-cassagnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48037-48190-chadenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48037-48190-chadenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48037-48190-chadenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48037-48190-chadenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48038-48600-bel_air_val_d’ance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48038-48600-bel_air_val_d’ance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48038-48600-bel_air_val_d’ance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48038-48600-bel_air_val_d’ance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48039-48230-chanac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48039-48230-chanac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48039-48230-chanac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48039-48230-chanac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48041-48300-chastanier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48041-48300-chastanier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48041-48300-chastanier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48041-48300-chastanier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48042-48000-chastel_nouvel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48042-48000-chastel_nouvel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48042-48000-chastel_nouvel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48042-48000-chastel_nouvel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48043-48170-chateauneuf_de_randon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48043-48170-chateauneuf_de_randon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48043-48170-chateauneuf_de_randon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48043-48170-chateauneuf_de_randon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48044-48310-chauchailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48044-48310-chauchailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48044-48310-chauchailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48044-48310-chauchailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48045-48170-chaudeyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48045-48170-chaudeyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48045-48170-chaudeyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48045-48170-chaudeyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48046-48140-chaulhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48046-48140-chaulhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48046-48140-chaulhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48046-48140-chaulhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48048-48300-cheylard_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48048-48300-cheylard_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48048-48300-cheylard_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48048-48300-cheylard_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48050-48400-bedoues_cocures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48050-48400-bedoues_cocures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48050-48400-bedoues_cocures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48050-48400-bedoues_cocures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48051-48160-le_collet_de_deze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48051-48160-le_collet_de_deze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48051-48160-le_collet_de_deze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48051-48160-le_collet_de_deze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48053-48190-cubieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48053-48190-cubieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48053-48190-cubieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48053-48190-cubieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48054-48190-cubierettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48054-48190-cubierettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48054-48190-cubierettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48054-48190-cubierettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48055-48230-cultures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48055-48230-cultures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48055-48230-cultures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48055-48230-cultures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48056-48230-esclanedes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48056-48230-esclanedes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48056-48230-esclanedes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48056-48230-esclanedes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48058-48310-la_fage_montivernoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48058-48310-la_fage_montivernoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48058-48310-la_fage_montivernoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48058-48310-la_fage_montivernoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48059-48200-la_fage_saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48059-48200-la_fage_saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48059-48200-la_fage_saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48059-48200-la_fage_saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48061-48400-florac_trois_rivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48061-48400-florac_trois_rivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48061-48400-florac_trois_rivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48061-48400-florac_trois_rivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48063-48700-fontans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48063-48700-fontans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48063-48700-fontans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48063-48700-fontans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48063-48120-fontans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48063-48120-fontans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48063-48120-fontans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48063-48120-fontans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48064-48310-fournels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48064-48310-fournels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48064-48310-fournels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48064-48310-fournels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48065-48400-fraissinet_de_fourques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48065-48400-fraissinet_de_fourques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48065-48400-fraissinet_de_fourques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48065-48400-fraissinet_de_fourques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48067-48110-gabriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48067-48110-gabriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48067-48110-gabriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48067-48110-gabriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48068-48100-gabrias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48068-48100-gabrias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48068-48100-gabrias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48068-48100-gabrias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48069-48150-gatuzieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48069-48150-gatuzieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48069-48150-gatuzieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48069-48150-gatuzieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48070-48600-grandrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48070-48600-grandrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48070-48600-grandrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48070-48600-grandrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48071-48260-grandvals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48071-48260-grandvals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48071-48260-grandvals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48071-48260-grandvals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48072-48100-grezes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48072-48100-grezes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48072-48100-grezes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48072-48100-grezes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48073-48340-les_hermaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48073-48340-les_hermaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48073-48340-les_hermaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48073-48340-les_hermaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48074-48150-hures_la_parade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48074-48150-hures_la_parade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48074-48150-hures_la_parade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48074-48150-hures_la_parade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48075-48320-ispagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48075-48320-ispagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48075-48320-ispagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48075-48320-ispagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48077-48140-julianges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48077-48140-julianges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48077-48140-julianges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48077-48140-julianges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48079-48120-lajo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48079-48120-lajo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48079-48120-lajo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48079-48120-lajo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48080-48300-langogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48080-48300-langogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48080-48300-langogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48080-48300-langogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48081-48000-lanuejols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48081-48000-lanuejols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48081-48000-lanuejols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48081-48000-lanuejols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48082-48170-laubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48082-48170-laubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48082-48170-laubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48082-48170-laubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48083-48700-les_laubies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48083-48700-les_laubies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48083-48700-les_laubies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48083-48700-les_laubies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48085-48500-laval_du_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48085-48500-laval_du_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48085-48500-laval_du_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48085-48500-laval_du_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48085-48210-laval_du_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48085-48210-laval_du_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48085-48210-laval_du_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48085-48210-laval_du_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48086-48250-luc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48086-48250-luc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48086-48250-luc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48086-48250-luc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48087-48270-prinsuejols_malbouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48087-48270-prinsuejols_malbouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48087-48270-prinsuejols_malbouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48087-48270-prinsuejols_malbouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48087-48100-prinsuejols_malbouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48087-48100-prinsuejols_malbouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48087-48100-prinsuejols_malbouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48087-48100-prinsuejols_malbouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48088-48210-la_malene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48088-48210-la_malene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48088-48210-la_malene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48088-48210-la_malene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48089-48140-le_malzieu_forain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48089-48140-le_malzieu_forain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48089-48140-le_malzieu_forain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48089-48140-le_malzieu_forain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48090-48140-le_malzieu_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48090-48140-le_malzieu_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48090-48140-le_malzieu_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48090-48140-le_malzieu_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48091-48260-marchastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48091-48260-marchastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48091-48260-marchastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48091-48260-marchastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48092-48100-marvejols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48092-48100-marvejols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48092-48100-marvejols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48092-48100-marvejols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48094-48500-massegros_causses_gorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48094-48500-massegros_causses_gorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48094-48500-massegros_causses_gorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48094-48500-massegros_causses_gorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48094-48210-massegros_causses_gorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48094-48210-massegros_causses_gorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48094-48210-massegros_causses_gorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48094-48210-massegros_causses_gorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48095-48000-mende/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48095-48000-mende/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48095-48000-mende/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48095-48000-mende/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48096-48150-meyrueis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48096-48150-meyrueis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48096-48150-meyrueis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48096-48150-meyrueis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48097-48110-moissac_vallee_francaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48097-48110-moissac_vallee_francaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48097-48110-moissac_vallee_francaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48097-48110-moissac_vallee_francaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48098-48110-molezon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48098-48110-molezon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48098-48110-molezon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48098-48110-molezon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48099-48100-bourgs_sur_colagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48099-48100-bourgs_sur_colagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48099-48100-bourgs_sur_colagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48099-48100-bourgs_sur_colagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48100-48170-montbel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48100-48170-montbel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48100-48170-montbel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48100-48170-montbel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48103-48100-montrodat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48103-48100-montrodat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48103-48100-montrodat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48103-48100-montrodat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48104-48260-nasbinals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48104-48260-nasbinals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48104-48260-nasbinals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48104-48260-nasbinals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48105-48300-naussac_fontanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48105-48300-naussac_fontanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48105-48300-naussac_fontanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48105-48300-naussac_fontanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48106-48310-noalhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48106-48310-noalhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48106-48310-noalhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48106-48310-noalhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48107-48100-palhers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48107-48100-palhers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48107-48100-palhers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48107-48100-palhers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48108-48600-la_panouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48108-48600-la_panouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48108-48600-la_panouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48108-48600-la_panouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48110-48140-paulhac_en_margeride/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48110-48140-paulhac_en_margeride/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48110-48140-paulhac_en_margeride/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48110-48140-paulhac_en_margeride/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48111-48000-pelouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48111-48000-pelouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48111-48000-pelouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48111-48000-pelouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48112-48300-pierrefiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48112-48300-pierrefiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48112-48300-pierrefiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48112-48300-pierrefiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48115-48110-le_pompidou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48115-48110-le_pompidou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48115-48110-le_pompidou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48115-48110-le_pompidou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48116-48220-pont_de_montvert___sud_mont_lozere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48116-48220-pont_de_montvert___sud_mont_lozere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48116-48220-pont_de_montvert___sud_mont_lozere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48116-48220-pont_de_montvert___sud_mont_lozere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48117-48800-pourcharesses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48117-48800-pourcharesses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48117-48800-pourcharesses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48117-48800-pourcharesses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48119-48800-prevencheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48119-48800-prevencheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48119-48800-prevencheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48119-48800-prevencheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48121-48200-prunieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48121-48200-prunieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48121-48200-prunieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48121-48200-prunieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48123-48260-recoules_d_aubrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48123-48260-recoules_d_aubrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48123-48260-recoules_d_aubrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48123-48260-recoules_d_aubrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48124-48100-recoules_de_fumas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48124-48100-recoules_de_fumas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48124-48100-recoules_de_fumas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48124-48100-recoules_de_fumas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48126-48700-lachamp_ribennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48126-48700-lachamp_ribennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48126-48700-lachamp_ribennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48126-48700-lachamp_ribennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48126-48100-lachamp_ribennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48126-48100-lachamp_ribennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48126-48100-lachamp_ribennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48126-48100-lachamp_ribennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48127-48700-monts_de_randon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48127-48700-monts_de_randon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48127-48700-monts_de_randon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48127-48700-monts_de_randon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48127-48000-monts_de_randon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48127-48000-monts_de_randon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48127-48000-monts_de_randon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48127-48000-monts_de_randon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48128-48200-rimeize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48128-48200-rimeize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48128-48200-rimeize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48128-48200-rimeize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48129-48300-rocles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48129-48300-rocles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48129-48300-rocles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48129-48300-rocles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48130-48400-rousses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48130-48400-rousses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48130-48400-rousses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48130-48400-rousses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48131-48150-le_rozier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48131-48150-le_rozier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48131-48150-le_rozier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48131-48150-le_rozier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48132-48120-saint_alban_sur_limagnole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48132-48120-saint_alban_sur_limagnole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48132-48120-saint_alban_sur_limagnole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48132-48120-saint_alban_sur_limagnole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48135-48800-saint_andre_capceze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48135-48800-saint_andre_capceze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48135-48800-saint_andre_capceze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48135-48800-saint_andre_capceze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48136-48240-saint_andre_de_lancize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48136-48240-saint_andre_de_lancize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48136-48240-saint_andre_de_lancize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48136-48240-saint_andre_de_lancize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48137-48000-saint_bauzile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48137-48000-saint_bauzile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48137-48000-saint_bauzile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48137-48000-saint_bauzile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48138-48100-saint_bonnet_de_chirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48138-48100-saint_bonnet_de_chirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48138-48100-saint_bonnet_de_chirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48138-48100-saint_bonnet_de_chirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48139-48600-saint_bonnet_laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48139-48600-saint_bonnet_laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48139-48600-saint_bonnet_laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48139-48600-saint_bonnet_laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48140-48200-saint_chely_d_apcher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48140-48200-saint_chely_d_apcher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48140-48200-saint_chely_d_apcher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48140-48200-saint_chely_d_apcher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48141-48210-mas_saint_chely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48141-48210-mas_saint_chely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48141-48210-mas_saint_chely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48141-48210-mas_saint_chely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48144-48110-sainte_croix_vallee_francaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48144-48110-sainte_croix_vallee_francaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48144-48110-sainte_croix_vallee_francaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48144-48110-sainte_croix_vallee_francaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48145-48700-saint_denis_en_margeride/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48145-48700-saint_denis_en_margeride/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48145-48700-saint_denis_en_margeride/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48145-48700-saint_denis_en_margeride/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48146-48210-gorges_du_tarn_causses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48146-48210-gorges_du_tarn_causses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48146-48210-gorges_du_tarn_causses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48146-48210-gorges_du_tarn_causses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48146-48320-gorges_du_tarn_causses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48146-48320-gorges_du_tarn_causses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48146-48320-gorges_du_tarn_causses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48146-48320-gorges_du_tarn_causses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48147-48000-saint_etienne_du_valdonnez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48147-48000-saint_etienne_du_valdonnez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48147-48000-saint_etienne_du_valdonnez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48147-48000-saint_etienne_du_valdonnez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48148-48330-saint_etienne_vallee_francaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48148-48330-saint_etienne_vallee_francaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48148-48330-saint_etienne_vallee_francaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48148-48330-saint_etienne_vallee_francaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48149-48120-sainte_eulalie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48149-48120-sainte_eulalie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48149-48120-sainte_eulalie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48149-48120-sainte_eulalie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48150-48300-saint_flour_de_mercoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48150-48300-saint_flour_de_mercoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48150-48300-saint_flour_de_mercoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48150-48300-saint_flour_de_mercoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48151-48170-saint_frezal_d_albuges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48151-48170-saint_frezal_d_albuges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48151-48170-saint_frezal_d_albuges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48151-48170-saint_frezal_d_albuges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48152-48240-ventalon_en_cevennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48152-48240-ventalon_en_cevennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48152-48240-ventalon_en_cevennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48152-48240-ventalon_en_cevennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48152-48160-ventalon_en_cevennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48152-48160-ventalon_en_cevennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48152-48160-ventalon_en_cevennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48152-48160-ventalon_en_cevennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48153-48700-saint_gal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48153-48700-saint_gal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48153-48700-saint_gal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48153-48700-saint_gal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48155-48370-saint_germain_de_calberte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48155-48370-saint_germain_de_calberte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48155-48370-saint_germain_de_calberte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48155-48370-saint_germain_de_calberte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48156-48340-saint_germain_du_teil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48156-48340-saint_germain_du_teil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48156-48340-saint_germain_du_teil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48156-48340-saint_germain_du_teil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48157-48190-sainte_helene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48157-48190-sainte_helene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48157-48190-sainte_helene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48157-48190-sainte_helene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48158-48160-saint_hilaire_de_lavit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48158-48160-saint_hilaire_de_lavit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48158-48160-saint_hilaire_de_lavit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48158-48160-saint_hilaire_de_lavit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48160-48170-saint_jean_la_fouillouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48160-48170-saint_jean_la_fouillouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48160-48170-saint_jean_la_fouillouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48160-48170-saint_jean_la_fouillouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48161-48310-saint_juery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48161-48310-saint_juery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48161-48310-saint_juery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48161-48310-saint_juery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48163-48160-saint_julien_des_points/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48163-48160-saint_julien_des_points/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48163-48160-saint_julien_des_points/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48163-48160-saint_julien_des_points/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48165-48100-saint_laurent_de_muret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48165-48100-saint_laurent_de_muret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48165-48100-saint_laurent_de_muret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48165-48100-saint_laurent_de_muret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48166-48400-cans_et_cevennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48166-48400-cans_et_cevennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48166-48400-cans_et_cevennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48166-48400-cans_et_cevennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48167-48310-saint_laurent_de_veyres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48167-48310-saint_laurent_de_veyres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48167-48310-saint_laurent_de_veyres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48167-48310-saint_laurent_de_veyres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48168-48100-saint_leger_de_peyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48168-48100-saint_leger_de_peyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48168-48100-saint_leger_de_peyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48168-48100-saint_leger_de_peyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48169-48140-saint_leger_du_malzieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48169-48140-saint_leger_du_malzieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48169-48140-saint_leger_du_malzieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48169-48140-saint_leger_du_malzieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48170-48160-saint_martin_de_boubaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48170-48160-saint_martin_de_boubaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48170-48160-saint_martin_de_boubaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48170-48160-saint_martin_de_boubaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48171-48110-saint_martin_de_lansuscle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48171-48110-saint_martin_de_lansuscle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48171-48110-saint_martin_de_lansuscle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48171-48110-saint_martin_de_lansuscle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48173-48160-saint_michel_de_deze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48173-48160-saint_michel_de_deze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48173-48160-saint_michel_de_deze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48173-48160-saint_michel_de_deze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48174-48600-saint_paul_le_froid/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48174-48600-saint_paul_le_froid/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48174-48600-saint_paul_le_froid/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48174-48600-saint_paul_le_froid/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48175-48340-saint_pierre_de_nogaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48175-48340-saint_pierre_de_nogaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48175-48340-saint_pierre_de_nogaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48175-48340-saint_pierre_de_nogaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48175-48500-saint_pierre_de_nogaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48175-48500-saint_pierre_de_nogaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48175-48500-saint_pierre_de_nogaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48175-48500-saint_pierre_de_nogaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48176-48150-saint_pierre_des_tripiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48176-48150-saint_pierre_des_tripiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48176-48150-saint_pierre_des_tripiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48176-48150-saint_pierre_des_tripiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48177-48200-saint_pierre_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48177-48200-saint_pierre_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48177-48200-saint_pierre_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48177-48200-saint_pierre_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48178-48240-saint_privat_de_vallongue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48178-48240-saint_privat_de_vallongue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48178-48240-saint_privat_de_vallongue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48178-48240-saint_privat_de_vallongue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48179-48140-saint_privat_du_fau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48179-48140-saint_privat_du_fau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48179-48140-saint_privat_du_fau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48179-48140-saint_privat_du_fau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48181-48500-saint_saturnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48181-48500-saint_saturnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48181-48500-saint_saturnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48181-48500-saint_saturnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48182-48170-saint_sauveur_de_ginestoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48182-48170-saint_sauveur_de_ginestoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48182-48170-saint_sauveur_de_ginestoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48182-48170-saint_sauveur_de_ginestoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48185-48230-les_salelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48185-48230-les_salelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48185-48230-les_salelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48185-48230-les_salelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48187-48100-les_salces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48187-48100-les_salces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48187-48100-les_salces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48187-48100-les_salces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48188-48700-serverette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48188-48700-serverette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48188-48700-serverette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48188-48700-serverette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48190-48310-termes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48190-48310-termes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48190-48310-termes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48190-48310-termes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48191-48500-la_tieule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48191-48500-la_tieule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48191-48500-la_tieule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48191-48500-la_tieule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48192-48340-trelans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48192-48340-trelans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48192-48340-trelans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48192-48340-trelans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48193-48400-vebron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48193-48400-vebron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48193-48400-vebron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48193-48400-vebron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48194-48220-vialas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48194-48220-vialas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48194-48220-vialas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48194-48220-vialas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48198-48800-villefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48198-48800-villefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48198-48800-villefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt48-lozere/commune48198-48800-villefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-49.xml
+++ b/public/sitemaps/sitemap-49.xml
@@ -5,438 +5,872 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49002-49650-allonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49002-49650-allonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49002-49650-allonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49002-49650-allonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49003-49700-tuffalun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49003-49700-tuffalun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49003-49700-tuffalun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49003-49700-tuffalun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49007-49000-angers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49007-49000-angers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49007-49000-angers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49007-49000-angers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49007-49100-angers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49007-49100-angers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49007-49100-angers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49007-49100-angers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49008-49440-angrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49008-49440-angrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49008-49440-angrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49008-49440-angrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49009-49260-antoigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49009-49260-antoigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49009-49260-antoigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49009-49260-antoigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49010-49420-armaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49010-49420-armaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49010-49420-armaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49010-49420-armaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49011-49260-artannes_sur_thouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49011-49260-artannes_sur_thouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49011-49260-artannes_sur_thouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49011-49260-artannes_sur_thouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49012-49540-aubigne_sur_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49012-49540-aubigne_sur_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49012-49540-aubigne_sur_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49012-49540-aubigne_sur_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49015-49240-avrille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49015-49240-avrille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49015-49240-avrille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49015-49240-avrille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49017-49430-barace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49017-49430-barace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49017-49430-barace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49017-49430-barace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49018-49150-bauge_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49018-49150-bauge_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49018-49150-bauge_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49018-49150-bauge_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49020-49070-beaucouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49020-49070-beaucouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49020-49070-beaucouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49020-49070-beaucouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49021-49250-beaufort_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49021-49250-beaufort_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49021-49250-beaufort_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49021-49250-beaufort_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49022-49750-beaulieu_sur_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49022-49750-beaulieu_sur_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49022-49750-beaulieu_sur_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49022-49750-beaulieu_sur_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49600-beaupreau_en_mauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49600-beaupreau_en_mauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49600-beaupreau_en_mauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49600-beaupreau_en_mauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49510-beaupreau_en_mauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49510-beaupreau_en_mauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49510-beaupreau_en_mauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49510-beaupreau_en_mauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49110-beaupreau_en_mauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49110-beaupreau_en_mauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49110-beaupreau_en_mauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49110-beaupreau_en_mauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49450-beaupreau_en_mauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49450-beaupreau_en_mauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49450-beaupreau_en_mauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49023-49450-beaupreau_en_mauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49026-49370-becon_les_granits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49026-49370-becon_les_granits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49026-49370-becon_les_granits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49026-49370-becon_les_granits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49027-49122-begrolles_en_mauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49027-49122-begrolles_en_mauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49027-49122-begrolles_en_mauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49027-49122-begrolles_en_mauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49028-49170-behuard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49028-49170-behuard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49028-49170-behuard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49028-49170-behuard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49029-49320-blaison_saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49029-49320-blaison_saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49029-49320-blaison_saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49029-49320-blaison_saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49030-49160-blou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49030-49160-blou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49030-49160-blou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49030-49160-blou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49035-49080-bouchemaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49035-49080-bouchemaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49035-49080-bouchemaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49035-49080-bouchemaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49036-49520-bouille_menard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49036-49520-bouille_menard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49036-49520-bouille_menard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49036-49520-bouille_menard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49038-49520-bourg_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49038-49520-bourg_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49038-49520-bourg_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49038-49520-bourg_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49041-49650-brain_sur_allonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49041-49650-brain_sur_allonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49041-49650-brain_sur_allonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49041-49650-brain_sur_allonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49045-49390-la_breille_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49045-49390-la_breille_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49045-49390-la_breille_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49045-49390-la_breille_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49048-49125-briollay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49048-49125-briollay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49048-49125-briollay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49048-49125-briollay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49050-49320-brissac_loire_aubance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49050-49320-brissac_loire_aubance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49050-49320-brissac_loire_aubance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49050-49320-brissac_loire_aubance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49050-49250-brissac_loire_aubance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49050-49250-brissac_loire_aubance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49050-49250-brissac_loire_aubance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49050-49250-brissac_loire_aubance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49053-49700-brossay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49053-49700-brossay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49053-49700-brossay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49053-49700-brossay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49054-49440-cande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49054-49440-cande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49054-49440-cande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49054-49440-cande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49055-49460-cantenay_epinard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49055-49460-cantenay_epinard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49055-49460-cantenay_epinard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49055-49460-cantenay_epinard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49056-49420-carbay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49056-49420-carbay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49056-49420-carbay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49056-49420-carbay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49057-49310-cernusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49057-49310-cernusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49057-49310-cernusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49057-49310-cernusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49058-49360-les_cerqueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49058-49360-les_cerqueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49058-49360-les_cerqueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49058-49360-les_cerqueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49060-49400-bellevigne_les_chateaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49060-49400-bellevigne_les_chateaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49060-49400-bellevigne_les_chateaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49060-49400-bellevigne_les_chateaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49060-49260-bellevigne_les_chateaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49060-49260-bellevigne_les_chateaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49060-49260-bellevigne_les_chateaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49060-49260-bellevigne_les_chateaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49061-49440-challain_la_potherie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49061-49440-challain_la_potherie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49061-49440-challain_la_potherie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49061-49440-challain_la_potherie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49063-49290-chalonnes_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49063-49290-chalonnes_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49063-49290-chalonnes_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49063-49290-chalonnes_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49064-49220-chambellay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49064-49220-chambellay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49064-49220-chambellay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49064-49220-chambellay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49067-49220-chenille_champteusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49067-49220-chenille_champteusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49067-49220-chenille_champteusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49067-49220-chenille_champteusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49068-49123-champtoce_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49068-49123-champtoce_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49068-49123-champtoce_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49068-49123-champtoce_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49069-49270-oree_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49069-49270-oree_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49069-49270-oree_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49069-49270-oree_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49069-49530-oree_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49069-49530-oree_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49069-49530-oree_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49069-49530-oree_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49070-49340-chanteloup_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49070-49340-chanteloup_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49070-49340-chanteloup_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49070-49340-chanteloup_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49076-49140-la_chapelle_saint_laud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49076-49140-la_chapelle_saint_laud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49076-49140-la_chapelle_saint_laud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49076-49140-la_chapelle_saint_laud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49080-49330-les_hauts_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49080-49330-les_hauts_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49080-49330-les_hauts_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49080-49330-les_hauts_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49082-49290-chaudefonds_sur_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49082-49290-chaudefonds_sur_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49082-49290-chaudefonds_sur_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49082-49290-chaudefonds_sur_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49086-49380-terranjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49086-49380-terranjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49086-49380-terranjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49086-49380-terranjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49086-49540-terranjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49086-49540-terranjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49086-49540-terranjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49086-49540-terranjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49089-49500-chaze_sur_argos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49089-49500-chaze_sur_argos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49089-49500-chaze_sur_argos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49089-49500-chaze_sur_argos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49090-49125-cheffes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49090-49125-cheffes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49090-49125-cheffes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49090-49125-cheffes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49120-chemille_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49120-chemille_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49120-chemille_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49120-chemille_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49750-chemille_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49750-chemille_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49750-chemille_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49750-chemille_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49670-chemille_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49670-chemille_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49670-chemille_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49670-chemille_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49310-chemille_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49310-chemille_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49310-chemille_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49092-49310-chemille_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49099-49300-cholet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49099-49300-cholet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49099-49300-cholet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49099-49300-cholet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49100-49700-cizay_la_madeleine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49100-49700-cizay_la_madeleine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49100-49700-cizay_la_madeleine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49100-49700-cizay_la_madeleine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49102-49560-clere_sur_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49102-49560-clere_sur_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49102-49560-clere_sur_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49102-49560-clere_sur_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49107-49140-cornille_les_caves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49107-49140-cornille_les_caves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49107-49140-cornille_les_caves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49107-49140-cornille_les_caves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49109-49690-coron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49109-49690-coron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49109-49690-coron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49109-49690-coron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49110-49140-corze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49110-49140-corze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49110-49140-corze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49110-49140-corze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49112-49260-le_coudray_macouard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49112-49260-le_coudray_macouard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49112-49260-le_coudray_macouard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49112-49260-le_coudray_macouard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49113-49260-courchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49113-49260-courchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49113-49260-courchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49113-49260-courchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49114-49390-courleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49114-49390-courleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49114-49390-courleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49114-49390-courleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49120-49190-denee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49120-49190-denee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49120-49190-denee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49120-49190-denee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49121-49700-deneze_sous_doue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49121-49700-deneze_sous_doue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49121-49700-deneze_sous_doue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49121-49700-deneze_sous_doue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49123-49400-distre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49123-49400-distre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49123-49400-distre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49123-49400-distre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49125-49700-doue_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49125-49700-doue_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49125-49700-doue_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49125-49700-doue_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49127-49430-durtal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49127-49430-durtal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49127-49430-durtal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49127-49430-durtal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49129-49000-ecouflant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49129-49000-ecouflant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49129-49000-ecouflant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49129-49000-ecouflant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49130-49460-ecuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49130-49460-ecuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49130-49460-ecuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49130-49460-ecuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49131-49260-epieds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49131-49260-epieds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49131-49260-epieds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49131-49260-epieds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49132-49330-etriche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49132-49330-etriche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49132-49330-etriche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49132-49330-etriche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49135-49460-feneu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49135-49460-feneu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49135-49460-feneu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49135-49460-feneu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49138-49250-les_bois_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49138-49250-les_bois_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49138-49250-les_bois_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49138-49250-les_bois_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49140-49590-fontevraud_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49140-49590-fontevraud_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49140-49590-fontevraud_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49140-49590-fontevraud_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49155-49220-grez_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49155-49220-grez_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49155-49220-grez_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49155-49220-grez_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49160-49123-ingrandes_le_fresne_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49160-49123-ingrandes_le_fresne_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49160-49123-ingrandes_le_fresne_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49160-49123-ingrandes_le_fresne_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49161-49220-la_jaille_yvon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49161-49220-la_jaille_yvon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49161-49220-la_jaille_yvon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49161-49220-la_jaille_yvon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49163-49140-jarze_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49163-49140-jarze_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49163-49140-jarze_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49163-49140-jarze_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49167-49610-les_garennes_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49167-49610-les_garennes_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49167-49610-les_garennes_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49167-49610-les_garennes_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49167-49320-les_garennes_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49167-49320-les_garennes_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49167-49320-les_garennes_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49167-49320-les_garennes_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49170-49330-juvardeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49170-49330-juvardeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49170-49330-juvardeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49170-49330-juvardeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49171-49150-la_lande_chasles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49171-49150-la_lande_chasles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49171-49150-la_lande_chasles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49171-49150-la_lande_chasles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49174-49430-huille_lezigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49174-49430-huille_lezigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49174-49430-huille_lezigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49174-49430-huille_lezigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49176-49220-le_lion_d_angers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49176-49220-le_lion_d_angers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49176-49220-le_lion_d_angers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49176-49220-le_lion_d_angers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49178-49440-loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49178-49440-loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49178-49440-loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49178-49440-loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49180-49160-longue_jumelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49180-49160-longue_jumelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49180-49160-longue_jumelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49180-49160-longue_jumelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49182-49700-louresse_rochemenier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49182-49700-louresse_rochemenier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49182-49700-louresse_rochemenier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49182-49700-louresse_rochemenier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49183-49370-val_d_erdre_auxence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49183-49370-val_d_erdre_auxence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49183-49370-val_d_erdre_auxence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49183-49370-val_d_erdre_auxence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49183-49440-val_d_erdre_auxence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49183-49440-val_d_erdre_auxence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49183-49440-val_d_erdre_auxence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49183-49440-val_d_erdre_auxence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49188-49140-marce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49188-49140-marce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49188-49140-marce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49188-49140-marce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49192-49360-maulevrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49192-49360-maulevrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49192-49360-maulevrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49192-49360-maulevrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49193-49122-le_may_sur_evre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49193-49122-le_may_sur_evre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49193-49122-le_may_sur_evre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49193-49122-le_may_sur_evre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49194-49630-maze_milon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49194-49630-maze_milon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49194-49630-maze_milon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49194-49630-maze_milon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49194-49140-maze_milon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49194-49140-maze_milon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49194-49140-maze_milon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49194-49140-maze_milon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49195-49280-mazieres_en_mauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49195-49280-mazieres_en_mauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49195-49280-mazieres_en_mauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49195-49280-mazieres_en_mauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49200-49770-longuenee_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49200-49770-longuenee_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49200-49770-longuenee_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49200-49770-longuenee_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49200-49220-longuenee_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49200-49220-longuenee_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49200-49220-longuenee_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49200-49220-longuenee_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49201-49250-la_menitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49201-49250-la_menitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49201-49250-la_menitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49201-49250-la_menitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49205-49330-mire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49205-49330-mire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49205-49330-mire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49205-49330-mire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49209-49430-montigne_les_rairies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49209-49430-montigne_les_rairies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49209-49430-montigne_les_rairies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49209-49430-montigne_les_rairies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49211-49310-montilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49211-49310-montilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49211-49310-montilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49211-49310-montilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49214-49460-montreuil_juigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49214-49460-montreuil_juigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49214-49460-montreuil_juigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49214-49460-montreuil_juigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49215-49260-montreuil_bellay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49215-49260-montreuil_bellay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49215-49260-montreuil_bellay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49215-49260-montreuil_bellay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49216-49140-montreuil_sur_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49216-49140-montreuil_sur_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49216-49140-montreuil_sur_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49216-49140-montreuil_sur_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49217-49220-montreuil_sur_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49217-49220-montreuil_sur_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49217-49220-montreuil_sur_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49217-49220-montreuil_sur_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49110-montrevault_sur_evre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49110-montrevault_sur_evre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49110-montrevault_sur_evre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49110-montrevault_sur_evre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49600-montrevault_sur_evre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49600-montrevault_sur_evre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49600-montrevault_sur_evre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49600-montrevault_sur_evre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49270-montrevault_sur_evre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49270-montrevault_sur_evre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49270-montrevault_sur_evre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49218-49270-montrevault_sur_evre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49219-49730-montsoreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49219-49730-montsoreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49219-49730-montsoreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49219-49730-montsoreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49220-49640-morannes_sur_sarthe_daumeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49220-49640-morannes_sur_sarthe_daumeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49220-49640-morannes_sur_sarthe_daumeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49220-49640-morannes_sur_sarthe_daumeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49221-49390-mouliherne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49221-49390-mouliherne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49221-49390-mouliherne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49221-49390-mouliherne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49222-49610-moze_sur_louet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49222-49610-moze_sur_louet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49222-49610-moze_sur_louet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49222-49610-moze_sur_louet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49223-49610-murs_erigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49223-49610-murs_erigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49223-49610-murs_erigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49223-49610-murs_erigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49224-49680-neuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49224-49680-neuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49224-49680-neuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49224-49680-neuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49228-49490-noyant_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49228-49490-noyant_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49228-49490-noyant_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49228-49490-noyant_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49228-49390-noyant_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49228-49390-noyant_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49228-49390-noyant_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49228-49390-noyant_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49231-49340-nuaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49231-49340-nuaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49231-49340-nuaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49231-49340-nuaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49235-49730-parnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49235-49730-parnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49235-49730-parnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49235-49730-parnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49236-49560-passavant_sur_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49236-49560-passavant_sur_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49236-49560-passavant_sur_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49236-49560-passavant_sur_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49237-49490-la_pellerine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49237-49490-la_pellerine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49237-49490-la_pellerine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49237-49490-la_pellerine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49240-49360-la_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49240-49360-la_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49240-49360-la_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49240-49360-la_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49241-49124-le_plessis_grammoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49241-49124-le_plessis_grammoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49241-49124-le_plessis_grammoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49241-49124-le_plessis_grammoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49620-mauges_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49620-mauges_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49620-mauges_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49620-mauges_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49410-mauges_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49410-mauges_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49410-mauges_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49410-mauges_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49110-mauges_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49110-mauges_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49110-mauges_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49110-mauges_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49290-mauges_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49290-mauges_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49290-mauges_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49290-mauges_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49570-mauges_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49570-mauges_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49570-mauges_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49244-49570-mauges_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49246-49130-les_ponts_de_ce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49246-49130-les_ponts_de_ce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49246-49130-les_ponts_de_ce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49246-49130-les_ponts_de_ce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49247-49170-la_possonniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49247-49170-la_possonniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49247-49170-la_possonniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49247-49170-la_possonniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49248-49420-ombree_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49248-49420-ombree_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49248-49420-ombree_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49248-49420-ombree_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49248-49520-ombree_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49248-49520-ombree_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49248-49520-ombree_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49248-49520-ombree_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49253-49260-le_puy_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49253-49260-le_puy_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49253-49260-le_puy_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49253-49260-le_puy_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49257-49430-les_rairies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49257-49430-les_rairies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49257-49430-les_rairies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49257-49430-les_rairies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49259-49190-rochefort_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49259-49190-rochefort_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49259-49190-rochefort_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49259-49190-rochefort_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49260-49740-la_romagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49260-49740-la_romagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49260-49740-la_romagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49260-49740-la_romagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49350-gennes_val_de_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49350-gennes_val_de_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49350-gennes_val_de_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49350-gennes_val_de_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49160-gennes_val_de_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49160-gennes_val_de_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49160-gennes_val_de_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49160-gennes_val_de_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49320-gennes_val_de_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49320-gennes_val_de_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49320-gennes_val_de_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49261-49320-gennes_val_de_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49262-49400-rou_marson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49262-49400-rou_marson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49262-49400-rou_marson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49262-49400-rou_marson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49266-49170-saint_augustin_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49266-49170-saint_augustin_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49266-49170-saint_augustin_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49266-49170-saint_augustin_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49267-49124-saint_barthelemy_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49267-49124-saint_barthelemy_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49267-49124-saint_barthelemy_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49267-49124-saint_barthelemy_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49269-49280-saint_christophe_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49269-49280-saint_christophe_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49269-49280-saint_christophe_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49269-49280-saint_christophe_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49271-49370-saint_clement_de_la_place/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49271-49370-saint_clement_de_la_place/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49271-49370-saint_clement_de_la_place/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49271-49370-saint_clement_de_la_place/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49272-49350-saint_clement_des_levees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49272-49350-saint_clement_des_levees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49272-49350-saint_clement_des_levees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49272-49350-saint_clement_des_levees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49278-49130-sainte_gemmes_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49278-49130-sainte_gemmes_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49278-49130-sainte_gemmes_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49278-49130-sainte_gemmes_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49283-49170-saint_georges_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49283-49170-saint_georges_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49283-49170-saint_georges_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49283-49170-saint_georges_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49284-49170-saint_germain_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49284-49170-saint_germain_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49284-49170-saint_germain_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49284-49170-saint_germain_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49288-49130-saint_jean_de_la_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49288-49130-saint_jean_de_la_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49288-49130-saint_jean_de_la_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49288-49130-saint_jean_de_la_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49291-49260-saint_just_sur_dive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49291-49260-saint_just_sur_dive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49291-49260-saint_just_sur_dive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49291-49260-saint_just_sur_dive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49292-49750-val_du_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49292-49750-val_du_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49292-49750-val_du_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49292-49750-val_du_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49292-49190-val_du_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49292-49190-val_du_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49292-49190-val_du_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49292-49190-val_du_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49294-49070-saint_lambert_la_potherie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49294-49070-saint_lambert_la_potherie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49294-49070-saint_lambert_la_potherie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49294-49070-saint_lambert_la_potherie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49298-49170-saint_leger_de_linieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49298-49170-saint_leger_de_linieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49298-49170-saint_leger_de_linieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49298-49170-saint_leger_de_linieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49298-49070-saint_leger_de_linieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49298-49070-saint_leger_de_linieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49298-49070-saint_leger_de_linieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49298-49070-saint_leger_de_linieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49299-49280-saint_leger_sous_cholet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49299-49280-saint_leger_sous_cholet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49299-49280-saint_leger_sous_cholet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49299-49280-saint_leger_sous_cholet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49230-sevremoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49230-sevremoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49230-sevremoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49230-sevremoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49710-sevremoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49710-sevremoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49710-sevremoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49710-sevremoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49450-sevremoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49450-sevremoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49450-sevremoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49450-sevremoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49660-sevremoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49660-sevremoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49660-sevremoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49301-49660-sevremoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49302-49260-saint_macaire_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49302-49260-saint_macaire_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49302-49260-saint_macaire_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49302-49260-saint_macaire_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49306-49170-saint_martin_du_fouilloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49306-49170-saint_martin_du_fouilloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49306-49170-saint_martin_du_fouilloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49306-49170-saint_martin_du_fouilloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49250-loire_authion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49250-loire_authion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49250-loire_authion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49250-loire_authion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49140-loire_authion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49140-loire_authion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49140-loire_authion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49140-loire_authion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49800-loire_authion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49800-loire_authion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49800-loire_authion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49800-loire_authion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49630-loire_authion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49630-loire_authion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49630-loire_authion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49307-49630-loire_authion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49308-49610-saint_melaine_sur_aubance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49308-49610-saint_melaine_sur_aubance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49308-49610-saint_melaine_sur_aubance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49308-49610-saint_melaine_sur_aubance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49310-49310-saint_paul_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49310-49310-saint_paul_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49310-49310-saint_paul_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49310-49310-saint_paul_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49311-49160-saint_philbert_du_peuple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49311-49160-saint_philbert_du_peuple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49311-49160-saint_philbert_du_peuple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49311-49160-saint_philbert_du_peuple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49321-49123-saint_sigismond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49321-49123-saint_sigismond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49321-49123-saint_sigismond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49321-49123-saint_sigismond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49323-49480-verrieres_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49323-49480-verrieres_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49323-49480-verrieres_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49323-49480-verrieres_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49323-49112-verrieres_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49323-49112-verrieres_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49323-49112-verrieres_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49323-49112-verrieres_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49326-49800-sarrigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49326-49800-sarrigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49326-49800-sarrigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49326-49800-sarrigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49328-49400-saumur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49328-49400-saumur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49328-49400-saumur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49328-49400-saumur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49329-49170-savennieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49329-49170-savennieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49329-49170-savennieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49329-49170-savennieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49330-49330-sceaux_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49330-49330-sceaux_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49330-49330-sceaux_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49330-49330-sceaux_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49331-49500-segre_en_anjou_bleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49331-49500-segre_en_anjou_bleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49331-49500-segre_en_anjou_bleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49331-49500-segre_en_anjou_bleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49331-49520-segre_en_anjou_bleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49331-49520-segre_en_anjou_bleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49331-49520-segre_en_anjou_bleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49331-49520-segre_en_anjou_bleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49332-49280-la_seguiniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49332-49280-la_seguiniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49332-49280-la_seguiniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49332-49280-la_seguiniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49333-49140-seiches_sur_le_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49333-49140-seiches_sur_le_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49333-49140-seiches_sur_le_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49333-49140-seiches_sur_le_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49334-49140-sermaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49334-49140-sermaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49334-49140-sermaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49334-49140-sermaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49336-49360-somloire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49336-49360-somloire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49336-49360-somloire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49336-49360-somloire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49338-49610-soulaines_sur_aubance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49338-49610-soulaines_sur_aubance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49338-49610-soulaines_sur_aubance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49338-49610-soulaines_sur_aubance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49339-49460-soulaire_et_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49339-49460-soulaire_et_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49339-49460-soulaire_et_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49339-49460-soulaire_et_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49341-49400-souzay_champigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49341-49400-souzay_champigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49341-49400-souzay_champigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49341-49400-souzay_champigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49343-49280-la_tessoualle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49343-49280-la_tessoualle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49343-49280-la_tessoualle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49343-49280-la_tessoualle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49344-49220-thorigne_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49344-49220-thorigne_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49344-49220-thorigne_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49344-49220-thorigne_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49345-49380-bellevigne_en_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49345-49380-bellevigne_en_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49345-49380-bellevigne_en_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49345-49380-bellevigne_en_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49345-49750-bellevigne_en_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49345-49750-bellevigne_en_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49345-49750-bellevigne_en_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49345-49750-bellevigne_en_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49347-49125-tierce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49347-49125-tierce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49347-49125-tierce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49347-49125-tierce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49352-49360-toutlemonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49352-49360-toutlemonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49352-49360-toutlemonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49352-49360-toutlemonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49353-49800-trelaze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49353-49800-trelaze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49353-49800-trelaze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49353-49800-trelaze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49355-49340-trementines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49355-49340-trementines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49355-49340-trementines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49355-49340-trementines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49358-49730-turquant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49358-49730-turquant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49358-49730-turquant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49358-49730-turquant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49359-49700-les_ulmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49359-49700-les_ulmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49359-49700-les_ulmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49359-49700-les_ulmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49361-49730-varennes_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49361-49730-varennes_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49361-49730-varennes_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49361-49730-varennes_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49362-49400-varrains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49362-49400-varrains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49362-49400-varrains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49362-49400-varrains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49364-49260-vaudelnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49364-49260-vaudelnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49364-49260-vaudelnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49364-49260-vaudelnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49367-49220-erdre_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49367-49220-erdre_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49367-49220-erdre_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49367-49220-erdre_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49367-49370-erdre_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49367-49370-erdre_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49367-49370-erdre_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49367-49370-erdre_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49368-49390-vernantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49368-49390-vernantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49368-49390-vernantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49368-49390-vernantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49369-49390-vernoil_le_fourrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49369-49390-vernoil_le_fourrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49369-49390-vernoil_le_fourrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49369-49390-vernoil_le_fourrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49370-49400-verrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49370-49400-verrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49370-49400-verrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49370-49400-verrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49371-49340-vezins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49371-49340-vezins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49371-49340-vezins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49371-49340-vezins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49310-lys_haut_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49310-lys_haut_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49310-lys_haut_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49310-lys_haut_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49540-lys_haut_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49540-lys_haut_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49540-lys_haut_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49540-lys_haut_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49560-lys_haut_layon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49560-lys_haut_layon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49560-lys_haut_layon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49373-49560-lys_haut_layon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49374-49400-villebernier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49374-49400-villebernier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49374-49400-villebernier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49374-49400-villebernier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49377-49140-rives_du_loir_en_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49377-49140-rives_du_loir_en_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49377-49140-rives_du_loir_en_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49377-49140-rives_du_loir_en_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49378-49680-vivy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49378-49680-vivy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49378-49680-vivy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49378-49680-vivy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49381-49360-yzernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49381-49360-yzernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49381-49360-yzernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt49-maine_et_loire/commune49381-49360-yzernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-50.xml
+++ b/public/sitemaps/sitemap-50.xml
@@ -5,942 +5,1880 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50002-50180-agneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50002-50180-agneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50002-50180-agneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50002-50180-agneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50003-50230-agon_coutainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50003-50230-agon_coutainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50003-50230-agon_coutainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50003-50230-agon_coutainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50004-50680-airel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50004-50680-airel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50004-50680-airel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50004-50680-airel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50006-50620-amigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50006-50620-amigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50006-50620-amigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50006-50620-amigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50008-50400-anctoville_sur_boscq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50008-50400-anctoville_sur_boscq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50008-50400-anctoville_sur_boscq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50008-50400-anctoville_sur_boscq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50013-50760-anneville_en_saire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50013-50760-anneville_en_saire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50013-50760-anneville_en_saire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50013-50760-anneville_en_saire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50015-50660-annoville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50015-50660-annoville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50015-50660-annoville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50015-50660-annoville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50016-50500-appeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50016-50500-appeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50016-50500-appeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50016-50500-appeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50019-50170-aucey_la_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50019-50170-aucey_la_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50019-50170-aucey_la_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50019-50170-aucey_la_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50021-50480-audouville_la_hubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50021-50480-audouville_la_hubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50021-50480-audouville_la_hubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50021-50480-audouville_la_hubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50022-50630-aumeville_lestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50022-50630-aumeville_lestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50022-50630-aumeville_lestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50022-50630-aumeville_lestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50023-50500-auvers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50023-50500-auvers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50023-50500-auvers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50023-50500-auvers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50024-50500-auxais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50024-50500-auxais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50024-50500-auxais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50024-50500-auxais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50025-50300-avranches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50025-50300-avranches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50025-50300-avranches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50025-50300-avranches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50026-50310-azeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50026-50310-azeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50026-50310-azeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50026-50310-azeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50027-50530-bacilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50027-50530-bacilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50027-50530-bacilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50027-50530-bacilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50028-50450-la_baleine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50028-50450-la_baleine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50028-50450-la_baleine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50028-50450-la_baleine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50029-50720-barenton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50029-50720-barenton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50029-50720-barenton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50029-50720-barenton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50030-50760-barfleur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50030-50760-barfleur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50030-50760-barfleur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50030-50760-barfleur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50031-50270-barneville_carteret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50031-50270-barneville_carteret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50031-50270-barneville_carteret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50031-50270-barneville_carteret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50032-50810-la_barre_de_semilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50032-50810-la_barre_de_semilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50032-50810-la_barre_de_semilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50032-50810-la_barre_de_semilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50033-50270-baubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50033-50270-baubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50033-50270-baubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50033-50270-baubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50034-50000-baudre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50034-50000-baudre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50034-50000-baudre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50034-50000-baudre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50036-50500-baupte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50036-50500-baupte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50036-50500-baupte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50036-50500-baupte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50038-50320-beauchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50038-50320-beauchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50038-50320-beauchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50038-50320-beauchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50039-50420-beaucoudray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50039-50420-beaucoudray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50039-50420-beaucoudray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50039-50420-beaucoudray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50040-50150-beauficel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50040-50150-beauficel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50040-50150-beauficel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50040-50150-beauficel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50440-la_hague/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50440-la_hague/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50440-la_hague/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50440-la_hague/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50460-la_hague/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50460-la_hague/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50460-la_hague/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50460-la_hague/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50690-la_hague/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50690-la_hague/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50690-la_hague/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50041-50690-la_hague/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50042-50170-beauvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50042-50170-beauvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50042-50170-beauvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50042-50170-beauvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50044-50210-belval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50044-50210-belval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50044-50210-belval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50044-50210-belval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50045-50340-benoitville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50045-50340-benoitville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50045-50340-benoitville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50045-50340-benoitville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50046-50810-berigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50046-50810-berigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50046-50810-berigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50046-50810-berigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50048-50800-beslon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50048-50800-beslon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50048-50800-beslon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50048-50800-beslon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50049-50390-besneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50049-50390-besneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50049-50390-besneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50049-50390-besneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50050-50420-beuvrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50050-50420-beuvrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50050-50420-beuvrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50050-50420-beuvrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50052-50360-beuzeville_la_bastille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50052-50360-beuzeville_la_bastille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50052-50360-beuzeville_la_bastille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50052-50360-beuzeville_la_bastille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50054-50160-bieville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50054-50160-bieville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50054-50160-bieville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50054-50160-bieville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50055-50390-biniville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50055-50390-biniville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50055-50390-biniville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50055-50390-biniville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50058-50560-blainville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50058-50560-blainville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50058-50560-blainville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50058-50560-blainville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50059-50480-blosville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50059-50480-blosville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50059-50480-blosville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50059-50480-blosville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50060-50800-la_bloutiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50060-50800-la_bloutiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50060-50800-la_bloutiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50060-50800-la_bloutiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50062-50800-boisyvon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50062-50800-boisyvon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50062-50800-boisyvon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50062-50800-boisyvon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50064-50360-la_bonneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50064-50360-la_bonneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50064-50360-la_bonneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50064-50360-la_bonneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50066-50610-jullouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50066-50610-jullouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50066-50610-jullouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50066-50610-jullouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50069-50800-bourguenolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50069-50800-bourguenolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50069-50800-bourguenolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50069-50800-bourguenolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50070-50480-boutteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50070-50480-boutteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50070-50480-boutteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50070-50480-boutteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50072-50200-brainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50072-50200-brainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50072-50200-brainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50072-50200-brainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50074-50370-brecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50074-50370-brecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50074-50370-brecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50074-50370-brecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50076-50290-brehal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50076-50290-brehal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50076-50290-brehal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50076-50290-brehal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50077-50110-bretteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50077-50110-bretteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50077-50110-bretteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50077-50110-bretteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50078-50430-bretteville_sur_ay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50078-50430-bretteville_sur_ay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50078-50430-bretteville_sur_ay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50078-50430-bretteville_sur_ay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50079-50260-breuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50079-50260-breuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50079-50260-breuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50079-50260-breuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50081-50290-breville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50081-50290-breville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50081-50290-breville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50081-50290-breville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50082-50260-bricquebec_en_cotentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50082-50260-bricquebec_en_cotentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50082-50260-bricquebec_en_cotentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50082-50260-bricquebec_en_cotentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50083-50340-bricquebosq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50083-50340-bricquebosq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50083-50340-bricquebosq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50083-50340-bricquebosq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50084-50200-bricqueville_la_blouette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50084-50200-bricqueville_la_blouette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50084-50200-bricqueville_la_blouette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50084-50200-bricqueville_la_blouette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50085-50290-bricqueville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50085-50290-bricqueville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50085-50290-bricqueville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50085-50290-bricqueville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50086-50330-brillevast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50086-50330-brillevast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50086-50330-brillevast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50086-50330-brillevast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50087-50700-brix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50087-50700-brix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50087-50700-brix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50087-50700-brix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50088-50150-brouains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50088-50150-brouains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50088-50150-brouains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50088-50150-brouains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50090-50640-buais_les_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50090-50640-buais_les_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50090-50640-buais_les_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50090-50640-buais_les_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50092-50200-cambernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50092-50200-cambernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50092-50200-cambernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50092-50200-cambernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50093-50570-cametours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50093-50570-cametours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50093-50570-cametours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50093-50570-cametours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50094-50210-camprond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50094-50210-camprond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50094-50210-camprond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50094-50210-camprond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50095-50750-canisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50095-50750-canisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50095-50750-canisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50095-50750-canisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50096-50330-canteloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50096-50330-canteloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50096-50330-canteloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50096-50330-canteloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50097-50580-canville_la_rocque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50097-50580-canville_la_rocque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50097-50580-canville_la_rocque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50097-50580-canville_la_rocque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50098-50570-carantilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50098-50570-carantilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50098-50570-carantilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50098-50570-carantilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50500-carentan_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50500-carentan_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50500-carentan_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50500-carentan_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50480-carentan_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50480-carentan_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50480-carentan_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50480-carentan_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50620-carentan_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50620-carentan_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50620-carentan_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50099-50620-carentan_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50101-50330-carneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50101-50330-carneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50101-50330-carneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50101-50330-carneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50102-50740-carolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50102-50740-carolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50102-50740-carolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50102-50740-carolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50105-50390-catteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50105-50390-catteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50105-50390-catteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50105-50390-catteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50106-50620-cavigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50106-50620-cavigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50106-50620-cavigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50106-50620-cavigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50108-50220-ceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50108-50220-ceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50108-50220-ceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50108-50220-ceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50109-50510-cerences/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50109-50510-cerences/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50109-50510-cerences/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50109-50510-cerences/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50110-50680-cerisy_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50110-50680-cerisy_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50110-50680-cerisy_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50110-50680-cerisy_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50111-50210-cerisy_la_salle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50111-50210-cerisy_la_salle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50111-50210-cerisy_la_salle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50111-50210-cerisy_la_salle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50112-50370-la_chaise_baudouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50112-50370-la_chaise_baudouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50112-50370-la_chaise_baudouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50112-50370-la_chaise_baudouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50115-50320-le_grippon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50115-50320-le_grippon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50115-50320-le_grippon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50115-50320-le_grippon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50117-50530-champeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50117-50530-champeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50117-50530-champeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50117-50530-champeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50118-50800-champrepus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50118-50800-champrepus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50118-50800-champrepus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50118-50800-champrepus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50120-50510-chanteloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50120-50510-chanteloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50120-50510-chanteloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50120-50510-chanteloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50121-50800-la_chapelle_cecelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50121-50800-la_chapelle_cecelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50121-50800-la_chapelle_cecelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50121-50800-la_chapelle_cecelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50124-50370-la_chapelle_uree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50124-50370-la_chapelle_uree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50124-50370-la_chapelle_uree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50124-50370-la_chapelle_uree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50126-50870-chavoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50126-50870-chavoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50126-50870-chavoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50126-50870-chavoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50100-cherbourg_en_cotentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50100-cherbourg_en_cotentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50100-cherbourg_en_cotentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50100-cherbourg_en_cotentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50130-cherbourg_en_cotentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50130-cherbourg_en_cotentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50130-cherbourg_en_cotentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50130-cherbourg_en_cotentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50120-cherbourg_en_cotentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50120-cherbourg_en_cotentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50120-cherbourg_en_cotentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50120-cherbourg_en_cotentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50470-cherbourg_en_cotentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50470-cherbourg_en_cotentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50470-cherbourg_en_cotentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50470-cherbourg_en_cotentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50460-cherbourg_en_cotentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50460-cherbourg_en_cotentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50460-cherbourg_en_cotentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50460-cherbourg_en_cotentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50110-cherbourg_en_cotentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50110-cherbourg_en_cotentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50110-cherbourg_en_cotentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50129-50110-cherbourg_en_cotentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50130-50800-cherence_le_heron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50130-50800-cherence_le_heron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50130-50800-cherence_le_heron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50130-50800-cherence_le_heron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50135-50330-clitourps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50135-50330-clitourps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50135-50330-clitourps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50135-50330-clitourps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50137-50800-la_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50137-50800-la_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50137-50800-la_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50137-50800-la_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50138-50700-colomby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50138-50700-colomby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50138-50700-colomby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50138-50700-colomby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50139-50890-conde_sur_vire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50139-50890-conde_sur_vire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50139-50890-conde_sur_vire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50139-50890-conde_sur_vire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50139-50420-conde_sur_vire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50139-50420-conde_sur_vire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50139-50420-conde_sur_vire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50139-50420-conde_sur_vire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50142-50330-vicq_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50142-50330-vicq_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50142-50330-vicq_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50142-50330-vicq_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50143-50290-coudeville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50143-50290-coudeville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50143-50290-coudeville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50143-50290-coudeville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50144-50670-coulouvray_boisbenatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50144-50670-coulouvray_boisbenatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50144-50670-coulouvray_boisbenatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50144-50670-coulouvray_boisbenatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50145-50200-courcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50145-50200-courcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50145-50200-courcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50145-50200-courcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50146-50220-courtils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50146-50220-courtils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50146-50220-courtils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50146-50220-courtils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50147-50200-coutances/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50147-50200-coutances/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50147-50200-coutances/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50147-50200-coutances/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50148-50680-couvains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50148-50680-couvains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50148-50680-couvains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50148-50680-couvains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50149-50690-couville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50149-50690-couville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50149-50690-couville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50149-50690-couville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50150-50630-crasville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50150-50630-crasville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50150-50630-crasville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50150-50630-crasville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50151-50710-creances/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50151-50710-creances/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50151-50710-creances/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50151-50710-creances/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50152-50370-les_cresnays/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50152-50370-les_cresnays/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50152-50370-les_cresnays/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50152-50370-les_cresnays/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50155-50220-crollon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50155-50220-crollon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50155-50220-crollon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50155-50220-crollon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50156-50360-crosville_sur_douve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50156-50360-crosville_sur_douve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50156-50360-crosville_sur_douve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50156-50360-crosville_sur_douve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50158-50670-cuves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50158-50670-cuves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50158-50670-cuves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50158-50670-cuves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50159-50750-dangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50159-50750-dangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50159-50750-dangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50159-50750-dangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50161-50620-le_dezert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50161-50620-le_dezert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50161-50620-le_dezert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50161-50620-le_dezert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50162-50110-digosville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50162-50110-digosville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50162-50110-digosville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50162-50110-digosville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50164-50420-domjean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50164-50420-domjean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50164-50420-domjean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50164-50420-domjean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50165-50350-donville_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50165-50350-donville_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50165-50350-donville_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50165-50350-donville_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50166-50250-doville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50166-50250-doville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50166-50250-doville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50166-50250-doville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50167-50530-dragey_ronthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50167-50530-dragey_ronthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50167-50530-dragey_ronthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50167-50530-dragey_ronthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50168-50220-ducey_les_cheris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50168-50220-ducey_les_cheris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50168-50220-ducey_les_cheris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50168-50220-ducey_les_cheris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50169-50310-ecausseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50169-50310-ecausseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50169-50310-ecausseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50169-50310-ecausseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50172-50310-emondeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50172-50310-emondeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50172-50310-emondeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50172-50310-emondeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50174-50320-equilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50174-50320-equilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50174-50320-equilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50174-50320-equilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50175-50310-eroudeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50175-50310-eroudeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50175-50310-eroudeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50175-50310-eroudeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50176-50260-l_etang_bertrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50176-50260-l_etang_bertrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50176-50260-l_etang_bertrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50176-50260-l_etang_bertrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50177-50360-etienville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50177-50360-etienville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50177-50360-etienville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50177-50360-etienville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50178-50840-fermanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50178-50840-fermanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50178-50840-fermanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50178-50840-fermanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50181-50190-feugeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50181-50190-feugeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50181-50190-feugeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50181-50190-feugeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50182-50190-la_feuillie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50182-50190-la_feuillie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50182-50190-la_feuillie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50182-50190-la_feuillie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50183-50580-fierville_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50183-50580-fierville_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50183-50580-fierville_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50183-50580-fierville_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50184-50340-flamanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50184-50340-flamanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50184-50340-flamanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50184-50340-flamanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50185-50800-fleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50185-50800-fleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50185-50800-fleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50185-50800-fleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50186-50700-flottemanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50186-50700-flottemanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50186-50700-flottemanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50186-50700-flottemanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50188-50320-folligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50188-50320-folligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50188-50320-folligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50188-50320-folligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50190-50310-fontenay_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50190-50310-fontenay_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50190-50310-fontenay_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50190-50310-fontenay_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50192-50420-fourneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50192-50420-fourneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50192-50420-fourneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50192-50420-fourneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50193-50850-le_fresne_poret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50193-50850-le_fresne_poret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50193-50850-le_fresne_poret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50193-50850-le_fresne_poret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50194-50310-fresville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50194-50310-fresville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50194-50310-fresville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50194-50310-fresville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50195-50150-gathemo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50195-50150-gathemo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50195-50150-gathemo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50195-50150-gathemo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50196-50760-gatteville_le_phare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50196-50760-gatteville_le_phare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50196-50760-gatteville_le_phare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50196-50760-gatteville_le_phare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50197-50450-gavray_sur_sienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50197-50450-gavray_sur_sienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50197-50450-gavray_sur_sienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50197-50450-gavray_sur_sienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50198-50560-geffosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50198-50560-geffosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50198-50560-geffosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50198-50560-geffosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50199-50530-genets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50199-50530-genets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50199-50530-genets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50199-50530-genets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50200-50850-ger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50200-50850-ger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50200-50850-ger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50200-50850-ger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50205-50300-la_godefroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50205-50300-la_godefroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50205-50300-la_godefroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50205-50300-la_godefroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50207-50390-golleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50207-50390-golleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50207-50390-golleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50207-50390-golleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50208-50190-gonfreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50208-50190-gonfreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50208-50190-gonfreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50208-50190-gonfreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50209-50330-gonneville_le_theil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50209-50330-gonneville_le_theil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50209-50330-gonneville_le_theil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50209-50330-gonneville_le_theil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50210-50190-gorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50210-50190-gorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50210-50190-gorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50210-50190-gorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50214-50420-gouvets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50214-50420-gouvets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50214-50420-gouvets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50214-50420-gouvets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50215-50560-gouville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50215-50560-gouville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50215-50560-gouville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50215-50560-gouville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50215-50200-gouville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50215-50200-gouville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50215-50200-gouville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50215-50200-gouville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50216-50620-graignes_mesnil_angot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50216-50620-graignes_mesnil_angot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50216-50620-graignes_mesnil_angot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50216-50620-graignes_mesnil_angot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50217-50370-le_grand_celland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50217-50370-le_grand_celland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50217-50370-le_grand_celland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50217-50370-le_grand_celland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50218-50400-granville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50218-50400-granville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50218-50400-granville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50218-50400-granville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50219-50200-gratot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50219-50200-gratot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50219-50200-gratot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50219-50200-gratot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50221-50450-grimesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50221-50450-grimesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50221-50450-grimesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50221-50450-grimesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50222-50340-grosville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50222-50340-grosville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50222-50340-grosville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50222-50340-grosville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50225-50410-le_guislain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50225-50410-le_guislain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50225-50410-le_guislain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50225-50410-le_guislain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50227-50310-le_ham/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50227-50310-le_ham/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50227-50310-le_ham/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50227-50310-le_ham/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50228-50450-hambye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50228-50450-hambye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50228-50450-hambye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50228-50450-hambye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50229-50730-hamelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50229-50730-hamelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50229-50730-hamelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50229-50730-hamelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50230-50690-hardinvast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50230-50690-hardinvast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50230-50690-hardinvast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50230-50690-hardinvast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50231-50590-hauteville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50231-50590-hauteville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50231-50590-hauteville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50231-50590-hauteville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50232-50570-hauteville_la_guichard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50232-50570-hauteville_la_guichard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50232-50570-hauteville_la_guichard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50232-50570-hauteville_la_guichard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50233-50390-hautteville_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50233-50390-hautteville_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50233-50390-hautteville_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50233-50390-hautteville_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50234-50410-la_haye_bellefond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50234-50410-la_haye_bellefond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50234-50410-la_haye_bellefond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50234-50410-la_haye_bellefond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50235-50270-la_haye_d_ectot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50235-50270-la_haye_d_ectot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50235-50270-la_haye_d_ectot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50235-50270-la_haye_d_ectot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50236-50250-la_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50236-50250-la_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50236-50250-la_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50236-50250-la_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50236-50580-la_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50236-50580-la_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50236-50580-la_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50236-50580-la_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50237-50320-la_haye_pesnel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50237-50320-la_haye_pesnel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50237-50320-la_haye_pesnel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50237-50320-la_haye_pesnel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50238-50340-heauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50238-50340-heauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50238-50340-heauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50238-50340-heauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50239-50180-thereval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50239-50180-thereval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50239-50180-thereval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50239-50180-thereval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50239-50570-thereval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50239-50570-thereval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50239-50570-thereval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50239-50570-thereval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50240-50340-helleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50240-50340-helleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50240-50340-helleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50240-50340-helleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50241-50700-hemevez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50241-50700-hemevez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50241-50700-hemevez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50241-50700-hemevez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50243-50200-heugueville_sur_sienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50243-50200-heugueville_sur_sienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50243-50200-heugueville_sur_sienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50243-50200-heugueville_sur_sienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50246-50480-hiesville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50246-50480-hiesville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50246-50480-hiesville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50246-50480-hiesville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50247-50320-hocquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50247-50320-hocquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50247-50320-hocquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50247-50320-hocquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50251-50700-huberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50251-50700-huberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50251-50700-huberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50251-50700-huberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50252-50510-hudimesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50252-50510-hudimesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50252-50510-hudimesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50252-50510-hudimesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50253-50170-huisnes_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50253-50170-huisnes_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50253-50170-huisnes_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50253-50170-huisnes_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50256-50540-isigny_le_buat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50256-50540-isigny_le_buat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50256-50540-isigny_le_buat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50256-50540-isigny_le_buat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50258-50310-joganville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50258-50310-joganville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50258-50310-joganville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50258-50310-joganville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50259-50220-juilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50259-50220-juilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50259-50220-juilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50259-50220-juilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50260-50520-juvigny_les_vallees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50260-50520-juvigny_les_vallees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50260-50520-juvigny_les_vallees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50260-50520-juvigny_les_vallees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50261-50160-lamberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50261-50160-lamberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50261-50160-lamberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50261-50160-lamberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50262-50800-la_lande_d_airou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50262-50800-la_lande_d_airou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50262-50800-la_lande_d_airou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50262-50800-la_lande_d_airou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50263-50600-lapenty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50263-50600-lapenty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50263-50600-lapenty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50263-50600-lapenty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50265-50430-laulne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50265-50430-laulne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50265-50430-laulne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50265-50430-laulne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50266-50450-lengronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50266-50450-lengronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50266-50450-lengronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50266-50450-lengronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50267-50430-lessay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50267-50430-lessay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50267-50430-lessay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50267-50430-lessay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50268-50310-lestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50268-50310-lestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50268-50310-lestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50268-50310-lestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50269-50480-liesville_sur_douve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50269-50480-liesville_sur_douve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50269-50480-liesville_sur_douve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50269-50480-liesville_sur_douve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50270-50700-lieusaint/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50270-50700-lieusaint/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50270-50700-lieusaint/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50270-50700-lieusaint/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50271-50670-lingeard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50271-50670-lingeard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50271-50670-lingeard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50271-50670-lingeard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50272-50660-lingreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50272-50660-lingreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50272-50660-lingreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50272-50660-lingreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50273-50250-montsenelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50273-50250-montsenelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50273-50250-montsenelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50273-50250-montsenelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50274-50600-les_loges_marchis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50274-50600-les_loges_marchis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50274-50600-les_loges_marchis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50274-50600-les_loges_marchis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50275-50370-les_loges_sur_brecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50275-50370-les_loges_sur_brecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50275-50370-les_loges_sur_brecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50275-50370-les_loges_sur_brecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50276-50530-lolif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50276-50530-lolif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50276-50530-lolif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50276-50530-lolif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50277-50290-longueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50277-50290-longueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50277-50290-longueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50277-50290-longueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50278-50510-le_loreur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50278-50510-le_loreur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50278-50510-le_loreur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50278-50510-le_loreur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50279-50570-le_lorey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50279-50570-le_lorey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50279-50570-le_lorey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50279-50570-le_lorey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50281-50320-la_lucerne_d_outremer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50281-50320-la_lucerne_d_outremer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50281-50320-la_lucerne_d_outremer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50281-50320-la_lucerne_d_outremer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50282-50870-le_luot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50282-50870-le_luot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50282-50870-le_luot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50282-50870-le_luot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50283-50680-la_luzerne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50283-50680-la_luzerne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50283-50680-la_luzerne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50283-50680-la_luzerne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50285-50260-magneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50285-50260-magneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50285-50260-magneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50285-50260-magneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50288-50300-marcey_les_greves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50288-50300-marcey_les_greves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50288-50300-marcey_les_greves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50288-50300-marcey_les_greves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50289-50190-marchesieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50289-50190-marchesieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50289-50190-marchesieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50289-50190-marchesieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50290-50220-marcilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50290-50220-marcilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50290-50220-marcilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50290-50220-marcilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50291-50410-margueray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50291-50410-margueray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50291-50410-margueray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50291-50410-margueray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50292-50570-marigny_le_lozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50292-50570-marigny_le_lozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50292-50570-marigny_le_lozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50292-50570-marigny_le_lozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50294-50690-martinvast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50294-50690-martinvast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50294-50690-martinvast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50294-50690-martinvast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50295-50410-maupertuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50295-50410-maupertuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50295-50410-maupertuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50295-50410-maupertuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50296-50330-maupertus_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50296-50330-maupertus_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50296-50330-maupertus_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50296-50330-maupertus_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50297-50880-la_meauffe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50297-50880-la_meauffe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50297-50880-la_meauffe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50297-50880-la_meauffe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50298-50500-meautis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50298-50500-meautis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50298-50500-meautis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50298-50500-meautis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50299-50580-le_mesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50299-50580-le_mesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50299-50580-le_mesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50299-50580-le_mesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50300-50520-le_mesnil_adelee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50300-50520-le_mesnil_adelee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50300-50520-le_mesnil_adelee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50300-50520-le_mesnil_adelee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50302-50570-le_mesnil_amey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50302-50570-le_mesnil_amey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50302-50570-le_mesnil_amey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50302-50570-le_mesnil_amey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50304-50510-le_mesnil_aubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50304-50510-le_mesnil_aubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50304-50510-le_mesnil_aubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50304-50510-le_mesnil_aubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50305-50110-le_mesnil_au_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50305-50110-le_mesnil_au_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50305-50110-le_mesnil_au_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50305-50110-le_mesnil_au_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50310-50570-le_mesnil_eury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50310-50570-le_mesnil_eury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50310-50570-le_mesnil_eury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50310-50570-le_mesnil_eury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50311-50450-le_mesnil_garnier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50311-50450-le_mesnil_garnier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50311-50450-le_mesnil_garnier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50311-50450-le_mesnil_garnier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50312-50670-le_mesnil_gilbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50312-50670-le_mesnil_gilbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50312-50670-le_mesnil_gilbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50312-50670-le_mesnil_gilbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50315-50600-le_mesnillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50315-50600-le_mesnillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50315-50600-le_mesnillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50315-50600-le_mesnillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50317-50220-le_mesnil_ozenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50317-50220-le_mesnil_ozenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50317-50220-le_mesnil_ozenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50317-50220-le_mesnil_ozenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50321-50000-le_mesnil_rouxelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50321-50000-le_mesnil_rouxelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50321-50000-le_mesnil_rouxelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50321-50000-le_mesnil_rouxelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50324-50620-le_mesnil_veneron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50324-50620-le_mesnil_veneron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50324-50620-le_mesnil_veneron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50324-50620-le_mesnil_veneron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50326-50450-le_mesnil_villeman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50326-50450-le_mesnil_villeman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50326-50450-le_mesnil_villeman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50326-50450-le_mesnil_villeman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50327-50510-la_meurdraquiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50327-50510-la_meurdraquiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50327-50510-la_meurdraquiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50327-50510-la_meurdraquiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50328-50190-millieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50328-50190-millieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50328-50190-millieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50328-50190-millieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50332-50270-les_moitiers_d_allonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50332-50270-les_moitiers_d_allonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50332-50270-les_moitiers_d_allonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50332-50270-les_moitiers_d_allonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50334-50410-montabot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50334-50410-montabot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50334-50410-montabot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50334-50410-montabot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50335-50700-montaigu_la_brisette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50335-50700-montaigu_la_brisette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50335-50700-montaigu_la_brisette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50335-50700-montaigu_la_brisette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50336-50450-montaigu_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50336-50450-montaigu_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50336-50450-montaigu_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50336-50450-montaigu_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50338-50410-montbray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50338-50410-montbray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50338-50410-montbray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50338-50410-montbray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50340-50490-montcuit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50340-50490-montcuit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50340-50490-montcuit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50340-50490-montcuit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50341-50310-montebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50341-50310-montebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50341-50310-montebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50341-50310-montebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50342-50760-montfarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50342-50760-montfarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50342-50760-montfarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50342-50760-montfarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50345-50200-monthuchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50345-50200-monthuchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50345-50200-monthuchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50345-50200-monthuchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50347-50240-montjoie_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50347-50240-montjoie_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50347-50240-montjoie_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50347-50240-montjoie_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50349-50590-montmartin_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50349-50590-montmartin_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50349-50590-montmartin_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50349-50590-montmartin_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50350-50210-montpinchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50350-50210-montpinchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50350-50210-montpinchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50350-50210-montpinchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50351-50810-montrabot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50351-50810-montrabot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50351-50810-montrabot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50351-50810-montrabot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50352-50570-montreuil_sur_lozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50352-50570-montreuil_sur_lozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50352-50570-montreuil_sur_lozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50352-50570-montreuil_sur_lozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50353-50170-le_mont_saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50353-50170-le_mont_saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50353-50170-le_mont_saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50353-50170-le_mont_saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50356-50680-moon_sur_elle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50356-50680-moon_sur_elle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50356-50680-moon_sur_elle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50356-50680-moon_sur_elle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50357-50410-morigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50357-50410-morigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50357-50410-morigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50357-50410-morigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50359-50140-mortain_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50359-50140-mortain_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50359-50140-mortain_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50359-50140-mortain_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50360-50700-morville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50360-50700-morville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50360-50700-morville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50360-50700-morville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50361-50320-la_mouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50361-50320-la_mouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50361-50320-la_mouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50361-50320-la_mouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50362-50600-moulines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50362-50600-moulines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50362-50600-moulines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50362-50600-moulines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50363-50860-moyon_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50363-50860-moyon_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50363-50860-moyon_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50363-50860-moyon_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50363-50420-moyon_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50363-50420-moyon_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50363-50420-moyon_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50363-50420-moyon_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50364-50490-muneville_le_bingard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50364-50490-muneville_le_bingard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50364-50490-muneville_le_bingard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50364-50490-muneville_le_bingard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50365-50290-muneville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50365-50290-muneville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50365-50290-muneville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50365-50290-muneville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50368-50190-nay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50368-50190-nay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50368-50190-nay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50368-50190-nay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50369-50260-negreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50369-50260-negreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50369-50260-negreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50369-50260-negreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50370-50390-nehou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50370-50390-nehou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50370-50390-nehou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50370-50390-nehou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50371-50140-le_neufbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50371-50140-le_neufbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50371-50140-le_neufbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50371-50140-le_neufbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50372-50250-neufmesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50372-50250-neufmesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50372-50250-neufmesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50372-50250-neufmesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50373-50480-neuville_au_plain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50373-50480-neuville_au_plain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50373-50480-neuville_au_plain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50373-50480-neuville_au_plain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50374-50250-neuville_en_beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50374-50250-neuville_en_beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50374-50250-neuville_en_beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50374-50250-neuville_en_beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50376-50200-nicorps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50376-50200-nicorps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50376-50200-nicorps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50376-50200-nicorps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50378-50210-notre_dame_de_cenilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50378-50210-notre_dame_de_cenilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50378-50210-notre_dame_de_cenilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50378-50210-notre_dame_de_cenilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50379-50370-notre_dame_de_livoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50379-50370-notre_dame_de_livoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50379-50370-notre_dame_de_livoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50379-50370-notre_dame_de_livoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50382-50690-nouainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50382-50690-nouainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50382-50690-nouainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50382-50690-nouainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50384-50630-octeville_l_avenel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50384-50630-octeville_l_avenel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50384-50630-octeville_l_avenel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50384-50630-octeville_l_avenel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50387-50390-orglandes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50387-50390-orglandes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50387-50390-orglandes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50387-50390-orglandes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50388-50660-orval_sur_sienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50388-50660-orval_sur_sienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50388-50660-orval_sur_sienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50388-50660-orval_sur_sienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50389-50210-ouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50389-50210-ouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50389-50210-ouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50389-50210-ouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50390-50310-ozeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50390-50310-ozeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50390-50310-ozeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50390-50310-ozeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50391-50600-grandparigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50391-50600-grandparigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50391-50600-grandparigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50391-50600-grandparigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50393-50410-percy_en_normandie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50393-50410-percy_en_normandie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50393-50410-percy_en_normandie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50393-50410-percy_en_normandie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50394-50190-periers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50394-50190-periers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50394-50190-periers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50394-50190-periers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50395-50630-la_pernelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50395-50630-la_pernelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50395-50630-la_pernelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50395-50630-la_pernelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50397-50150-perriers_en_beauficel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50397-50150-perriers_en_beauficel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50397-50150-perriers_en_beauficel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50397-50150-perriers_en_beauficel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50398-50160-le_perron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50398-50160-le_perron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50398-50160-le_perron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50398-50160-le_perron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50399-50370-le_petit_celland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50399-50370-le_petit_celland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50399-50370-le_petit_celland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50399-50370-le_petit_celland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50360-picauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50360-picauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50360-picauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50360-picauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50480-picauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50480-picauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50480-picauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50480-picauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50250-picauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50250-picauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50250-picauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50400-50250-picauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50401-50340-pierreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50401-50340-pierreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50401-50340-pierreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50401-50340-pierreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50402-50340-les_pieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50402-50340-les_pieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50402-50340-les_pieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50402-50340-les_pieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50403-50770-pirou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50403-50770-pirou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50403-50770-pirou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50403-50770-pirou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50405-50250-le_plessis_lastelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50405-50250-le_plessis_lastelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50405-50250-le_plessis_lastelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50405-50250-le_plessis_lastelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50407-50220-poilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50407-50220-poilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50407-50220-poilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50407-50220-poilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50408-50220-pontaubault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50408-50220-pontaubault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50408-50220-pontaubault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50408-50220-pontaubault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50409-50880-pont_hebert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50409-50880-pont_hebert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50409-50880-pont_hebert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50409-50880-pont_hebert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50410-50170-pontorson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50410-50170-pontorson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50410-50170-pontorson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50410-50170-pontorson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50411-50300-ponts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50411-50300-ponts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50411-50300-ponts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50411-50300-ponts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50412-50580-port_bail_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50412-50580-port_bail_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50412-50580-port_bail_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50412-50580-port_bail_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50413-50220-precey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50413-50220-precey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50413-50220-precey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50413-50220-precey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50417-50630-quettehou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50417-50630-quettehou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50417-50630-quettehou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50417-50630-quettehou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50419-50660-quettreville_sur_sienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50419-50660-quettreville_sur_sienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50419-50660-quettreville_sur_sienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50419-50660-quettreville_sur_sienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50419-50210-quettreville_sur_sienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50419-50210-quettreville_sur_sienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50419-50210-quettreville_sur_sienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50419-50210-quettreville_sur_sienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50420-50750-quibou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50420-50750-quibou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50420-50750-quibou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50420-50750-quibou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50421-50310-quineville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50421-50310-quineville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50421-50310-quineville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50421-50310-quineville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50422-50500-raids/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50422-50500-raids/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50422-50500-raids/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50422-50500-raids/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50423-50000-rampan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50423-50000-rampan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50423-50000-rampan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50423-50000-rampan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50425-50260-rauville_la_bigot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50425-50260-rauville_la_bigot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50425-50260-rauville_la_bigot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50425-50260-rauville_la_bigot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50426-50390-rauville_la_place/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50426-50390-rauville_la_place/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50426-50390-rauville_la_place/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50426-50390-rauville_la_place/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50428-50520-reffuveille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50428-50520-reffuveille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50428-50520-reffuveille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50428-50520-reffuveille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50429-50590-regneville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50429-50590-regneville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50429-50590-regneville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50429-50590-regneville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50430-50390-reigneville_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50430-50390-reigneville_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50430-50390-reigneville_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50430-50390-reigneville_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50431-50570-remilly_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50431-50570-remilly_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50431-50570-remilly_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50431-50570-remilly_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50431-50620-remilly_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50431-50620-remilly_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50431-50620-remilly_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50431-50620-remilly_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50433-50760-reville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50433-50760-reville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50433-50760-reville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50433-50760-reville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50435-50260-rocheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50435-50260-rocheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50435-50260-rocheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50435-50260-rocheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50436-50140-romagny_fontenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50436-50140-romagny_fontenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50436-50140-romagny_fontenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50436-50140-romagny_fontenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50437-50210-roncey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50437-50210-roncey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50437-50210-roncey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50437-50210-roncey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50442-50340-le_rozel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50442-50340-le_rozel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50442-50340-le_rozel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50442-50340-le_rozel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50443-50170-sacey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50443-50170-sacey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50443-50170-sacey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50443-50170-sacey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50444-50160-saint_amand_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50444-50160-saint_amand_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50444-50160-saint_amand_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50444-50160-saint_amand_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50445-50500-saint_andre_de_bohon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50445-50500-saint_andre_de_bohon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50445-50500-saint_andre_de_bohon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50445-50500-saint_andre_de_bohon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50446-50680-saint_andre_de_l_epine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50446-50680-saint_andre_de_l_epine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50446-50680-saint_andre_de_l_epine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50446-50680-saint_andre_de_l_epine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50447-50380-saint_aubin_des_preaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50447-50380-saint_aubin_des_preaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50447-50380-saint_aubin_des_preaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50447-50380-saint_aubin_des_preaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50448-50240-saint_aubin_de_terregatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50448-50240-saint_aubin_de_terregatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50448-50240-saint_aubin_de_terregatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50448-50240-saint_aubin_de_terregatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50450-50140-saint_barthelemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50450-50140-saint_barthelemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50450-50140-saint_barthelemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50450-50140-saint_barthelemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50451-50300-saint_brice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50451-50300-saint_brice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50451-50300-saint_brice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50451-50300-saint_brice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50452-50730-saint_brice_de_landelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50452-50730-saint_brice_de_landelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50452-50730-saint_brice_de_landelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50452-50730-saint_brice_de_landelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50453-50800-sainte_cecile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50453-50800-sainte_cecile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50453-50800-sainte_cecile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50453-50800-sainte_cecile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50454-50340-saint_christophe_du_foc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50454-50340-saint_christophe_du_foc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50454-50340-saint_christophe_du_foc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50454-50340-saint_christophe_du_foc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50455-50680-saint_clair_sur_l_elle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50455-50680-saint_clair_sur_l_elle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50455-50680-saint_clair_sur_l_elle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50455-50680-saint_clair_sur_l_elle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50456-50140-saint_clement_rancoudray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50456-50140-saint_clement_rancoudray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50456-50140-saint_clement_rancoudray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50456-50140-saint_clement_rancoudray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50457-50390-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50457-50390-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50457-50390-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50457-50390-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50461-50310-saint_cyr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50461-50310-saint_cyr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50461-50310-saint_cyr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50461-50310-saint_cyr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50462-50720-saint_cyr_du_bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50462-50720-saint_cyr_du_bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50462-50720-saint_cyr_du_bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50462-50720-saint_cyr_du_bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50463-50450-saint_denis_le_gast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50463-50450-saint_denis_le_gast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50463-50450-saint_denis_le_gast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50463-50450-saint_denis_le_gast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50464-50210-saint_denis_le_vetu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50464-50210-saint_denis_le_vetu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50464-50210-saint_denis_le_vetu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50464-50210-saint_denis_le_vetu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50467-50310-saint_floxel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50467-50310-saint_floxel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50467-50310-saint_floxel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50467-50310-saint_floxel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50468-50620-saint_fromond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50468-50620-saint_fromond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50468-50620-saint_fromond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50468-50620-saint_fromond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50469-50760-sainte_genevieve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50469-50760-sainte_genevieve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50469-50760-sainte_genevieve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50469-50760-sainte_genevieve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50471-50270-saint_georges_de_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50471-50270-saint_georges_de_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50471-50270-saint_georges_de_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50471-50270-saint_georges_de_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50472-50370-saint_georges_de_livoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50472-50370-saint_georges_de_livoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50472-50370-saint_georges_de_livoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50472-50370-saint_georges_de_livoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50473-50680-saint_georges_d_elle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50473-50680-saint_georges_d_elle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50473-50680-saint_georges_d_elle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50473-50680-saint_georges_d_elle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50474-50720-saint_georges_de_rouelley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50474-50720-saint_georges_de_rouelley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50474-50720-saint_georges_de_rouelley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50474-50720-saint_georges_de_rouelley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50475-50000-saint_georges_montcocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50475-50000-saint_georges_montcocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50475-50000-saint_georges_montcocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50475-50000-saint_georges_montcocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50476-50810-saint_germain_d_elle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50476-50810-saint_germain_d_elle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50476-50810-saint_germain_d_elle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50476-50810-saint_germain_d_elle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50478-50700-saint_germain_de_tournebut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50478-50700-saint_germain_de_tournebut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50478-50700-saint_germain_de_tournebut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50478-50700-saint_germain_de_tournebut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50479-50480-saint_germain_de_varreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50479-50480-saint_germain_de_varreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50479-50480-saint_germain_de_varreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50479-50480-saint_germain_de_varreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50480-50340-saint_germain_le_gaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50480-50340-saint_germain_le_gaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50480-50340-saint_germain_le_gaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50480-50340-saint_germain_le_gaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50481-50430-saint_germain_sur_ay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50481-50430-saint_germain_sur_ay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50481-50430-saint_germain_sur_ay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50481-50430-saint_germain_sur_ay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50482-50190-saint_germain_sur_seves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50482-50190-saint_germain_sur_seves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50482-50190-saint_germain_sur_seves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50482-50190-saint_germain_sur_seves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50483-50180-saint_gilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50483-50180-saint_gilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50483-50180-saint_gilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50483-50180-saint_gilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50484-50600-saint_hilaire_du_harcouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50484-50600-saint_hilaire_du_harcouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50484-50600-saint_hilaire_du_harcouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50484-50600-saint_hilaire_du_harcouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50484-50730-saint_hilaire_du_harcouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50484-50730-saint_hilaire_du_harcouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50484-50730-saint_hilaire_du_harcouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50484-50730-saint_hilaire_du_harcouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50486-50390-saint_jacques_de_nehou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50486-50390-saint_jacques_de_nehou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50486-50390-saint_jacques_de_nehou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50486-50390-saint_jacques_de_nehou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50487-50240-saint_james/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50487-50240-saint_james/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50487-50240-saint_james/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50487-50240-saint_james/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50488-50620-saint_jean_de_daye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50488-50620-saint_jean_de_daye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50488-50620-saint_jean_de_daye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50488-50620-saint_jean_de_daye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50489-50300-saint_jean_de_la_haize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50489-50300-saint_jean_de_la_haize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50489-50300-saint_jean_de_la_haize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50489-50300-saint_jean_de_la_haize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50490-50270-saint_jean_de_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50490-50270-saint_jean_de_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50490-50270-saint_jean_de_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50490-50270-saint_jean_de_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50491-50680-saint_jean_de_savigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50491-50680-saint_jean_de_savigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50491-50680-saint_jean_de_savigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50491-50680-saint_jean_de_savigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50492-50810-saint_jean_d_elle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50492-50810-saint_jean_d_elle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50492-50810-saint_jean_d_elle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50492-50810-saint_jean_d_elle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50493-50320-saint_jean_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50493-50320-saint_jean_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50493-50320-saint_jean_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50493-50320-saint_jean_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50495-50370-saint_jean_du_corail_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50495-50370-saint_jean_du_corail_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50495-50370-saint_jean_du_corail_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50495-50370-saint_jean_du_corail_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50496-50530-saint_jean_le_thomas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50496-50530-saint_jean_le_thomas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50496-50530-saint_jean_le_thomas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50496-50530-saint_jean_le_thomas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50498-50700-saint_joseph/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50498-50700-saint_joseph/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50498-50700-saint_joseph/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50498-50700-saint_joseph/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50499-50670-saint_laurent_de_cuves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50499-50670-saint_laurent_de_cuves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50499-50670-saint_laurent_de_cuves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50499-50670-saint_laurent_de_cuves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50500-50240-saint_laurent_de_terregatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50500-50240-saint_laurent_de_terregatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50500-50240-saint_laurent_de_terregatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50500-50240-saint_laurent_de_terregatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50502-50000-saint_lo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50502-50000-saint_lo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50502-50000-saint_lo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50502-50000-saint_lo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50504-50420-saint_louet_sur_vire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50504-50420-saint_louet_sur_vire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50504-50420-saint_louet_sur_vire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50504-50420-saint_louet_sur_vire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50505-50300-saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50505-50300-saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50505-50300-saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50505-50300-saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50506-50200-saint_malo_de_la_lande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50506-50200-saint_malo_de_la_lande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50506-50200-saint_malo_de_la_lande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50506-50200-saint_malo_de_la_lande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50507-50310-saint_marcouf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50507-50310-saint_marcouf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50507-50310-saint_marcouf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50507-50310-saint_marcouf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50509-50480-sainte_marie_du_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50509-50480-sainte_marie_du_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50509-50480-sainte_marie_du_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50509-50480-sainte_marie_du_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50510-50190-saint_martin_d_aubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50510-50190-saint_martin_d_aubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50510-50190-saint_martin_d_aubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50510-50190-saint_martin_d_aubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50511-50310-saint_martin_d_audouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50511-50310-saint_martin_d_audouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50511-50310-saint_martin_d_audouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50511-50310-saint_martin_d_audouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50512-50750-saint_martin_de_bonfosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50512-50750-saint_martin_de_bonfosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50512-50750-saint_martin_de_bonfosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50512-50750-saint_martin_de_bonfosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50513-50210-saint_martin_de_cenilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50513-50210-saint_martin_de_cenilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50513-50210-saint_martin_de_cenilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50513-50210-saint_martin_de_cenilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50514-50150-chaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50514-50150-chaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50514-50150-chaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50514-50150-chaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50517-50480-saint_martin_de_varreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50517-50480-saint_martin_de_varreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50517-50480-saint_martin_de_varreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50517-50480-saint_martin_de_varreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50518-50800-saint_martin_le_bouillant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50518-50800-saint_martin_le_bouillant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50518-50800-saint_martin_le_bouillant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50518-50800-saint_martin_le_bouillant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50519-50690-saint_martin_le_greard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50519-50690-saint_martin_le_greard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50519-50690-saint_martin_le_greard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50519-50690-saint_martin_le_greard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50521-50800-saint_maur_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50521-50800-saint_maur_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50521-50800-saint_maur_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50521-50800-saint_maur_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50522-50270-saint_maurice_en_cotentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50522-50270-saint_maurice_en_cotentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50522-50270-saint_maurice_en_cotentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50522-50270-saint_maurice_en_cotentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50523-50480-sainte_mere_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50523-50480-sainte_mere_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50523-50480-sainte_mere_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50523-50480-sainte_mere_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50525-50670-saint_michel_de_montjoie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50525-50670-saint_michel_de_montjoie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50525-50670-saint_michel_de_montjoie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50525-50670-saint_michel_de_montjoie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50528-50250-saint_nicolas_de_pierrepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50528-50250-saint_nicolas_de_pierrepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50528-50250-saint_nicolas_de_pierrepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50528-50250-saint_nicolas_de_pierrepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50529-50370-saint_nicolas_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50529-50370-saint_nicolas_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50529-50370-saint_nicolas_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50529-50370-saint_nicolas_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50531-50300-saint_ovin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50531-50300-saint_ovin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50531-50300-saint_ovin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50531-50300-saint_ovin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50531-50220-saint_ovin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50531-50220-saint_ovin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50531-50220-saint_ovin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50531-50220-saint_ovin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50532-50380-saint_pair_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50532-50380-saint_pair_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50532-50380-saint_pair_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50532-50380-saint_pair_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50533-50190-saint_patrice_de_claids/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50533-50190-saint_patrice_de_claids/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50533-50190-saint_patrice_de_claids/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50533-50190-saint_patrice_de_claids/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50535-50870-le_parc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50535-50870-le_parc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50535-50870-le_parc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50535-50870-le_parc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50536-50270-saint_pierre_d_artheglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50536-50270-saint_pierre_d_artheglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50536-50270-saint_pierre_d_artheglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50536-50270-saint_pierre_d_artheglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50537-50200-saint_pierre_de_coutances/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50537-50200-saint_pierre_de_coutances/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50537-50200-saint_pierre_de_coutances/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50537-50200-saint_pierre_de_coutances/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50538-50810-saint_pierre_de_semilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50538-50810-saint_pierre_de_semilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50538-50810-saint_pierre_de_semilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50538-50810-saint_pierre_de_semilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50539-50330-saint_pierre_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50539-50330-saint_pierre_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50539-50330-saint_pierre_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50539-50330-saint_pierre_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50540-50530-saint_pierre_langers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50540-50530-saint_pierre_langers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50540-50530-saint_pierre_langers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50540-50530-saint_pierre_langers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50541-50400-saint_planchers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50541-50400-saint_planchers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50541-50400-saint_planchers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50541-50400-saint_planchers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50542-50670-saint_pois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50542-50670-saint_pois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50542-50670-saint_pois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50542-50670-saint_pois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50543-50220-saint_quentin_sur_le_homme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50543-50220-saint_quentin_sur_le_homme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50543-50220-saint_quentin_sur_le_homme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50543-50220-saint_quentin_sur_le_homme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50546-50750-bourgvallees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50546-50750-bourgvallees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50546-50750-bourgvallees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50546-50750-bourgvallees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50548-50250-saint_sauveur_de_pierrepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50548-50250-saint_sauveur_de_pierrepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50548-50250-saint_sauveur_de_pierrepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50548-50250-saint_sauveur_de_pierrepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50549-50510-saint_sauveur_la_pommeraye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50549-50510-saint_sauveur_la_pommeraye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50549-50510-saint_sauveur_la_pommeraye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50549-50510-saint_sauveur_la_pommeraye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50550-50490-saint_sauveur_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50550-50490-saint_sauveur_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50550-50490-saint_sauveur_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50550-50490-saint_sauveur_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50550-50200-saint_sauveur_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50550-50200-saint_sauveur_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50550-50200-saint_sauveur_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50550-50200-saint_sauveur_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50551-50390-saint_sauveur_le_vicomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50551-50390-saint_sauveur_le_vicomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50551-50390-saint_sauveur_le_vicomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50551-50390-saint_sauveur_le_vicomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50552-50190-saint_sebastien_de_raids/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50552-50190-saint_sebastien_de_raids/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50552-50190-saint_sebastien_de_raids/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50552-50190-saint_sebastien_de_raids/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50553-50240-saint_senier_de_beuvron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50553-50240-saint_senier_de_beuvron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50553-50240-saint_senier_de_beuvron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50553-50240-saint_senier_de_beuvron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50554-50300-saint_senier_sous_avranches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50554-50300-saint_senier_sous_avranches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50554-50300-saint_senier_sous_avranches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50554-50300-saint_senier_sous_avranches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50556-50750-sainte_suzanne_sur_vire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50556-50750-sainte_suzanne_sur_vire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50556-50750-sainte_suzanne_sur_vire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50556-50750-sainte_suzanne_sur_vire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50562-50550-saint_vaast_la_hougue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50562-50550-saint_vaast_la_hougue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50562-50550-saint_vaast_la_hougue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50562-50550-saint_vaast_la_hougue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50563-50420-saint_vigor_des_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50563-50420-saint_vigor_des_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50563-50420-saint_vigor_des_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50563-50420-saint_vigor_des_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50564-50500-terre_et_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50564-50500-terre_et_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50564-50500-terre_et_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50564-50500-terre_et_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50565-50530-sartilly_baie_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50565-50530-sartilly_baie_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50565-50530-sartilly_baie_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50565-50530-sartilly_baie_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50567-50700-saussemesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50567-50700-saussemesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50567-50700-saussemesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50567-50700-saussemesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50568-50200-saussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50568-50200-saussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50568-50200-saussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50568-50200-saussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50569-50210-savigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50569-50210-savigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50569-50210-savigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50569-50210-savigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50570-50640-savigny_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50570-50640-savigny_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50570-50640-savigny_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50570-50640-savigny_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50571-50480-sebeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50571-50480-sebeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50571-50480-sebeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50571-50480-sebeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50572-50270-senoville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50572-50270-senoville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50572-50270-senoville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50572-50270-senoville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50574-50170-servon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50574-50170-servon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50574-50170-servon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50574-50170-servon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50575-50690-sideville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50575-50690-sideville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50575-50690-sideville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50575-50690-sideville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50576-50340-siouville_hague/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50576-50340-siouville_hague/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50576-50340-siouville_hague/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50576-50340-siouville_hague/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50577-50270-sortosville_en_beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50577-50270-sortosville_en_beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50577-50270-sortosville_en_beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50577-50270-sortosville_en_beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50578-50310-sortosville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50578-50310-sortosville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50578-50310-sortosville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50578-50310-sortosville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50579-50260-sottevast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50579-50260-sottevast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50579-50260-sottevast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50579-50260-sottevast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50580-50340-sotteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50580-50340-sotteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50580-50340-sotteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50580-50340-sotteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50582-50150-sourdeval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50582-50150-sourdeval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50582-50150-sourdeval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50582-50150-sourdeval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50584-50870-subligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50584-50870-subligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50584-50870-subligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50584-50870-subligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50585-50270-surtainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50585-50270-surtainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50585-50270-surtainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50585-50270-surtainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50587-50390-taillepied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50587-50390-taillepied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50587-50390-taillepied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50587-50390-taillepied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50588-50700-tamerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50588-50700-tamerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50588-50700-tamerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50588-50700-tamerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50589-50170-tanis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50589-50170-tanis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50589-50170-tanis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50589-50170-tanis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50590-50320-le_tanu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50590-50320-le_tanu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50590-50320-le_tanu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50590-50320-le_tanu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50591-50640-le_teilleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50591-50640-le_teilleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50591-50640-le_teilleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50591-50640-le_teilleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50592-50420-tessy_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50592-50420-tessy_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50592-50420-tessy_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50592-50420-tessy_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50593-50630-teurtheville_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50593-50630-teurtheville_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50593-50630-teurtheville_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50593-50630-teurtheville_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50594-50690-teurtheville_hague/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50594-50690-teurtheville_hague/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50594-50690-teurtheville_hague/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50594-50690-teurtheville_hague/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50596-50330-theville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50596-50330-theville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50596-50330-theville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50596-50330-theville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50597-50870-tirepied_sur_see/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50597-50870-tirepied_sur_see/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50597-50870-tirepied_sur_see/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50597-50870-tirepied_sur_see/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50597-50300-tirepied_sur_see/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50597-50300-tirepied_sur_see/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50597-50300-tirepied_sur_see/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50597-50300-tirepied_sur_see/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50598-50330-tocqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50598-50330-tocqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50598-50330-tocqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50598-50330-tocqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50599-50470-tollevast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50599-50470-tollevast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50599-50470-tollevast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50599-50470-tollevast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50601-50160-torigny_les_villes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50601-50160-torigny_les_villes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50601-50160-torigny_les_villes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50601-50160-torigny_les_villes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50603-50200-tourville_sur_sienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50603-50200-tourville_sur_sienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50603-50200-tourville_sur_sienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50603-50200-tourville_sur_sienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50604-50340-treauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50604-50340-treauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50604-50340-treauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50604-50340-treauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50606-50620-tribehou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50606-50620-tribehou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50606-50620-tribehou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50606-50620-tribehou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50607-50800-la_trinite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50607-50800-la_trinite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50607-50800-la_trinite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50607-50800-la_trinite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50609-50480-turqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50609-50480-turqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50609-50480-turqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50609-50480-turqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50610-50700-urville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50610-50700-urville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50610-50700-urville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50610-50700-urville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50612-50300-vains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50612-50300-vains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50612-50300-vains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50612-50300-vains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50613-50760-valcanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50613-50760-valcanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50613-50760-valcanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50613-50760-valcanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50615-50700-valognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50615-50700-valognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50615-50700-valognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50615-50700-valognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50616-50300-le_val_saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50616-50300-le_val_saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50616-50300-le_val_saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50616-50300-le_val_saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50617-50250-varenguebec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50617-50250-varenguebec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50617-50250-varenguebec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50617-50250-varenguebec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50618-50330-varouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50618-50330-varouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50618-50330-varouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50618-50330-varouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50619-50630-le_vast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50619-50630-le_vast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50619-50630-le_vast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50619-50630-le_vast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50621-50310-vaudreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50621-50310-vaudreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50621-50310-vaudreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50621-50310-vaudreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50624-50200-la_vendelee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50624-50200-la_vendelee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50624-50200-la_vendelee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50624-50200-la_vendelee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50626-50450-ver/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50626-50450-ver/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50626-50450-ver/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50626-50450-ver/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50628-50370-vernix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50628-50370-vernix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50628-50370-vernix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50628-50370-vernix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50629-50430-vesly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50629-50430-vesly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50629-50430-vesly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50629-50430-vesly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50633-50760-le_vicel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50633-50760-le_vicel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50633-50760-le_vicel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50633-50760-le_vicel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50634-50630-videcosville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50634-50630-videcosville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50634-50630-videcosville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50634-50630-videcosville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50637-50410-villebaudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50637-50410-villebaudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50637-50410-villebaudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50637-50410-villebaudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50639-50800-villedieu_les_poeles_rouffigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50639-50800-villedieu_les_poeles_rouffigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50639-50800-villedieu_les_poeles_rouffigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50639-50800-villedieu_les_poeles_rouffigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50641-50680-villiers_fossard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50641-50680-villiers_fossard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50641-50680-villiers_fossard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50641-50680-villiers_fossard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50643-50690-virandeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50643-50690-virandeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50643-50690-virandeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50643-50690-virandeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50647-50400-yquelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50647-50400-yquelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50647-50400-yquelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50647-50400-yquelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50648-50700-yvetot_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50648-50700-yvetot_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50648-50700-yvetot_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt50-manche/commune50648-50700-yvetot_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-51.xml
+++ b/public/sitemaps/sitemap-51.xml
@@ -5,1238 +5,2472 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51001-51240-ablancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51001-51240-ablancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51001-51240-ablancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51001-51240-ablancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51002-51530-saint_martin_d_ablois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51002-51530-saint_martin_d_ablois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51002-51530-saint_martin_d_ablois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51002-51530-saint_martin_d_ablois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51003-51150-aigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51003-51150-aigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51003-51150-aigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51003-51150-aigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51004-51260-allemanche_launay_et_soyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51004-51260-allemanche_launay_et_soyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51004-51260-allemanche_launay_et_soyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51004-51260-allemanche_launay_et_soyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51005-51120-allemant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51005-51120-allemant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51005-51120-allemant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51005-51120-allemant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51006-51250-alliancelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51006-51250-alliancelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51006-51250-alliancelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51006-51250-alliancelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51007-51150-ambonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51007-51150-ambonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51007-51150-ambonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51007-51150-ambonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51008-51290-ambrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51008-51290-ambrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51008-51290-ambrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51008-51290-ambrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51009-51260-anglure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51009-51260-anglure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51009-51260-anglure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51009-51260-anglure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51010-51230-angluzelles_et_courcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51010-51230-angluzelles_et_courcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51010-51230-angluzelles_et_courcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51010-51230-angluzelles_et_courcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51012-51700-anthenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51012-51700-anthenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51012-51700-anthenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51012-51700-anthenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51013-51170-aougny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51013-51170-aougny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51013-51170-aougny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51013-51170-aougny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51014-51170-arcis_le_ponsart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51014-51170-arcis_le_ponsart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51014-51170-arcis_le_ponsart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51014-51170-arcis_le_ponsart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51015-51800-argers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51015-51800-argers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51015-51800-argers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51015-51800-argers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51016-51290-arrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51016-51290-arrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51016-51290-arrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51016-51290-arrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51017-51290-arzillieres_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51017-51290-arzillieres_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51017-51290-arzillieres_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51017-51290-arzillieres_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51018-51150-athis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51018-51150-athis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51018-51150-athis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51018-51150-athis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51019-51600-auberive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51019-51600-auberive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51019-51600-auberive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51019-51600-auberive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51020-51170-aubilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51020-51170-aubilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51020-51170-aubilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51020-51170-aubilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51022-51240-aulnay_l_aitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51022-51240-aulnay_l_aitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51022-51240-aulnay_l_aitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51022-51240-aulnay_l_aitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51023-51150-aulnay_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51023-51150-aulnay_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51023-51150-aulnay_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51023-51150-aulnay_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51025-51110-aumenancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51025-51110-aumenancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51025-51110-aumenancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51025-51110-aumenancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51027-51800-auve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51027-51800-auve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51027-51800-auve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51027-51800-auve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51028-51160-avenay_val_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51028-51160-avenay_val_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51028-51160-avenay_val_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51028-51160-avenay_val_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51029-51190-avize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51029-51190-avize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51029-51190-avize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51029-51190-avize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51030-51150-aÿ_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51030-51150-aÿ_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51030-51150-aÿ_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51030-51150-aÿ_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51030-51160-aÿ_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51030-51160-aÿ_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51030-51160-aÿ_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51030-51160-aÿ_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51031-51400-baconnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51031-51400-baconnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51031-51400-baconnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51031-51400-baconnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51032-51260-bagneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51032-51260-bagneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51032-51260-bagneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51032-51260-bagneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51033-51270-le_baizil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51033-51270-le_baizil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51033-51270-le_baizil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51033-51270-le_baizil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51034-51270-bannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51034-51270-bannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51034-51270-bannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51034-51270-bannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51035-51230-bannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51035-51230-bannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51035-51230-bannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51035-51230-bannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51036-51120-barbonne_fayel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51036-51120-barbonne_fayel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51036-51120-barbonne_fayel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51036-51120-barbonne_fayel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51037-51170-baslieux_les_fismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51037-51170-baslieux_les_fismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51037-51170-baslieux_les_fismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51037-51170-baslieux_les_fismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51038-51700-baslieux_sous_chatillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51038-51700-baslieux_sous_chatillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51038-51700-baslieux_sous_chatillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51038-51700-baslieux_sous_chatillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51039-51300-bassu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51039-51300-bassu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51039-51300-bassu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51039-51300-bassu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51040-51300-bassuet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51040-51300-bassuet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51040-51300-bassuet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51040-51300-bassuet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51041-51260-baudement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51041-51260-baudement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51041-51260-baudement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51041-51260-baudement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51042-51270-baye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51042-51270-baye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51042-51270-baye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51042-51270-baye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51043-51110-bazancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51043-51110-bazancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51043-51110-bazancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51043-51110-bazancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51044-51360-beaumont_sur_vesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51044-51360-beaumont_sur_vesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51044-51360-beaumont_sur_vesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51044-51360-beaumont_sur_vesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51045-51270-beaunay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51045-51270-beaunay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51045-51270-beaunay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51045-51270-beaunay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51046-51490-beine_nauroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51046-51490-beine_nauroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51046-51490-beine_nauroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51046-51490-beine_nauroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51047-51330-belval_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51047-51330-belval_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51047-51330-belval_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51047-51330-belval_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51048-51480-belval_sous_chatillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51048-51480-belval_sous_chatillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51048-51480-belval_sous_chatillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51048-51480-belval_sous_chatillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51049-51130-bergeres_les_vertus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51049-51130-bergeres_les_vertus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51049-51130-bergeres_les_vertus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51049-51130-bergeres_les_vertus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51050-51210-bergeres_sous_montmirail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51050-51210-bergeres_sous_montmirail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51050-51210-bergeres_sous_montmirail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51050-51210-bergeres_sous_montmirail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51051-51220-bermericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51051-51220-bermericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51051-51220-bermericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51051-51220-bermericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51052-51420-berru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51052-51420-berru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51052-51420-berru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51052-51420-berru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51053-51800-berzieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51053-51800-berzieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51053-51800-berzieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51053-51800-berzieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51054-51490-betheniville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51054-51490-betheniville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51054-51490-betheniville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51054-51490-betheniville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51055-51450-betheny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51055-51450-betheny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51055-51450-betheny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51055-51450-betheny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51056-51260-bethon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51056-51260-bethon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51056-51260-bethon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51056-51260-bethon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51057-51330-bettancourt_la_longue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51057-51330-bettancourt_la_longue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51057-51330-bettancourt_la_longue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51057-51330-bettancourt_la_longue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51058-51430-bezannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51058-51430-bezannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51058-51430-bezannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51058-51430-bezannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51059-51300-bignicourt_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51059-51300-bignicourt_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51059-51300-bignicourt_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51059-51300-bignicourt_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51060-51340-bignicourt_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51060-51340-bignicourt_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51060-51340-bignicourt_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51060-51340-bignicourt_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51061-51400-billy_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51061-51400-billy_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51061-51400-billy_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51061-51400-billy_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51062-51800-binarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51062-51800-binarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51062-51800-binarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51062-51800-binarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51063-51700-binson_et_orquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51063-51700-binson_et_orquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51063-51700-binson_et_orquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51063-51700-binson_et_orquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51065-51300-blacy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51065-51300-blacy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51065-51300-blacy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51065-51300-blacy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51066-51300-blaise_sous_arzillieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51066-51300-blaise_sous_arzillieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51066-51300-blaise_sous_arzillieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51066-51300-blaise_sous_arzillieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51068-51340-blesme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51068-51340-blesme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51068-51340-blesme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51068-51340-blesme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51069-51170-bligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51069-51170-bligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51069-51170-bligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51069-51170-bligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51070-51210-boissy_le_repos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51070-51210-boissy_le_repos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51070-51210-boissy_le_repos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51070-51210-boissy_le_repos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51071-51310-bouchy_saint_genest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51071-51310-bouchy_saint_genest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51071-51310-bouchy_saint_genest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51071-51310-bouchy_saint_genest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51072-51390-bouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51072-51390-bouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51072-51390-bouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51072-51390-bouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51073-51170-bouleuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51073-51170-bouleuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51073-51170-bouleuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51073-51170-bouleuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51074-51110-boult_sur_suippe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51074-51110-boult_sur_suippe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51074-51110-boult_sur_suippe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51074-51110-boult_sur_suippe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51075-51110-bourgogne_fresne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51075-51110-bourgogne_fresne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51075-51110-bourgogne_fresne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51075-51110-bourgogne_fresne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51076-51480-boursault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51076-51480-boursault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51076-51480-boursault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51076-51480-boursault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51077-51140-bouvancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51077-51140-bouvancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51077-51140-bouvancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51077-51140-bouvancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51078-51400-bouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51078-51400-bouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51078-51400-bouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51078-51400-bouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51079-51150-bouzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51079-51150-bouzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51079-51150-bouzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51079-51150-bouzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51080-51290-brandonvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51080-51290-brandonvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51080-51290-brandonvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51080-51290-brandonvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51081-51140-branscourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51081-51140-branscourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51081-51140-branscourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51081-51140-branscourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51082-51800-braux_sainte_cohiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51082-51800-braux_sainte_cohiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51082-51800-braux_sainte_cohiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51082-51800-braux_sainte_cohiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51083-51800-braux_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51083-51800-braux_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51083-51800-braux_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51083-51800-braux_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51084-51320-breban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51084-51320-breban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51084-51320-breban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51084-51320-breban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51085-51210-le_breuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51085-51210-le_breuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51085-51210-le_breuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51085-51210-le_breuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51086-51140-breuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51086-51140-breuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51086-51140-breuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51086-51140-breuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51087-51240-breuvery_sur_coole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51087-51240-breuvery_sur_coole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51087-51240-breuvery_sur_coole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51087-51240-breuvery_sur_coole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51088-51220-brimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51088-51220-brimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51088-51220-brimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51088-51220-brimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51089-51170-brouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51089-51170-brouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51089-51170-brouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51089-51170-brouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51090-51230-broussy_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51090-51230-broussy_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51090-51230-broussy_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51090-51230-broussy_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51091-51230-broussy_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51091-51230-broussy_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51091-51230-broussy_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51091-51230-broussy_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51092-51120-broyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51092-51120-broyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51092-51120-broyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51092-51120-broyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51093-51530-brugny_vaudancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51093-51530-brugny_vaudancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51093-51530-brugny_vaudancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51093-51530-brugny_vaudancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51094-51300-brusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51094-51300-brusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51094-51300-brusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51094-51300-brusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51095-51300-le_buisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51095-51300-le_buisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51095-51300-le_buisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51095-51300-le_buisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51097-51600-bussy_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51097-51600-bussy_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51097-51600-bussy_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51097-51600-bussy_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51098-51330-bussy_le_repos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51098-51330-bussy_le_repos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51098-51330-bussy_le_repos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51098-51330-bussy_le_repos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51099-51320-bussy_lettree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51099-51320-bussy_lettree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51099-51320-bussy_lettree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51099-51320-bussy_lettree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51100-51270-la_caure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51100-51270-la_caure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51100-51270-la_caure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51100-51270-la_caure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51101-51110-caurel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51101-51110-caurel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51101-51110-caurel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51101-51110-caurel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51102-51220-cauroy_les_hermonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51102-51220-cauroy_les_hermonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51102-51220-cauroy_les_hermonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51102-51220-cauroy_les_hermonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51103-51260-la_celle_sous_chantemerle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51103-51260-la_celle_sous_chantemerle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51103-51260-la_celle_sous_chantemerle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51103-51260-la_celle_sous_chantemerle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51104-51800-cernay_en_dormois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51104-51800-cernay_en_dormois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51104-51800-cernay_en_dormois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51104-51800-cernay_en_dormois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51105-51420-cernay_les_reims/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51105-51420-cernay_les_reims/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51105-51420-cernay_les_reims/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51105-51420-cernay_les_reims/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51106-51240-cernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51106-51240-cernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51106-51240-cernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51106-51240-cernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51107-51130-chaintrix_bierges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51107-51130-chaintrix_bierges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51107-51130-chaintrix_bierges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51107-51130-chaintrix_bierges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51108-51000-chalons_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51108-51000-chalons_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51108-51000-chalons_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51108-51000-chalons_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51109-51140-chalons_sur_vesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51109-51140-chalons_sur_vesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51109-51140-chalons_sur_vesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51109-51140-chalons_sur_vesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51110-51130-chaltrait/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51110-51130-chaltrait/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51110-51130-chaltrait/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51110-51130-chaltrait/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51111-51170-chambrecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51111-51170-chambrecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51111-51170-chambrecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51111-51170-chambrecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51112-51500-chamery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51112-51500-chamery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51112-51500-chamery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51112-51500-chamery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51113-51270-champaubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51113-51270-champaubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51113-51270-champaubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51113-51270-champaubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51115-51500-champfleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51115-51500-champfleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51115-51500-champfleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51115-51500-champfleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51116-51310-champguyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51116-51310-champguyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51116-51310-champguyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51116-51310-champguyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51117-51150-champigneul_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51117-51150-champigneul_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51117-51150-champigneul_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51117-51150-champigneul_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51118-51370-champigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51118-51370-champigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51118-51370-champigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51118-51370-champigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51119-51160-champillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51119-51160-champillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51119-51160-champillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51119-51160-champillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51120-51480-champlat_et_boujacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51120-51480-champlat_et_boujacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51120-51480-champlat_et_boujacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51120-51480-champlat_et_boujacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51121-51700-champvoisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51121-51700-champvoisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51121-51700-champvoisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51121-51700-champvoisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51122-51300-changy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51122-51300-changy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51122-51300-changy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51122-51300-changy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51124-51260-chantemerle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51124-51260-chantemerle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51124-51260-chantemerle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51124-51260-chantemerle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51125-51290-chapelaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51125-51290-chapelaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51125-51290-chapelaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51125-51290-chapelaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51126-51800-la_chapelle_felcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51126-51800-la_chapelle_felcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51126-51800-la_chapelle_felcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51126-51800-la_chapelle_felcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51127-51260-la_chapelle_lasson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51127-51260-la_chapelle_lasson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51127-51260-la_chapelle_lasson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51127-51260-la_chapelle_lasson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51128-51270-la_chapelle_sous_orbais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51128-51270-la_chapelle_sous_orbais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51128-51270-la_chapelle_sous_orbais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51128-51270-la_chapelle_sous_orbais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51129-51120-charleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51129-51120-charleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51129-51120-charleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51129-51120-charleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51130-51330-charmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51130-51330-charmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51130-51330-charmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51130-51330-charmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51132-51330-les_charmontois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51132-51330-les_charmontois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51132-51330-les_charmontois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51132-51330-les_charmontois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51133-51330-le_chatelier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51133-51330-le_chatelier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51133-51330-le_chatelier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51133-51330-le_chatelier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51134-51300-chatelraould_saint_louvent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51134-51300-chatelraould_saint_louvent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51134-51300-chatelraould_saint_louvent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51134-51300-chatelraould_saint_louvent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51135-51290-chatillon_sur_broue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51135-51290-chatillon_sur_broue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51135-51290-chatillon_sur_broue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51135-51290-chatillon_sur_broue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51136-51700-chatillon_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51136-51700-chatillon_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51136-51700-chatillon_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51136-51700-chatillon_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51137-51310-chatillon_sur_morin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51137-51310-chatillon_sur_morin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51137-51310-chatillon_sur_morin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51137-51310-chatillon_sur_morin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51138-51800-chatrices/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51138-51800-chatrices/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51138-51800-chatrices/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51138-51800-chatrices/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51139-51800-chaudefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51139-51800-chaudefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51139-51800-chaudefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51139-51800-chaudefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51140-51170-chaumuzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51140-51170-chaumuzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51140-51170-chaumuzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51140-51170-chaumuzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51141-51240-la_chaussee_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51141-51240-la_chaussee_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51141-51240-la_chaussee_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51141-51240-la_chaussee_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51142-51530-chavot_courcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51142-51530-chavot_courcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51142-51530-chavot_courcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51142-51530-chavot_courcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51143-51800-le_chemin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51143-51800-le_chemin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51143-51800-le_chemin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51143-51800-le_chemin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51144-51250-cheminon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51144-51250-cheminon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51144-51250-cheminon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51144-51250-cheminon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51145-51140-chenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51145-51140-chenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51145-51140-chenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51145-51140-chenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51146-51510-cheniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51146-51510-cheniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51146-51510-cheniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51146-51510-cheniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51147-51600-la_cheppe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51147-51600-la_cheppe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51147-51600-la_cheppe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51147-51600-la_cheppe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51148-51240-cheppes_la_prairie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51148-51240-cheppes_la_prairie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51148-51240-cheppes_la_prairie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51148-51240-cheppes_la_prairie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51149-51240-chepy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51149-51240-chepy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51149-51240-chepy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51149-51240-chepy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51150-51150-cherville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51150-51150-cherville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51150-51150-cherville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51150-51150-cherville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51151-51120-chichey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51151-51120-chichey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51151-51120-chichey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51151-51120-chichey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51152-51500-chigny_les_roses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51152-51500-chigny_les_roses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51152-51500-chigny_les_roses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51152-51500-chigny_les_roses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51153-51530-chouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51153-51530-chouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51153-51530-chouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51153-51530-chouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51154-51130-clamanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51154-51130-clamanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51154-51130-clamanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51154-51130-clamanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51155-51260-clesles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51155-51260-clesles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51155-51260-clesles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51155-51260-clesles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51156-51300-cloyes_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51156-51300-cloyes_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51156-51300-cloyes_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51156-51300-cloyes_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51157-51270-coizard_joches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51157-51270-coizard_joches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51157-51270-coizard_joches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51157-51270-coizard_joches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51158-51130-val_des_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51158-51130-val_des_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51158-51130-val_des_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51158-51130-val_des_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51160-51510-compertrix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51160-51510-compertrix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51160-51510-compertrix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51160-51510-compertrix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51161-51150-conde_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51161-51150-conde_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51161-51150-conde_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51161-51150-conde_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51162-51260-conflans_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51162-51260-conflans_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51162-51260-conflans_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51162-51260-conflans_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51163-51270-congy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51163-51270-congy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51163-51270-congy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51163-51270-congy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51164-51230-connantray_vaurefroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51164-51230-connantray_vaurefroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51164-51230-connantray_vaurefroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51164-51230-connantray_vaurefroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51165-51230-connantre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51165-51230-connantre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51165-51230-connantre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51165-51230-connantre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51166-51330-contault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51166-51330-contault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51166-51330-contault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51166-51330-contault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51167-51320-coole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51167-51320-coole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51167-51320-coole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51167-51320-coole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51168-51510-coolus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51168-51510-coolus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51168-51510-coolus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51168-51510-coolus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51169-51320-corbeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51169-51320-corbeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51169-51320-corbeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51169-51320-corbeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51170-51210-corfelix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51170-51210-corfelix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51170-51210-corfelix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51170-51210-corfelix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51171-51220-cormicy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51171-51220-cormicy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51171-51220-cormicy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51171-51220-cormicy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51172-51350-cormontreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51172-51350-cormontreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51172-51350-cormontreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51172-51350-cormontreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51173-51480-cormoyeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51173-51480-cormoyeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51173-51480-cormoyeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51173-51480-cormoyeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51174-51270-corribert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51174-51270-corribert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51174-51270-corribert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51174-51270-corribert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51175-51210-corrobert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51175-51210-corrobert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51175-51210-corrobert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51175-51210-corrobert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51176-51230-corroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51176-51230-corroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51176-51230-corroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51176-51230-corroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51177-51390-coulommes_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51177-51390-coulommes_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51177-51390-coulommes_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51177-51390-coulommes_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51178-51240-coupetz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51178-51240-coupetz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51178-51240-coupetz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51178-51240-coupetz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51179-51240-coupeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51179-51240-coupeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51179-51240-coupeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51179-51240-coupeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51181-51140-courcelles_sapicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51181-51140-courcelles_sapicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51181-51140-courcelles_sapicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51181-51140-courcelles_sapicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51182-51260-courcemain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51182-51260-courcemain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51182-51260-courcemain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51182-51260-courcemain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51183-51220-courcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51183-51220-courcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51183-51220-courcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51183-51220-courcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51184-51300-courdemanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51184-51300-courdemanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51184-51300-courdemanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51184-51300-courdemanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51185-51310-courgivaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51185-51310-courgivaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51185-51310-courgivaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51185-51310-courgivaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51186-51270-courjeonnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51186-51270-courjeonnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51186-51270-courjeonnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51186-51270-courjeonnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51187-51170-courlandon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51187-51170-courlandon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51187-51170-courlandon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51187-51170-courlandon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51188-51390-courmas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51188-51390-courmas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51188-51390-courmas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51188-51390-courmas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51190-51480-courtagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51190-51480-courtagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51190-51480-courtagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51190-51480-courtagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51191-51800-courtemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51191-51800-courtemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51191-51800-courtemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51191-51800-courtemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51192-51700-courthiezy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51192-51700-courthiezy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51192-51700-courthiezy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51192-51700-courthiezy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51193-51460-courtisols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51193-51460-courtisols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51193-51460-courtisols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51193-51460-courtisols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51194-51170-courville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51194-51170-courville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51194-51170-courville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51194-51170-courville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51195-51300-couvrot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51195-51300-couvrot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51195-51300-couvrot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51195-51300-couvrot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51196-51530-cramant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51196-51530-cramant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51196-51530-cramant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51196-51530-cramant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51197-51600-la_croix_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51197-51600-la_croix_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51197-51600-la_croix_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51197-51600-la_croix_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51198-51170-crugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51198-51170-crugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51198-51170-crugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51198-51170-crugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51199-51480-cuchery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51199-51480-cuchery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51199-51480-cuchery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51199-51480-cuchery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51200-51530-cuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51200-51530-cuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51200-51530-cuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51200-51530-cuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51201-51700-cuisles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51201-51700-cuisles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51201-51700-cuisles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51201-51700-cuisles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51202-51480-cumieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51202-51480-cumieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51202-51480-cumieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51202-51480-cumieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51203-51400-cuperly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51203-51400-cuperly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51203-51400-cuperly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51203-51400-cuperly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51204-51480-damery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51204-51480-damery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51204-51480-damery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51204-51480-damery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51205-51400-dampierre_au_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51205-51400-dampierre_au_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51205-51400-dampierre_au_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51205-51400-dampierre_au_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51206-51330-dampierre_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51206-51330-dampierre_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51206-51330-dampierre_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51206-51330-dampierre_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51208-51240-dampierre_sur_moivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51208-51240-dampierre_sur_moivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51208-51240-dampierre_sur_moivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51208-51240-dampierre_sur_moivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51210-51530-dizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51210-51530-dizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51210-51530-dizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51210-51530-dizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51211-51800-dommartin_dampierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51211-51800-dommartin_dampierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51211-51800-dommartin_dampierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51211-51800-dommartin_dampierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51212-51320-dommartin_lettree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51212-51320-dommartin_lettree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51212-51320-dommartin_lettree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51212-51320-dommartin_lettree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51213-51800-dommartin_sous_hans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51213-51800-dommartin_sous_hans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51213-51800-dommartin_sous_hans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51213-51800-dommartin_sous_hans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51214-51330-dommartin_varimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51214-51330-dommartin_varimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51214-51330-dommartin_varimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51214-51330-dommartin_varimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51215-51300-dompremy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51215-51300-dompremy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51215-51300-dompremy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51215-51300-dompremy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51216-51490-dontrien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51216-51490-dontrien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51216-51490-dontrien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51216-51490-dontrien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51217-51700-dormans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51217-51700-dormans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51217-51700-dormans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51217-51700-dormans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51218-51340-val_de_viere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51218-51340-val_de_viere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51218-51340-val_de_viere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51218-51340-val_de_viere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51219-51290-drosnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51219-51290-drosnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51219-51290-drosnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51219-51290-drosnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51220-51300-drouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51220-51300-drouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51220-51300-drouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51220-51300-drouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51222-51800-eclaires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51222-51800-eclaires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51222-51800-eclaires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51222-51800-eclaires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51223-51290-ecollemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51223-51290-ecollemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51223-51290-ecollemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51223-51290-ecollemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51224-51300-ecriennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51224-51300-ecriennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51224-51300-ecriennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51224-51300-ecriennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51225-51500-ecueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51225-51500-ecueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51225-51500-ecueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51225-51500-ecueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51226-51230-ecury_le_repos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51226-51230-ecury_le_repos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51226-51230-ecury_le_repos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51226-51230-ecury_le_repos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51227-51240-ecury_sur_coole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51227-51240-ecury_sur_coole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51227-51240-ecury_sur_coole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51227-51240-ecury_sur_coole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51228-51800-elise_daucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51228-51800-elise_daucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51228-51800-elise_daucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51228-51800-elise_daucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51229-51330-epense/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51229-51330-epense/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51229-51330-epense/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51229-51330-epense/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51230-51200-epernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51230-51200-epernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51230-51200-epernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51230-51200-epernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51231-51460-l_epine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51231-51460-l_epine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51231-51460-l_epine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51231-51460-l_epine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51232-51490-epoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51232-51490-epoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51232-51490-epoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51232-51490-epoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51233-51310-escardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51233-51310-escardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51233-51310-escardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51233-51310-escardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51234-51260-esclavolles_lurey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51234-51260-esclavolles_lurey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51234-51260-esclavolles_lurey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51234-51260-esclavolles_lurey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51235-51120-les_essarts_les_sezanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51235-51120-les_essarts_les_sezanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51235-51120-les_essarts_les_sezanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51235-51120-les_essarts_les_sezanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51236-51310-les_essarts_le_vicomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51236-51310-les_essarts_le_vicomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51236-51310-les_essarts_le_vicomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51236-51310-les_essarts_le_vicomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51237-51310-esternay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51237-51310-esternay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51237-51310-esternay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51237-51310-esternay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51238-51270-etoges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51238-51270-etoges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51238-51270-etoges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51238-51270-etoges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51239-51130-etrechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51239-51130-etrechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51239-51130-etrechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51239-51130-etrechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51240-51340-etrepy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51240-51340-etrepy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51240-51340-etrepy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51240-51340-etrepy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51241-51230-euvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51241-51230-euvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51241-51230-euvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51241-51230-euvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51242-51510-fagnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51242-51510-fagnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51242-51510-fagnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51242-51510-fagnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51243-51230-faux_fresnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51243-51230-faux_fresnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51243-51230-faux_fresnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51243-51230-faux_fresnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51244-51320-faux_vesigneul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51244-51320-faux_vesigneul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51244-51320-faux_vesigneul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51244-51320-faux_vesigneul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51245-51170-faverolles_et_coemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51245-51170-faverolles_et_coemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51245-51170-faverolles_et_coemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51245-51170-faverolles_et_coemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51246-51300-favresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51246-51300-favresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51246-51300-favresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51246-51300-favresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51247-51270-ferebrianges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51247-51270-ferebrianges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51247-51270-ferebrianges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51247-51270-ferebrianges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51248-51230-fere_champenoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51248-51230-fere_champenoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51248-51230-fere_champenoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51248-51230-fere_champenoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51249-51700-festigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51249-51700-festigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51249-51700-festigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51249-51700-festigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51250-51170-fismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51250-51170-fismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51250-51170-fismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51250-51170-fismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51251-51190-flavigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51251-51190-flavigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51251-51190-flavigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51251-51190-flavigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51252-51480-fleury_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51252-51480-fleury_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51252-51480-fleury_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51252-51480-fleury_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51253-51800-florent_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51253-51800-florent_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51253-51800-florent_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51253-51800-florent_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51253-55120-florent_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51253-55120-florent_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51253-55120-florent_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51253-55120-florent_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51254-51120-fontaine_denis_nuisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51254-51120-fontaine_denis_nuisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51254-51120-fontaine_denis_nuisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51254-51120-fontaine_denis_nuisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51255-51800-fontaine_en_dormois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51255-51800-fontaine_en_dormois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51255-51800-fontaine_en_dormois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51255-51800-fontaine_en_dormois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51256-51160-fontaine_sur_ay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51256-51160-fontaine_sur_ay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51256-51160-fontaine_sur_ay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51256-51160-fontaine_sur_ay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51258-51120-la_forestiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51258-51120-la_forestiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51258-51120-la_forestiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51258-51120-la_forestiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51259-51240-francheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51259-51240-francheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51259-51240-francheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51259-51240-francheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51260-51240-le_fresne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51260-51240-le_fresne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51260-51240-le_fresne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51260-51240-le_fresne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51262-51300-frignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51262-51300-frignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51262-51300-frignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51262-51300-frignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51263-51210-fromentieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51263-51210-fromentieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51263-51210-fromentieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51263-51210-fromentieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51264-51210-le_gault_soigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51264-51210-le_gault_soigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51264-51210-le_gault_soigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51264-51210-le_gault_soigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51265-51120-gaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51265-51120-gaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51265-51120-gaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51265-51120-gaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51266-51160-germaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51266-51160-germaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51266-51160-germaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51266-51160-germaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51267-51390-germigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51267-51390-germigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51267-51390-germigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51267-51390-germigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51268-51130-germinon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51268-51130-germinon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51268-51130-germinon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51268-51130-germinon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51269-51290-giffaumont_champaubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51269-51290-giffaumont_champaubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51269-51290-giffaumont_champaubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51269-51290-giffaumont_champaubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51270-51290-gigny_bussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51270-51290-gigny_bussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51270-51290-gigny_bussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51270-51290-gigny_bussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51272-51330-givry_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51272-51330-givry_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51272-51330-givry_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51272-51330-givry_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51273-51130-givry_les_loisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51273-51130-givry_les_loisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51273-51130-givry_les_loisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51273-51130-givry_les_loisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51274-51800-gizaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51274-51800-gizaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51274-51800-gizaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51274-51800-gizaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51275-51300-glannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51275-51300-glannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51275-51300-glannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51275-51300-glannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51276-51230-gourgancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51276-51230-gourgancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51276-51230-gourgancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51276-51230-gourgancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51277-51290-sainte_marie_du_lac_nuisement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51277-51290-sainte_marie_du_lac_nuisement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51277-51290-sainte_marie_du_lac_nuisement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51277-51290-sainte_marie_du_lac_nuisement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51278-51400-les_grandes_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51278-51400-les_grandes_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51278-51400-les_grandes_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51278-51400-les_grandes_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51279-51260-granges_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51279-51260-granges_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51279-51260-granges_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51279-51260-granges_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51280-51800-gratreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51280-51800-gratreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51280-51800-gratreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51280-51800-gratreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51281-51190-grauves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51281-51190-grauves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51281-51190-grauves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51281-51190-grauves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51282-51390-gueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51282-51390-gueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51282-51390-gueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51282-51390-gueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51283-51800-hans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51283-51800-hans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51283-51800-hans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51283-51800-hans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51284-51300-haussignemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51284-51300-haussignemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51284-51300-haussignemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51284-51300-haussignemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51285-51320-haussimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51285-51320-haussimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51285-51320-haussimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51285-51320-haussimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51286-51290-hauteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51286-51290-hauteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51286-51290-hauteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51286-51290-hauteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51287-51160-hautvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51287-51160-hautvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51287-51160-hautvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51287-51160-hautvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51288-51300-heiltz_le_hutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51288-51300-heiltz_le_hutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51288-51300-heiltz_le_hutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51288-51300-heiltz_le_hutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51289-51340-heiltz_le_maurupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51289-51340-heiltz_le_maurupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51289-51340-heiltz_le_maurupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51289-51340-heiltz_le_maurupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51290-51340-heiltz_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51290-51340-heiltz_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51290-51340-heiltz_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51290-51340-heiltz_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51291-51220-hermonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51291-51220-hermonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51291-51220-hermonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51291-51220-hermonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51292-51460-herpont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51292-51460-herpont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51292-51460-herpont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51292-51460-herpont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51293-51110-heutregiville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51293-51110-heutregiville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51293-51110-heutregiville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51293-51110-heutregiville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51294-51140-hourges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51294-51140-hourges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51294-51140-hourges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51294-51140-hourges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51295-51300-huiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51295-51300-huiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51295-51300-huiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51295-51300-huiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51296-51320-humbauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51296-51320-humbauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51296-51320-humbauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51296-51320-humbauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51298-51700-igny_comblizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51298-51700-igny_comblizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51298-51700-igny_comblizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51298-51700-igny_comblizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51299-51110-isles_sur_suippe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51299-51110-isles_sur_suippe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51299-51110-isles_sur_suippe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51299-51110-isles_sur_suippe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51300-51290-isle_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51300-51290-isle_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51300-51290-isle_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51300-51290-isle_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51301-51150-isse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51301-51150-isse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51301-51150-isse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51301-51150-isse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51302-51190-les_istres_et_bury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51302-51190-les_istres_et_bury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51302-51190-les_istres_et_bury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51302-51190-les_istres_et_bury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51303-51150-jalons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51303-51150-jalons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51303-51150-jalons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51303-51150-jalons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51304-51210-janvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51304-51210-janvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51304-51210-janvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51304-51210-janvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51305-51390-janvry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51305-51390-janvry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51305-51390-janvry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51305-51390-janvry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51306-51310-joiselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51306-51310-joiselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51306-51310-joiselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51306-51310-joiselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51307-51600-jonchery_sur_suippe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51307-51600-jonchery_sur_suippe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51307-51600-jonchery_sur_suippe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51307-51600-jonchery_sur_suippe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51308-51140-jonchery_sur_vesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51308-51140-jonchery_sur_vesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51308-51140-jonchery_sur_vesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51308-51140-jonchery_sur_vesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51309-51700-jonquery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51309-51700-jonquery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51309-51700-jonquery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51309-51700-jonquery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51310-51390-jouy_les_reims/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51310-51390-jouy_les_reims/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51310-51390-jouy_les_reims/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51310-51390-jouy_les_reims/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51311-51340-jussecourt_minecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51311-51340-jussecourt_minecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51311-51340-jussecourt_minecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51311-51340-jussecourt_minecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51312-51150-juvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51312-51150-juvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51312-51150-juvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51312-51150-juvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51313-51120-lachy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51313-51120-lachy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51313-51120-lachy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51313-51120-lachy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51314-51170-lagery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51314-51170-lagery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51314-51170-lagery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51314-51170-lagery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51315-51290-landricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51315-51290-landricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51315-51290-landricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51315-51290-landricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51316-51290-larzicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51316-51290-larzicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51316-51290-larzicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51316-51290-larzicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51317-51600-laval_sur_tourbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51317-51600-laval_sur_tourbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51317-51600-laval_sur_tourbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51317-51600-laval_sur_tourbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51318-51110-lavannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51318-51110-lavannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51318-51110-lavannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51318-51110-lavannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51319-51230-lenharree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51319-51230-lenharree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51319-51230-lenharree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51319-51230-lenharree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51320-51700-leuvrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51320-51700-leuvrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51320-51700-leuvrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51320-51700-leuvrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51321-51170-lhery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51321-51170-lhery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51321-51170-lhery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51321-51170-lhery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51322-51290-lignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51322-51290-lignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51322-51290-lignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51322-51290-lignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51323-51230-linthelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51323-51230-linthelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51323-51230-linthelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51323-51230-linthelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51324-51230-linthes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51324-51230-linthes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51324-51230-linthes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51324-51230-linthes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51325-51300-lisse_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51325-51300-lisse_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51325-51300-lisse_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51325-51300-lisse_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51326-51400-livry_louvercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51326-51400-livry_louvercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51326-51400-livry_louvercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51326-51400-livry_louvercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51327-51130-loisy_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51327-51130-loisy_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51327-51130-loisy_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51327-51130-loisy_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51328-51300-loisy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51328-51300-loisy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51328-51300-loisy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51328-51300-loisy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51329-51220-loivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51329-51220-loivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51329-51220-loivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51329-51220-loivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51333-51500-ludes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51333-51500-ludes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51333-51500-ludes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51333-51500-ludes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51334-51300-luxemont_et_villotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51334-51300-luxemont_et_villotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51334-51300-luxemont_et_villotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51334-51300-luxemont_et_villotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51336-51800-maffrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51336-51800-maffrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51336-51800-maffrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51336-51800-maffrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51337-51170-magneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51337-51170-magneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51337-51170-magneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51337-51170-magneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51338-51500-mailly_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51338-51500-mailly_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51338-51500-mailly_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51338-51500-mailly_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51339-51240-mairy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51339-51240-mairy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51339-51240-mairy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51339-51240-mairy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51340-51300-maisons_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51340-51300-maisons_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51340-51300-maisons_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51340-51300-maisons_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51341-51800-malmy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51341-51800-malmy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51341-51800-malmy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51341-51800-malmy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51342-51530-mancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51342-51530-mancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51342-51530-mancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51342-51530-mancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51343-51260-marcilly_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51343-51260-marcilly_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51343-51260-marcilly_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51343-51260-marcilly_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51344-51530-mardeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51344-51530-mardeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51344-51530-mardeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51344-51530-mardeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51345-51270-mareuil_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51345-51270-mareuil_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51345-51270-mareuil_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51345-51270-mareuil_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51346-51700-mareuil_le_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51346-51700-mareuil_le_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51346-51700-mareuil_le_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51346-51700-mareuil_le_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51348-51170-marfaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51348-51170-marfaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51348-51170-marfaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51348-51170-marfaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51349-51290-margerie_hancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51349-51290-margerie_hancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51349-51290-margerie_hancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51349-51290-margerie_hancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51350-51210-margny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51350-51210-margny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51350-51210-margny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51350-51210-margny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51351-51230-marigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51351-51230-marigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51351-51230-marigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51351-51230-marigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51352-51300-marolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51352-51300-marolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51352-51300-marolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51352-51300-marolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51353-51260-marsangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51353-51260-marsangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51353-51260-marsangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51353-51260-marsangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51354-51240-marson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51354-51240-marson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51354-51240-marson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51354-51240-marson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51355-51800-massiges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51355-51800-massiges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51355-51800-massiges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51355-51800-massiges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51356-51300-matignicourt_goncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51356-51300-matignicourt_goncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51356-51300-matignicourt_goncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51356-51300-matignicourt_goncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51357-51510-matougues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51357-51510-matougues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51357-51510-matougues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51357-51510-matougues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51358-51340-maurupt_le_montois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51358-51340-maurupt_le_montois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51358-51340-maurupt_le_montois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51358-51340-maurupt_le_montois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51359-51210-mecringes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51359-51210-mecringes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51359-51210-mecringes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51359-51210-mecringes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51360-51120-le_meix_saint_epoing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51360-51120-le_meix_saint_epoing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51360-51120-le_meix_saint_epoing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51360-51120-le_meix_saint_epoing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51361-51320-le_meix_tiercelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51361-51320-le_meix_tiercelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51361-51320-le_meix_tiercelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51361-51320-le_meix_tiercelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51362-51220-merfy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51362-51220-merfy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51362-51220-merfy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51362-51220-merfy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51363-51300-merlaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51363-51300-merlaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51363-51300-merlaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51363-51300-merlaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51364-51390-mery_premecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51364-51390-mery_premecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51364-51390-mery_premecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51364-51390-mery_premecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51365-51370-les_mesneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51365-51370-les_mesneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51365-51370-les_mesneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51365-51370-les_mesneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51367-51190-le_mesnil_sur_oger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51367-51190-le_mesnil_sur_oger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51367-51190-le_mesnil_sur_oger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51367-51190-le_mesnil_sur_oger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51368-51800-minaucourt_le_mesnil_les_hurlus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51368-51800-minaucourt_le_mesnil_les_hurlus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51368-51800-minaucourt_le_mesnil_les_hurlus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51368-51800-minaucourt_le_mesnil_les_hurlus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51369-51120-moeurs_verdey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51369-51120-moeurs_verdey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51369-51120-moeurs_verdey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51369-51120-moeurs_verdey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51370-51800-moiremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51370-51800-moiremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51370-51800-moiremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51370-51800-moiremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51371-51240-moivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51371-51240-moivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51371-51240-moivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51371-51240-moivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51372-51470-moncetz_longevas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51372-51470-moncetz_longevas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51372-51470-moncetz_longevas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51372-51470-moncetz_longevas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51373-51290-moncetz_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51373-51290-moncetz_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51373-51290-moncetz_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51373-51290-moncetz_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51374-51120-mondement_montgivroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51374-51120-mondement_montgivroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51374-51120-mondement_montgivroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51374-51120-mondement_montgivroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51375-51500-montbre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51375-51500-montbre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51375-51500-montbre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51375-51500-montbre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51376-51260-montgenost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51376-51260-montgenost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51376-51260-montgenost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51376-51260-montgenost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51377-51320-montepreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51377-51320-montepreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51377-51320-montepreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51377-51320-montepreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51378-51530-monthelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51378-51530-monthelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51378-51530-monthelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51378-51530-monthelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51379-51140-montigny_sur_vesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51379-51140-montigny_sur_vesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51379-51140-montigny_sur_vesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51379-51140-montigny_sur_vesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51380-51210-montmirail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51380-51210-montmirail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51380-51210-montmirail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51380-51210-montmirail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51381-51270-montmort_lucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51381-51270-montmort_lucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51381-51270-montmort_lucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51381-51270-montmort_lucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51382-51170-mont_sur_courville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51382-51170-mont_sur_courville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51382-51170-mont_sur_courville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51382-51170-mont_sur_courville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51384-51530-morangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51384-51530-morangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51384-51530-morangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51384-51530-morangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51386-51210-morsains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51386-51210-morsains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51386-51210-morsains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51386-51210-morsains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51387-51530-moslins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51387-51530-moslins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51387-51530-moslins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51387-51530-moslins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51388-51400-mourmelon_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51388-51400-mourmelon_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51388-51400-mourmelon_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51388-51400-mourmelon_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51389-51400-mourmelon_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51389-51400-mourmelon_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51389-51400-mourmelon_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51389-51400-mourmelon_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51390-51530-moussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51390-51530-moussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51390-51530-moussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51390-51530-moussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51391-51140-muizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51391-51140-muizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51391-51140-muizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51391-51140-muizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51392-51160-mutigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51392-51160-mutigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51392-51160-mutigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51392-51160-mutigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51393-51480-nanteuil_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51393-51480-nanteuil_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51393-51480-nanteuil_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51393-51480-nanteuil_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51395-51120-nesle_la_reposte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51395-51120-nesle_la_reposte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51395-51120-nesle_la_reposte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51395-51120-nesle_la_reposte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51396-51700-nesle_le_repons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51396-51700-nesle_le_repons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51396-51700-nesle_le_repons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51396-51700-nesle_le_repons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51397-51330-la_neuville_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51397-51330-la_neuville_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51397-51330-la_neuville_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51397-51330-la_neuville_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51398-51480-la_neuville_aux_larris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51398-51480-la_neuville_aux_larris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51398-51480-la_neuville_aux_larris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51398-51480-la_neuville_aux_larris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51399-51800-la_neuville_au_pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51399-51800-la_neuville_au_pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51399-51800-la_neuville_au_pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51399-51800-la_neuville_au_pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51402-51310-neuvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51402-51310-neuvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51402-51310-neuvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51402-51310-neuvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51403-51420-nogent_l_abbesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51403-51420-nogent_l_abbesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51403-51420-nogent_l_abbesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51403-51420-nogent_l_abbesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51404-51330-noirlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51404-51330-noirlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51404-51330-noirlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51404-51330-noirlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51406-51300-norrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51406-51300-norrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51406-51300-norrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51406-51300-norrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51407-51310-la_noue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51407-51310-la_noue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51407-51310-la_noue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51407-51310-la_noue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51409-51240-nuisement_sur_coole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51409-51240-nuisement_sur_coole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51409-51240-nuisement_sur_coole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51409-51240-nuisement_sur_coole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51410-51480-oeuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51410-51480-oeuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51410-51480-oeuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51410-51480-oeuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51412-51230-ognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51412-51230-ognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51412-51230-ognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51412-51230-ognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51413-51530-oiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51413-51530-oiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51413-51530-oiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51413-51530-oiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51414-51700-olizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51414-51700-olizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51414-51700-olizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51414-51700-olizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51415-51240-omey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51415-51240-omey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51415-51240-omey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51415-51240-omey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51416-51270-orbais_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51416-51270-orbais_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51416-51270-orbais_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51416-51270-orbais_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51417-51300-orconte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51417-51300-orconte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51417-51300-orconte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51417-51300-orconte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51418-51370-ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51418-51370-ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51418-51370-ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51418-51370-ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51419-51290-outines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51419-51290-outines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51419-51290-outines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51419-51290-outines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51420-51300-outrepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51420-51300-outrepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51420-51300-outrepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51420-51300-outrepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51421-51120-oyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51421-51120-oyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51421-51120-oyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51421-51120-oyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51422-51390-pargny_les_reims/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51422-51390-pargny_les_reims/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51422-51390-pargny_les_reims/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51422-51390-pargny_les_reims/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51423-51340-pargny_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51423-51340-pargny_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51423-51340-pargny_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51423-51340-pargny_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51424-51800-passavant_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51424-51800-passavant_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51424-51800-passavant_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51424-51800-passavant_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51425-51700-passy_grigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51425-51700-passy_grigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51425-51700-passy_grigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51425-51700-passy_grigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51426-51120-peas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51426-51120-peas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51426-51120-peas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51426-51120-peas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51428-51400-les_petites_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51428-51400-les_petites_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51428-51400-les_petites_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51428-51400-les_petites_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51429-51140-pevy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51429-51140-pevy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51429-51140-pevy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51429-51140-pevy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51430-51130-pierre_morains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51430-51130-pierre_morains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51430-51130-pierre_morains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51430-51130-pierre_morains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51431-51530-pierry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51431-51530-pierry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51431-51530-pierry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51431-51530-pierry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51432-51230-pleurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51432-51230-pleurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51432-51230-pleurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51432-51230-pleurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51433-51300-plichancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51433-51300-plichancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51433-51300-plichancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51433-51300-plichancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51434-51150-plivot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51434-51150-plivot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51434-51150-plivot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51434-51150-plivot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51435-51130-pocancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51435-51130-pocancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51435-51130-pocancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51435-51130-pocancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51436-51240-pogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51436-51240-pogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51436-51240-pogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51436-51240-pogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51437-51170-poilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51437-51170-poilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51437-51170-poilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51437-51170-poilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51438-51460-poix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51438-51460-poix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51438-51460-poix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51438-51460-poix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51439-51110-pomacle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51439-51110-pomacle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51439-51110-pomacle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51439-51110-pomacle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51440-51490-pontfaverger_moronvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51440-51490-pontfaverger_moronvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51440-51490-pontfaverger_moronvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51440-51490-pontfaverger_moronvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51441-51300-ponthion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51441-51300-ponthion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51441-51300-ponthion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51441-51300-ponthion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51442-51330-possesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51442-51330-possesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51442-51330-possesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51442-51330-possesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51443-51260-potangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51443-51260-potangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51443-51260-potangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51443-51260-potangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51444-51220-pouillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51444-51220-pouillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51444-51220-pouillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51444-51220-pouillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51445-51480-pourcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51445-51480-pourcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51445-51480-pourcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51445-51480-pourcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51446-51300-pringy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51446-51300-pringy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51446-51300-pringy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51446-51300-pringy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51447-51400-prosnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51447-51400-prosnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51447-51400-prosnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51447-51400-prosnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51448-51140-prouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51448-51140-prouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51448-51140-prouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51448-51140-prouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51449-51360-prunay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51449-51360-prunay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51449-51360-prunay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51449-51360-prunay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51450-51500-puisieulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51450-51500-puisieulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51450-51500-puisieulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51450-51500-puisieulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51451-51120-queudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51451-51120-queudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51451-51120-queudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51451-51120-queudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51452-51330-rapsecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51452-51330-rapsecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51452-51330-rapsecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51452-51330-rapsecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51453-51520-recy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51453-51520-recy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51453-51520-recy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51453-51520-recy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51454-51100-reims/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51454-51100-reims/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51454-51100-reims/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51454-51100-reims/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51455-51300-reims_la_brulee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51455-51300-reims_la_brulee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51455-51300-reims_la_brulee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51455-51300-reims_la_brulee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51456-51330-remicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51456-51330-remicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51456-51330-remicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51456-51330-remicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51457-51480-reuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51457-51480-reuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51457-51480-reuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51457-51480-reuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51458-51120-reuves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51458-51120-reuves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51458-51120-reuves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51458-51120-reuves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51459-51310-reveillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51459-51310-reveillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51459-51310-reveillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51459-51310-reveillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51460-51210-rieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51460-51210-rieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51460-51210-rieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51460-51210-rieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51461-51500-rilly_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51461-51500-rilly_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51461-51500-rilly_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51461-51500-rilly_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51463-51300-les_rivieres_henruel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51463-51300-les_rivieres_henruel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51463-51300-les_rivieres_henruel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51463-51300-les_rivieres_henruel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51464-51140-romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51464-51140-romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51464-51140-romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51464-51140-romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51465-51480-romery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51465-51480-romery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51465-51480-romery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51465-51480-romery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51466-51170-romigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51466-51170-romigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51466-51170-romigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51466-51170-romigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51468-51390-rosnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51468-51390-rosnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51468-51390-rosnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51468-51390-rosnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51469-51130-rouffy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51469-51130-rouffy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51469-51130-rouffy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51469-51130-rouffy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51470-51800-rouvroy_ripont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51470-51800-rouvroy_ripont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51470-51800-rouvroy_ripont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51470-51800-rouvroy_ripont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51471-51500-sacy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51471-51500-sacy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51471-51500-sacy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51471-51500-sacy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51472-51300-saint_amand_sur_fion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51472-51300-saint_amand_sur_fion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51472-51300-saint_amand_sur_fion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51472-51300-saint_amand_sur_fion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51473-51310-saint_bon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51473-51310-saint_bon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51473-51310-saint_bon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51473-51310-saint_bon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51474-51370-saint_brice_courcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51474-51370-saint_brice_courcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51474-51370-saint_brice_courcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51474-51370-saint_brice_courcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51475-51290-saint_cheron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51475-51290-saint_cheron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51475-51290-saint_cheron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51475-51290-saint_cheron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51476-51460-saint_etienne_au_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51476-51460-saint_etienne_au_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51476-51460-saint_etienne_au_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51476-51460-saint_etienne_au_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51477-51110-saint_etienne_sur_suippe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51477-51110-saint_etienne_sur_suippe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51477-51110-saint_etienne_sur_suippe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51477-51110-saint_etienne_sur_suippe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51478-52100-saint_eulien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51478-52100-saint_eulien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51478-52100-saint_eulien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51478-52100-saint_eulien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51479-51390-saint_euphraise_et_clairizet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51479-51390-saint_euphraise_et_clairizet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51479-51390-saint_euphraise_et_clairizet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51479-51390-saint_euphraise_et_clairizet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51480-51700-sainte_gemme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51480-51700-sainte_gemme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51480-51700-sainte_gemme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51480-51700-sainte_gemme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51482-51240-saint_germain_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51482-51240-saint_germain_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51482-51240-saint_germain_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51482-51240-saint_germain_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51483-51510-saint_gibrien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51483-51510-saint_gibrien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51483-51510-saint_gibrien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51483-51510-saint_gibrien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51484-51170-saint_gilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51484-51170-saint_gilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51484-51170-saint_gilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51484-51170-saint_gilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51485-51400-saint_hilaire_au_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51485-51400-saint_hilaire_au_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51485-51400-saint_hilaire_au_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51485-51400-saint_hilaire_au_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51486-51600-saint_hilaire_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51486-51600-saint_hilaire_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51486-51600-saint_hilaire_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51486-51600-saint_hilaire_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51487-51490-saint_hilaire_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51487-51490-saint_hilaire_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51487-51490-saint_hilaire_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51487-51490-saint_hilaire_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51488-51160-saint_imoges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51488-51160-saint_imoges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51488-51160-saint_imoges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51488-51160-saint_imoges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51489-51330-saint_jean_devant_possesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51489-51330-saint_jean_devant_possesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51489-51330-saint_jean_devant_possesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51489-51330-saint_jean_devant_possesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51490-51240-saint_jean_sur_moivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51490-51240-saint_jean_sur_moivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51490-51240-saint_jean_sur_moivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51490-51240-saint_jean_sur_moivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51491-51600-saint_jean_sur_tourbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51491-51600-saint_jean_sur_tourbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51491-51600-saint_jean_sur_tourbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51491-51600-saint_jean_sur_tourbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51492-51260-saint_just_sauvage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51492-51260-saint_just_sauvage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51492-51260-saint_just_sauvage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51492-51260-saint_just_sauvage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51493-51500-saint_leonard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51493-51500-saint_leonard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51493-51500-saint_leonard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51493-51500-saint_leonard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51495-51120-saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51495-51120-saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51495-51120-saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51495-51120-saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51496-51300-saint_lumier_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51496-51300-saint_lumier_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51496-51300-saint_lumier_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51496-51300-saint_lumier_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51497-51340-saint_lumier_la_populeuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51497-51340-saint_lumier_la_populeuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51497-51340-saint_lumier_la_populeuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51497-51340-saint_lumier_la_populeuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51498-51800-saint_mard_sur_auve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51498-51800-saint_mard_sur_auve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51498-51800-saint_mard_sur_auve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51498-51800-saint_mard_sur_auve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51499-51130-saint_mard_les_rouffy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51499-51130-saint_mard_les_rouffy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51499-51130-saint_mard_les_rouffy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51499-51130-saint_mard_les_rouffy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51500-51330-saint_mard_sur_le_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51500-51330-saint_mard_sur_le_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51500-51330-saint_mard_sur_le_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51500-51330-saint_mard_sur_le_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51501-51600-sainte_marie_a_py/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51501-51600-sainte_marie_a_py/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51501-51600-sainte_marie_a_py/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51501-51600-sainte_marie_a_py/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51502-51240-saint_martin_aux_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51502-51240-saint_martin_aux_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51502-51240-saint_martin_aux_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51502-51240-saint_martin_aux_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51503-51490-saint_martin_l_heureux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51503-51490-saint_martin_l_heureux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51503-51490-saint_martin_l_heureux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51503-51490-saint_martin_l_heureux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51504-51520-saint_martin_sur_le_pre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51504-51520-saint_martin_sur_le_pre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51504-51520-saint_martin_sur_le_pre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51504-51520-saint_martin_sur_le_pre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51505-51490-saint_masmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51505-51490-saint_masmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51505-51490-saint_masmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51505-51490-saint_masmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51506-51470-saint_memmie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51506-51470-saint_memmie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51506-51470-saint_memmie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51506-51470-saint_memmie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51507-51800-sainte_menehould/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51507-51800-sainte_menehould/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51507-51800-sainte_menehould/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51507-51800-sainte_menehould/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51507-55120-sainte_menehould/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51507-55120-sainte_menehould/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51507-55120-sainte_menehould/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51507-55120-sainte_menehould/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51508-51320-saint_ouen_domprot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51508-51320-saint_ouen_domprot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51508-51320-saint_ouen_domprot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51508-51320-saint_ouen_domprot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51509-51510-saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51509-51510-saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51509-51510-saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51509-51510-saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51510-51300-saint_quentin_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51510-51300-saint_quentin_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51510-51300-saint_quentin_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51510-51300-saint_quentin_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51511-51120-saint_quentin_le_verger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51511-51120-saint_quentin_le_verger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51511-51120-saint_quentin_le_verger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51511-51120-saint_quentin_le_verger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51512-51240-saint_quentin_sur_coole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51512-51240-saint_quentin_sur_coole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51512-51240-saint_quentin_sur_coole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51512-51240-saint_quentin_sur_coole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51513-51290-saint_remy_en_bouzemont_saint_genest_et_isson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51513-51290-saint_remy_en_bouzemont_saint_genest_et_isson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51513-51290-saint_remy_en_bouzemont_saint_genest_et_isson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51513-51290-saint_remy_en_bouzemont_saint_genest_et_isson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51514-51120-saint_remy_sous_broyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51514-51120-saint_remy_sous_broyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51514-51120-saint_remy_sous_broyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51514-51120-saint_remy_sous_broyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51515-51600-saint_remy_sur_bussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51515-51600-saint_remy_sur_bussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51515-51600-saint_remy_sur_bussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51515-51600-saint_remy_sur_bussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51516-51260-saint_saturnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51516-51260-saint_saturnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51516-51260-saint_saturnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51516-51260-saint_saturnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51517-51600-saint_souplet_sur_py/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51517-51600-saint_souplet_sur_py/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51517-51600-saint_souplet_sur_py/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51517-51600-saint_souplet_sur_py/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51518-51220-saint_thierry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51518-51220-saint_thierry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51518-51220-saint_thierry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51518-51220-saint_thierry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51519-51800-saint_thomas_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51519-51800-saint_thomas_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51519-51800-saint_thomas_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51519-51800-saint_thomas_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51520-51290-saint_utin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51520-51290-saint_utin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51520-51290-saint_utin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51520-51290-saint_utin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51521-51340-saint_vrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51521-51340-saint_vrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51521-51340-saint_vrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51521-51340-saint_vrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51522-52100-sapignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51522-52100-sapignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51522-52100-sapignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51522-52100-sapignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51523-51170-sarcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51523-51170-sarcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51523-51170-sarcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51523-51170-sarcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51524-51260-saron_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51524-51260-saron_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51524-51260-saron_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51524-51260-saron_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51525-51520-sarry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51525-51520-sarry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51525-51520-sarry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51525-51520-sarry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51526-51120-saudoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51526-51120-saudoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51526-51120-saudoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51526-51120-saudoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51527-51170-savigny_sur_ardres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51527-51170-savigny_sur_ardres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51527-51170-savigny_sur_ardres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51527-51170-savigny_sur_ardres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51528-51340-scrupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51528-51340-scrupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51528-51340-scrupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51528-51340-scrupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51529-51490-selles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51529-51490-selles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51529-51490-selles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51529-51490-selles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51530-51400-sept_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51530-51400-sept_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51530-51400-sept_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51530-51400-sept_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51531-51250-sermaize_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51531-51250-sermaize_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51531-51250-sermaize_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51531-51250-sermaize_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51532-51500-sermiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51532-51500-sermiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51532-51500-sermiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51532-51500-sermiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51533-51800-servon_melzicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51533-51800-servon_melzicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51533-51800-servon_melzicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51533-51800-servon_melzicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51534-51170-serzy_et_prin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51534-51170-serzy_et_prin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51534-51170-serzy_et_prin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51534-51170-serzy_et_prin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51535-51120-sezanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51535-51120-sezanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51535-51120-sezanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51535-51120-sezanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51536-51500-sillery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51536-51500-sillery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51536-51500-sillery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51536-51500-sillery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51537-51800-sivry_ante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51537-51800-sivry_ante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51537-51800-sivry_ante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51537-51800-sivry_ante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51538-51520-sogny_aux_moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51538-51520-sogny_aux_moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51538-51520-sogny_aux_moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51538-51520-sogny_aux_moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51539-51340-sogny_en_l_angle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51539-51340-sogny_en_l_angle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51539-51340-sogny_en_l_angle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51539-51340-sogny_en_l_angle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51542-51120-soizy_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51542-51120-soizy_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51542-51120-soizy_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51542-51120-soizy_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51543-51800-somme_bionne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51543-51800-somme_bionne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51543-51800-somme_bionne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51543-51800-somme_bionne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51544-51600-sommepy_tahure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51544-51600-sommepy_tahure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51544-51600-sommepy_tahure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51544-51600-sommepy_tahure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51545-51320-sommesous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51545-51320-sommesous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51545-51320-sommesous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51545-51320-sommesous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51546-51600-somme_suippe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51546-51600-somme_suippe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51546-51600-somme_suippe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51546-51600-somme_suippe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51547-51600-somme_tourbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51547-51600-somme_tourbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51547-51600-somme_tourbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51547-51600-somme_tourbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51548-51460-somme_vesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51548-51460-somme_vesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51548-51460-somme_vesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51548-51460-somme_vesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51549-51330-somme_yevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51549-51330-somme_yevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51549-51330-somme_yevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51549-51330-somme_yevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51550-51320-sompuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51550-51320-sompuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51550-51320-sompuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51550-51320-sompuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51551-51290-somsois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51551-51290-somsois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51551-51290-somsois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51551-51290-somsois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51552-51240-songy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51552-51240-songy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51552-51240-songy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51552-51240-songy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51553-51600-souain_perthes_les_hurlus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51553-51600-souain_perthes_les_hurlus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51553-51600-souain_perthes_les_hurlus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51553-51600-souain_perthes_les_hurlus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51555-51320-soude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51555-51320-soude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51555-51320-soude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51555-51320-soude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51556-51320-soudron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51556-51320-soudron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51556-51320-soudron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51556-51320-soudron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51557-51300-soulanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51557-51300-soulanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51557-51300-soulanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51557-51300-soulanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51558-51130-soulieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51558-51130-soulieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51558-51130-soulieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51558-51130-soulieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51559-51600-suippes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51559-51600-suippes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51559-51600-suippes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51559-51600-suippes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51560-51270-suizy_le_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51560-51270-suizy_le_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51560-51270-suizy_le_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51560-51270-suizy_le_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51562-51500-taissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51562-51500-taissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51562-51500-taissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51562-51500-taissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51563-51270-talus_saint_prix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51563-51270-talus_saint_prix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51563-51270-talus_saint_prix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51563-51270-talus_saint_prix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51564-51150-val_de_livre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51564-51150-val_de_livre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51564-51150-val_de_livre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51564-51150-val_de_livre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51565-51230-thaas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51565-51230-thaas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51565-51230-thaas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51565-51230-thaas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51566-51510-thibie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51566-51510-thibie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51566-51510-thibie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51566-51510-thibie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51567-51300-thieblemont_faremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51567-51300-thieblemont_faremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51567-51300-thieblemont_faremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51567-51300-thieblemont_faremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51568-51220-thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51568-51220-thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51568-51220-thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51568-51220-thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51569-51370-thillois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51569-51370-thillois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51569-51370-thillois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51569-51370-thillois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51570-51210-le_thoult_trosnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51570-51210-le_thoult_trosnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51570-51210-le_thoult_trosnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51570-51210-le_thoult_trosnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51571-51360-val_de_vesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51571-51360-val_de_vesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51571-51360-val_de_vesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51571-51360-val_de_vesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51572-51460-tilloy_et_bellay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51572-51460-tilloy_et_bellay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51572-51460-tilloy_et_bellay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51572-51460-tilloy_et_bellay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51573-51430-tinqueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51573-51430-tinqueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51573-51430-tinqueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51573-51430-tinqueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51574-51240-togny_aux_boeufs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51574-51240-togny_aux_boeufs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51574-51240-togny_aux_boeufs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51574-51240-togny_aux_boeufs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51576-51150-tours_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51576-51150-tours_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51576-51150-tours_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51576-51150-tours_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51577-51170-tramery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51577-51170-tramery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51577-51170-tramery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51577-51170-tramery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51578-51130-trecon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51578-51130-trecon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51578-51130-trecon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51578-51130-trecon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51579-51210-trefols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51579-51210-trefols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51579-51210-trefols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51579-51210-trefols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51580-51380-trepail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51580-51380-trepail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51580-51380-trepail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51580-51380-trepail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51581-51140-treslon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51581-51140-treslon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51581-51140-treslon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51581-51140-treslon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51582-51140-trigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51582-51140-trigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51582-51140-trigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51582-51140-trigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51583-51340-trois_fontaines_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51583-51340-trois_fontaines_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51583-51340-trois_fontaines_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51583-51340-trois_fontaines_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51584-51500-trois_puits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51584-51500-trois_puits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51584-51500-trois_puits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51584-51500-trois_puits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51585-51700-troissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51585-51700-troissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51585-51700-troissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51585-51700-troissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51586-51170-unchair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51586-51170-unchair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51586-51170-unchair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51586-51170-unchair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51587-51400-vadenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51587-51400-vadenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51587-51400-vadenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51587-51400-vadenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51588-51800-valmy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51588-51800-valmy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51588-51800-valmy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51588-51800-valmy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51589-51330-vanault_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51589-51330-vanault_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51589-51330-vanault_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51589-51330-vanault_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51590-51340-vanault_les_dames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51590-51340-vanault_les_dames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51590-51340-vanault_les_dames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51590-51340-vanault_les_dames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51591-51140-vandeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51591-51140-vandeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51591-51140-vandeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51591-51140-vandeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51592-51700-vandieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51592-51700-vandieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51592-51700-vandieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51592-51700-vandieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51594-51320-vassimont_et_chapelaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51594-51320-vassimont_et_chapelaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51594-51320-vassimont_et_chapelaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51594-51320-vassimont_et_chapelaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51595-51320-vatry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51595-51320-vatry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51595-51320-vatry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51595-51320-vatry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51596-51210-vauchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51596-51210-vauchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51596-51210-vauchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51596-51210-vauchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51597-51480-vauciennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51597-51480-vauciennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51597-51480-vauciennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51597-51480-vauciennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51598-51300-vauclerc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51598-51300-vauclerc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51598-51300-vauclerc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51598-51300-vauclerc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51599-51380-vaudemange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51599-51380-vaudemange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51599-51380-vaudemange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51599-51380-vaudemange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51600-51600-vaudesincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51600-51600-vaudesincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51600-51600-vaudesincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51600-51600-vaudesincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51601-51300-vavray_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51601-51300-vavray_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51601-51300-vavray_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51601-51300-vavray_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51602-51300-vavray_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51602-51300-vavray_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51602-51300-vavray_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51602-51300-vavray_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51603-51130-velye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51603-51130-velye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51603-51130-velye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51603-51130-velye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51604-51140-ventelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51604-51140-ventelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51604-51140-ventelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51604-51140-ventelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51605-51480-venteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51605-51480-venteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51605-51480-venteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51605-51480-venteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51607-51210-verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51607-51210-verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51607-51210-verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51607-51210-verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51608-51330-vernancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51608-51330-vernancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51608-51330-vernancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51608-51330-vernancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51609-51700-verneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51609-51700-verneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51609-51700-verneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51609-51700-verneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51610-51800-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51610-51800-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51610-51800-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51610-51800-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51611-51130-vert_toulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51611-51130-vert_toulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51611-51130-vert_toulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51611-51130-vert_toulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51612-51130-blancs_coteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51612-51130-blancs_coteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51612-51130-blancs_coteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51612-51130-blancs_coteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51613-51360-verzenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51613-51360-verzenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51613-51360-verzenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51613-51360-verzenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51614-51380-verzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51614-51380-verzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51614-51380-verzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51614-51380-verzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51616-51240-vesigneul_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51616-51240-vesigneul_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51616-51240-vesigneul_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51616-51240-vesigneul_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51617-51520-la_veuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51617-51520-la_veuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51617-51520-la_veuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51617-51520-la_veuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51618-51210-le_vezier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51618-51210-le_vezier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51618-51210-le_vezier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51618-51210-le_vezier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51619-51330-le_vieil_dampierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51619-51330-le_vieil_dampierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51619-51330-le_vieil_dampierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51619-51330-le_vieil_dampierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51620-51800-vienne_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51620-51800-vienne_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51620-51800-vienne_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51620-51800-vienne_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51621-51800-vienne_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51621-51800-vienne_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51621-51800-vienne_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51621-51800-vienne_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51622-51390-ville_dommange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51622-51390-ville_dommange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51622-51390-ville_dommange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51622-51390-ville_dommange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51623-51500-ville_en_selve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51623-51500-ville_en_selve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51623-51500-ville_en_selve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51623-51500-ville_en_selve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51624-51170-ville_en_tardenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51624-51170-ville_en_tardenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51624-51170-ville_en_tardenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51624-51170-ville_en_tardenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51625-51310-villeneuve_la_lionne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51625-51310-villeneuve_la_lionne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51625-51310-villeneuve_la_lionne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51625-51310-villeneuve_la_lionne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51626-51120-la_villeneuve_les_charleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51626-51120-la_villeneuve_les_charleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51626-51120-la_villeneuve_les_charleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51626-51120-la_villeneuve_les_charleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51627-51130-villeneuve_renneville_chevigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51627-51130-villeneuve_renneville_chevigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51627-51130-villeneuve_renneville_chevigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51627-51130-villeneuve_renneville_chevigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51628-51120-villeneuve_saint_vistre_et_villevotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51628-51120-villeneuve_saint_vistre_et_villevotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51628-51120-villeneuve_saint_vistre_et_villevotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51628-51120-villeneuve_saint_vistre_et_villevotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51629-51500-villers_allerand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51629-51500-villers_allerand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51629-51500-villers_allerand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51629-51500-villers_allerand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51630-51130-villers_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51630-51130-villers_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51630-51130-villers_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51630-51130-villers_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51631-51500-villers_aux_noeuds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51631-51500-villers_aux_noeuds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51631-51500-villers_aux_noeuds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51631-51500-villers_aux_noeuds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51632-51800-villers_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51632-51800-villers_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51632-51800-villers_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51632-51800-villers_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51633-51220-villers_franqueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51633-51220-villers_franqueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51633-51220-villers_franqueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51633-51220-villers_franqueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51634-51510-villers_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51634-51510-villers_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51634-51510-villers_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51634-51510-villers_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51635-51250-villers_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51635-51250-villers_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51635-51250-villers_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51635-51250-villers_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51636-51380-villers_marmery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51636-51380-villers_marmery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51636-51380-villers_marmery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51636-51380-villers_marmery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51637-51700-villers_sous_chatillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51637-51700-villers_sous_chatillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51637-51700-villers_sous_chatillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51637-51700-villers_sous_chatillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51638-51130-villeseneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51638-51130-villeseneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51638-51130-villeseneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51638-51130-villeseneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51639-51270-la_ville_sous_orbais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51639-51270-la_ville_sous_orbais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51639-51270-la_ville_sous_orbais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51639-51270-la_ville_sous_orbais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51640-51800-ville_sur_tourbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51640-51800-ville_sur_tourbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51640-51800-ville_sur_tourbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51640-51800-ville_sur_tourbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51641-51270-villevenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51641-51270-villevenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51641-51270-villevenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51641-51270-villevenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51642-51260-villiers_aux_corneilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51642-51260-villiers_aux_corneilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51642-51260-villiers_aux_corneilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51642-51260-villiers_aux_corneilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51643-51530-vinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51643-51530-vinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51643-51530-vinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51643-51530-vinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51644-51700-vincelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51644-51700-vincelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51644-51700-vincelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51644-51700-vincelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51645-51120-vindey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51645-51120-vindey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51645-51120-vindey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51645-51120-vindey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51646-51800-virginy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51646-51800-virginy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51646-51800-virginy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51646-51800-virginy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51647-51300-vitry_en_perthois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51647-51300-vitry_en_perthois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51647-51300-vitry_en_perthois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51647-51300-vitry_en_perthois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51648-51240-vitry_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51648-51240-vitry_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51648-51240-vitry_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51648-51240-vitry_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51649-51300-vitry_le_francois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51649-51300-vitry_le_francois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51649-51300-vitry_le_francois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51649-51300-vitry_le_francois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51650-51800-voilemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51650-51800-voilemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51650-51800-voilemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51650-51800-voilemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51652-51260-vouarces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51652-51260-vouarces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51652-51260-vouarces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51652-51260-vouarces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51654-51340-vouillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51654-51340-vouillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51654-51340-vouillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51654-51340-vouillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51655-51130-vouzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51655-51130-vouzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51655-51130-vouzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51655-51130-vouzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51656-51150-vraux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51656-51150-vraux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51656-51150-vraux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51656-51150-vraux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51657-51390-vrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51657-51390-vrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51657-51390-vrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51657-51390-vrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51658-51330-vroil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51658-51330-vroil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51658-51330-vroil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51658-51330-vroil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51659-51800-wargemoulin_hurlus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51659-51800-wargemoulin_hurlus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51659-51800-wargemoulin_hurlus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51659-51800-wargemoulin_hurlus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51660-51110-warmeriville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51660-51110-warmeriville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51660-51110-warmeriville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51660-51110-warmeriville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51662-51420-witry_les_reims/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51662-51420-witry_les_reims/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51662-51420-witry_les_reims/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51662-51420-witry_les_reims/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51663-51530-magenta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51663-51530-magenta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51663-51530-magenta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt51-marne/commune51663-51530-magenta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-52.xml
+++ b/public/sitemaps/sitemap-52.xml
@@ -5,868 +5,1732 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52001-52340-ageville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52001-52340-ageville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52001-52340-ageville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52001-52340-ageville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52002-52400-aigremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52002-52400-aigremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52002-52400-aigremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52002-52400-aigremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52003-52700-aillianville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52003-52700-aillianville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52003-52700-aillianville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52003-52700-aillianville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52004-52230-aingoulaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52004-52230-aingoulaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52004-52230-aingoulaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52004-52230-aingoulaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52005-52120-aizanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52005-52120-aizanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52005-52120-aizanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52005-52120-aizanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52006-52130-allichamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52006-52130-allichamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52006-52130-allichamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52006-52130-allichamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52007-52110-ambonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52007-52110-ambonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52007-52110-ambonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52007-52110-ambonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52008-52700-andelot_blancheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52008-52700-andelot_blancheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52008-52700-andelot_blancheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52008-52700-andelot_blancheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52009-52360-andilly_en_bassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52009-52360-andilly_en_bassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52009-52360-andilly_en_bassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52009-52360-andilly_en_bassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52011-52310-anneville_la_prairie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52011-52310-anneville_la_prairie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52011-52310-anneville_la_prairie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52011-52310-anneville_la_prairie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52012-52230-annonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52012-52230-annonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52012-52230-annonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52012-52230-annonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52013-52500-anrosey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52013-52500-anrosey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52013-52500-anrosey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52013-52500-anrosey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52014-52250-aprey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52014-52250-aprey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52014-52250-aprey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52014-52250-aprey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52015-52500-arbigny_sous_varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52015-52500-arbigny_sous_varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52015-52500-arbigny_sous_varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52015-52500-arbigny_sous_varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52016-52160-arbot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52016-52160-arbot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52016-52160-arbot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52016-52160-arbot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52017-52210-arc_en_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52017-52210-arc_en_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52017-52210-arc_en_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52017-52210-arc_en_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52019-52110-arnancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52019-52110-arnancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52019-52110-arnancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52019-52110-arnancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52021-52130-attancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52021-52130-attancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52021-52130-attancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52021-52130-attancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52022-52210-aubepierre_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52022-52210-aubepierre_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52022-52210-aubepierre_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52022-52210-aubepierre_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52023-52160-auberive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52023-52160-auberive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52023-52160-auberive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52023-52160-auberive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52025-52240-audeloncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52025-52240-audeloncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52025-52240-audeloncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52025-52240-audeloncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52027-52190-aujeurres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52027-52190-aujeurres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52027-52190-aujeurres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52027-52190-aujeurres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52028-52160-aulnoy_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52028-52160-aulnoy_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52028-52160-aulnoy_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52028-52160-aulnoy_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52029-52300-autigny_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52029-52300-autigny_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52029-52300-autigny_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52029-52300-autigny_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52030-52300-autigny_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52030-52300-autigny_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52030-52300-autigny_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52030-52300-autigny_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52031-52120-autreville_sur_la_renne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52031-52120-autreville_sur_la_renne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52031-52120-autreville_sur_la_renne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52031-52120-autreville_sur_la_renne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52031-52330-autreville_sur_la_renne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52031-52330-autreville_sur_la_renne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52031-52330-autreville_sur_la_renne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52031-52330-autreville_sur_la_renne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52033-52140-avrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52033-52140-avrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52033-52140-avrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52033-52140-avrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52034-52130-bailly_aux_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52034-52130-bailly_aux_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52034-52130-bailly_aux_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52034-52130-bailly_aux_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52035-52250-baissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52035-52250-baissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52035-52250-baissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52035-52250-baissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52037-52360-bannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52037-52360-bannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52037-52360-bannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52037-52360-bannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52038-52240-bassoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52038-52240-bassoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52038-52240-bassoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52038-52240-bassoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52039-52110-baudrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52039-52110-baudrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52039-52110-baudrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52039-52110-baudrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52040-52160-bay_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52040-52160-bay_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52040-52160-bay_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52040-52160-bay_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52042-52260-beauchemin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52042-52260-beauchemin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52042-52260-beauchemin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52042-52260-beauchemin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52043-52500-belmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52043-52500-belmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52043-52500-belmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52043-52500-belmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52044-52270-roches_bettaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52044-52270-roches_bettaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52044-52270-roches_bettaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52044-52270-roches_bettaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52045-52100-bettancourt_la_ferree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52045-52100-bettancourt_la_ferree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52045-52100-bettancourt_la_ferree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52045-52100-bettancourt_la_ferree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52047-52110-beurville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52047-52110-beurville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52047-52110-beurville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52047-52110-beurville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52050-52340-biesles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52050-52340-biesles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52050-52340-biesles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52050-52340-biesles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52051-52500-bize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52051-52500-bize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52051-52500-bize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52051-52500-bize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52053-52330-blaisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52053-52330-blaisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52053-52330-blaisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52053-52330-blaisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52055-52300-blecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52055-52300-blecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52055-52300-blecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52055-52300-blecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52056-52120-blessonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52056-52120-blessonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52056-52120-blessonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52056-52120-blessonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52057-52110-blumeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52057-52110-blumeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52057-52110-blumeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52057-52110-blumeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52058-52310-bologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52058-52310-bologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52058-52310-bologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52058-52310-bologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52059-52360-bonnecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52059-52360-bonnecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52059-52360-bonnecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52059-52360-bonnecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52060-52400-bourbonne_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52060-52400-bourbonne_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52060-52400-bourbonne_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52060-52400-bourbonne_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52061-52700-bourdons_sur_rognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52061-52700-bourdons_sur_rognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52061-52700-bourdons_sur_rognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52061-52700-bourdons_sur_rognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52062-52200-bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52062-52200-bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52062-52200-bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52062-52200-bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52063-52150-bourg_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52063-52150-bourg_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52063-52150-bourg_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52063-52150-bourg_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52064-52150-bourmont_entre_meuse_et_mouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52064-52150-bourmont_entre_meuse_et_mouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52064-52150-bourmont_entre_meuse_et_mouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52064-52150-bourmont_entre_meuse_et_mouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52065-52110-bouzancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52065-52110-bouzancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52065-52110-bouzancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52065-52110-bouzancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52066-52110-brachay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52066-52110-brachay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52066-52110-brachay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52066-52110-brachay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52067-52150-brainville_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52067-52150-brainville_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52067-52150-brainville_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52067-52150-brainville_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52069-52120-braux_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52069-52120-braux_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52069-52120-braux_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52069-52120-braux_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52070-52200-brennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52070-52200-brennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52070-52200-brennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52070-52200-brennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52072-52000-brethenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52072-52000-brethenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52072-52000-brethenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52072-52000-brethenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52074-52240-breuvannes_en_bassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52074-52240-breuvannes_en_bassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52074-52240-breuvannes_en_bassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52074-52240-breuvannes_en_bassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52075-52700-briaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52075-52700-briaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52075-52700-briaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52075-52700-briaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52076-52120-bricon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52076-52120-bricon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52076-52120-bricon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52076-52120-bricon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52079-52130-brousseval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52079-52130-brousseval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52079-52130-brousseval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52079-52130-brousseval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52082-52210-bugnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52082-52210-bugnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52082-52210-bugnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52082-52210-bugnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52083-52500-champsevraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52083-52500-champsevraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52083-52500-champsevraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52083-52500-champsevraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52084-52700-busson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52084-52700-busson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52084-52700-busson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52084-52700-busson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52085-52240-buxieres_les_clefmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52085-52240-buxieres_les_clefmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52085-52240-buxieres_les_clefmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52085-52240-buxieres_les_clefmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52087-52000-buxieres_les_villiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52087-52000-buxieres_les_villiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52087-52000-buxieres_les_villiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52087-52000-buxieres_les_villiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52088-52220-ceffonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52088-52220-ceffonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52088-52220-ceffonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52088-52220-ceffonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52089-52360-celles_en_bassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52089-52360-celles_en_bassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52089-52360-celles_en_bassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52089-52360-celles_en_bassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52090-52600-celsoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52090-52600-celsoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52090-52600-celsoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52090-52600-celsoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52091-52320-cerisieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52091-52320-cerisieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52091-52320-cerisieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52091-52320-cerisieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52092-52160-chalancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52092-52160-chalancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52092-52160-chalancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52092-52160-chalancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52093-52600-chalindrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52093-52600-chalindrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52093-52600-chalindrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52093-52600-chalindrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52094-52160-vals_des_tilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52094-52160-vals_des_tilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52094-52160-vals_des_tilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52094-52160-vals_des_tilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52095-52700-chalvraines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52095-52700-chalvraines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52095-52700-chalvraines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52095-52700-chalvraines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52097-52700-chambroncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52097-52700-chambroncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52097-52700-chambroncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52097-52700-chambroncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52099-52410-chamouilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52099-52410-chamouilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52099-52410-chamouilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52099-52410-chamouilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52101-52150-champigneulles_en_bassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52101-52150-champigneulles_en_bassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52101-52150-champigneulles_en_bassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52101-52150-champigneulles_en_bassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52102-52200-champigny_les_langres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52102-52200-champigny_les_langres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52102-52200-champigny_les_langres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52102-52200-champigny_les_langres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52103-52400-champigny_sous_varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52103-52400-champigny_sous_varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52103-52400-champigny_sous_varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52103-52400-champigny_sous_varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52104-52100-chancenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52104-52100-chancenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52104-52100-chancenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52104-52100-chancenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52105-52360-changey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52105-52360-changey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52105-52360-changey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52105-52360-changey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52106-52260-chanoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52106-52260-chanoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52106-52260-chanoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52106-52260-chanoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52107-52700-chantraines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52107-52700-chantraines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52107-52700-chantraines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52107-52700-chantraines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52108-52360-charmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52108-52360-charmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52108-52360-charmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52108-52360-charmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52109-52110-charmes_en_l_angle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52109-52110-charmes_en_l_angle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52109-52110-charmes_en_l_angle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52109-52110-charmes_en_l_angle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52110-52110-charmes_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52110-52110-charmes_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52110-52110-charmes_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52110-52110-charmes_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52113-52190-chassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52113-52190-chassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52113-52190-chassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52113-52190-chassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52114-52120-chateauvillain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52114-52120-chateauvillain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52114-52120-chateauvillain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52114-52120-chateauvillain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52115-52200-chatenay_macheron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52115-52200-chatenay_macheron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52115-52200-chatenay_macheron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52115-52200-chatenay_macheron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52116-52360-chatenay_vaudin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52116-52360-chatenay_vaudin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52116-52360-chatenay_vaudin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52116-52360-chatenay_vaudin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52118-52300-chatonrupt_sommermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52118-52300-chatonrupt_sommermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52118-52300-chatonrupt_sommermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52118-52300-chatonrupt_sommermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52119-52600-chaudenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52119-52600-chaudenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52119-52600-chaudenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52119-52600-chaudenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52120-52140-chauffourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52120-52140-chauffourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52120-52140-chauffourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52120-52140-chauffourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52121-52000-chaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52121-52000-chaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52121-52000-chaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52121-52000-chaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52122-52150-chaumont_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52122-52150-chaumont_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52122-52150-chaumont_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52122-52150-chaumont_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52123-52170-chevillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52123-52170-chevillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52123-52170-chevillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52123-52170-chevillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52124-52400-chezeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52124-52400-chezeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52124-52400-chezeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52124-52400-chezeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52125-52000-chamarandes_choignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52125-52000-chamarandes_choignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52125-52000-chamarandes_choignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52125-52000-chamarandes_choignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52126-52190-choilley_dardenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52126-52190-choilley_dardenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52126-52190-choilley_dardenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52126-52190-choilley_dardenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52127-52240-choiseul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52127-52240-choiseul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52127-52240-choiseul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52127-52240-choiseul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52128-52700-cirey_les_mareilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52128-52700-cirey_les_mareilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52128-52700-cirey_les_mareilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52128-52700-cirey_les_mareilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52129-52110-cirey_sur_blaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52129-52110-cirey_sur_blaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52129-52110-cirey_sur_blaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52129-52110-cirey_sur_blaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52130-52370-cirfontaines_en_azois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52130-52370-cirfontaines_en_azois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52130-52370-cirfontaines_en_azois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52130-52370-cirfontaines_en_azois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52131-52230-cirfontaines_en_ornois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52131-52230-cirfontaines_en_ornois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52131-52230-cirfontaines_en_ornois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52131-52230-cirfontaines_en_ornois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52132-52240-clefmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52132-52240-clefmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52132-52240-clefmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52132-52240-clefmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52133-52700-clinchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52133-52700-clinchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52133-52700-clinchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52133-52700-clinchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52134-52600-cohons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52134-52600-cohons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52134-52600-cohons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52134-52600-cohons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52135-52400-coiffy_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52135-52400-coiffy_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52135-52400-coiffy_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52135-52400-coiffy_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52136-52400-coiffy_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52136-52400-coiffy_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52136-52400-coiffy_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52136-52400-coiffy_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52137-52160-colmier_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52137-52160-colmier_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52137-52160-colmier_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52137-52160-colmier_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52138-52160-colmier_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52138-52160-colmier_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52138-52160-colmier_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52138-52160-colmier_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52140-52330-colombey_les_deux_eglises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52140-52330-colombey_les_deux_eglises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52140-52330-colombey_les_deux_eglises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52140-52330-colombey_les_deux_eglises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52141-52000-condes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52141-52000-condes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52141-52000-condes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52141-52000-condes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52142-52700-consigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52142-52700-consigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52142-52700-consigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52142-52700-consigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52145-52500-coublanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52145-52500-coublanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52145-52500-coublanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52145-52500-coublanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52146-52210-coupray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52146-52210-coupray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52146-52210-coupray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52146-52210-coupray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52147-52200-courcelles_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52147-52200-courcelles_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52147-52200-courcelles_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52147-52200-courcelles_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52149-52110-courcelles_sur_blaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52149-52110-courcelles_sur_blaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52149-52110-courcelles_sur_blaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52149-52110-courcelles_sur_blaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52151-52210-cour_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52151-52210-cour_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52151-52210-cour_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52151-52210-cour_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52155-52600-culmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52155-52600-culmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52155-52600-culmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52155-52600-culmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52156-52300-curel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52156-52300-curel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52156-52300-curel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52156-52300-curel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52157-52330-curmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52157-52330-curmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52157-52330-curmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52157-52330-curmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52158-52190-cusey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52158-52190-cusey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52158-52190-cusey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52158-52190-cusey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52159-52240-cuves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52159-52240-cuves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52159-52240-cuves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52159-52240-cuves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52160-52110-daillancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52160-52110-daillancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52160-52110-daillancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52160-52110-daillancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52161-52240-daillecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52161-52240-daillecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52161-52240-daillecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52161-52240-daillecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52162-52140-dammartin_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52162-52140-dammartin_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52162-52140-dammartin_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52162-52140-dammartin_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52163-52360-dampierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52163-52360-dampierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52163-52360-dampierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52163-52360-dampierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52164-52400-damremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52164-52400-damremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52164-52400-damremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52164-52400-damremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52165-52210-dancevoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52165-52210-dancevoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52165-52210-dancevoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52165-52210-dancevoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52167-52700-darmannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52167-52700-darmannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52167-52700-darmannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52167-52700-darmannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52168-52120-dinteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52168-52120-dinteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52168-52120-dinteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52168-52120-dinteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52169-52130-domblain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52169-52130-domblain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52169-52130-domblain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52169-52130-domblain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52170-52190-dommarien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52170-52190-dommarien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52170-52190-dommarien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52170-52190-dommarien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52171-52110-dommartin_le_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52171-52110-dommartin_le_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52171-52110-dommartin_le_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52171-52110-dommartin_le_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52172-52110-dommartin_le_saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52172-52110-dommartin_le_saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52172-52110-dommartin_le_saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52172-52110-dommartin_le_saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52173-52270-domremy_landeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52173-52270-domremy_landeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52173-52270-domremy_landeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52173-52270-domremy_landeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52174-52150-doncourt_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52174-52150-doncourt_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52174-52150-doncourt_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52174-52150-doncourt_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52175-52300-donjeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52175-52300-donjeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52175-52300-donjeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52175-52300-donjeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52177-52270-doulaincourt_saucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52177-52270-doulaincourt_saucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52177-52270-doulaincourt_saucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52177-52270-doulaincourt_saucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52178-52110-doulevant_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52178-52110-doulevant_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52178-52110-doulevant_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52178-52110-doulevant_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52179-52130-doulevant_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52179-52130-doulevant_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52179-52130-doulevant_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52179-52130-doulevant_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52181-52230-echenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52181-52230-echenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52181-52230-echenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52181-52230-echenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52182-52290-eclaron_braucourt_sainte_liviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52182-52290-eclaron_braucourt_sainte_liviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52182-52290-eclaron_braucourt_sainte_liviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52182-52290-eclaron_braucourt_sainte_liviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52183-52700-ecot_la_combe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52183-52700-ecot_la_combe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52183-52700-ecot_la_combe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52183-52700-ecot_la_combe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52184-52300-effincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52184-52300-effincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52184-52300-effincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52184-52300-effincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52185-52400-enfonvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52185-52400-enfonvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52185-52400-enfonvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52185-52400-enfonvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52187-52230-epizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52187-52230-epizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52187-52230-epizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52187-52230-epizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52187-52270-epizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52187-52270-epizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52187-52270-epizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52187-52270-epizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52189-52190-le_val_d_esnoms/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52189-52190-le_val_d_esnoms/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52189-52190-le_val_d_esnoms/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52189-52190-le_val_d_esnoms/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52190-52340-esnouveaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52190-52340-esnouveaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52190-52340-esnouveaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52190-52340-esnouveaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52193-52000-euffigneix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52193-52000-euffigneix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52193-52000-euffigneix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52193-52000-euffigneix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52194-52410-eurville_bienville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52194-52410-eurville_bienville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52194-52410-eurville_bienville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52194-52410-eurville_bienville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52195-52500-farincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52195-52500-farincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52195-52500-farincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52195-52500-farincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52196-52260-faverolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52196-52260-faverolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52196-52260-faverolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52196-52260-faverolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52197-52500-fayl_billot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52197-52500-fayl_billot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52197-52500-fayl_billot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52197-52500-fayl_billot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52198-52130-fays/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52198-52130-fays/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52198-52130-fays/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52198-52130-fays/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52199-52300-ferriere_et_lafolie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52199-52300-ferriere_et_lafolie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52199-52300-ferriere_et_lafolie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52199-52300-ferriere_et_lafolie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52200-52250-flagey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52200-52250-flagey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52200-52250-flagey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52200-52250-flagey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52201-52110-flammerecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52201-52110-flammerecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52201-52110-flammerecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52201-52110-flammerecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52203-52170-fontaines_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52203-52170-fontaines_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52203-52170-fontaines_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52203-52170-fontaines_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52204-52700-forcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52204-52700-forcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52204-52700-forcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52204-52700-forcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52205-52000-foulain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52205-52000-foulain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52205-52000-foulain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52205-52000-foulain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52205-52800-foulain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52205-52800-foulain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52205-52800-foulain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52205-52800-foulain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52206-52220-frampas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52206-52220-frampas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52206-52220-frampas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52206-52220-frampas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52207-52360-frecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52207-52360-frecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52207-52360-frecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52207-52360-frecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52208-52400-fresnes_sur_apance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52208-52400-fresnes_sur_apance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52208-52400-fresnes_sur_apance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52208-52400-fresnes_sur_apance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52211-52320-froncles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52211-52320-froncles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52211-52320-froncles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52211-52320-froncles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52212-52300-fronville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52212-52300-fronville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52212-52300-fronville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52212-52300-fronville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52213-52500-genevrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52213-52500-genevrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52213-52500-genevrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52213-52500-genevrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52214-52320-la_genevroye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52214-52320-la_genevroye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52214-52320-la_genevroye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52214-52320-la_genevroye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52216-52160-germaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52216-52160-germaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52216-52160-germaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52216-52160-germaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52217-52150-germainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52217-52150-germainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52217-52150-germainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52217-52150-germainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52218-52230-germay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52218-52230-germay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52218-52230-germay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52218-52230-germay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52219-52230-germisay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52219-52230-germisay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52219-52230-germisay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52219-52230-germisay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52220-52210-giey_sur_aujon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52220-52210-giey_sur_aujon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52220-52210-giey_sur_aujon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52220-52210-giey_sur_aujon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52221-52330-gillancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52221-52330-gillancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52221-52330-gillancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52221-52330-gillancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52222-52230-gillaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52222-52230-gillaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52222-52230-gillaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52222-52230-gillaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52223-52500-gilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52223-52500-gilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52223-52500-gilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52223-52500-gilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52227-52150-graffigny_chemin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52227-52150-graffigny_chemin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52227-52150-graffigny_chemin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52227-52150-graffigny_chemin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52228-52600-grandchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52228-52600-grandchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52228-52600-grandchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52228-52600-grandchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52229-52500-grenant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52229-52500-grenant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52229-52500-grenant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52229-52500-grenant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52230-52320-gudmont_villiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52230-52320-gudmont_villiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52230-52320-gudmont_villiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52230-52320-gudmont_villiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52231-52300-guindrecourt_aux_ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52231-52300-guindrecourt_aux_ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52231-52300-guindrecourt_aux_ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52231-52300-guindrecourt_aux_ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52232-52330-guindrecourt_sur_blaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52232-52330-guindrecourt_sur_blaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52232-52330-guindrecourt_sur_blaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52232-52330-guindrecourt_sur_blaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52233-52400-guyonvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52233-52400-guyonvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52233-52400-guyonvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52233-52400-guyonvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52234-52150-hacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52234-52150-hacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52234-52150-hacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52234-52150-hacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52235-52100-hallignicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52235-52100-hallignicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52235-52100-hallignicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52235-52100-hallignicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52237-52150-harreville_les_chanteurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52237-52150-harreville_les_chanteurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52237-52150-harreville_les_chanteurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52237-52150-harreville_les_chanteurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52240-52600-heuilley_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52240-52600-heuilley_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52240-52600-heuilley_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52240-52600-heuilley_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52242-52600-haute_amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52242-52600-haute_amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52242-52600-haute_amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52242-52600-haute_amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52243-52150-huilliecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52243-52150-huilliecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52243-52150-huilliecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52243-52150-huilliecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52244-52290-humbecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52244-52290-humbecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52244-52290-humbecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52244-52290-humbecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52245-52700-humberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52245-52700-humberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52245-52700-humberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52245-52700-humberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52246-52200-humes_jorquenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52246-52200-humes_jorquenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52246-52200-humes_jorquenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52246-52200-humes_jorquenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52247-52150-illoud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52247-52150-illoud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52247-52150-illoud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52247-52150-illoud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52248-52140-is_en_bassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52248-52140-is_en_bassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52248-52140-is_en_bassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52248-52140-is_en_bassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52249-52190-isomes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52249-52190-isomes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52249-52190-isomes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52249-52190-isomes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52250-52300-joinville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52250-52300-joinville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52250-52300-joinville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52250-52300-joinville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52251-52000-jonchery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52251-52000-jonchery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52251-52000-jonchery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52251-52000-jonchery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52253-52330-juzennecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52253-52330-juzennecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52253-52330-juzennecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52253-52330-juzennecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52254-52330-lachapelle_en_blaisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52254-52330-lachapelle_en_blaisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52254-52330-lachapelle_en_blaisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52254-52330-lachapelle_en_blaisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52256-52700-lafauche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52256-52700-lafauche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52256-52700-lafauche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52256-52700-lafauche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52257-52500-laferte_sur_amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52257-52500-laferte_sur_amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52257-52500-laferte_sur_amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52257-52500-laferte_sur_amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52258-52120-laferte_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52258-52120-laferte_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52258-52120-laferte_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52258-52120-laferte_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52260-52310-lamancine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52260-52310-lamancine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52260-52310-lamancine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52260-52310-lamancine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52264-52400-laneuvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52264-52400-laneuvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52264-52400-laneuvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52264-52400-laneuvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52265-52170-bayard_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52265-52170-bayard_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52265-52170-bayard_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52265-52170-bayard_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52266-52220-laneuville_a_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52266-52220-laneuville_a_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52266-52220-laneuville_a_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52266-52220-laneuville_a_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52267-52100-laneuville_au_pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52267-52100-laneuville_au_pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52267-52100-laneuville_au_pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52267-52100-laneuville_au_pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52269-52200-langres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52269-52200-langres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52269-52200-langres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52269-52200-langres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52271-52800-lanques_sur_rognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52271-52800-lanques_sur_rognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52271-52800-lanques_sur_rognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52271-52800-lanques_sur_rognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52272-52120-lanty_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52272-52120-lanty_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52272-52120-lanty_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52272-52120-lanty_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52273-52400-lariviere_arnoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52273-52400-lariviere_arnoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52273-52400-lariviere_arnoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52273-52400-lariviere_arnoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52274-52120-latrecey_ormoy_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52274-52120-latrecey_ormoy_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52274-52120-latrecey_ormoy_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52274-52120-latrecey_ormoy_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52275-52140-lavernoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52275-52140-lavernoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52275-52140-lavernoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52275-52140-lavernoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52276-52000-laville_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52276-52000-laville_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52276-52000-laville_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52276-52000-laville_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52277-52140-lavilleneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52277-52140-lavilleneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52277-52140-lavilleneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52277-52140-lavilleneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52278-52330-lavilleneuve_au_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52278-52330-lavilleneuve_au_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52278-52330-lavilleneuve_au_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52278-52330-lavilleneuve_au_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52280-52360-lecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52280-52360-lecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52280-52360-lecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52280-52360-lecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52282-52210-leffonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52282-52210-leffonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52282-52210-leffonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52282-52210-leffonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52284-52110-lescheres_sur_le_blaiseron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52284-52110-lescheres_sur_le_blaiseron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52284-52110-lescheres_sur_le_blaiseron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52284-52110-lescheres_sur_le_blaiseron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52285-52190-leuchey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52285-52190-leuchey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52285-52190-leuchey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52285-52190-leuchey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52286-52700-leurville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52286-52700-leurville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52286-52700-leurville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52286-52700-leurville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52287-52150-levecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52287-52150-levecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52287-52150-levecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52287-52150-levecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52288-52230-lezeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52288-52230-lezeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52288-52230-lezeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52288-52230-lezeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52289-52700-liffol_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52289-52700-liffol_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52289-52700-liffol_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52289-52700-liffol_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52290-52500-les_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52290-52500-les_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52290-52500-les_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52290-52500-les_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52291-52240-longchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52291-52240-longchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52291-52240-longchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52291-52240-longchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52292-52250-longeau_percey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52292-52250-longeau_percey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52292-52250-longeau_percey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52292-52250-longeau_percey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52294-52130-louvemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52294-52130-louvemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52294-52130-louvemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52294-52130-louvemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52295-52800-louvieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52295-52800-louvieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52295-52800-louvieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52295-52800-louvieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52297-52000-luzy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52297-52000-luzy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52297-52000-luzy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52297-52000-luzy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52298-52500-maatz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52298-52500-maatz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52298-52500-maatz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52298-52500-maatz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52300-52130-magneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52300-52130-magneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52300-52130-magneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52300-52130-magneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52301-52240-maisoncelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52301-52240-maisoncelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52301-52240-maisoncelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52301-52240-maisoncelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52302-52300-maizieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52302-52300-maizieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52302-52300-maizieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52302-52300-maizieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52303-52500-maizieres_sur_amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52303-52500-maizieres_sur_amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52303-52500-maizieres_sur_amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52303-52500-maizieres_sur_amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52304-52150-malaincourt_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52304-52150-malaincourt_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52304-52150-malaincourt_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52304-52150-malaincourt_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52305-52800-mandres_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52305-52800-mandres_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52305-52800-mandres_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52305-52800-mandres_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52306-52700-manois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52306-52700-manois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52306-52700-manois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52306-52700-manois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52307-52260-marac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52307-52260-marac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52307-52260-marac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52307-52260-marac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52308-52370-maranville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52308-52370-maranville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52308-52370-maranville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52308-52370-maranville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52310-52320-marbeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52310-52320-marbeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52310-52320-marbeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52310-52320-marbeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52311-52360-marcilly_en_bassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52311-52360-marcilly_en_bassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52311-52360-marcilly_en_bassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52311-52360-marcilly_en_bassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52312-52200-mardor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52312-52200-mardor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52312-52200-mardor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52312-52200-mardor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52313-52700-mareilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52313-52700-mareilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52313-52700-mareilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52313-52700-mareilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52315-52800-marnay_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52315-52800-marnay_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52315-52800-marnay_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52315-52800-marnay_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52316-52300-mathons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52316-52300-mathons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52316-52300-mathons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52316-52300-mathons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52318-52400-melay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52318-52400-melay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52318-52400-melay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52318-52400-melay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52319-52240-mennouveaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52319-52240-mennouveaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52319-52240-mennouveaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52319-52240-mennouveaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52320-52240-merrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52320-52240-merrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52320-52240-merrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52320-52240-merrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52321-52110-mertrud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52321-52110-mertrud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52321-52110-mertrud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52321-52110-mertrud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52322-52310-meures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52322-52310-meures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52322-52310-meures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52322-52310-meures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52325-52240-millieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52325-52240-millieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52325-52240-millieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52325-52240-millieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52326-52320-mirbel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52326-52320-mirbel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52326-52320-mirbel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52326-52320-mirbel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52327-52100-moeslains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52327-52100-moeslains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52327-52100-moeslains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52327-52100-moeslains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52328-52400-montcharvot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52328-52400-montcharvot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52328-52400-montcharvot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52328-52400-montcharvot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52330-52330-montheries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52330-52330-montheries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52330-52330-montheries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52330-52330-montheries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52331-52220-la_porte_du_der/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52331-52220-la_porte_du_der/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52331-52220-la_porte_du_der/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52331-52220-la_porte_du_der/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52332-52140-val_de_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52332-52140-val_de_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52332-52140-val_de_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52332-52140-val_de_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52332-52240-val_de_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52332-52240-val_de_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52332-52240-val_de_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52332-52240-val_de_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52335-52700-montot_sur_rognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52335-52700-montot_sur_rognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52335-52700-montot_sur_rognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52335-52700-montot_sur_rognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52336-52130-montreuil_sur_blaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52336-52130-montreuil_sur_blaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52336-52130-montreuil_sur_blaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52336-52130-montreuil_sur_blaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52337-52230-montreuil_sur_thonnance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52337-52230-montreuil_sur_thonnance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52337-52230-montreuil_sur_thonnance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52337-52230-montreuil_sur_thonnance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52341-52110-morancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52341-52110-morancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52341-52110-morancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52341-52110-morancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52342-52700-morionvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52342-52700-morionvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52342-52700-morionvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52342-52700-morionvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52344-52160-mouilleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52344-52160-mouilleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52344-52160-mouilleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52344-52160-mouilleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52346-52300-mussey_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52346-52300-mussey_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52346-52300-mussey_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52346-52300-mussey_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52347-52170-narcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52347-52170-narcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52347-52170-narcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52347-52170-narcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52348-52360-neuilly_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52348-52360-neuilly_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52348-52360-neuilly_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52348-52360-neuilly_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52349-52000-neuilly_sur_suize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52349-52000-neuilly_sur_suize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52349-52000-neuilly_sur_suize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52349-52000-neuilly_sur_suize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52350-52400-neuvelle_les_voisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52350-52400-neuvelle_les_voisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52350-52400-neuvelle_les_voisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52350-52400-neuvelle_les_voisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52352-52800-ninville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52352-52800-ninville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52352-52800-ninville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52352-52800-ninville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52353-52800-nogent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52353-52800-nogent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52353-52800-nogent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52353-52800-nogent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52354-52600-noidant_chatenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52354-52600-noidant_chatenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52354-52600-noidant_chatenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52354-52600-noidant_chatenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52355-52200-noidant_le_rocheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52355-52200-noidant_le_rocheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52355-52200-noidant_le_rocheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52355-52200-noidant_le_rocheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52356-52300-nomecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52356-52300-nomecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52356-52300-nomecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52356-52300-nomecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52357-52230-noncourt_sur_le_rongeant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52357-52230-noncourt_sur_le_rongeant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52357-52230-noncourt_sur_le_rongeant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52357-52230-noncourt_sur_le_rongeant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52358-52240-noyers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52358-52240-noyers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52358-52240-noyers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52358-52240-noyers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52359-52110-nully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52359-52110-nully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52359-52110-nully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52359-52110-nully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52360-52190-occey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52360-52190-occey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52360-52190-occey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52360-52190-occey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52362-52360-orbigny_au_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52362-52360-orbigny_au_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52362-52360-orbigny_au_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52362-52360-orbigny_au_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52363-52360-orbigny_au_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52363-52360-orbigny_au_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52363-52360-orbigny_au_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52363-52360-orbigny_au_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52364-52250-orcevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52364-52250-orcevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52364-52250-orcevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52364-52250-orcevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52365-52120-orges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52365-52120-orges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52365-52120-orges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52365-52120-orges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52366-52200-ormancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52366-52200-ormancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52366-52200-ormancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52366-52200-ormancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52367-52310-ormoy_les_sexfontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52367-52310-ormoy_les_sexfontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52367-52310-ormoy_les_sexfontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52367-52310-ormoy_les_sexfontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52369-52700-orquevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52369-52700-orquevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52369-52700-orquevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52369-52700-orquevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52370-52300-osne_le_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52370-52300-osne_le_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52370-52300-osne_le_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52370-52300-osne_le_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52371-52310-oudincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52371-52310-oudincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52371-52310-oudincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52371-52310-oudincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52372-52150-outremecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52372-52150-outremecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52372-52150-outremecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52372-52150-outremecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52373-52700-ozieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52373-52700-ozieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52373-52700-ozieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52373-52700-ozieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52374-52600-le_pailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52374-52600-le_pailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52374-52600-le_pailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52374-52600-le_pailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52375-52600-palaiseul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52375-52600-palaiseul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52375-52600-palaiseul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52375-52600-palaiseul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52376-52230-pansey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52376-52230-pansey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52376-52230-pansey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52376-52230-pansey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52377-52400-parnoy_en_bassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52377-52400-parnoy_en_bassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52377-52400-parnoy_en_bassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52377-52400-parnoy_en_bassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52378-52300-paroy_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52378-52300-paroy_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52378-52300-paroy_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52378-52300-paroy_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52380-52200-peigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52380-52200-peigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52380-52200-peigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52380-52200-peigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52383-52200-perrancey_les_vieux_moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52383-52200-perrancey_les_vieux_moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52383-52200-perrancey_les_vieux_moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52383-52200-perrancey_les_vieux_moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52384-52160-perrogney_les_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52384-52160-perrogney_les_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52384-52160-perrogney_les_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52384-52160-perrogney_les_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52385-52240-perrusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52385-52240-perrusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52385-52240-perrusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52385-52240-perrusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52386-52100-perthes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52386-52100-perthes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52386-52100-perthes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52386-52100-perthes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52388-52500-pierremont_sur_amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52388-52500-pierremont_sur_amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52388-52500-pierremont_sur_amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52388-52500-pierremont_sur_amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52390-52500-pisseloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52390-52500-pisseloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52390-52500-pisseloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52390-52500-pisseloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52391-52220-planrupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52391-52220-planrupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52391-52220-planrupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52391-52220-planrupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52392-52360-plesnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52392-52360-plesnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52392-52360-plesnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52392-52360-plesnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52393-52160-poinsenot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52393-52160-poinsenot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52393-52160-poinsenot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52393-52160-poinsenot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52394-52500-poinson_les_fayl/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52394-52500-poinson_les_fayl/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52394-52500-poinson_les_fayl/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52394-52500-poinson_les_fayl/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52395-52160-poinson_les_grancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52395-52160-poinson_les_grancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52395-52160-poinson_les_grancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52395-52160-poinson_les_grancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52396-52800-poinson_les_nogent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52396-52800-poinson_les_nogent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52396-52800-poinson_les_nogent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52396-52800-poinson_les_nogent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52397-52360-poiseul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52397-52360-poiseul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52397-52360-poiseul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52397-52360-poiseul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52398-52230-poissons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52398-52230-poissons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52398-52230-poissons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52398-52230-poissons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52399-52120-pont_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52399-52120-pont_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52399-52120-pont_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52399-52120-pont_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52400-52400-le_chatelet_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52400-52400-le_chatelet_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52400-52400-le_chatelet_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52400-52400-le_chatelet_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52401-52800-poulangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52401-52800-poulangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52401-52800-poulangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52401-52800-poulangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52403-52160-praslay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52403-52160-praslay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52403-52160-praslay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52403-52160-praslay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52405-52190-le_montsaugeonnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52405-52190-le_montsaugeonnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52405-52190-le_montsaugeonnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52405-52190-le_montsaugeonnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52406-52500-pressigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52406-52500-pressigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52406-52500-pressigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52406-52500-pressigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52407-52700-prez_sous_lafauche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52407-52700-prez_sous_lafauche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52407-52700-prez_sous_lafauche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52407-52700-prez_sous_lafauche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52411-52220-rives_dervoises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52411-52220-rives_dervoises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52411-52220-rives_dervoises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52411-52220-rives_dervoises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52413-52130-rachecourt_suzemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52413-52130-rachecourt_suzemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52413-52130-rachecourt_suzemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52413-52130-rachecourt_suzemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52414-52170-rachecourt_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52414-52170-rachecourt_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52414-52170-rachecourt_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52414-52170-rachecourt_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52415-52140-ranconnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52415-52140-ranconnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52415-52140-ranconnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52415-52140-ranconnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52416-52140-rangecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52416-52140-rangecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52416-52140-rangecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52416-52140-rangecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52419-52370-rennepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52419-52370-rennepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52419-52370-rennepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52419-52370-rennepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52420-52700-reynel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52420-52700-reynel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52420-52700-reynel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52420-52700-reynel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52421-52000-riaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52421-52000-riaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52421-52000-riaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52421-52000-riaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52422-52120-richebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52422-52120-richebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52422-52120-richebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52422-52120-richebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52423-52700-rimaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52423-52700-rimaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52423-52700-rimaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52423-52700-rimaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52424-52600-rivieres_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52424-52600-rivieres_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52424-52600-rivieres_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52424-52600-rivieres_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52425-52190-riviere_les_fosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52425-52190-riviere_les_fosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52425-52190-riviere_les_fosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52425-52190-riviere_les_fosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52426-52330-rizaucourt_buchey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52426-52330-rizaucourt_buchey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52426-52330-rizaucourt_buchey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52426-52330-rizaucourt_buchey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52428-52700-rochefort_sur_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52428-52700-rochefort_sur_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52428-52700-rochefort_sur_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52428-52700-rochefort_sur_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52429-52410-roches_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52429-52410-roches_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52429-52410-roches_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52429-52410-roches_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52431-52210-rochetaillee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52431-52210-rochetaillee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52431-52210-rochetaillee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52431-52210-rochetaillee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52432-52260-rolampont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52432-52260-rolampont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52432-52260-rolampont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52432-52260-rolampont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52433-52150-romain_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52433-52150-romain_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52433-52150-romain_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52433-52150-romain_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52436-52320-rouecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52436-52320-rouecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52436-52320-rouecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52436-52320-rouecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52437-52160-rouelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52437-52160-rouelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52437-52160-rouelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52437-52160-rouelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52438-52500-rougeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52438-52500-rougeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52438-52500-rougeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52438-52500-rougeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52439-52160-rouvres_sur_aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52439-52160-rouvres_sur_aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52439-52160-rouvres_sur_aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52439-52160-rouvres_sur_aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52440-52300-rouvroy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52440-52300-rouvroy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52440-52300-rouvroy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52440-52300-rouvroy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52442-52300-rupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52442-52300-rupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52442-52300-rupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52442-52300-rupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52443-52230-sailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52443-52230-sailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52443-52230-sailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52443-52230-sailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52444-52700-saint_blin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52444-52700-saint_blin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52444-52700-saint_blin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52444-52700-saint_blin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52445-52190-saint_broingt_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52445-52190-saint_broingt_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52445-52190-saint_broingt_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52445-52190-saint_broingt_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52446-52190-saint_broingt_les_fosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52446-52190-saint_broingt_les_fosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52446-52190-saint_broingt_les_fosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52446-52190-saint_broingt_les_fosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52447-52200-saint_ciergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52447-52200-saint_ciergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52447-52200-saint_ciergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52447-52200-saint_ciergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52448-52100-saint_dizier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52448-52100-saint_dizier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52448-52100-saint_dizier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52448-52100-saint_dizier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52449-52200-saints_geosmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52449-52200-saints_geosmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52449-52200-saints_geosmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52449-52200-saints_geosmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52450-52210-saint_loup_sur_aujon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52450-52210-saint_loup_sur_aujon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52450-52210-saint_loup_sur_aujon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52450-52210-saint_loup_sur_aujon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52452-52200-saint_martin_les_langres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52452-52200-saint_martin_les_langres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52452-52200-saint_martin_les_langres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52452-52200-saint_martin_les_langres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52453-52200-saint_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52453-52200-saint_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52453-52200-saint_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52453-52200-saint_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52455-52150-saint_thiebault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52455-52150-saint_thiebault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52455-52150-saint_thiebault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52455-52150-saint_thiebault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52456-52300-saint_urbain_maconcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52456-52300-saint_urbain_maconcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52456-52300-saint_urbain_maconcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52456-52300-saint_urbain_maconcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52457-52200-saint_vallier_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52457-52200-saint_vallier_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52457-52200-saint_vallier_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52457-52200-saint_vallier_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52459-52800-sarcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52459-52800-sarcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52459-52800-sarcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52459-52800-sarcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52461-52140-sarrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52461-52140-sarrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52461-52140-sarrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52461-52140-sarrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52463-52230-saudron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52463-52230-saudron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52463-52230-saudron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52463-52230-saudron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52464-52500-saulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52464-52500-saulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52464-52500-saulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52464-52500-saulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52465-52140-saulxures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52465-52140-saulxures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52465-52140-saulxures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52465-52140-saulxures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52467-52500-savigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52467-52500-savigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52467-52500-savigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52467-52500-savigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52468-52700-semilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52468-52700-semilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52468-52700-semilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52468-52700-semilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52469-52000-semoutiers_montsaon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52469-52000-semoutiers_montsaon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52469-52000-semoutiers_montsaon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52469-52000-semoutiers_montsaon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52470-52400-serqueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52470-52400-serqueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52470-52400-serqueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52470-52400-serqueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52472-52330-sexfontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52472-52330-sexfontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52472-52330-sexfontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52472-52330-sexfontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52473-52700-signeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52473-52700-signeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52473-52700-signeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52473-52700-signeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52474-52120-silvarouvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52474-52120-silvarouvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52474-52120-silvarouvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52474-52120-silvarouvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52475-52130-sommancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52475-52130-sommancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52475-52130-sommancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52475-52130-sommancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52476-52150-sommerecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52476-52150-sommerecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52476-52150-sommerecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52476-52150-sommerecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52479-52220-sommevoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52479-52220-sommevoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52479-52220-sommevoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52479-52220-sommevoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52480-52320-soncourt_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52480-52320-soncourt_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52480-52320-soncourt_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52480-52320-soncourt_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52482-52150-soulaucourt_sur_mouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52482-52150-soulaucourt_sur_mouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52482-52150-soulaucourt_sur_mouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52482-52150-soulaucourt_sur_mouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52483-52400-soyers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52483-52400-soyers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52483-52400-soyers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52483-52400-soyers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52484-52300-suzannecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52484-52300-suzannecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52484-52300-suzannecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52484-52300-suzannecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52486-52210-ternat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52486-52210-ternat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52486-52210-ternat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52486-52210-ternat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52487-52220-thilleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52487-52220-thilleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52487-52220-thilleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52487-52220-thilleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52488-52800-thivet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52488-52800-thivet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52488-52800-thivet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52488-52800-thivet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52489-52240-thol_les_millieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52489-52240-thol_les_millieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52489-52240-thol_les_millieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52489-52240-thol_les_millieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52490-52300-thonnance_les_joinville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52490-52300-thonnance_les_joinville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52490-52300-thonnance_les_joinville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52490-52300-thonnance_les_joinville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52491-52230-thonnance_les_moulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52491-52230-thonnance_les_moulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52491-52230-thonnance_les_moulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52491-52230-thonnance_les_moulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52492-52600-torcenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52492-52600-torcenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52492-52600-torcenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52492-52600-torcenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52493-52500-tornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52493-52500-tornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52493-52500-tornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52493-52500-tornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52494-52000-treix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52494-52000-treix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52494-52000-treix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52494-52000-treix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52495-52110-tremilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52495-52110-tremilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52495-52110-tremilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52495-52110-tremilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52497-52130-troisfontaines_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52497-52130-troisfontaines_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52497-52130-troisfontaines_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52497-52130-troisfontaines_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52499-52160-vaillant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52499-52160-vaillant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52499-52160-vaillant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52499-52160-vaillant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52500-52100-valcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52500-52100-valcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52500-52100-valcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52500-52100-valcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52502-52130-valleret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52502-52130-valleret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52502-52130-valleret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52502-52130-valleret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52503-52500-valleroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52503-52500-valleroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52503-52500-valleroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52503-52500-valleroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52504-52400-varennes_sur_amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52504-52400-varennes_sur_amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52504-52400-varennes_sur_amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52504-52400-varennes_sur_amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52505-52150-vaudrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52505-52150-vaudrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52505-52150-vaudrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52505-52150-vaudrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52506-52330-vaudremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52506-52330-vaudremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52506-52330-vaudremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52506-52330-vaudremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52507-52200-vauxbons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52507-52200-vauxbons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52507-52200-vauxbons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52507-52200-vauxbons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52510-52130-vaux_sur_blaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52510-52130-vaux_sur_blaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52510-52130-vaux_sur_blaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52510-52130-vaux_sur_blaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52511-52300-vaux_sur_saint_urbain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52511-52300-vaux_sur_saint_urbain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52511-52300-vaux_sur_saint_urbain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52511-52300-vaux_sur_saint_urbain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52512-52300-vecqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52512-52300-vecqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52512-52300-vecqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52512-52300-vecqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52513-52500-velles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52513-52500-velles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52513-52500-velles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52513-52500-velles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52514-52000-verbiesles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52514-52000-verbiesles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52514-52000-verbiesles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52514-52000-verbiesles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52515-52250-verseilles_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52515-52250-verseilles_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52515-52250-verseilles_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52515-52250-verseilles_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52516-52250-verseilles_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52516-52250-verseilles_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52516-52250-verseilles_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52516-52250-verseilles_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52517-52700-vesaignes_sous_lafauche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52517-52700-vesaignes_sous_lafauche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52517-52700-vesaignes_sous_lafauche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52517-52700-vesaignes_sous_lafauche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52518-52800-vesaignes_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52518-52800-vesaignes_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52518-52800-vesaignes_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52518-52800-vesaignes_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52519-52190-vesvres_sous_chalancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52519-52190-vesvres_sous_chalancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52519-52190-vesvres_sous_chalancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52519-52190-vesvres_sous_chalancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52520-52400-vicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52520-52400-vicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52520-52400-vicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52520-52400-vicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52522-52310-vieville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52522-52310-vieville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52522-52310-vieville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52522-52310-vieville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52523-52700-vignes_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52523-52700-vignes_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52523-52700-vignes_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52523-52700-vignes_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52524-52320-vignory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52524-52320-vignory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52524-52320-vignory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52524-52320-vignory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52525-52120-villars_en_azois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52525-52120-villars_en_azois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52525-52120-villars_en_azois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52525-52120-villars_en_azois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52526-52160-villars_santenoge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52526-52160-villars_santenoge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52526-52160-villars_santenoge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52526-52160-villars_santenoge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52528-52130-ville_en_blaisois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52528-52130-ville_en_blaisois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52528-52130-ville_en_blaisois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52528-52130-ville_en_blaisois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52529-52190-villegusien_le_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52529-52190-villegusien_le_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52529-52190-villegusien_le_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52529-52190-villegusien_le_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52529-52600-villegusien_le_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52529-52600-villegusien_le_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52529-52600-villegusien_le_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52529-52600-villegusien_le_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52534-52100-villiers_en_lieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52534-52100-villiers_en_lieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52534-52100-villiers_en_lieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52534-52100-villiers_en_lieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52535-52000-villiers_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52535-52000-villiers_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52535-52000-villiers_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52535-52000-villiers_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52536-52190-villiers_les_aprey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52536-52190-villiers_les_aprey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52536-52190-villiers_les_aprey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52536-52190-villiers_les_aprey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52538-52210-villiers_sur_suize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52538-52210-villiers_sur_suize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52538-52210-villiers_sur_suize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52538-52210-villiers_sur_suize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52539-52600-violot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52539-52600-violot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52539-52600-violot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52539-52600-violot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52540-52160-vitry_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52540-52160-vitry_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52540-52160-vitry_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52540-52160-vitry_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52541-52800-vitry_les_nogent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52541-52800-vitry_les_nogent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52541-52800-vitry_les_nogent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52541-52800-vitry_les_nogent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52542-52160-vivey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52542-52160-vivey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52542-52160-vivey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52542-52160-vivey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52543-52130-voillecomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52543-52130-voillecomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52543-52130-voillecomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52543-52130-voillecomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52544-52400-voisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52544-52400-voisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52544-52400-voisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52544-52400-voisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52545-52200-voisines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52545-52200-voisines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52545-52200-voisines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52545-52200-voisines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52546-52500-voncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52546-52500-voncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52546-52500-voncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52546-52500-voncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52547-52320-vouecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52547-52320-vouecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52547-52320-vouecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52547-52320-vouecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52548-52310-vraincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52548-52310-vraincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52548-52310-vraincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52548-52310-vraincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52549-52240-vroncourt_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52549-52240-vroncourt_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52549-52240-vroncourt_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52549-52240-vroncourt_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52550-52130-wassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52550-52130-wassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52550-52130-wassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt52-haute_marne/commune52550-52130-wassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-53.xml
+++ b/public/sitemaps/sitemap-53.xml
@@ -5,494 +5,984 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53001-53940-ahuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53001-53940-ahuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53001-53940-ahuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53001-53940-ahuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53002-53240-alexain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53002-53240-alexain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53002-53240-alexain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53002-53240-alexain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53003-53300-ambrieres_les_vallees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53003-53300-ambrieres_les_vallees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53003-53300-ambrieres_les_vallees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53003-53300-ambrieres_les_vallees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53005-53240-andouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53005-53240-andouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53005-53240-andouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53005-53240-andouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53007-53210-argentre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53007-53210-argentre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53007-53210-argentre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53007-53210-argentre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53008-53440-aron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53008-53440-aron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53008-53440-aron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53008-53440-aron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53009-53170-arquenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53009-53170-arquenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53009-53170-arquenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53009-53170-arquenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53010-53600-asse_le_berenger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53010-53600-asse_le_berenger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53010-53600-asse_le_berenger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53010-53600-asse_le_berenger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53011-53230-astille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53011-53230-astille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53011-53230-astille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53011-53230-astille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53012-53400-athee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53012-53400-athee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53012-53400-athee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53012-53400-athee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53013-53700-averton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53013-53700-averton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53013-53700-averton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53013-53700-averton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53015-53240-la_baconniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53015-53240-la_baconniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53015-53240-la_baconniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53015-53240-la_baconniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53016-53160-bais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53016-53160-bais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53016-53160-bais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53016-53160-bais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53017-53340-val_du_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53017-53340-val_du_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53017-53340-val_du_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53017-53340-val_du_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53018-53350-ballots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53018-53350-ballots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53018-53350-ballots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53018-53350-ballots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53019-53340-bannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53019-53340-bannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53019-53340-bannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53019-53340-bannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53021-53440-la_bazoge_montpincon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53021-53440-la_bazoge_montpincon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53021-53440-la_bazoge_montpincon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53021-53440-la_bazoge_montpincon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53022-53170-la_bazouge_de_chemere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53022-53170-la_bazouge_de_chemere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53022-53170-la_bazouge_de_chemere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53022-53170-la_bazouge_de_chemere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53023-53470-la_bazouge_des_alleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53023-53470-la_bazouge_des_alleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53023-53470-la_bazouge_des_alleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53023-53470-la_bazouge_des_alleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53025-53170-bazougers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53025-53170-bazougers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53025-53170-bazougers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53025-53170-bazougers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53026-53320-beaulieu_sur_oudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53026-53320-beaulieu_sur_oudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53026-53320-beaulieu_sur_oudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53026-53320-beaulieu_sur_oudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53027-53290-beaumont_pied_de_boeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53027-53290-beaumont_pied_de_boeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53027-53290-beaumont_pied_de_boeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53027-53290-beaumont_pied_de_boeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53028-53440-belgeard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53028-53440-belgeard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53028-53440-belgeard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53028-53440-belgeard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53029-53290-bierne_les_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53029-53290-bierne_les_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53029-53290-bierne_les_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53029-53290-bierne_les_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53030-53170-le_bignon_du_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53030-53170-le_bignon_du_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53030-53170-le_bignon_du_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53030-53170-le_bignon_du_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53031-53240-la_bigottiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53031-53240-la_bigottiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53031-53240-la_bigottiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53031-53240-la_bigottiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53033-53800-la_boissiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53033-53800-la_boissiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53033-53800-la_boissiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53033-53800-la_boissiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53034-53960-bonchamp_les_laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53034-53960-bonchamp_les_laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53034-53960-bonchamp_les_laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53034-53960-bonchamp_les_laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53035-53800-bouchamps_les_craon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53035-53800-bouchamps_les_craon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53035-53800-bouchamps_les_craon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53035-53800-bouchamps_les_craon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53036-53290-bouere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53036-53290-bouere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53036-53290-bouere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53036-53290-bouere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53037-53290-bouessay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53037-53290-bouessay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53037-53290-bouessay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53037-53290-bouessay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53038-53370-boulay_les_ifs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53038-53370-boulay_les_ifs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53038-53370-boulay_les_ifs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53038-53370-boulay_les_ifs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53039-53410-le_bourgneuf_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53039-53410-le_bourgneuf_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53039-53410-le_bourgneuf_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53039-53410-le_bourgneuf_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53040-53410-bourgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53040-53410-bourgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53040-53410-bourgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53040-53410-bourgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53041-53350-brains_sur_les_marches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53041-53350-brains_sur_les_marches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53041-53350-brains_sur_les_marches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53041-53350-brains_sur_les_marches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53042-53120-brece/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53042-53120-brece/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53042-53120-brece/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53042-53120-brece/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53043-53150-bree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53043-53150-bree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53043-53150-bree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53043-53150-bree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53045-53410-la_brulatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53045-53410-la_brulatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53045-53410-la_brulatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53045-53410-la_brulatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53046-53170-le_buret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53046-53170-le_buret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53046-53170-le_buret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53046-53170-le_buret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53047-53120-carelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53047-53120-carelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53047-53120-carelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53047-53120-carelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53048-53420-chailland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53048-53420-chailland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53048-53420-chailland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53048-53420-chailland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53049-53470-chalons_du_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53049-53470-chalons_du_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53049-53470-chalons_du_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53049-53470-chalons_du_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53051-53640-champeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53051-53640-champeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53051-53640-champeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53051-53640-champeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53052-53370-champfremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53052-53370-champfremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53052-53370-champfremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53052-53370-champfremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53053-53160-champgeneteux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53053-53160-champgeneteux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53053-53160-champgeneteux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53053-53160-champgeneteux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53054-53810-change/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53054-53810-change/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53054-53810-change/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53054-53810-change/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53055-53300-chantrigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53055-53300-chantrigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53055-53300-chantrigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53055-53300-chantrigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53056-53950-la_chapelle_anthenaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53056-53950-la_chapelle_anthenaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53056-53950-la_chapelle_anthenaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53056-53950-la_chapelle_anthenaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53057-53440-la_chapelle_au_riboul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53057-53440-la_chapelle_au_riboul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53057-53440-la_chapelle_au_riboul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53057-53440-la_chapelle_au_riboul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53058-53230-la_chapelle_craonnaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53058-53230-la_chapelle_craonnaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53058-53230-la_chapelle_craonnaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53058-53230-la_chapelle_craonnaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53059-53150-la_chapelle_rainsouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53059-53150-la_chapelle_rainsouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53059-53150-la_chapelle_rainsouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53059-53150-la_chapelle_rainsouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53061-53250-charchigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53061-53250-charchigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53061-53250-charchigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53061-53250-charchigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53062-53200-chateau_gontier_sur_mayenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53062-53200-chateau_gontier_sur_mayenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53062-53200-chateau_gontier_sur_mayenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53062-53200-chateau_gontier_sur_mayenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53063-53200-chatelain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53063-53200-chatelain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53063-53200-chatelain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53063-53200-chatelain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53064-53100-chatillon_sur_colmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53064-53100-chatillon_sur_colmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53064-53100-chatillon_sur_colmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53064-53100-chatillon_sur_colmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53066-53200-chemaze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53066-53200-chemaze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53066-53200-chemaze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53066-53200-chemaze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53067-53340-chemere_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53067-53340-chemere_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53067-53340-chemere_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53067-53340-chemere_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53068-53400-cherance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53068-53400-cherance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53068-53400-cherance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53068-53400-cherance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53069-53250-chevaigne_du_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53069-53250-chevaigne_du_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53069-53250-chevaigne_du_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53069-53250-chevaigne_du_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53071-53120-colombiers_du_plessis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53071-53120-colombiers_du_plessis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53071-53120-colombiers_du_plessis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53071-53120-colombiers_du_plessis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53072-53470-commer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53072-53470-commer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53072-53470-commer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53072-53470-commer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53073-53800-congrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53073-53800-congrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53073-53800-congrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53073-53800-congrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53074-53100-contest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53074-53100-contest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53074-53100-contest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53074-53100-contest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53075-53230-cosmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53075-53230-cosmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53075-53230-cosmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53075-53230-cosmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53076-53340-cosse_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53076-53340-cosse_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53076-53340-cosse_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53076-53340-cosse_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53077-53230-cosse_le_vivien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53077-53230-cosse_le_vivien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53077-53230-cosse_le_vivien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53077-53230-cosse_le_vivien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53078-53200-coudray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53078-53200-coudray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53078-53200-coudray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53078-53200-coudray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53079-53300-couesmes_vauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53079-53300-couesmes_vauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53079-53300-couesmes_vauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53079-53300-couesmes_vauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53080-53250-couptrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53080-53250-couptrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53080-53250-couptrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53080-53250-couptrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53082-53230-courbeveille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53082-53230-courbeveille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53082-53230-courbeveille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53082-53230-courbeveille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53083-53700-courcite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53083-53700-courcite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53083-53700-courcite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53083-53700-courcite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53084-53400-craon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53084-53400-craon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53084-53400-craon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53084-53400-craon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53085-53700-crennes_sur_fraubee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53085-53700-crennes_sur_fraubee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53085-53700-crennes_sur_fraubee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53085-53700-crennes_sur_fraubee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53086-53380-la_croixille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53086-53380-la_croixille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53086-53380-la_croixille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53086-53380-la_croixille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53087-53170-la_cropte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53087-53170-la_cropte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53087-53170-la_cropte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53087-53170-la_cropte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53088-53540-cuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53088-53540-cuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53088-53540-cuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53088-53540-cuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53089-53200-daon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53089-53200-daon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53089-53200-daon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53089-53200-daon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53090-53400-denaze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53090-53400-denaze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53090-53400-denaze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53090-53400-denaze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53091-53190-desertines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53091-53190-desertines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53091-53190-desertines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53091-53190-desertines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53093-53190-la_doree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53093-53190-la_doree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53093-53190-la_doree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53093-53190-la_doree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53094-53260-entrammes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53094-53260-entrammes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53094-53260-entrammes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53094-53260-entrammes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53096-53500-ernee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53096-53500-ernee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53096-53500-ernee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53096-53500-ernee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53097-53600-evron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53097-53600-evron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53097-53600-evron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53097-53600-evron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53097-53150-evron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53097-53150-evron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53097-53150-evron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53097-53150-evron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53098-53350-fontaine_couverte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53098-53350-fontaine_couverte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53098-53350-fontaine_couverte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53098-53350-fontaine_couverte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53099-53260-force/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53099-53260-force/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53099-53260-force/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53099-53260-force/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53100-53190-fougerolles_du_plessis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53100-53190-fougerolles_du_plessis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53100-53190-fougerolles_du_plessis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53100-53190-fougerolles_du_plessis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53101-53200-fromentieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53101-53200-fromentieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53101-53200-fromentieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53101-53200-fromentieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53102-53540-gastines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53102-53540-gastines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53102-53540-gastines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53102-53540-gastines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53103-53940-le_genest_saint_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53103-53940-le_genest_saint_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53103-53940-le_genest_saint_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53103-53940-le_genest_saint_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53104-53200-gennes_longuefuye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53104-53200-gennes_longuefuye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53104-53200-gennes_longuefuye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53104-53200-gennes_longuefuye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53105-53150-gesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53105-53150-gesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53105-53150-gesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53105-53150-gesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53106-53370-gesvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53106-53370-gesvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53106-53370-gesvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53106-53370-gesvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53107-53120-gorron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53107-53120-gorron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53107-53120-gorron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53107-53120-gorron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53108-53410-la_gravelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53108-53410-la_gravelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53108-53410-la_gravelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53108-53410-la_gravelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53109-53440-grazay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53109-53440-grazay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53109-53440-grazay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53109-53440-grazay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53110-53290-grez_en_bouere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53110-53290-grez_en_bouere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53110-53290-grez_en_bouere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53110-53290-grez_en_bouere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53111-53300-la_haie_traversaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53111-53300-la_haie_traversaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53111-53300-la_haie_traversaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53111-53300-la_haie_traversaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53112-53250-le_ham/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53112-53250-le_ham/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53112-53250-le_ham/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53112-53250-le_ham/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53113-53160-hambers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53113-53160-hambers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53113-53160-hambers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53113-53160-hambers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53114-53640-hardanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53114-53640-hardanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53114-53640-hardanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53114-53640-hardanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53115-53120-herce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53115-53120-herce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53115-53120-herce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53115-53120-herce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53116-53640-le_horps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53116-53640-le_horps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53116-53640-le_horps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53116-53640-le_horps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53117-53360-houssay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53117-53360-houssay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53117-53360-houssay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53117-53360-houssay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53118-53110-le_housseau_bretignolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53118-53110-le_housseau_bretignolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53118-53110-le_housseau_bretignolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53118-53110-le_housseau_bretignolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53119-53970-l_huisserie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53119-53970-l_huisserie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53119-53970-l_huisserie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53119-53970-l_huisserie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53120-53160-ize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53120-53160-ize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53120-53160-ize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53120-53160-ize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53121-53250-javron_les_chapelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53121-53250-javron_les_chapelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53121-53250-javron_les_chapelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53121-53250-javron_les_chapelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53122-53160-jublains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53122-53160-jublains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53122-53160-jublains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53122-53160-jublains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53123-53380-juvigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53123-53380-juvigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53123-53380-juvigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53123-53380-juvigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53124-53200-pree_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53124-53200-pree_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53124-53200-pree_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53124-53200-pree_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53125-53190-landivy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53125-53190-landivy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53125-53190-landivy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53125-53190-landivy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53126-53220-larchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53126-53220-larchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53126-53220-larchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53126-53220-larchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53127-53110-lassay_les_chateaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53127-53110-lassay_les_chateaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53127-53110-lassay_les_chateaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53127-53110-lassay_les_chateaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53128-53540-laubrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53128-53540-laubrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53128-53540-laubrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53128-53540-laubrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53129-53410-launay_villiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53129-53410-launay_villiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53129-53410-launay_villiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53129-53410-launay_villiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53130-53000-laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53130-53000-laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53130-53000-laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53130-53000-laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53131-53120-lesbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53131-53120-lesbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53131-53120-lesbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53131-53120-lesbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53132-53120-levare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53132-53120-levare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53132-53120-levare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53132-53120-levare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53133-53140-lignieres_orgeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53133-53140-lignieres_orgeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53133-53140-lignieres_orgeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53133-53140-lignieres_orgeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53134-53150-livet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53134-53150-livet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53134-53150-livet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53134-53150-livet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53135-53400-livre_la_touche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53135-53400-livre_la_touche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53135-53400-livre_la_touche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53135-53400-livre_la_touche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53136-53200-la_roche_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53136-53200-la_roche_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53136-53200-la_roche_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53136-53200-la_roche_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53136-53360-la_roche_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53136-53360-la_roche_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53136-53360-la_roche_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53136-53360-la_roche_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53137-53320-loiron_ruille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53137-53320-loiron_ruille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53137-53320-loiron_ruille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53137-53320-loiron_ruille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53139-53700-loupfougeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53139-53700-loupfougeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53139-53700-loupfougeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53139-53700-loupfougeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53140-53950-louverne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53140-53950-louverne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53140-53950-louverne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53140-53950-louverne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53141-53210-louvigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53141-53210-louvigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53141-53210-louvigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53141-53210-louvigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53142-53250-madre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53142-53250-madre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53142-53250-madre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53142-53250-madre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53143-53170-maisoncelles_du_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53143-53170-maisoncelles_du_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53143-53170-maisoncelles_du_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53143-53170-maisoncelles_du_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53144-53440-marcille_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53144-53440-marcille_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53144-53440-marcille_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53144-53440-marcille_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53145-53200-marigne_peuton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53145-53200-marigne_peuton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53145-53200-marigne_peuton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53145-53200-marigne_peuton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53146-53470-martigne_sur_mayenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53146-53470-martigne_sur_mayenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53146-53470-martigne_sur_mayenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53146-53470-martigne_sur_mayenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53147-53100-mayenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53147-53100-mayenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53147-53100-mayenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53147-53100-mayenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53148-53400-mee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53148-53400-mee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53148-53400-mee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53148-53400-mee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53150-53200-menil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53150-53200-menil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53150-53200-menil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53150-53200-menil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53151-53230-meral/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53151-53230-meral/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53151-53230-meral/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53151-53230-meral/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53152-53170-meslay_du_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53152-53170-meslay_du_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53152-53170-meslay_du_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53152-53170-meslay_du_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53153-53600-mezangers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53153-53600-mezangers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53153-53600-mezangers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53153-53600-mezangers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53154-53220-montaudin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53154-53220-montaudin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53154-53220-montaudin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53154-53220-montaudin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53155-53500-montenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53155-53500-montenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53155-53500-montenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53155-53500-montenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53156-53240-montflours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53156-53240-montflours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53156-53240-montflours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53156-53240-montflours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53157-53970-montigne_le_brillant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53157-53970-montigne_le_brillant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53157-53970-montigne_le_brillant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53157-53970-montigne_le_brillant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53158-53320-montjean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53158-53320-montjean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53158-53320-montjean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53158-53320-montjean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53160-53640-montreuil_poulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53160-53640-montreuil_poulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53160-53640-montreuil_poulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53160-53640-montreuil_poulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53161-53150-montsurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53161-53150-montsurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53161-53150-montsurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53161-53150-montsurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53162-53100-moulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53162-53100-moulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53162-53100-moulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53162-53100-moulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53163-53150-neau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53163-53150-neau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53163-53150-neau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53163-53150-neau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53164-53250-neuilly_le_vendin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53164-53250-neuilly_le_vendin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53164-53250-neuilly_le_vendin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53164-53250-neuilly_le_vendin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53165-53400-niafles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53165-53400-niafles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53165-53400-niafles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53165-53400-niafles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53168-53970-nuille_sur_vicoin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53168-53970-nuille_sur_vicoin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53168-53970-nuille_sur_vicoin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53168-53970-nuille_sur_vicoin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53169-53410-olivet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53169-53410-olivet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53169-53410-olivet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53169-53410-olivet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53170-53300-oisseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53170-53300-oisseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53170-53300-oisseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53170-53300-oisseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53172-53360-origne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53172-53360-origne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53172-53360-origne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53172-53360-origne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53173-53140-la_pallu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53173-53140-la_pallu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53173-53140-la_pallu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53173-53140-la_pallu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53174-53100-parigne_sur_braye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53174-53100-parigne_sur_braye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53174-53100-parigne_sur_braye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53174-53100-parigne_sur_braye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53175-53260-parne_sur_roc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53175-53260-parne_sur_roc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53175-53260-parne_sur_roc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53175-53260-parne_sur_roc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53176-53300-le_pas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53176-53300-le_pas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53176-53300-le_pas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53176-53300-le_pas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53177-53220-la_pellerine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53177-53220-la_pellerine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53177-53220-la_pellerine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53177-53220-la_pellerine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53178-53360-peuton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53178-53360-peuton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53178-53360-peuton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53178-53360-peuton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53179-53240-place/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53179-53240-place/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53179-53240-place/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53179-53240-place/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53180-53400-pommerieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53180-53400-pommerieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53180-53400-pommerieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53180-53400-pommerieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53181-53220-pontmain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53181-53220-pontmain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53181-53220-pontmain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53181-53220-pontmain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53182-53410-port_brillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53182-53410-port_brillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53182-53410-port_brillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53182-53410-port_brillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53184-53340-preaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53184-53340-preaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53184-53340-preaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53184-53340-preaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53185-53140-pre_en_pail_saint_samson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53185-53140-pre_en_pail_saint_samson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53185-53140-pre_en_pail_saint_samson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53185-53140-pre_en_pail_saint_samson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53186-53360-quelaines_saint_gault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53186-53360-quelaines_saint_gault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53186-53360-quelaines_saint_gault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53186-53360-quelaines_saint_gault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53187-53370-ravigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53187-53370-ravigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53187-53370-ravigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53187-53370-ravigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53188-53800-renaze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53188-53800-renaze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53188-53800-renaze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53188-53800-renaze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53189-53110-rennes_en_grenouilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53189-53110-rennes_en_grenouilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53189-53110-rennes_en_grenouilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53189-53110-rennes_en_grenouilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53190-53640-le_ribay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53190-53640-le_ribay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53190-53640-le_ribay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53190-53640-le_ribay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53191-53350-la_roe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53191-53350-la_roe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53191-53350-la_roe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53191-53350-la_roe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53192-53390-la_rouaudiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53192-53390-la_rouaudiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53192-53390-la_rouaudiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53192-53390-la_rouaudiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53193-53170-ruille_froid_fonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53193-53170-ruille_froid_fonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53193-53170-ruille_froid_fonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53193-53170-ruille_froid_fonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53195-53470-sace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53195-53470-sace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53195-53470-sace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53195-53470-sace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53196-53250-saint_aignan_de_couptrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53196-53250-saint_aignan_de_couptrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53196-53250-saint_aignan_de_couptrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53196-53250-saint_aignan_de_couptrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53197-53390-saint_aignan_sur_roe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53197-53390-saint_aignan_sur_roe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53197-53390-saint_aignan_sur_roe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53197-53390-saint_aignan_sur_roe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53198-53700-saint_aubin_du_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53198-53700-saint_aubin_du_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53198-53700-saint_aubin_du_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53198-53700-saint_aubin_du_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53199-53120-saint_aubin_fosse_louvain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53199-53120-saint_aubin_fosse_louvain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53199-53120-saint_aubin_fosse_louvain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53199-53120-saint_aubin_fosse_louvain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53200-53100-saint_baudelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53200-53100-saint_baudelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53200-53100-saint_baudelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53200-53100-saint_baudelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53201-53940-saint_berthevin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53201-53940-saint_berthevin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53201-53940-saint_berthevin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53201-53940-saint_berthevin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53202-53220-saint_berthevin_la_tanniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53202-53220-saint_berthevin_la_tanniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53202-53220-saint_berthevin_la_tanniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53202-53220-saint_berthevin_la_tanniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53203-53290-saint_brice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53203-53290-saint_brice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53203-53290-saint_brice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53203-53290-saint_brice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53204-53140-saint_calais_du_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53204-53140-saint_calais_du_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53204-53140-saint_calais_du_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53204-53140-saint_calais_du_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53206-53170-saint_charles_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53206-53170-saint_charles_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53206-53170-saint_charles_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53206-53170-saint_charles_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53208-53140-saint_cyr_en_pail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53208-53140-saint_cyr_en_pail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53208-53140-saint_cyr_en_pail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53208-53140-saint_cyr_en_pail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53209-53320-saint_cyr_le_gravelais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53209-53320-saint_cyr_le_gravelais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53209-53320-saint_cyr_le_gravelais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53209-53320-saint_cyr_le_gravelais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53210-53290-saint_denis_d_anjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53210-53290-saint_denis_d_anjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53210-53290-saint_denis_d_anjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53210-53290-saint_denis_d_anjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53211-53500-saint_denis_de_gastines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53211-53500-saint_denis_de_gastines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53211-53500-saint_denis_de_gastines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53211-53500-saint_denis_de_gastines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53212-53170-saint_denis_du_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53212-53170-saint_denis_du_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53212-53170-saint_denis_du_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53212-53170-saint_denis_du_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53213-53220-saint_ellier_du_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53213-53220-saint_ellier_du_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53213-53220-saint_ellier_du_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53213-53220-saint_ellier_du_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53214-53390-saint_erblon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53214-53390-saint_erblon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53214-53390-saint_erblon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53214-53390-saint_erblon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53216-53300-saint_fraimbault_de_prieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53216-53300-saint_fraimbault_de_prieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53216-53300-saint_fraimbault_de_prieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53216-53300-saint_fraimbault_de_prieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53218-53600-sainte_gemmes_le_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53218-53600-sainte_gemmes_le_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53218-53600-sainte_gemmes_le_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53218-53600-sainte_gemmes_le_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53219-53100-saint_georges_buttavent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53219-53100-saint_georges_buttavent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53219-53100-saint_georges_buttavent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53219-53100-saint_georges_buttavent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53220-53480-saint_georges_le_flechard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53220-53480-saint_georges_le_flechard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53220-53480-saint_georges_le_flechard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53220-53480-saint_georges_le_flechard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53221-53600-saint_georges_sur_erve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53221-53600-saint_georges_sur_erve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53221-53600-saint_georges_sur_erve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53221-53600-saint_georges_sur_erve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53222-53240-saint_germain_d_anxure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53222-53240-saint_germain_d_anxure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53222-53240-saint_germain_d_anxure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53222-53240-saint_germain_d_anxure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53223-53700-saint_germain_de_coulamer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53223-53700-saint_germain_de_coulamer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53223-53700-saint_germain_de_coulamer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53223-53700-saint_germain_de_coulamer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53224-53240-saint_germain_le_fouilloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53224-53240-saint_germain_le_fouilloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53224-53240-saint_germain_le_fouilloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53224-53240-saint_germain_le_fouilloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53225-53240-saint_germain_le_guillaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53225-53240-saint_germain_le_guillaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53225-53240-saint_germain_le_guillaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53225-53240-saint_germain_le_guillaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53226-53380-saint_hilaire_du_maine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53226-53380-saint_hilaire_du_maine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53226-53380-saint_hilaire_du_maine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53226-53380-saint_hilaire_du_maine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53228-53270-blandouet_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53228-53270-blandouet_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53228-53270-blandouet_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53228-53270-blandouet_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53229-53240-saint_jean_sur_mayenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53229-53240-saint_jean_sur_mayenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53229-53240-saint_jean_sur_mayenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53229-53240-saint_jean_sur_mayenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53230-53110-saint_julien_du_terroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53230-53110-saint_julien_du_terroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53230-53110-saint_julien_du_terroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53230-53110-saint_julien_du_terroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53232-53480-saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53232-53480-saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53232-53480-saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53232-53480-saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53233-53290-saint_loup_du_dorat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53233-53290-saint_loup_du_dorat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53233-53290-saint_loup_du_dorat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53233-53290-saint_loup_du_dorat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53234-53300-saint_loup_du_gast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53234-53300-saint_loup_du_gast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53234-53300-saint_loup_du_gast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53234-53300-saint_loup_du_gast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53235-53110-sainte_marie_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53235-53110-sainte_marie_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53235-53110-sainte_marie_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53235-53110-sainte_marie_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53236-53700-saint_mars_du_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53236-53700-saint_mars_du_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53236-53700-saint_mars_du_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53236-53700-saint_mars_du_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53237-53300-saint_mars_sur_colmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53237-53300-saint_mars_sur_colmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53237-53300-saint_mars_sur_colmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53237-53300-saint_mars_sur_colmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53238-53220-saint_mars_sur_la_futaie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53238-53220-saint_mars_sur_la_futaie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53238-53220-saint_mars_sur_la_futaie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53238-53220-saint_mars_sur_la_futaie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53239-53160-saint_martin_de_connee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53239-53160-saint_martin_de_connee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53239-53160-saint_martin_de_connee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53239-53160-saint_martin_de_connee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53240-53800-saint_martin_du_limet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53240-53800-saint_martin_du_limet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53240-53800-saint_martin_du_limet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53240-53800-saint_martin_du_limet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53242-53350-saint_michel_de_la_roe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53242-53350-saint_michel_de_la_roe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53242-53350-saint_michel_de_la_roe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53242-53350-saint_michel_de_la_roe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53243-53410-saint_ouen_des_toits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53243-53410-saint_ouen_des_toits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53243-53410-saint_ouen_des_toits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53243-53410-saint_ouen_des_toits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53245-53500-saint_pierre_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53245-53500-saint_pierre_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53245-53500-saint_pierre_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53245-53500-saint_pierre_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53246-53370-saint_pierre_des_nids/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53246-53370-saint_pierre_des_nids/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53246-53370-saint_pierre_des_nids/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53246-53370-saint_pierre_des_nids/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53247-53410-saint_pierre_la_cour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53247-53410-saint_pierre_la_cour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53247-53410-saint_pierre_la_cour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53247-53410-saint_pierre_la_cour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53248-53270-saint_pierre_sur_erve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53248-53270-saint_pierre_sur_erve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53248-53270-saint_pierre_sur_erve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53248-53270-saint_pierre_sur_erve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53249-53160-saint_pierre_sur_orthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53249-53160-saint_pierre_sur_orthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53249-53160-saint_pierre_sur_orthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53249-53160-saint_pierre_sur_orthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53250-53540-saint_poix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53250-53540-saint_poix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53250-53540-saint_poix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53250-53540-saint_poix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53251-53400-saint_quentin_les_anges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53251-53400-saint_quentin_les_anges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53251-53400-saint_quentin_les_anges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53251-53400-saint_quentin_les_anges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53253-53800-saint_saturnin_du_limet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53253-53800-saint_saturnin_du_limet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53253-53800-saint_saturnin_du_limet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53253-53800-saint_saturnin_du_limet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53255-53270-sainte_suzanne_et_chammes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53255-53270-sainte_suzanne_et_chammes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53255-53270-sainte_suzanne_et_chammes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53255-53270-sainte_suzanne_et_chammes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53256-53160-saint_thomas_de_courceriers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53256-53160-saint_thomas_de_courceriers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53256-53160-saint_thomas_de_courceriers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53256-53160-saint_thomas_de_courceriers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53257-53340-saulges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53257-53340-saulges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53257-53340-saulges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53257-53340-saulges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53258-53800-la_selle_craonnaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53258-53800-la_selle_craonnaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53258-53800-la_selle_craonnaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53258-53800-la_selle_craonnaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53259-53390-senonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53259-53390-senonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53259-53390-senonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53259-53390-senonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53260-53360-simple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53260-53360-simple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53260-53360-simple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53260-53360-simple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53261-53300-souce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53261-53300-souce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53261-53300-souce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53261-53300-souce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53262-53210-soulge_sur_ouette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53262-53210-soulge_sur_ouette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53262-53210-soulge_sur_ouette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53262-53210-soulge_sur_ouette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53263-53110-thuboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53263-53110-thuboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53263-53110-thuboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53263-53110-thuboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53264-53270-thorigne_en_charnie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53264-53270-thorigne_en_charnie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53264-53270-thorigne_en_charnie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53264-53270-thorigne_en_charnie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53265-53270-torce_viviers_en_charnie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53265-53270-torce_viviers_en_charnie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53265-53270-torce_viviers_en_charnie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53265-53270-torce_viviers_en_charnie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53266-53160-trans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53266-53160-trans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53266-53160-trans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53266-53160-trans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53267-53480-vaiges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53267-53480-vaiges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53267-53480-vaiges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53267-53480-vaiges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53269-53500-vautorte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53269-53500-vautorte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53269-53500-vautorte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53269-53500-vautorte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53270-53120-vieuvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53270-53120-vieuvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53270-53120-vieuvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53270-53120-vieuvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53271-53700-villaines_la_juhel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53271-53700-villaines_la_juhel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53271-53700-villaines_la_juhel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53271-53700-villaines_la_juhel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53272-53250-villepail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53272-53250-villepail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53272-53250-villepail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53272-53250-villepail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53273-53170-villiers_charlemagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53273-53170-villiers_charlemagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53273-53170-villiers_charlemagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53273-53170-villiers_charlemagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53274-53160-vimarce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53274-53160-vimarce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53274-53160-vimarce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53274-53160-vimarce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53276-53600-voutre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53276-53600-voutre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53276-53600-voutre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt53-mayenne/commune53276-53600-voutre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-54.xml
+++ b/public/sitemaps/sitemap-54.xml
@@ -5,1198 +5,2392 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54001-54610-abaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54001-54610-abaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54001-54610-abaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54001-54610-abaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54002-54800-abbeville_les_conflans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54002-54800-abbeville_les_conflans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54002-54800-abbeville_les_conflans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54002-54800-abbeville_les_conflans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54003-54115-aboncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54003-54115-aboncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54003-54115-aboncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54003-54115-aboncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54004-54800-affleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54004-54800-affleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54004-54800-affleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54004-54800-affleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54005-54740-affracourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54005-54740-affracourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54005-54740-affracourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54005-54740-affracourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54006-54770-agincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54006-54770-agincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54006-54770-agincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54006-54770-agincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54007-54460-aingeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54007-54460-aingeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54007-54460-aingeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54007-54460-aingeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54008-54170-allain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54008-54170-allain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54008-54170-allain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54008-54170-allain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54009-54800-allamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54009-54800-allamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54009-54800-allamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54009-54800-allamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54010-54112-allamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54010-54112-allamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54010-54112-allamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54010-54112-allamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54011-54260-allondrelle_la_malmaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54011-54260-allondrelle_la_malmaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54011-54260-allondrelle_la_malmaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54011-54260-allondrelle_la_malmaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54012-54770-amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54012-54770-amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54012-54770-amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54012-54770-amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54013-54450-amenoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54013-54450-amenoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54013-54450-amenoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54013-54450-amenoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54014-54450-ancerviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54014-54450-ancerviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54014-54450-ancerviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54014-54450-ancerviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54015-54560-anderny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54015-54560-anderny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54015-54560-anderny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54015-54560-anderny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54016-54200-andilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54016-54200-andilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54016-54200-andilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54016-54200-andilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54017-54540-angomont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54017-54540-angomont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54017-54540-angomont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54017-54540-angomont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54018-54150-anoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54018-54150-anoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54018-54150-anoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54018-54150-anoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54019-54470-ansauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54019-54470-ansauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54019-54470-ansauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54019-54470-ansauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54020-54110-anthelupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54020-54110-anthelupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54020-54110-anthelupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54020-54110-anthelupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54021-54760-armaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54021-54760-armaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54021-54760-armaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54021-54760-armaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54022-54530-arnaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54022-54530-arnaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54022-54530-arnaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54022-54530-arnaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54023-54370-arracourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54023-54370-arracourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54023-54370-arracourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54023-54370-arracourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54024-54760-arraye_et_han/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54024-54760-arraye_et_han/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54024-54760-arraye_et_han/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54024-54760-arraye_et_han/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54025-54510-art_sur_meurthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54025-54510-art_sur_meurthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54025-54510-art_sur_meurthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54025-54510-art_sur_meurthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54026-54370-athienville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54026-54370-athienville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54026-54370-athienville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54026-54370-athienville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54027-54700-atton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54027-54700-atton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54027-54700-atton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54027-54700-atton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54028-54580-auboue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54028-54580-auboue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54028-54580-auboue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54028-54580-auboue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54029-54560-audun_le_roman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54029-54560-audun_le_roman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54029-54560-audun_le_roman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54029-54560-audun_le_roman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54030-54450-autrepierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54030-54450-autrepierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54030-54450-autrepierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54030-54450-autrepierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54031-54380-autreville_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54031-54380-autreville_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54031-54380-autreville_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54031-54380-autreville_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54032-54160-autrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54032-54160-autrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54032-54160-autrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54032-54160-autrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54033-54490-avillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54033-54490-avillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54033-54490-avillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54033-54490-avillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54034-54385-avrainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54034-54385-avrainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54034-54385-avrainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54034-54385-avrainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54035-54450-avricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54035-54450-avricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54035-54450-avricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54035-54450-avricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54036-54150-avril/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54036-54150-avril/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54036-54150-avril/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54036-54150-avril/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54037-54210-azelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54037-54210-azelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54037-54210-azelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54037-54210-azelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54038-54122-azerailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54038-54122-azerailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54038-54122-azerailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54038-54122-azerailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54039-54120-baccarat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54039-54120-baccarat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54039-54120-baccarat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54039-54120-baccarat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54040-54540-badonviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54040-54540-badonviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54040-54540-badonviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54040-54540-badonviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54041-54170-bagneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54041-54170-bagneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54041-54170-bagneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54041-54170-bagneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54042-54290-bainville_aux_miroirs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54042-54290-bainville_aux_miroirs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54042-54290-bainville_aux_miroirs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54042-54290-bainville_aux_miroirs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54043-54550-bainville_sur_madon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54043-54550-bainville_sur_madon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54043-54550-bainville_sur_madon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54043-54550-bainville_sur_madon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54044-54450-barbas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54044-54450-barbas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54044-54450-barbas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54044-54450-barbas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54045-54360-barbonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54045-54360-barbonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54045-54360-barbonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54045-54360-barbonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54046-54170-barisey_au_plain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54046-54170-barisey_au_plain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54046-54170-barisey_au_plain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54046-54170-barisey_au_plain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54047-54170-barisey_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54047-54170-barisey_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54047-54170-barisey_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54047-54170-barisey_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54048-54150-les_baroches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54048-54150-les_baroches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54048-54150-les_baroches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54048-54150-les_baroches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54049-54620-baslieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54049-54620-baslieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54049-54620-baslieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54049-54620-baslieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54050-54370-bathelemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54050-54370-bathelemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54050-54370-bathelemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54050-54370-bathelemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54051-54980-batilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54051-54980-batilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54051-54980-batilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54051-54980-batilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54052-54115-battigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54052-54115-battigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54052-54115-battigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54052-54115-battigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54053-54370-bauzemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54053-54370-bauzemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54053-54370-bauzemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54053-54370-bauzemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54054-54290-bayon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54054-54290-bayon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54054-54290-bayon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54054-54290-bayon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54055-54890-bayonville_sur_mad/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54055-54890-bayonville_sur_mad/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54055-54890-bayonville_sur_mad/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54055-54890-bayonville_sur_mad/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54056-54620-bazailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54056-54620-bazailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54056-54620-bazailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54056-54620-bazailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54057-54470-beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54057-54470-beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54057-54470-beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54057-54470-beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54058-54800-bechamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54058-54800-bechamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54058-54800-bechamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54058-54800-bechamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54059-54610-belleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54059-54610-belleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54059-54610-belleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54059-54610-belleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54060-54940-belleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54060-54940-belleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54060-54940-belleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54060-54940-belleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54061-54450-benamenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54061-54450-benamenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54061-54450-benamenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54061-54450-benamenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54062-54740-benney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54062-54740-benney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54062-54740-benney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54062-54740-benney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54063-54470-bernecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54063-54470-bernecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54063-54470-bernecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54063-54470-bernecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54064-54480-bertrambois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54064-54480-bertrambois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54064-54480-bertrambois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54064-54480-bertrambois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54065-54120-bertrichamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54065-54120-bertrichamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54065-54120-bertrichamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54065-54120-bertrichamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54066-54640-bettainvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54066-54640-bettainvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54066-54640-bettainvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54066-54640-bettainvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54067-54620-beuveille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54067-54620-beuveille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54067-54620-beuveille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54067-54620-beuveille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54068-54115-beuvezin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54068-54115-beuvezin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54068-54115-beuvezin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54068-54115-beuvezin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54069-54560-beuvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54069-54560-beuvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54069-54560-beuvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54069-54560-beuvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54070-54760-bey_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54070-54760-bey_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54070-54760-bey_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54070-54760-bey_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54071-54370-bezange_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54071-54370-bezange_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54071-54370-bezange_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54071-54370-bezange_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54072-54380-bezaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54072-54380-bezaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54072-54380-bezaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54072-54380-bezaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54073-54200-bicqueley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54073-54200-bicqueley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54073-54200-bicqueley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54073-54200-bicqueley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54074-54300-bienville_la_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54074-54300-bienville_la_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54074-54300-bienville_la_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54074-54300-bienville_la_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54075-54540-bionville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54075-54540-bionville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54075-54540-bionville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54075-54540-bionville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54076-54360-blainville_sur_l_eau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54076-54360-blainville_sur_l_eau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54076-54360-blainville_sur_l_eau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54076-54360-blainville_sur_l_eau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54077-54450-blamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54077-54450-blamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54077-54450-blamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54077-54450-blamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54078-54450-blemerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54078-54450-blemerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54078-54450-blemerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54078-54450-blemerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54079-54700-blenod_les_pont_a_mousson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54079-54700-blenod_les_pont_a_mousson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54079-54700-blenod_les_pont_a_mousson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54079-54700-blenod_les_pont_a_mousson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54080-54113-blenod_les_toul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54080-54113-blenod_les_toul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54080-54113-blenod_les_toul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54080-54113-blenod_les_toul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54081-54620-boismont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54081-54620-boismont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54081-54620-boismont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54081-54620-boismont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54082-54800-boncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54082-54800-boncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54082-54800-boncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54082-54800-boncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54083-54300-bonviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54083-54300-bonviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54083-54300-bonviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54083-54300-bonviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54084-54111-mont_bonvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54084-54111-mont_bonvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54084-54111-mont_bonvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54084-54111-mont_bonvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54085-54290-borville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54085-54290-borville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54085-54290-borville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54085-54290-borville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54086-54200-boucq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54086-54200-boucq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54086-54200-boucq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54086-54200-boucq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54087-54470-bouillonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54087-54470-bouillonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54087-54470-bouillonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54087-54470-bouillonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54088-54200-bouvron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54088-54200-bouvron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54088-54200-bouvron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54088-54200-bouvron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54089-54770-bouxieres_aux_chenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54089-54770-bouxieres_aux_chenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54089-54770-bouxieres_aux_chenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54089-54770-bouxieres_aux_chenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54090-54136-bouxieres_aux_dames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54090-54136-bouxieres_aux_dames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54090-54136-bouxieres_aux_dames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54090-54136-bouxieres_aux_dames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54091-54700-bouxieres_sous_froidmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54091-54700-bouxieres_sous_froidmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54091-54700-bouxieres_sous_froidmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54091-54700-bouxieres_sous_froidmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54092-54930-bouzanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54092-54930-bouzanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54092-54930-bouzanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54092-54930-bouzanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54093-54800-brainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54093-54800-brainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54093-54800-brainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54093-54800-brainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54094-54740-bralleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54094-54740-bralleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54094-54740-bralleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54094-54740-bralleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54095-54610-bratte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54095-54610-bratte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54095-54610-bratte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54095-54610-bratte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54096-54190-brehain_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54096-54190-brehain_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54096-54190-brehain_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54096-54190-brehain_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54097-54540-bremenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54097-54540-bremenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54097-54540-bremenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54097-54540-bremenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54098-54290-bremoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54098-54290-bremoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54098-54290-bremoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54098-54290-bremoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54099-54150-val_de_briey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54099-54150-val_de_briey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54099-54150-val_de_briey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54099-54150-val_de_briey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54100-54280-brin_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54100-54280-brin_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54100-54280-brin_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54100-54280-brin_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54101-54120-brouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54101-54120-brouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54101-54120-brouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54101-54120-brouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54102-54200-bruley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54102-54200-bruley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54102-54200-bruley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54102-54200-bruley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54103-54800-bruville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54103-54800-bruville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54103-54800-bruville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54103-54800-bruville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54104-54110-buissoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54104-54110-buissoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54104-54110-buissoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54104-54110-buissoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54105-54113-bulligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54105-54113-bulligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54105-54113-bulligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54105-54113-bulligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54106-54370-bures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54106-54370-bures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54106-54370-bures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54106-54370-bures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54107-54450-buriville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54107-54450-buriville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54107-54450-buriville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54107-54450-buriville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54108-54210-burthecourt_aux_chenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54108-54210-burthecourt_aux_chenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54108-54210-burthecourt_aux_chenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54108-54210-burthecourt_aux_chenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54109-54134-ceintrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54109-54134-ceintrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54109-54134-ceintrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54109-54134-ceintrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54110-54420-cerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54110-54420-cerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54110-54420-cerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54110-54420-cerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54111-54230-chaligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54111-54230-chaligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54111-54230-chaligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54111-54230-chaligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54112-54890-chambley_bussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54112-54890-chambley_bussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54112-54890-chambley_bussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54112-54890-chambley_bussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54113-54280-champenoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54113-54280-champenoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54113-54280-champenoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54113-54280-champenoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54114-54700-champey_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54114-54700-champey_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54114-54700-champey_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54114-54700-champey_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54115-54250-champigneulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54115-54250-champigneulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54115-54250-champigneulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54115-54250-champigneulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54116-54300-chanteheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54116-54300-chanteheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54116-54300-chanteheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54116-54300-chanteheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54117-54330-chaouilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54117-54330-chaouilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54117-54330-chaouilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54117-54330-chaouilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54118-54260-charency_vezin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54118-54260-charency_vezin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54118-54260-charency_vezin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54118-54260-charency_vezin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54119-54470-charey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54119-54470-charey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54119-54470-charey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54119-54470-charey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54120-54113-charmes_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54120-54113-charmes_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54120-54113-charmes_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54120-54113-charmes_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54121-54360-charmois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54121-54360-charmois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54121-54360-charmois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54121-54360-charmois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54122-54200-chaudeney_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54122-54200-chaudeney_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54122-54200-chaudeney_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54122-54200-chaudeney_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54123-54230-chavigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54123-54230-chavigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54123-54230-chavigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54123-54230-chavigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54124-54450-chazelles_sur_albe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54124-54450-chazelles_sur_albe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54124-54450-chazelles_sur_albe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54124-54450-chazelles_sur_albe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54125-54122-chenevieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54125-54122-chenevieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54125-54122-chenevieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54125-54122-chenevieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54126-54610-chenicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54126-54610-chenicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54126-54610-chenicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54126-54610-chenicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54127-54720-chenieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54127-54720-chenieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54127-54720-chenieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54127-54720-chenieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54128-54200-choloy_menillot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54128-54200-choloy_menillot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54128-54200-choloy_menillot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54128-54200-choloy_menillot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54129-54480-cirey_sur_vezouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54129-54480-cirey_sur_vezouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54129-54480-cirey_sur_vezouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54129-54480-cirey_sur_vezouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54130-54290-clayeures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54130-54290-clayeures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54130-54290-clayeures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54130-54290-clayeures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54131-54610-clemery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54131-54610-clemery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54131-54610-clemery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54131-54610-clemery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54132-54330-clerey_sur_brenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54132-54330-clerey_sur_brenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54132-54330-clerey_sur_brenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54132-54330-clerey_sur_brenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54133-54370-coincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54133-54370-coincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54133-54370-coincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54133-54370-coincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54134-54260-colmey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54134-54260-colmey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54134-54260-colmey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54134-54260-colmey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54135-54170-colombey_les_belles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54135-54170-colombey_les_belles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54135-54170-colombey_les_belles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54135-54170-colombey_les_belles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54136-54800-conflans_en_jarnisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54136-54800-conflans_en_jarnisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54136-54800-conflans_en_jarnisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54136-54800-conflans_en_jarnisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54137-54870-cons_la_grandville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54137-54870-cons_la_grandville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54137-54870-cons_la_grandville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54137-54870-cons_la_grandville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54138-54400-cosnes_et_romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54138-54400-cosnes_et_romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54138-54400-cosnes_et_romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54138-54400-cosnes_et_romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54139-54110-courbesseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54139-54110-courbesseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54139-54110-courbesseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54139-54110-courbesseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54140-54930-courcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54140-54930-courcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54140-54930-courcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54140-54930-courcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54141-54210-coyviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54141-54210-coyviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54141-54210-coyviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54141-54210-coyviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54142-54740-crantenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54142-54740-crantenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54142-54740-crantenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54142-54740-crantenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54143-54170-crepey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54143-54170-crepey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54143-54170-crepey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54143-54170-crepey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54144-54290-crevechamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54144-54290-crevechamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54144-54290-crevechamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54144-54290-crevechamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54145-54110-crevic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54145-54110-crevic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54145-54110-crevic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54145-54110-crevic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54146-54113-crezilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54146-54113-crezilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54146-54113-crezilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54146-54113-crezilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54147-54300-crion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54147-54300-crion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54147-54300-crion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54147-54300-crion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54148-54300-croismare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54148-54300-croismare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54148-54300-croismare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54148-54300-croismare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54149-54680-crusnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54149-54680-crusnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54149-54680-crusnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54149-54680-crusnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54150-54670-custines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54150-54670-custines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54150-54670-custines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54150-54670-custines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54151-54720-cutry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54151-54720-cutry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54151-54720-cutry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54151-54720-cutry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54152-54360-damelevieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54152-54360-damelevieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54152-54360-damelevieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54152-54360-damelevieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54153-54470-dampvitoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54153-54470-dampvitoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54153-54470-dampvitoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54153-54470-dampvitoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54154-54120-deneuvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54154-54120-deneuvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54154-54120-deneuvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54154-54120-deneuvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54155-54370-deuxville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54155-54370-deuxville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54155-54370-deuxville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54155-54370-deuxville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54156-54930-diarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54156-54930-diarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54156-54930-diarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54156-54930-diarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54157-54380-dieulouard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54157-54380-dieulouard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54157-54380-dieulouard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54157-54380-dieulouard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54158-54170-dolcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54158-54170-dolcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54158-54170-dolcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54158-54170-dolcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54159-54110-dombasle_sur_meurthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54159-54110-dombasle_sur_meurthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54159-54110-dombasle_sur_meurthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54159-54110-dombasle_sur_meurthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54160-54385-domevre_en_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54160-54385-domevre_en_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54160-54385-domevre_en_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54160-54385-domevre_en_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54161-54450-domevre_sur_vezouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54161-54450-domevre_sur_vezouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54161-54450-domevre_sur_vezouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54161-54450-domevre_sur_vezouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54162-54119-domgermain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54162-54119-domgermain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54162-54119-domgermain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54162-54119-domgermain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54163-54450-domjevin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54163-54450-domjevin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54163-54450-domjevin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54163-54450-domjevin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54164-54115-dommarie_eulmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54164-54115-dommarie_eulmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54164-54115-dommarie_eulmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54164-54115-dommarie_eulmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54165-54130-dommartemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54165-54130-dommartemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54165-54130-dommartemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54165-54130-dommartemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54166-54470-dommartin_la_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54166-54470-dommartin_la_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54166-54470-dommartin_la_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54166-54470-dommartin_la_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54167-54200-dommartin_les_toul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54167-54200-dommartin_les_toul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54167-54200-dommartin_les_toul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54167-54200-dommartin_les_toul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54168-54770-dommartin_sous_amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54168-54770-dommartin_sous_amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54168-54770-dommartin_sous_amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54168-54770-dommartin_sous_amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54169-54490-domprix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54169-54490-domprix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54169-54490-domprix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54169-54490-domprix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54170-54290-domptail_en_l_air/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54170-54290-domptail_en_l_air/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54170-54290-domptail_en_l_air/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54170-54290-domptail_en_l_air/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54171-54800-doncourt_les_conflans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54171-54800-doncourt_les_conflans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54171-54800-doncourt_les_conflans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54171-54800-doncourt_les_conflans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54172-54620-doncourt_les_longuyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54172-54620-doncourt_les_longuyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54172-54620-doncourt_les_longuyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54172-54620-doncourt_les_longuyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54173-54370-drouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54173-54370-drouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54173-54370-drouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54173-54370-drouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54174-54200-ecrouves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54174-54200-ecrouves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54174-54200-ecrouves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54174-54200-ecrouves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54175-54360-einvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54175-54360-einvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54175-54360-einvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54175-54360-einvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54176-54370-einville_au_jard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54176-54370-einville_au_jard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54176-54370-einville_au_jard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54176-54370-einville_au_jard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54177-54370-embermenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54177-54370-embermenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54177-54370-embermenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54177-54370-embermenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54178-54260-epiez_sur_chiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54178-54260-epiez_sur_chiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54178-54260-epiez_sur_chiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54178-54260-epiez_sur_chiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54179-54610-eply/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54179-54610-eply/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54179-54610-eply/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54179-54610-eply/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54180-54280-erbeviller_sur_amezule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54180-54280-erbeviller_sur_amezule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54180-54280-erbeviller_sur_amezule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54180-54280-erbeviller_sur_amezule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54181-54680-errouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54181-54680-errouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54181-54680-errouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54181-54680-errouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54182-54470-essey_et_maizerais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54182-54470-essey_et_maizerais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54182-54470-essey_et_maizerais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54182-54470-essey_et_maizerais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54183-54830-essey_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54183-54830-essey_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54183-54830-essey_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54183-54830-essey_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54184-54270-essey_les_nancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54184-54270-essey_les_nancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54184-54270-essey_les_nancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54184-54270-essey_les_nancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54185-54330-etreval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54185-54330-etreval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54185-54330-etreval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54185-54330-etreval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54186-54690-eulmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54186-54690-eulmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54186-54690-eulmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54186-54690-eulmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54187-54470-euvezin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54187-54470-euvezin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54187-54470-euvezin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54187-54470-euvezin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54188-54760-faulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54188-54760-faulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54188-54760-faulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54188-54760-faulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54189-54115-favieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54189-54115-favieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54189-54115-favieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54189-54115-favieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54190-54115-fecocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54190-54115-fecocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54190-54115-fecocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54190-54115-fecocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54191-54540-fenneviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54191-54540-fenneviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54191-54540-fenneviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54191-54540-fenneviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54192-54210-ferrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54192-54210-ferrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54192-54210-ferrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54192-54210-ferrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54193-54470-fey_en_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54193-54470-fey_en_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54193-54470-fey_en_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54193-54470-fey_en_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54194-54560-fillieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54194-54560-fillieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54194-54560-fillieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54194-54560-fillieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54195-54110-flainval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54195-54110-flainval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54195-54110-flainval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54195-54110-flainval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54196-54630-flavigny_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54196-54630-flavigny_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54196-54630-flavigny_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54196-54630-flavigny_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54197-54710-fleville_devant_nancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54197-54710-fleville_devant_nancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54197-54710-fleville_devant_nancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54197-54710-fleville_devant_nancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54198-54150-fleville_lixieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54198-54150-fleville_lixieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54198-54150-fleville_lixieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54198-54150-fleville_lixieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54199-54122-flin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54199-54122-flin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54199-54122-flin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54199-54122-flin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54200-54470-flirey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54200-54470-flirey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54200-54470-flirey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54200-54470-flirey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54201-54122-fontenoy_la_joute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54201-54122-fontenoy_la_joute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54201-54122-fontenoy_la_joute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54201-54122-fontenoy_la_joute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54202-54840-fontenoy_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54202-54840-fontenoy_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54202-54840-fontenoy_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54202-54840-fontenoy_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54203-54330-forcelles_saint_gorgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54203-54330-forcelles_saint_gorgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54203-54330-forcelles_saint_gorgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54203-54330-forcelles_saint_gorgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54204-54930-forcelles_sous_gugney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54204-54930-forcelles_sous_gugney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54204-54930-forcelles_sous_gugney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54204-54930-forcelles_sous_gugney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54205-54570-foug/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54205-54570-foug/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54205-54570-foug/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54205-54570-foug/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54206-54300-fraimbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54206-54300-fraimbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54206-54300-fraimbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54206-54300-fraimbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54207-54930-fraisnes_en_saintois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54207-54930-fraisnes_en_saintois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54207-54930-fraisnes_en_saintois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54207-54930-fraisnes_en_saintois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54208-54200-francheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54208-54200-francheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54208-54200-francheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54208-54200-francheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54209-54830-franconville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54209-54830-franconville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54209-54830-franconville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54209-54830-franconville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54210-54450-fremenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54210-54450-fremenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54210-54450-fremenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54210-54450-fremenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54211-54450-fremonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54211-54450-fremonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54211-54450-fremonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54211-54450-fremonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54212-54260-fresnois_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54212-54260-fresnois_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54212-54260-fresnois_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54212-54260-fresnois_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54213-54800-friauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54213-54800-friauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54213-54800-friauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54213-54800-friauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54214-54160-frolois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54214-54160-frolois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54214-54160-frolois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54214-54160-frolois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54215-54390-frouard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54215-54390-frouard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54215-54390-frouard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54215-54390-frouard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54215-54250-frouard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54215-54250-frouard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54215-54250-frouard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54215-54250-frouard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54216-54290-froville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54216-54290-froville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54216-54290-froville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54216-54290-froville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54217-54120-gelacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54217-54120-gelacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54217-54120-gelacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54217-54120-gelacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54218-54115-gelaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54218-54115-gelaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54218-54115-gelaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54218-54115-gelaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54219-54110-gellenoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54219-54110-gellenoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54219-54110-gellenoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54219-54110-gellenoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54220-54115-gemonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54220-54115-gemonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54220-54115-gemonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54220-54115-gemonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54221-54740-gerbecourt_et_haplemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54221-54740-gerbecourt_et_haplemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54221-54740-gerbecourt_et_haplemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54221-54740-gerbecourt_et_haplemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54222-54830-gerbeviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54222-54830-gerbeviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54222-54830-gerbeviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54222-54830-gerbeviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54223-54170-germiny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54223-54170-germiny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54223-54170-germiny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54223-54170-germiny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54224-54740-germonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54224-54740-germonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54224-54740-germonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54224-54740-germonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54225-54380-gezoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54225-54380-gezoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54225-54380-gezoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54225-54380-gezoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54226-54112-gibeaumeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54226-54112-gibeaumeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54226-54112-gibeaumeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54226-54112-gibeaumeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54227-54780-giraumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54227-54780-giraumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54227-54780-giraumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54227-54780-giraumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54228-54830-giriviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54228-54830-giriviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54228-54830-giriviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54228-54830-giriviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54229-54122-glonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54229-54122-glonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54229-54122-glonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54229-54122-glonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54230-54450-gogney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54230-54450-gogney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54230-54450-gogney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54230-54450-gogney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54231-54800-gondrecourt_aix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54231-54800-gondrecourt_aix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54231-54800-gondrecourt_aix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54231-54800-gondrecourt_aix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54232-54840-gondreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54232-54840-gondreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54232-54840-gondreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54232-54840-gondreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54233-54450-gondrexon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54233-54450-gondrexon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54233-54450-gondrexon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54233-54450-gondrexon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54234-54730-gorcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54234-54730-gorcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54234-54730-gorcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54234-54730-gorcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54235-54330-goviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54235-54330-goviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54235-54330-goviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54235-54330-goviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54236-54260-grand_failly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54236-54260-grand_failly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54236-54260-grand_failly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54236-54260-grand_failly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54237-54115-grimonviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54237-54115-grimonviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54237-54115-grimonviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54237-54115-grimonviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54238-54290-gripport/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54238-54290-gripport/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54238-54290-gripport/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54238-54290-gripport/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54239-54380-griscourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54239-54380-griscourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54239-54380-griscourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54239-54380-griscourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54240-54470-grosrouvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54240-54470-grosrouvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54240-54470-grosrouvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54240-54470-grosrouvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54241-54930-gugney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54241-54930-gugney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54241-54930-gugney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54241-54930-gugney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54242-54113-gye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54242-54113-gye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54242-54113-gye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54242-54113-gye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54243-54120-hablainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54243-54120-hablainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54243-54120-hablainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54243-54120-hablainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54244-54470-hageville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54244-54470-hageville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54244-54470-hageville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54244-54470-hageville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54245-54290-haigneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54245-54290-haigneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54245-54290-haigneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54245-54290-haigneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54246-54450-halloville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54246-54450-halloville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54246-54450-halloville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54246-54450-halloville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54247-54330-hammeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54247-54330-hammeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54247-54330-hammeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54247-54330-hammeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54248-54470-hamonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54248-54470-hamonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54248-54470-hamonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54248-54470-hamonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54249-54800-hannonville_suzemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54249-54800-hannonville_suzemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54249-54800-hannonville_suzemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54249-54800-hannonville_suzemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54250-54110-haraucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54250-54110-haraucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54250-54110-haraucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54250-54110-haraucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54251-54450-harbouey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54251-54450-harbouey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54251-54450-harbouey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54251-54450-harbouey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54252-54740-haroue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54252-54740-haroue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54252-54740-haroue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54252-54740-haroue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54253-54800-hatrize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54253-54800-hatrize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54253-54800-hatrize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54253-54800-hatrize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54254-54860-haucourt_moulaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54254-54860-haucourt_moulaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54254-54860-haucourt_moulaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54254-54860-haucourt_moulaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54255-54830-haudonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54255-54830-haudonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54255-54830-haudonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54255-54830-haudonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54256-54290-haussonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54256-54290-haussonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54256-54290-haussonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54256-54290-haussonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54257-54180-heillecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54257-54180-heillecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54257-54180-heillecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54257-54180-heillecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54258-54370-henamenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54258-54370-henamenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54258-54370-henamenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54258-54370-henamenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54259-54450-herbeviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54259-54450-herbeviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54259-54450-herbeviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54259-54450-herbeviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54260-54300-herimenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54260-54300-herimenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54260-54300-herimenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54260-54300-herimenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54261-54440-herserange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54261-54440-herserange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54261-54440-herserange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54261-54440-herserange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54262-54370-hoeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54262-54370-hoeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54262-54370-hoeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54262-54370-hoeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54263-54310-homecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54263-54310-homecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54263-54310-homecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54263-54310-homecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54264-54330-houdelmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54264-54330-houdelmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54264-54330-houdelmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54264-54330-houdelmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54265-54180-houdemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54265-54180-houdemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54265-54180-houdemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54265-54180-houdemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54266-54330-houdreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54266-54330-houdreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54266-54330-houdreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54266-54330-houdreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54268-54930-housseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54268-54930-housseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54268-54930-housseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54268-54930-housseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54269-54110-hudiviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54269-54110-hudiviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54269-54110-hudiviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54269-54110-hudiviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54270-54590-hussigny_godbrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54270-54590-hussigny_godbrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54270-54590-hussigny_godbrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54270-54590-hussigny_godbrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54271-54450-igney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54271-54450-igney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54271-54450-igney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54271-54450-igney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54272-54200-jaillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54272-54200-jaillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54272-54200-jaillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54272-54200-jaillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54273-54800-jarny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54273-54800-jarny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54273-54800-jarny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54273-54800-jarny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54274-54140-jarville_la_malgrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54274-54140-jarville_la_malgrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54274-54140-jarville_la_malgrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54274-54140-jarville_la_malgrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54275-54470-jaulny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54275-54470-jaulny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54275-54470-jaulny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54275-54470-jaulny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54276-54114-jeandelaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54276-54114-jeandelaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54276-54114-jeandelaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54276-54114-jeandelaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54277-54800-jeandelize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54277-54800-jeandelize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54277-54800-jeandelize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54277-54800-jeandelize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54278-54740-jevoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54278-54740-jevoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54278-54740-jevoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54278-54740-jevoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54279-54700-jezainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54279-54700-jezainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54279-54700-jezainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54279-54700-jezainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54280-54240-joeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54280-54240-joeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54280-54240-joeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54280-54240-joeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54281-54300-jolivet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54281-54300-jolivet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54281-54300-jolivet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54281-54300-jolivet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54282-54620-joppecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54282-54620-joppecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54282-54620-joppecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54282-54620-joppecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54283-54800-jouaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54283-54800-jouaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54283-54800-jouaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54283-54800-jouaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54284-54490-joudreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54284-54490-joudreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54284-54490-joudreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54284-54490-joudreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54285-54370-juvrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54285-54370-juvrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54285-54370-juvrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54285-54370-juvrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54286-54800-labry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54286-54800-labry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54286-54800-labry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54286-54800-labry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54287-54120-lachapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54287-54120-lachapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54287-54120-lachapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54287-54120-lachapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54288-54200-lagney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54288-54200-lagney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54288-54200-lagney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54288-54200-lagney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54289-54770-laitre_sous_amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54289-54770-laitre_sous_amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54289-54770-laitre_sous_amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54289-54770-laitre_sous_amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54290-54720-laix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54290-54720-laix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54290-54720-laix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54290-54720-laix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54291-54115-laloeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54291-54115-laloeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54291-54115-laloeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54291-54115-laloeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54292-54300-lamath/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54292-54300-lamath/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54292-54300-lamath/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54292-54300-lamath/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54293-54360-landecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54293-54360-landecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54293-54360-landecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54293-54360-landecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54294-54380-landremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54294-54380-landremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54294-54380-landremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54294-54380-landremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54295-54970-landres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54295-54970-landres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54295-54970-landres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54295-54970-landres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54296-54280-laneuvelotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54296-54280-laneuvelotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54296-54280-laneuvelotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54296-54280-laneuvelotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54297-54370-laneuveville_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54297-54370-laneuveville_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54297-54370-laneuveville_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54297-54370-laneuveville_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54298-54570-laneuveville_derriere_foug/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54298-54570-laneuveville_derriere_foug/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54298-54570-laneuveville_derriere_foug/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54298-54570-laneuveville_derriere_foug/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54299-54740-laneuveville_devant_bayon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54299-54740-laneuveville_devant_bayon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54299-54740-laneuveville_devant_bayon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54299-54740-laneuveville_devant_bayon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54300-54410-laneuveville_devant_nancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54300-54410-laneuveville_devant_nancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54300-54410-laneuveville_devant_nancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54300-54410-laneuveville_devant_nancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54301-54760-lanfroicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54301-54760-lanfroicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54301-54760-lanfroicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54301-54760-lanfroicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54302-54150-lantefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54302-54150-lantefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54302-54150-lantefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54302-54150-lantefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54303-54950-laronxe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54303-54950-laronxe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54303-54950-laronxe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54303-54950-laronxe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54304-54520-laxou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54304-54520-laxou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54304-54520-laxou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54304-54520-laxou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54305-54690-lay_saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54305-54690-lay_saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54305-54690-lay_saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54305-54690-lay_saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54306-54570-lay_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54306-54570-lay_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54306-54570-lay_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54306-54570-lay_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54307-54740-lebeuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54307-54740-lebeuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54307-54740-lebeuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54307-54740-lebeuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54308-54450-leintrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54308-54450-leintrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54308-54450-leintrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54308-54450-leintrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54309-54740-lemainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54309-54740-lemainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54309-54740-lemainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54309-54740-lemainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54310-54740-lemenil_mitry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54310-54740-lemenil_mitry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54310-54740-lemenil_mitry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54310-54740-lemenil_mitry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54311-54110-lenoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54311-54110-lenoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54311-54110-lenoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54311-54110-lenoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54312-54700-lesmenils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54312-54700-lesmenils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54312-54700-lesmenils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54312-54700-lesmenils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54313-54610-letricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54313-54610-letricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54313-54610-letricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54313-54610-letricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54314-54720-lexy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54314-54720-lexy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54314-54720-lexy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54314-54720-lexy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54315-54760-leyr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54315-54760-leyr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54315-54760-leyr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54315-54760-leyr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54316-54470-limey_remenauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54316-54470-limey_remenauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54316-54470-limey_remenauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54316-54470-limey_remenauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54317-54470-lironville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54317-54470-lironville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54317-54470-lironville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54317-54470-lironville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54318-54460-liverdun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54318-54460-liverdun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54318-54460-liverdun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54318-54460-liverdun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54320-54700-loisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54320-54700-loisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54320-54700-loisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54320-54700-loisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54321-54810-longlaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54321-54810-longlaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54321-54810-longlaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54321-54810-longlaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54322-54260-longuyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54322-54260-longuyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54322-54260-longuyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54322-54260-longuyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54323-54400-longwy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54323-54400-longwy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54323-54400-longwy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54323-54400-longwy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54324-54290-lorey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54324-54290-lorey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54324-54290-lorey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54324-54290-lorey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54325-54290-loromontzey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54325-54290-loromontzey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54325-54290-loromontzey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54325-54290-loromontzey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54326-54150-lubey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54326-54150-lubey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54326-54150-lubey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54326-54150-lubey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54327-54200-lucey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54327-54200-lucey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54327-54200-lucey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54327-54200-lucey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54328-54710-ludres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54328-54710-ludres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54328-54710-ludres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54328-54710-ludres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54329-54300-luneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54329-54300-luneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54329-54300-luneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54329-54300-luneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54330-54210-lupcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54330-54210-lupcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54330-54210-lupcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54330-54210-lupcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54331-54129-magnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54331-54129-magnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54331-54129-magnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54331-54129-magnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54332-54700-maidieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54332-54700-maidieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54332-54700-maidieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54332-54700-maidieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54333-54610-mailly_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54333-54610-mailly_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54333-54610-mailly_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54333-54610-mailly_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54334-54150-mairy_mainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54334-54150-mairy_mainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54334-54150-mairy_mainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54334-54150-mairy_mainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54335-54370-maixe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54335-54370-maixe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54335-54370-maixe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54335-54370-maixe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54336-54550-maizieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54336-54550-maizieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54336-54550-maizieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54336-54550-maizieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54337-54560-malavillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54337-54560-malavillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54337-54560-malavillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54337-54560-malavillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54338-54670-malleloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54338-54670-malleloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54338-54670-malleloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54338-54670-malleloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54339-54220-malzeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54339-54220-malzeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54339-54220-malzeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54339-54220-malzeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54340-54470-mamey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54340-54470-mamey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54340-54470-mamey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54340-54470-mamey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54343-54470-mandres_aux_quatre_tours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54343-54470-mandres_aux_quatre_tours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54343-54470-mandres_aux_quatre_tours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54343-54470-mandres_aux_quatre_tours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54344-54290-mangonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54344-54290-mangonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54344-54290-mangonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54344-54290-mangonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54345-54210-manoncourt_en_vermois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54345-54210-manoncourt_en_vermois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54345-54210-manoncourt_en_vermois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54345-54210-manoncourt_en_vermois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54346-54385-manoncourt_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54346-54385-manoncourt_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54346-54385-manoncourt_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54346-54385-manoncourt_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54348-54385-manonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54348-54385-manonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54348-54385-manonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54348-54385-manonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54349-54300-manonviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54349-54300-manonviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54349-54300-manonviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54349-54300-manonviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54350-54300-marainviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54350-54300-marainviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54350-54300-marainviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54350-54300-marainviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54351-54820-marbache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54351-54820-marbache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54351-54820-marbache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54351-54820-marbache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54352-54230-maron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54352-54230-maron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54352-54230-maron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54352-54230-maron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54353-54800-mars_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54353-54800-mars_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54353-54800-mars_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54353-54800-mars_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54354-54330-marthemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54354-54330-marthemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54354-54330-marthemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54354-54330-marthemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54355-54380-martincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54355-54380-martincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54355-54380-martincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54355-54380-martincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54356-54830-mattexey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54356-54830-mattexey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54356-54830-mattexey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54356-54830-mattexey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54357-54320-maxeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54357-54320-maxeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54357-54320-maxeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54357-54320-maxeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54358-54280-mazerulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54358-54280-mazerulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54358-54280-mazerulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54358-54280-mazerulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54359-54360-mehoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54359-54360-mehoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54359-54360-mehoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54359-54360-mehoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54360-54200-menil_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54360-54200-menil_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54360-54200-menil_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54360-54200-menil_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54362-54960-mercy_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54362-54960-mercy_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54362-54960-mercy_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54362-54960-mercy_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54363-54560-mercy_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54363-54560-mercy_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54363-54560-mercy_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54363-54560-mercy_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54364-54850-mereville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54364-54850-mereville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54364-54850-mereville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54364-54850-mereville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54365-54120-merviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54365-54120-merviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54365-54120-merviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54365-54120-merviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54366-54850-messein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54366-54850-messein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54366-54850-messein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54366-54850-messein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54367-54135-mexy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54367-54135-mexy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54367-54135-mexy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54367-54135-mexy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54368-54540-migneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54368-54540-migneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54368-54540-migneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54368-54540-migneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54369-54670-millery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54369-54670-millery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54369-54670-millery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54369-54670-millery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54370-54385-minorville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54370-54385-minorville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54370-54385-minorville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54370-54385-minorville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54371-54580-moineville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54371-54580-moineville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54371-54580-moineville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54371-54580-moineville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54372-54760-moivrons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54372-54760-moivrons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54372-54760-moivrons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54372-54760-moivrons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54373-54300-moncel_les_luneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54373-54300-moncel_les_luneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54373-54300-moncel_les_luneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54373-54300-moncel_les_luneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54374-54280-moncel_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54374-54280-moncel_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54374-54280-moncel_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54374-54280-moncel_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54375-54700-montauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54375-54700-montauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54375-54700-montauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54375-54700-montauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54376-54760-montenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54376-54760-montenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54376-54760-montenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54376-54760-montenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54377-54540-montigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54377-54540-montigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54377-54540-montigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54377-54540-montigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54378-54870-montigny_sur_chiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54378-54870-montigny_sur_chiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54378-54870-montigny_sur_chiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54378-54870-montigny_sur_chiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54379-54170-mont_l_etroit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54379-54170-mont_l_etroit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54379-54170-mont_l_etroit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54379-54170-mont_l_etroit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54380-54113-mont_le_vignoble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54380-54113-mont_le_vignoble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54380-54113-mont_le_vignoble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54380-54113-mont_le_vignoble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54381-54450-montreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54381-54450-montreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54381-54450-montreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54381-54450-montreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54382-54350-mont_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54382-54350-mont_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54382-54350-mont_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54382-54350-mont_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54383-54360-mont_sur_meurthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54383-54360-mont_sur_meurthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54383-54360-mont_sur_meurthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54383-54360-mont_sur_meurthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54385-54920-morfontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54385-54920-morfontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54385-54920-morfontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54385-54920-morfontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54386-54830-moriviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54386-54830-moriviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54386-54830-moriviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54386-54830-moriviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54387-54700-morville_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54387-54700-morville_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54387-54700-morville_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54387-54700-morville_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54388-54370-mouacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54388-54370-mouacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54388-54370-mouacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54388-54370-mouacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54389-54800-mouaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54389-54800-mouaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54389-54800-mouaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54389-54800-mouaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54390-54700-mousson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54390-54700-mousson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54390-54700-mousson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54390-54700-mousson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54391-54660-moutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54391-54660-moutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54391-54660-moutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54391-54660-moutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54392-54113-moutrot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54392-54113-moutrot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54392-54113-moutrot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54392-54113-moutrot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54393-54118-moyen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54393-54118-moyen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54393-54118-moyen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54393-54118-moyen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54394-54490-murville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54394-54490-murville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54394-54490-murville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54394-54490-murville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54395-54100-nancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54395-54100-nancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54395-54100-nancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54395-54100-nancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54395-54000-nancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54395-54000-nancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54395-54000-nancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54395-54000-nancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54396-54540-neufmaisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54396-54540-neufmaisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54396-54540-neufmaisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54396-54540-neufmaisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54397-54230-neuves_maisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54397-54230-neuves_maisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54397-54230-neuves_maisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54397-54230-neuves_maisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54398-54540-neuviller_les_badonviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54398-54540-neuviller_les_badonviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54398-54540-neuviller_les_badonviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54398-54540-neuviller_les_badonviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54399-54290-neuviller_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54399-54290-neuviller_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54399-54290-neuviller_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54399-54290-neuviller_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54400-54610-nomeny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54400-54610-nomeny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54400-54610-nomeny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54400-54610-nomeny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54401-54450-nonhigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54401-54450-nonhigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54401-54450-nonhigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54401-54450-nonhigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54402-54150-norroy_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54402-54150-norroy_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54402-54150-norroy_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54402-54150-norroy_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54403-54700-norroy_les_pont_a_mousson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54403-54700-norroy_les_pont_a_mousson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54403-54700-norroy_les_pont_a_mousson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54403-54700-norroy_les_pont_a_mousson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54404-54385-noviant_aux_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54404-54385-noviant_aux_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54404-54385-noviant_aux_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54404-54385-noviant_aux_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54405-54170-ochey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54405-54170-ochey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54405-54170-ochey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54405-54170-ochey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54405-54201-ochey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54405-54201-ochey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54405-54201-ochey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54405-54201-ochey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54406-54450-ogeviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54406-54450-ogeviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54406-54450-ogeviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54406-54450-ogeviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54407-54330-ogneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54407-54330-ogneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54407-54330-ogneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54407-54330-ogneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54408-54800-olley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54408-54800-olley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54408-54800-olley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54408-54800-olley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54409-54330-omelmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54409-54330-omelmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54409-54330-omelmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54409-54330-omelmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54410-54890-onville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54410-54890-onville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54410-54890-onville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54410-54890-onville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54411-54740-ormes_et_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54411-54740-ormes_et_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54411-54740-ormes_et_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54411-54740-ormes_et_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54412-54260-othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54412-54260-othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54412-54260-othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54412-54260-othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54413-54150-ozerailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54413-54150-ozerailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54413-54150-ozerailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54413-54150-ozerailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54414-54200-pagney_derriere_barine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54414-54200-pagney_derriere_barine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54414-54200-pagney_derriere_barine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54414-54200-pagney_derriere_barine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54415-54530-pagny_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54415-54530-pagny_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54415-54530-pagny_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54415-54530-pagny_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54416-54470-pannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54416-54470-pannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54416-54470-pannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54416-54470-pannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54417-54330-parey_saint_cesaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54417-54330-parey_saint_cesaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54417-54330-parey_saint_cesaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54417-54330-parey_saint_cesaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54418-54370-parroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54418-54370-parroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54418-54370-parroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54418-54370-parroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54419-54480-parux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54419-54480-parux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54419-54480-parux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54419-54480-parux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54420-54260-petit_failly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54420-54260-petit_failly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54420-54260-petit_failly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54420-54260-petit_failly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54421-54480-petitmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54421-54480-petitmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54421-54480-petitmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54421-54480-petitmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54422-54120-pettonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54422-54120-pettonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54422-54120-pettonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54422-54120-pettonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54423-54540-pexonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54423-54540-pexonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54423-54540-pexonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54423-54540-pexonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54424-54610-phlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54424-54610-phlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54424-54610-phlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54424-54610-phlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54425-54490-piennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54425-54490-piennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54425-54490-piennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54425-54490-piennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54426-54200-pierre_la_treiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54426-54200-pierre_la_treiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54426-54200-pierre_la_treiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54426-54200-pierre_la_treiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54427-54540-pierre_percee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54427-54540-pierre_percee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54427-54540-pierre_percee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54427-54540-pierre_percee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54428-54620-pierrepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54428-54620-pierrepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54428-54620-pierrepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54428-54620-pierrepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54429-54160-pierreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54429-54160-pierreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54429-54160-pierreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54429-54160-pierreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54430-54340-pompey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54430-54340-pompey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54430-54340-pompey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54430-54340-pompey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54431-54700-pont_a_mousson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54431-54700-pont_a_mousson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54431-54700-pont_a_mousson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54431-54700-pont_a_mousson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54432-54550-pont_saint_vincent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54432-54550-pont_saint_vincent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54432-54550-pont_saint_vincent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54432-54550-pont_saint_vincent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54433-54700-port_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54433-54700-port_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54433-54700-port_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54433-54700-port_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54434-54116-praye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54434-54116-praye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54434-54116-praye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54434-54116-praye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54435-54530-preny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54435-54530-preny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54435-54530-preny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54435-54530-preny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54436-54490-preutin_higny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54436-54490-preutin_higny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54436-54490-preutin_higny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54436-54490-preutin_higny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54437-54160-pulligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54437-54160-pulligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54437-54160-pulligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54437-54160-pulligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54438-54115-pulney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54438-54115-pulney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54438-54115-pulney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54438-54115-pulney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54439-54425-pulnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54439-54425-pulnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54439-54425-pulnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54439-54425-pulnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54440-54800-puxe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54440-54800-puxe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54440-54800-puxe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54440-54800-puxe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54441-54800-puxieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54441-54800-puxieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54441-54800-puxieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54441-54800-puxieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54442-54330-quevilloncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54442-54330-quevilloncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54442-54330-quevilloncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54442-54330-quevilloncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54443-54540-raon_les_leau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54443-54540-raon_les_leau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54443-54540-raon_les_leau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54443-54540-raon_les_leau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54444-54610-raucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54444-54610-raucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54444-54610-raucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54444-54610-raucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54445-54370-raville_sur_sanon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54445-54370-raville_sur_sanon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54445-54370-raville_sur_sanon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54445-54370-raville_sur_sanon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54446-54370-rechicourt_la_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54446-54370-rechicourt_la_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54446-54370-rechicourt_la_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54446-54370-rechicourt_la_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54447-54450-reclonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54447-54450-reclonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54447-54450-reclonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54447-54450-reclonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54449-54300-rehainviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54449-54300-rehainviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54449-54300-rehainviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54449-54300-rehainviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54450-54120-reherrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54450-54120-reherrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54450-54120-reherrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54450-54120-reherrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54451-54430-rehon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54451-54430-rehon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54451-54430-rehon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54451-54430-rehon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54452-54450-reillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54452-54450-reillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54452-54450-reillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54452-54450-reillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54453-54470-rembercourt_sur_mad/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54453-54470-rembercourt_sur_mad/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54453-54470-rembercourt_sur_mad/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54453-54470-rembercourt_sur_mad/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54455-54830-remenoville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54455-54830-remenoville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54455-54830-remenoville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54455-54830-remenoville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54456-54110-remereville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54456-54110-remereville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54456-54110-remereville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54456-54110-remereville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54457-54370-remoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54457-54370-remoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54457-54370-remoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54457-54370-remoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54458-54450-repaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54458-54450-repaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54458-54450-repaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54458-54450-repaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54459-54630-richardmenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54459-54630-richardmenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54459-54630-richardmenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54459-54630-richardmenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54460-54380-rogeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54460-54380-rogeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54460-54380-rogeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54460-54380-rogeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54461-54360-romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54461-54360-romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54461-54360-romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54461-54360-romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54462-54110-rosieres_aux_salines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54462-54110-rosieres_aux_salines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54462-54110-rosieres_aux_salines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54462-54110-rosieres_aux_salines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54463-54207-rosieres_en_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54463-54207-rosieres_en_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54463-54207-rosieres_en_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54463-54207-rosieres_en_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54463-54385-rosieres_en_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54463-54385-rosieres_en_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54463-54385-rosieres_en_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54463-54385-rosieres_en_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54464-54610-rouves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54464-54610-rouves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54464-54610-rouves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54464-54610-rouves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54465-54290-roville_devant_bayon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54465-54290-roville_devant_bayon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54465-54290-roville_devant_bayon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54465-54290-roville_devant_bayon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54466-54200-royaumeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54466-54200-royaumeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54466-54200-royaumeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54466-54200-royaumeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54467-54290-rozelieures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54467-54290-rozelieures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54467-54290-rozelieures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54467-54290-rozelieures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54468-54210-saffais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54468-54210-saffais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54468-54210-saffais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54468-54210-saffais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54469-54580-saint_ail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54469-54580-saint_ail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54469-54580-saint_ail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54469-54580-saint_ail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54470-54470-saint_baussant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54470-54470-saint_baussant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54470-54470-saint_baussant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54470-54470-saint_baussant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54471-54290-saint_boingt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54471-54290-saint_boingt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54471-54290-saint_boingt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54471-54290-saint_boingt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54472-54950-saint_clement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54472-54950-saint_clement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54472-54950-saint_clement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54472-54950-saint_clement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54473-54930-saint_firmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54473-54930-saint_firmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54473-54930-saint_firmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54473-54930-saint_firmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54474-54700-sainte_genevieve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54474-54700-sainte_genevieve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54474-54700-sainte_genevieve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54474-54700-sainte_genevieve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54475-54290-saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54475-54290-saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54475-54290-saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54475-54290-saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54476-54260-saint_jean_les_longuyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54476-54260-saint_jean_les_longuyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54476-54260-saint_jean_les_longuyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54476-54260-saint_jean_les_longuyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54477-54470-saint_julien_les_gorze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54477-54470-saint_julien_les_gorze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54477-54470-saint_julien_les_gorze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54477-54470-saint_julien_les_gorze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54478-54800-saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54478-54800-saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54478-54800-saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54478-54800-saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54479-54290-saint_mard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54479-54290-saint_mard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54479-54290-saint_mard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54479-54290-saint_mard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54480-54450-saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54480-54450-saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54480-54450-saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54480-54450-saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54481-54540-saint_maurice_aux_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54481-54540-saint_maurice_aux_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54481-54540-saint_maurice_aux_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54481-54540-saint_maurice_aux_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54482-54130-saint_max/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54482-54130-saint_max/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54482-54130-saint_max/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54482-54130-saint_max/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54483-54210-saint_nicolas_de_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54483-54210-saint_nicolas_de_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54483-54210-saint_nicolas_de_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54483-54210-saint_nicolas_de_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54484-54540-sainte_pole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54484-54540-sainte_pole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54484-54540-sainte_pole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54484-54540-sainte_pole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54485-54730-saint_pancre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54485-54730-saint_pancre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54485-54730-saint_pancre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54485-54730-saint_pancre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54486-54740-saint_remimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54486-54740-saint_remimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54486-54740-saint_remimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54486-54740-saint_remimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54487-54290-saint_remy_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54487-54290-saint_remy_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54487-54290-saint_remy_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54487-54290-saint_remy_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54488-54480-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54488-54480-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54488-54480-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54488-54480-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54489-54620-saint_supplet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54489-54620-saint_supplet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54489-54620-saint_supplet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54489-54620-saint_supplet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54490-54380-saizerais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54490-54380-saizerais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54490-54380-saizerais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54490-54380-saizerais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54490-54460-saizerais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54490-54460-saizerais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54490-54460-saizerais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54490-54460-saizerais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54491-54560-sancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54491-54560-sancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54491-54560-sancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54491-54560-sancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54492-54200-sanzey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54492-54200-sanzey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54492-54200-sanzey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54492-54200-sanzey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54493-54650-saulnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54493-54650-saulnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54493-54650-saulnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54493-54650-saulnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54494-54115-saulxerotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54494-54115-saulxerotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54494-54115-saulxerotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54494-54115-saulxerotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54495-54420-saulxures_les_nancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54495-54420-saulxures_les_nancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54495-54420-saulxures_les_nancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54495-54420-saulxures_les_nancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54496-54170-saulxures_les_vannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54496-54170-saulxures_les_vannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54496-54170-saulxures_les_vannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54496-54170-saulxures_les_vannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54497-54330-saxon_sion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54497-54330-saxon_sion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54497-54330-saxon_sion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54497-54330-saxon_sion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54498-54280-seichamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54498-54280-seichamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54498-54280-seichamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54498-54280-seichamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54499-54470-seicheprey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54499-54470-seicheprey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54499-54470-seicheprey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54499-54470-seicheprey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54500-54170-selaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54500-54170-selaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54500-54170-selaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54500-54170-selaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54501-54830-seranville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54501-54830-seranville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54501-54830-seranville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54501-54830-seranville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54502-54370-serres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54502-54370-serres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54502-54370-serres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54502-54370-serres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54504-54560-serrouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54504-54560-serrouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54504-54560-serrouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54504-54560-serrouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54505-54550-sexey_aux_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54505-54550-sexey_aux_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54505-54550-sexey_aux_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54505-54550-sexey_aux_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54507-54300-sionviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54507-54300-sionviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54507-54300-sionviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54507-54300-sionviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54508-54610-sivry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54508-54610-sivry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54508-54610-sivry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54508-54610-sivry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54509-54110-sommerviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54509-54110-sommerviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54509-54110-sommerviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54509-54110-sommerviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54510-54280-sorneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54510-54280-sorneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54510-54280-sorneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54510-54280-sorneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54511-54800-sponville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54511-54800-sponville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54511-54800-sponville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54511-54800-sponville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54512-54480-tanconville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54512-54480-tanconville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54512-54480-tanconville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54512-54480-tanconville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54513-54116-tantonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54513-54116-tantonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54513-54116-tantonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54513-54116-tantonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54514-54260-tellancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54514-54260-tellancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54514-54260-tellancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54514-54260-tellancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54515-54330-thelod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54515-54330-thelod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54515-54330-thelod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54515-54330-thelod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54516-54930-they_sous_vaudemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54516-54930-they_sous_vaudemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54516-54930-they_sous_vaudemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54516-54930-they_sous_vaudemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54517-54610-thezey_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54517-54610-thezey_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54517-54610-thezey_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54517-54610-thezey_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54518-54470-thiaucourt_regnieville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54518-54470-thiaucourt_regnieville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54518-54470-thiaucourt_regnieville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54518-54470-thiaucourt_regnieville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54519-54120-thiaville_sur_meurthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54519-54120-thiaville_sur_meurthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54519-54120-thiaville_sur_meurthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54519-54120-thiaville_sur_meurthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54520-54300-thiebaumenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54520-54300-thiebaumenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54520-54300-thiebaumenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54520-54300-thiebaumenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54521-54880-thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54521-54880-thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54521-54880-thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54521-54880-thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54522-54115-thorey_lyautey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54522-54115-thorey_lyautey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54522-54115-thorey_lyautey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54522-54115-thorey_lyautey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54523-54170-thuilley_aux_groseilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54523-54170-thuilley_aux_groseilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54523-54170-thuilley_aux_groseilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54523-54170-thuilley_aux_groseilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54524-54800-thumereville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54524-54800-thumereville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54524-54800-thumereville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54524-54800-thumereville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54525-54190-tiercelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54525-54190-tiercelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54525-54190-tiercelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54525-54190-tiercelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54526-54510-tomblaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54526-54510-tomblaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54526-54510-tomblaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54526-54510-tomblaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54527-54210-tonnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54527-54210-tonnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54527-54210-tonnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54527-54210-tonnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54528-54200-toul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54528-54200-toul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54528-54200-toul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54528-54200-toul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54529-54115-tramont_emy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54529-54115-tramont_emy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54529-54115-tramont_emy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54529-54115-tramont_emy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54530-54115-tramont_lassus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54530-54115-tramont_lassus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54530-54115-tramont_lassus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54530-54115-tramont_lassus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54531-54115-tramont_saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54531-54115-tramont_saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54531-54115-tramont_saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54531-54115-tramont_saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54532-54385-tremblecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54532-54385-tremblecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54532-54385-tremblecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54532-54385-tremblecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54533-54750-trieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54533-54750-trieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54533-54750-trieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54533-54750-trieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54534-54570-trondes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54534-54570-trondes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54534-54570-trondes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54534-54570-trondes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54535-54800-tronville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54535-54800-tronville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54535-54800-tronville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54535-54800-tronville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54536-54640-tucquegnieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54536-54640-tucquegnieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54536-54640-tucquegnieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54536-54640-tucquegnieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54537-54870-ugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54537-54870-ugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54537-54870-ugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54537-54870-ugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54538-54112-uruffe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54538-54112-uruffe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54538-54112-uruffe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54538-54112-uruffe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54539-54540-vacqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54539-54540-vacqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54539-54540-vacqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54539-54540-vacqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54540-54480-val_et_chatillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54540-54480-val_et_chatillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54540-54480-val_et_chatillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54540-54480-val_et_chatillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54541-54370-valhey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54541-54370-valhey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54541-54370-valhey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54541-54370-valhey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54542-54910-valleroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54542-54910-valleroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54542-54910-valleroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54542-54910-valleroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54543-54830-vallois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54543-54830-vallois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54543-54830-vallois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54543-54830-vallois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54544-54890-vandelainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54544-54890-vandelainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54544-54890-vandelainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54544-54890-vandelainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54545-54115-vandeleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54545-54115-vandeleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54545-54115-vandeleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54545-54115-vandeleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54546-54121-vandieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54546-54121-vandieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54546-54121-vandieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54546-54121-vandieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54547-54500-vandoeuvre_les_nancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54547-54500-vandoeuvre_les_nancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54547-54500-vandoeuvre_les_nancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54547-54500-vandoeuvre_les_nancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54548-54112-vannes_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54548-54112-vannes_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54548-54112-vannes_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54548-54112-vannes_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54549-54110-varangeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54549-54110-varangeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54549-54110-varangeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54549-54110-varangeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54550-54122-vathimenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54550-54122-vathimenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54550-54122-vathimenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54550-54122-vathimenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54551-54370-vaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54551-54370-vaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54551-54370-vaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54551-54370-vaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54552-54330-vaudemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54552-54330-vaudemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54552-54330-vaudemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54552-54330-vaudemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54553-54740-vaudeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54553-54740-vaudeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54553-54740-vaudeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54553-54740-vaudeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54554-54740-vaudigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54554-54740-vaudigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54554-54740-vaudigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54554-54740-vaudigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54555-54120-vaxainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54555-54120-vaxainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54555-54120-vaxainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54555-54120-vaxainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54556-54450-veho/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54556-54450-veho/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54556-54450-veho/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54556-54450-veho/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54557-54840-bois_de_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54557-54840-bois_de_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54557-54840-bois_de_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54557-54840-bois_de_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54558-54280-velaine_sous_amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54558-54280-velaine_sous_amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54558-54280-velaine_sous_amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54558-54280-velaine_sous_amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54559-54290-velle_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54559-54290-velle_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54559-54290-velle_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54559-54290-velle_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54560-54540-veney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54560-54540-veney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54560-54540-veney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54560-54540-veney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54561-54830-vennezey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54561-54830-vennezey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54561-54830-vennezey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54561-54830-vennezey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54562-54450-verdenal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54562-54450-verdenal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54562-54450-verdenal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54562-54450-verdenal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54563-54330-vezelise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54563-54330-vezelise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54563-54330-vezelise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54563-54330-vezelise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54564-54470-vieville_en_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54564-54470-vieville_en_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54564-54470-vieville_en_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54564-54470-vieville_en_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54565-54360-vigneulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54565-54360-vigneulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54565-54360-vigneulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54565-54360-vigneulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54566-54700-vilcey_sur_trey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54566-54700-vilcey_sur_trey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54566-54700-vilcey_sur_trey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54566-54700-vilcey_sur_trey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54567-54290-villacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54567-54290-villacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54567-54290-villacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54567-54290-villacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54568-54620-ville_au_montois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54568-54620-ville_au_montois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54568-54620-ville_au_montois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54568-54620-ville_au_montois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54569-54380-ville_au_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54569-54380-ville_au_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54569-54380-ville_au_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54569-54380-ville_au_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54570-54890-villecey_sur_mad/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54570-54890-villecey_sur_mad/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54570-54890-villecey_sur_mad/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54570-54890-villecey_sur_mad/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54571-54210-ville_en_vermois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54571-54210-ville_en_vermois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54571-54210-ville_en_vermois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54571-54210-ville_en_vermois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54572-54730-ville_houdlemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54572-54730-ville_houdlemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54572-54730-ville_houdlemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54572-54730-ville_houdlemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54573-54380-villers_en_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54573-54380-villers_en_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54573-54380-villers_en_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54573-54380-villers_en_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54574-54870-villers_la_chevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54574-54870-villers_la_chevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54574-54870-villers_la_chevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54574-54870-villers_la_chevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54575-54920-villers_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54575-54920-villers_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54575-54920-villers_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54575-54920-villers_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54576-54260-villers_le_rond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54576-54260-villers_le_rond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54576-54260-villers_le_rond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54576-54260-villers_le_rond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54577-54760-villers_les_moivrons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54577-54760-villers_les_moivrons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54577-54760-villers_les_moivrons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54577-54760-villers_les_moivrons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54578-54600-villers_les_nancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54578-54600-villers_les_nancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54578-54600-villers_les_nancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54578-54600-villers_les_nancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54579-54700-villers_sous_preny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54579-54700-villers_sous_preny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54579-54700-villers_sous_preny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54579-54700-villers_sous_preny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54580-54190-villerupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54580-54190-villerupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54580-54190-villerupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54580-54190-villerupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54581-54800-ville_sur_yron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54581-54800-ville_sur_yron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54581-54800-ville_sur_yron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54581-54800-ville_sur_yron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54582-54260-villette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54582-54260-villette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54582-54260-villette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54582-54260-villette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54583-54840-villey_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54583-54840-villey_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54583-54840-villey_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54583-54840-villey_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54584-54200-villey_saint_etienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54584-54200-villey_saint_etienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54584-54200-villey_saint_etienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54584-54200-villey_saint_etienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54585-54290-virecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54585-54290-virecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54585-54290-virecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54585-54290-virecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54586-54123-viterne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54586-54123-viterne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54586-54123-viterne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54586-54123-viterne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54587-54330-vitrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54587-54330-vitrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54587-54330-vitrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54587-54330-vitrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54588-54300-vitrimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54588-54300-vitrimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54588-54300-vitrimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54588-54300-vitrimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54589-54700-vittonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54589-54700-vittonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54589-54700-vittonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54589-54700-vittonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54590-54260-viviers_sur_chiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54590-54260-viviers_sur_chiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54590-54260-viviers_sur_chiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54590-54260-viviers_sur_chiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54591-54134-voinemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54591-54134-voinemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54591-54134-voinemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54591-54134-voinemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54592-54330-vroncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54592-54330-vroncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54592-54330-vroncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54592-54330-vroncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54593-54890-waville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54593-54890-waville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54593-54890-waville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54593-54890-waville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54594-54470-xammes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54594-54470-xammes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54594-54470-xammes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54594-54470-xammes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54595-54300-xermamenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54595-54300-xermamenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54595-54300-xermamenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54595-54300-xermamenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54596-54990-xeuilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54596-54990-xeuilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54596-54990-xeuilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54596-54990-xeuilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54597-54740-xirocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54597-54740-xirocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54597-54740-xirocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54597-54740-xirocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54598-54490-xivry_circourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54598-54490-xivry_circourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54598-54490-xivry_circourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54598-54490-xivry_circourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54599-54800-xonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54599-54800-xonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54599-54800-xonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54599-54800-xonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54600-54370-xousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54600-54370-xousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54600-54370-xousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54600-54370-xousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54601-54370-xures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54601-54370-xures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54601-54370-xures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54601-54370-xures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54602-54620-han_devant_pierrepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54602-54620-han_devant_pierrepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54602-54620-han_devant_pierrepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt54-meurthe_et_moselle/commune54602-54620-han_devant_pierrepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-55.xml
+++ b/public/sitemaps/sitemap-55.xml
@@ -5,1006 +5,2008 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55001-55130-abainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55001-55130-abainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55001-55130-abainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55001-55130-abainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55002-55400-abaucourt_hautecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55002-55400-abaucourt_hautecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55002-55400-abaucourt_hautecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55002-55400-abaucourt_hautecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55004-55110-aincreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55004-55110-aincreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55004-55110-aincreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55004-55110-aincreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55005-55130-amanty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55005-55130-amanty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55005-55130-amanty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55005-55130-amanty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55007-55300-ambly_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55007-55300-ambly_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55007-55300-ambly_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55007-55300-ambly_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55008-55230-amel_sur_l_etang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55008-55230-amel_sur_l_etang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55008-55230-amel_sur_l_etang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55008-55230-amel_sur_l_etang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55009-55320-ancemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55009-55320-ancemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55009-55320-ancemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55009-55320-ancemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55010-55170-ancerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55010-55170-ancerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55010-55170-ancerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55010-55170-ancerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55011-55800-andernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55011-55800-andernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55011-55800-andernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55011-55800-andernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55012-55300-apremont_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55012-55300-apremont_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55012-55300-apremont_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55012-55300-apremont_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55013-55230-arrancy_sur_crusne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55013-55230-arrancy_sur_crusne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55013-55230-arrancy_sur_crusne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55013-55230-arrancy_sur_crusne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55014-55120-aubreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55014-55120-aubreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55014-55120-aubreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55014-55120-aubreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55015-55170-aulnois_en_perthois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55015-55170-aulnois_en_perthois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55015-55170-aulnois_en_perthois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55015-55170-aulnois_en_perthois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55017-55120-autrecourt_sur_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55017-55120-autrecourt_sur_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55017-55120-autrecourt_sur_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55017-55120-autrecourt_sur_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55018-55700-autreville_saint_lambert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55018-55700-autreville_saint_lambert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55018-55700-autreville_saint_lambert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55018-55700-autreville_saint_lambert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55021-55210-avillers_sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55021-55210-avillers_sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55021-55210-avillers_sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55021-55210-avillers_sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55022-55600-avioth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55022-55600-avioth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55022-55600-avioth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55022-55600-avioth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55023-55270-avocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55023-55270-avocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55023-55270-avocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55023-55270-avocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55024-55150-azannes_et_soumazannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55024-55150-azannes_et_soumazannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55024-55150-azannes_et_soumazannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55024-55150-azannes_et_soumazannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55025-55700-baalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55025-55700-baalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55025-55700-baalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55025-55700-baalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55026-55130-badonvilliers_gerauvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55026-55130-badonvilliers_gerauvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55026-55130-badonvilliers_gerauvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55026-55130-badonvilliers_gerauvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55027-55300-bannoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55027-55300-bannoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55027-55300-bannoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55027-55300-bannoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55028-55110-bantheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55028-55110-bantheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55028-55110-bantheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55028-55110-bantheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55029-55000-bar_le_duc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55029-55000-bar_le_duc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55029-55000-bar_le_duc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55029-55000-bar_le_duc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55031-55170-baudonvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55031-55170-baudonvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55031-55170-baudonvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55031-55170-baudonvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55032-55260-baudremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55032-55260-baudremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55032-55260-baudremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55032-55260-baudremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55033-55270-baulny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55033-55270-baulny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55033-55270-baulny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55033-55270-baulny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55034-55600-bazeilles_sur_othain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55034-55600-bazeilles_sur_othain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55034-55600-bazeilles_sur_othain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55034-55600-bazeilles_sur_othain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55035-55170-bazincourt_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55035-55170-bazincourt_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55035-55170-bazincourt_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55035-55170-bazincourt_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55036-55700-beauclair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55036-55700-beauclair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55036-55700-beauclair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55036-55700-beauclair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55037-55700-beaufort_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55037-55700-beaufort_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55037-55700-beaufort_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55037-55700-beaufort_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55038-55250-beaulieu_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55038-55250-beaulieu_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55038-55250-beaulieu_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55038-55250-beaulieu_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55039-55100-beaumont_en_verdunois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55039-55100-beaumont_en_verdunois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55039-55100-beaumont_en_verdunois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55039-55100-beaumont_en_verdunois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55040-55250-beausite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55040-55250-beausite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55040-55250-beausite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55040-55250-beausite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55041-55000-behonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55041-55000-behonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55041-55000-behonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55041-55000-behonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55042-55100-belleray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55042-55100-belleray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55042-55100-belleray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55042-55100-belleray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55043-55430-belleville_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55043-55430-belleville_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55043-55430-belleville_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55043-55430-belleville_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55044-55260-belrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55044-55260-belrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55044-55260-belrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55044-55260-belrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55045-55100-belrupt_en_verdunois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55045-55100-belrupt_en_verdunois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55045-55100-belrupt_en_verdunois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55045-55100-belrupt_en_verdunois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55046-55210-beney_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55046-55210-beney_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55046-55210-beney_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55046-55210-beney_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55047-55100-bethelainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55047-55100-bethelainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55047-55100-bethelainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55047-55100-bethelainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55048-55270-bethincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55048-55270-bethincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55048-55270-bethincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55048-55270-bethincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55049-55000-beurey_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55049-55000-beurey_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55049-55000-beurey_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55049-55000-beurey_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55050-55100-bezonvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55050-55100-bezonvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55050-55100-bezonvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55050-55100-bezonvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55051-55290-biencourt_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55051-55290-biencourt_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55051-55290-biencourt_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55051-55290-biencourt_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55053-55230-billy_sous_mangiennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55053-55230-billy_sous_mangiennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55053-55230-billy_sous_mangiennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55053-55230-billy_sous_mangiennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55054-55300-bislee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55054-55300-bislee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55054-55300-bislee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55054-55300-bislee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55055-55400-blanzee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55055-55400-blanzee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55055-55400-blanzee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55055-55400-blanzee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55057-55400-boinville_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55057-55400-boinville_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55057-55400-boinville_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55057-55400-boinville_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55058-55200-boncourt_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55058-55200-boncourt_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55058-55200-boncourt_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55058-55200-boncourt_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55059-55130-bonnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55059-55130-bonnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55059-55130-bonnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55059-55130-bonnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55060-55160-bonzee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55060-55160-bonzee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55060-55160-bonzee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55060-55160-bonzee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55061-55500-le_bouchon_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55061-55500-le_bouchon_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55061-55500-le_bouchon_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55061-55500-le_bouchon_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55062-55300-bouconville_sur_madt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55062-55300-bouconville_sur_madt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55062-55300-bouconville_sur_madt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55062-55300-bouconville_sur_madt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55063-55240-bouligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55063-55240-bouligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55063-55240-bouligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55063-55240-bouligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55064-55300-bouquemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55064-55300-bouquemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55064-55300-bouquemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55064-55300-bouquemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55065-55270-boureuilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55065-55270-boureuilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55065-55270-boureuilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55065-55270-boureuilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55066-55190-bovee_sur_barboure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55066-55190-bovee_sur_barboure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55066-55190-bovee_sur_barboure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55066-55190-bovee_sur_barboure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55067-55500-boviolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55067-55500-boviolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55067-55500-boviolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55067-55500-boviolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55068-55120-brabant_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55068-55120-brabant_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55068-55120-brabant_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55068-55120-brabant_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55069-55800-brabant_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55069-55800-brabant_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55069-55800-brabant_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55069-55800-brabant_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55070-55100-brabant_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55070-55100-brabant_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55070-55100-brabant_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55070-55100-brabant_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55071-55150-brandeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55071-55150-brandeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55071-55150-brandeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55071-55150-brandeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55072-55400-braquis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55072-55400-braquis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55072-55400-braquis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55072-55400-braquis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55073-55100-bras_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55073-55100-bras_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55073-55100-bras_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55073-55100-bras_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55075-55170-brauvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55075-55170-brauvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55075-55170-brauvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55075-55170-brauvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55076-55150-breheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55076-55150-breheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55076-55150-breheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55076-55150-breheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55077-55600-breux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55077-55600-breux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55077-55600-breux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55077-55600-breux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55078-55110-brieulles_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55078-55110-brieulles_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55078-55110-brieulles_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55078-55110-brieulles_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55079-55000-brillon_en_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55079-55000-brillon_en_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55079-55000-brillon_en_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55079-55000-brillon_en_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55080-55140-brixey_aux_chanoines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55080-55140-brixey_aux_chanoines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55080-55140-brixey_aux_chanoines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55080-55140-brixey_aux_chanoines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55081-55250-brizeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55081-55250-brizeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55081-55250-brizeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55081-55250-brizeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55082-55120-brocourt_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55082-55120-brocourt_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55082-55120-brocourt_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55082-55120-brocourt_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55083-55700-brouennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55083-55700-brouennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55083-55700-brouennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55083-55700-brouennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55084-55190-broussey_en_blois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55084-55190-broussey_en_blois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55084-55190-broussey_en_blois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55084-55190-broussey_en_blois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55085-55200-broussey_raulecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55085-55200-broussey_raulecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55085-55200-broussey_raulecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55085-55200-broussey_raulecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55087-55290-bure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55087-55290-bure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55087-55290-bure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55087-55290-bure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55088-55140-burey_en_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55088-55140-burey_en_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55088-55140-burey_en_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55088-55140-burey_en_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55089-55140-burey_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55089-55140-burey_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55089-55140-burey_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55089-55140-burey_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55093-55300-buxieres_sous_les_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55093-55300-buxieres_sous_les_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55093-55300-buxieres_sous_les_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55093-55300-buxieres_sous_les_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55094-55400-buzy_darmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55094-55400-buzy_darmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55094-55400-buzy_darmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55094-55400-buzy_darmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55095-55700-cesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55095-55700-cesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55095-55700-cesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55095-55700-cesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55096-55210-chaillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55096-55210-chaillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55096-55210-chaillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55096-55210-chaillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55097-55140-chalaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55097-55140-chalaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55097-55140-chalaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55097-55140-chalaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55099-55100-champneuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55099-55100-champneuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55099-55100-champneuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55099-55100-champneuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55100-55140-champougny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55100-55140-champougny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55100-55140-champougny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55100-55140-champougny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55101-55000-chardogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55101-55000-chardogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55101-55000-chardogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55101-55000-chardogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55102-55100-charny_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55102-55100-charny_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55102-55100-charny_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55102-55100-charny_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55103-55270-charpentry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55103-55270-charpentry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55103-55270-charpentry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55103-55270-charpentry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55104-55130-chassey_beaupre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55104-55130-chassey_beaupre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55104-55130-chassey_beaupre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55104-55130-chassey_beaupre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55105-55400-chatillon_sous_les_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55105-55400-chatillon_sous_les_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55105-55400-chatillon_sous_les_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55105-55400-chatillon_sous_les_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55106-55100-chattancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55106-55100-chattancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55106-55100-chattancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55106-55100-chattancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55107-55150-chaumont_devant_damvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55107-55150-chaumont_devant_damvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55107-55150-chaumont_devant_damvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55107-55150-chaumont_devant_damvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55108-55260-chaumont_sur_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55108-55260-chaumont_sur_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55108-55260-chaumont_sur_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55108-55260-chaumont_sur_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55109-55600-chauvency_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55109-55600-chauvency_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55109-55600-chauvency_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55109-55600-chauvency_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55110-55600-chauvency_saint_hubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55110-55600-chauvency_saint_hubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55110-55600-chauvency_saint_hubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55110-55600-chauvency_saint_hubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55111-55300-chauvoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55111-55300-chauvoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55111-55300-chauvoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55111-55300-chauvoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55113-55270-cheppy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55113-55270-cheppy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55113-55270-cheppy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55113-55270-cheppy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55114-55200-chonville_malaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55114-55200-chonville_malaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55114-55200-chonville_malaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55114-55200-chonville_malaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55115-55270-cierges_sous_montfaucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55115-55270-cierges_sous_montfaucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55115-55270-cierges_sous_montfaucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55115-55270-cierges_sous_montfaucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55116-55120-le_claon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55116-55120-le_claon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55116-55120-le_claon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55116-55120-le_claon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55117-55120-clermont_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55117-55120-clermont_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55117-55120-clermont_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55117-55120-clermont_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55118-55110-clery_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55118-55110-clery_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55118-55110-clery_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55118-55110-clery_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55119-55110-clery_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55119-55110-clery_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55119-55110-clery_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55119-55110-clery_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55120-55000-combles_en_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55120-55000-combles_en_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55120-55000-combles_en_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55120-55000-combles_en_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55121-55160-combres_sous_les_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55121-55160-combres_sous_les_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55121-55160-combres_sous_les_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55121-55160-combres_sous_les_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55122-55200-commercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55122-55200-commercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55122-55200-commercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55122-55200-commercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55123-55000-les_hauts_de_chee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55123-55000-les_hauts_de_chee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55123-55000-les_hauts_de_chee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55123-55000-les_hauts_de_chee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55124-55110-consenvoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55124-55110-consenvoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55124-55110-consenvoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55124-55110-consenvoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55125-55800-contrisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55125-55800-contrisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55125-55800-contrisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55125-55800-contrisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55127-55260-courcelles_en_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55127-55260-courcelles_en_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55127-55260-courcelles_en_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55127-55260-courcelles_en_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55128-55260-courcelles_sur_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55128-55260-courcelles_sur_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55128-55260-courcelles_sur_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55128-55260-courcelles_sur_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55129-55260-courouvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55129-55260-courouvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55129-55260-courouvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55129-55260-courouvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55132-55170-cousances_les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55132-55170-cousances_les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55132-55170-cousances_les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55132-55170-cousances_les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55133-55290-couvertpuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55133-55290-couvertpuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55133-55290-couvertpuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55133-55290-couvertpuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55134-55800-couvonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55134-55800-couvonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55134-55800-couvonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55134-55800-couvonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55137-55270-cuisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55137-55270-cuisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55137-55270-cuisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55137-55270-cuisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55138-55000-culey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55138-55000-culey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55138-55000-culey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55138-55000-culey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55139-55100-cumieres_le_mort_homme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55139-55100-cumieres_le_mort_homme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55139-55100-cumieres_le_mort_homme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55139-55100-cumieres_le_mort_homme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55140-55110-cunel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55140-55110-cunel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55140-55110-cunel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55140-55110-cunel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55141-55500-dagonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55141-55500-dagonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55141-55500-dagonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55141-55500-dagonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55142-55130-dainville_bertheleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55142-55130-dainville_bertheleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55142-55130-dainville_bertheleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55142-55130-dainville_bertheleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55143-55400-damloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55143-55400-damloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55143-55400-damloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55143-55400-damloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55144-55500-dammarie_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55144-55500-dammarie_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55144-55500-dammarie_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55144-55500-dammarie_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55145-55150-damvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55145-55150-damvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55145-55150-damvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55145-55150-damvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55146-55110-dannevoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55146-55110-dannevoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55146-55110-dannevoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55146-55110-dannevoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55148-55130-delouze_rosieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55148-55130-delouze_rosieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55148-55130-delouze_rosieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55148-55130-delouze_rosieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55149-55150-delut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55149-55150-delut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55149-55150-delut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55149-55150-delut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55150-55130-demange_baudignecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55150-55130-demange_baudignecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55150-55130-demange_baudignecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55150-55130-demange_baudignecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55153-55400-dieppe_sous_douaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55153-55400-dieppe_sous_douaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55153-55400-dieppe_sous_douaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55153-55400-dieppe_sous_douaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55154-55320-dieue_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55154-55320-dieue_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55154-55320-dieue_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55154-55320-dieue_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55155-55120-dombasle_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55155-55120-dombasle_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55155-55120-dombasle_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55155-55120-dombasle_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55156-55150-dombras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55156-55150-dombras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55156-55150-dombras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55156-55150-dombras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55157-55160-dommartin_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55157-55160-dommartin_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55157-55160-dommartin_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55157-55160-dommartin_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55158-55240-dommary_baroncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55158-55240-dommary_baroncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55158-55240-dommary_baroncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55158-55240-dommary_baroncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55159-55300-dompcevrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55159-55300-dompcevrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55159-55300-dompcevrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55159-55300-dompcevrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55160-55300-dompierre_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55160-55300-dompierre_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55160-55300-dompierre_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55160-55300-dompierre_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55162-55240-domremy_la_canne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55162-55240-domremy_la_canne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55162-55240-domremy_la_canne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55162-55240-domremy_la_canne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55163-55160-doncourt_aux_templiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55163-55160-doncourt_aux_templiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55163-55160-doncourt_aux_templiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55163-55160-doncourt_aux_templiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55165-55110-doulcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55165-55110-doulcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55165-55110-doulcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55165-55110-doulcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55166-55100-dugny_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55166-55100-dugny_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55166-55100-dugny_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55166-55100-dugny_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55167-55110-dun_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55167-55110-dun_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55167-55110-dun_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55167-55110-dun_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55168-55230-duzey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55168-55230-duzey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55168-55230-duzey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55168-55230-duzey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55169-55600-ecouviez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55169-55600-ecouviez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55169-55600-ecouviez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55169-55600-ecouviez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55170-55150-ecurey_en_verdunois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55170-55150-ecurey_en_verdunois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55170-55150-ecurey_en_verdunois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55170-55150-ecurey_en_verdunois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55171-55400-eix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55171-55400-eix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55171-55400-eix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55171-55400-eix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55172-55160-les_eparges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55172-55160-les_eparges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55172-55160-les_eparges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55172-55160-les_eparges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55173-55140-epiez_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55173-55140-epiez_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55173-55140-epiez_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55173-55140-epiez_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55174-55270-epinonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55174-55270-epinonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55174-55270-epinonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55174-55270-epinonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55175-55260-erize_la_brulee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55175-55260-erize_la_brulee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55175-55260-erize_la_brulee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55175-55260-erize_la_brulee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55177-55260-erize_la_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55177-55260-erize_la_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55177-55260-erize_la_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55177-55260-erize_la_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55178-55000-erize_saint_dizier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55178-55000-erize_saint_dizier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55178-55000-erize_saint_dizier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55178-55000-erize_saint_dizier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55179-55500-erneville_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55179-55500-erneville_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55179-55500-erneville_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55179-55500-erneville_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55180-55100-esnes_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55180-55100-esnes_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55180-55100-esnes_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55180-55100-esnes_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55181-55400-etain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55181-55400-etain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55181-55400-etain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55181-55400-etain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55182-55240-eton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55182-55240-eton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55182-55240-eton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55182-55240-eton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55183-55150-etraye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55183-55150-etraye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55183-55150-etraye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55183-55150-etraye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55184-55200-euville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55184-55200-euville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55184-55200-euville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55184-55200-euville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55185-55250-evres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55185-55250-evres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55185-55250-evres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55185-55250-evres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55186-55000-fains_veel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55186-55000-fains_veel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55186-55000-fains_veel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55186-55000-fains_veel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55188-55600-flassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55188-55600-flassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55188-55600-flassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55188-55600-flassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55189-55100-fleury_devant_douaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55189-55100-fleury_devant_douaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55189-55100-fleury_devant_douaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55189-55100-fleury_devant_douaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55191-55400-foameix_ornel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55191-55400-foameix_ornel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55191-55400-foameix_ornel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55191-55400-foameix_ornel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55192-55110-fontaines_saint_clair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55192-55110-fontaines_saint_clair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55192-55110-fontaines_saint_clair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55192-55110-fontaines_saint_clair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55193-55110-forges_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55193-55110-forges_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55193-55110-forges_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55193-55110-forges_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55194-55250-foucaucourt_sur_thabas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55194-55250-foucaucourt_sur_thabas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55194-55250-foucaucourt_sur_thabas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55194-55250-foucaucourt_sur_thabas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55195-55500-foucheres_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55195-55500-foucheres_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55195-55500-foucheres_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55195-55500-foucheres_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55196-55200-fremereville_sous_les_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55196-55200-fremereville_sous_les_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55196-55200-fremereville_sous_les_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55196-55200-fremereville_sous_les_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55197-55260-fresnes_au_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55197-55260-fresnes_au_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55197-55260-fresnes_au_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55197-55260-fresnes_au_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55198-55160-fresnes_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55198-55160-fresnes_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55198-55160-fresnes_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55198-55160-fresnes_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55199-55120-froidos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55199-55120-froidos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55199-55120-froidos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55199-55120-froidos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55200-55100-fromereville_les_vallons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55200-55100-fromereville_les_vallons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55200-55100-fromereville_les_vallons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55200-55100-fromereville_les_vallons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55201-55400-fromezey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55201-55400-fromezey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55201-55400-fromezey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55201-55400-fromezey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55202-55120-futeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55202-55120-futeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55202-55120-futeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55202-55120-futeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55204-55320-genicourt_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55204-55320-genicourt_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55204-55320-genicourt_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55204-55320-genicourt_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55206-55110-gercourt_et_drillancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55206-55110-gercourt_et_drillancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55206-55110-gercourt_et_drillancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55206-55110-gercourt_et_drillancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55207-55000-gery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55207-55000-gery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55207-55000-gery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55207-55000-gery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55208-55110-gesnes_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55208-55110-gesnes_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55208-55110-gesnes_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55208-55110-gesnes_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55210-55260-gimecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55210-55260-gimecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55210-55260-gimecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55210-55260-gimecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55211-55400-gincrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55211-55400-gincrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55211-55400-gincrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55211-55400-gincrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55212-55200-girauvoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55212-55200-girauvoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55212-55200-girauvoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55212-55200-girauvoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55214-55500-givrauval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55214-55500-givrauval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55214-55500-givrauval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55214-55500-givrauval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55215-55130-gondrecourt_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55215-55130-gondrecourt_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55215-55130-gondrecourt_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55215-55130-gondrecourt_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55216-55230-gouraincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55216-55230-gouraincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55216-55230-gouraincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55216-55230-gouraincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55217-55140-goussaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55217-55140-goussaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55217-55140-goussaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55217-55140-goussaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55218-55150-gremilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55218-55150-gremilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55218-55150-gremilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55218-55150-gremilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55219-55400-grimaucourt_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55219-55400-grimaucourt_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55219-55400-grimaucourt_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55219-55400-grimaucourt_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55220-55500-grimaucourt_pres_sampigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55220-55500-grimaucourt_pres_sampigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55220-55500-grimaucourt_pres_sampigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55220-55500-grimaucourt_pres_sampigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55221-55000-guerpont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55221-55000-guerpont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55221-55000-guerpont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55221-55000-guerpont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55222-55400-gussainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55222-55400-gussainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55222-55400-gussainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55222-55400-gussainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55224-55000-haironville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55224-55000-haironville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55224-55000-haironville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55224-55000-haironville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55225-55700-halles_sous_les_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55225-55700-halles_sous_les_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55225-55700-halles_sous_les_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55225-55700-halles_sous_les_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55226-55600-han_les_juvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55226-55600-han_les_juvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55226-55600-han_les_juvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55226-55600-han_les_juvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55228-55210-hannonville_sous_les_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55228-55210-hannonville_sous_les_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55228-55210-hannonville_sous_les_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55228-55210-hannonville_sous_les_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55229-55300-han_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55229-55300-han_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55229-55300-han_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55229-55300-han_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55232-55160-harville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55232-55160-harville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55232-55160-harville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55232-55160-harville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55236-55100-haudainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55236-55100-haudainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55236-55100-haudainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55236-55100-haudainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55237-55160-haudiomont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55237-55160-haudiomont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55237-55160-haudiomont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55237-55160-haudiomont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55239-55100-haumont_pres_samogneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55239-55100-haumont_pres_samogneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55239-55100-haumont_pres_samogneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55239-55100-haumont_pres_samogneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55241-55220-heippes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55241-55220-heippes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55241-55220-heippes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55241-55220-heippes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55242-55160-hennemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55242-55160-hennemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55242-55160-hennemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55242-55160-hennemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55243-55210-herbeuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55243-55210-herbeuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55243-55210-herbeuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55243-55210-herbeuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55244-55400-hermeville_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55244-55400-hermeville_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55244-55400-hermeville_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55244-55400-hermeville_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55245-55210-heudicourt_sous_les_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55245-55210-heudicourt_sous_les_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55245-55210-heudicourt_sous_les_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55245-55210-heudicourt_sous_les_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55246-55290-hevilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55246-55290-hevilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55246-55290-hevilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55246-55290-hevilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55247-55130-horville_en_ornois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55247-55130-horville_en_ornois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55247-55130-horville_en_ornois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55247-55130-horville_en_ornois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55248-55130-houdelaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55248-55130-houdelaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55248-55130-houdelaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55248-55130-houdelaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55250-55700-inor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55250-55700-inor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55250-55700-inor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55250-55700-inor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55251-55220-ippecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55251-55220-ippecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55251-55220-ippecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55251-55220-ippecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55252-55600-ire_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55252-55600-ire_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55252-55600-ire_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55252-55600-ire_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55253-55120-les_islettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55253-55120-les_islettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55253-55120-les_islettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55253-55120-les_islettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55254-55220-les_trois_domaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55254-55220-les_trois_domaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55254-55220-les_trois_domaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55254-55220-les_trois_domaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55255-55600-jametz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55255-55600-jametz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55255-55600-jametz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55255-55600-jametz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55256-55160-jonville_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55256-55160-jonville_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55256-55160-jonville_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55256-55160-jonville_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55257-55120-jouy_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55257-55120-jouy_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55257-55120-jouy_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55257-55120-jouy_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55258-55200-geville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55258-55200-geville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55258-55200-geville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55258-55200-geville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55260-55120-julvecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55260-55120-julvecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55260-55120-julvecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55260-55120-julvecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55261-55170-juvigny_en_perthois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55261-55170-juvigny_en_perthois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55261-55170-juvigny_en_perthois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55261-55170-juvigny_en_perthois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55262-55600-juvigny_sur_loison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55262-55600-juvigny_sur_loison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55262-55600-juvigny_sur_loison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55262-55600-juvigny_sur_loison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55263-55300-koeur_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55263-55300-koeur_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55263-55300-koeur_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55263-55300-koeur_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55264-55300-koeur_la_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55264-55300-koeur_la_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55264-55300-koeur_la_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55264-55300-koeur_la_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55265-55160-labeuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55265-55160-labeuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55265-55160-labeuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55265-55160-labeuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55266-55120-lachalade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55266-55120-lachalade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55266-55120-lachalade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55266-55120-lachalade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55267-55210-lachaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55267-55210-lachaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55267-55210-lachaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55267-55210-lachaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55268-55300-lacroix_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55268-55300-lacroix_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55268-55300-lacroix_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55268-55300-lacroix_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55269-55260-lahaymeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55269-55260-lahaymeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55269-55260-lahaymeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55269-55260-lahaymeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55270-55300-lahayville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55270-55300-lahayville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55270-55300-lahayville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55270-55300-lahayville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55271-55800-laheycourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55271-55800-laheycourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55271-55800-laheycourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55271-55800-laheycourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55272-55800-laimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55272-55800-laimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55272-55800-laimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55272-55800-laimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55274-55300-lamorville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55274-55300-lamorville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55274-55300-lamorville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55274-55300-lamorville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55275-55700-lamouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55275-55700-lamouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55275-55700-lamouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55275-55700-lamouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55276-55100-landrecourt_lempire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55276-55100-landrecourt_lempire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55276-55100-landrecourt_lempire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55276-55100-landrecourt_lempire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55278-55190-laneuville_au_rupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55278-55190-laneuville_au_rupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55278-55190-laneuville_au_rupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55278-55190-laneuville_au_rupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55279-55700-laneuville_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55279-55700-laneuville_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55279-55700-laneuville_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55279-55700-laneuville_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55280-55400-lanheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55280-55400-lanheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55280-55400-lanheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55280-55400-lanheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55281-55160-latour_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55281-55160-latour_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55281-55160-latour_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55281-55160-latour_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55282-55260-lavallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55282-55260-lavallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55282-55260-lavallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55282-55260-lavallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55284-55170-lavincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55284-55170-lavincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55284-55170-lavincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55284-55170-lavincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55285-55120-lavoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55285-55120-lavoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55285-55120-lavoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55285-55120-lavoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55286-55220-lemmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55286-55220-lemmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55286-55220-lemmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55286-55220-lemmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55288-55200-lerouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55288-55200-lerouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55288-55200-lerouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55288-55200-lerouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55289-55260-levoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55289-55260-levoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55289-55260-levoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55289-55260-levoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55290-55260-lignieres_sur_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55290-55260-lignieres_sur_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55290-55260-lignieres_sur_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55290-55260-lignieres_sur_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55291-55500-ligny_en_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55291-55500-ligny_en_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55291-55500-ligny_en_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55291-55500-ligny_en_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55292-55110-liny_devant_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55292-55110-liny_devant_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55292-55110-liny_devant_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55292-55110-liny_devant_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55293-55110-lion_devant_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55293-55110-lion_devant_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55293-55110-lion_devant_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55293-55110-lion_devant_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55295-55250-lisle_en_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55295-55250-lisle_en_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55295-55250-lisle_en_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55295-55250-lisle_en_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55296-55000-l_isle_en_rigault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55296-55000-l_isle_en_rigault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55296-55000-l_isle_en_rigault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55296-55000-l_isle_en_rigault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55297-55150-lissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55297-55150-lissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55297-55150-lissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55297-55150-lissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55298-55000-loisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55298-55000-loisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55298-55000-loisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55298-55000-loisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55299-55230-loison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55299-55230-loison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55299-55230-loison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55299-55230-loison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55300-55500-longeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55300-55500-longeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55300-55500-longeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55300-55500-longeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55301-55260-longchamps_sur_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55301-55260-longchamps_sur_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55301-55260-longchamps_sur_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55301-55260-longchamps_sur_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55302-55000-longeville_en_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55302-55000-longeville_en_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55302-55000-longeville_en_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55302-55000-longeville_en_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55303-55300-loupmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55303-55300-loupmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55303-55300-loupmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55303-55300-loupmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55304-55800-louppy_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55304-55800-louppy_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55304-55800-louppy_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55304-55800-louppy_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55306-55600-louppy_sur_loison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55306-55600-louppy_sur_loison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55306-55600-louppy_sur_loison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55306-55600-louppy_sur_loison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55307-55100-louvemont_cote_du_poivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55307-55100-louvemont_cote_du_poivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55307-55100-louvemont_cote_du_poivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55307-55100-louvemont_cote_du_poivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55310-55700-luzy_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55310-55700-luzy_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55310-55700-luzy_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55310-55700-luzy_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55311-55160-maizeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55311-55160-maizeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55311-55160-maizeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55311-55160-maizeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55312-55300-maizey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55312-55300-maizey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55312-55300-maizey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55312-55300-maizey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55313-55270-malancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55313-55270-malancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55313-55270-malancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55313-55270-malancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55315-55290-mandres_en_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55315-55290-mandres_en_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55315-55290-mandres_en_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55315-55290-mandres_en_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55316-55150-mangiennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55316-55150-mangiennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55316-55150-mangiennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55316-55150-mangiennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55317-55160-manheulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55317-55160-manheulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55317-55160-manheulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55317-55160-manheulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55320-55160-marcheville_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55320-55160-marcheville_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55320-55160-marcheville_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55320-55160-marcheville_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55321-55100-marre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55321-55100-marre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55321-55100-marre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55321-55100-marre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55322-55190-marson_sur_barboure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55322-55190-marson_sur_barboure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55322-55190-marson_sur_barboure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55322-55190-marson_sur_barboure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55323-55700-martincourt_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55323-55700-martincourt_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55323-55700-martincourt_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55323-55700-martincourt_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55324-55600-marville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55324-55600-marville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55324-55600-marville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55324-55600-marville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55325-55400-maucourt_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55325-55400-maucourt_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55325-55400-maucourt_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55325-55400-maucourt_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55326-55500-maulan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55326-55500-maulan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55326-55500-maulan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55326-55500-maulan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55327-55190-mauvages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55327-55190-mauvages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55327-55190-mauvages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55327-55190-mauvages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55328-55140-maxey_sur_vaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55328-55140-maxey_sur_vaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55328-55140-maxey_sur_vaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55328-55140-maxey_sur_vaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55329-55300-mecrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55329-55300-mecrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55329-55300-mecrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55329-55300-mecrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55330-55190-meligny_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55330-55190-meligny_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55330-55190-meligny_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55330-55190-meligny_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55331-55190-meligny_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55331-55190-meligny_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55331-55190-meligny_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55331-55190-meligny_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55332-55500-menaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55332-55500-menaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55332-55500-menaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55332-55500-menaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55333-55260-menil_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55333-55260-menil_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55333-55260-menil_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55333-55260-menil_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55334-55190-menil_la_horgne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55334-55190-menil_la_horgne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55334-55190-menil_la_horgne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55334-55190-menil_la_horgne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55335-55500-menil_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55335-55500-menil_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55335-55500-menil_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55335-55500-menil_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55336-55150-merles_sur_loison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55336-55150-merles_sur_loison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55336-55150-merles_sur_loison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55336-55150-merles_sur_loison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55338-55110-milly_sur_bradon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55338-55110-milly_sur_bradon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55338-55110-milly_sur_bradon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55338-55110-milly_sur_bradon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55339-55400-mogeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55339-55400-mogeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55339-55400-mogeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55339-55400-mogeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55340-55800-mogneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55340-55800-mogneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55340-55800-mogneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55340-55800-mogneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55341-55150-moirey_flabas_crepion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55341-55150-moirey_flabas_crepion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55341-55150-moirey_flabas_crepion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55341-55150-moirey_flabas_crepion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55343-55270-montblainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55343-55270-montblainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55343-55270-montblainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55343-55270-montblainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55344-55140-montbras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55344-55140-montbras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55344-55140-montbras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55344-55140-montbras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55345-55110-mont_devant_sassey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55345-55110-mont_devant_sassey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55345-55110-mont_devant_sassey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55345-55110-mont_devant_sassey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55346-55270-montfaucon_d_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55346-55270-montfaucon_d_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55346-55270-montfaucon_d_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55346-55270-montfaucon_d_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55347-55320-les_monthairons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55347-55320-les_monthairons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55347-55320-les_monthairons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55347-55320-les_monthairons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55348-55290-montiers_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55348-55290-montiers_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55348-55290-montiers_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55348-55290-montiers_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55349-55110-montigny_devant_sassey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55349-55110-montigny_devant_sassey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55349-55110-montigny_devant_sassey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55349-55110-montigny_devant_sassey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55350-55140-montigny_les_vaucouleurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55350-55140-montigny_les_vaucouleurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55350-55140-montigny_les_vaucouleurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55350-55140-montigny_les_vaucouleurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55351-55600-montmedy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55351-55600-montmedy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55351-55600-montmedy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55351-55600-montmedy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55352-55000-montplonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55352-55000-montplonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55352-55000-montplonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55352-55000-montplonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55353-55300-montsec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55353-55300-montsec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55353-55300-montsec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55353-55300-montsec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55355-55100-montzeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55355-55100-montzeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55355-55100-montzeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55355-55100-montzeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55356-55400-moranville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55356-55400-moranville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55356-55400-moranville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55356-55400-moranville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55357-55400-morgemoulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55357-55400-morgemoulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55357-55400-morgemoulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55357-55400-morgemoulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55358-55500-chanteraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55358-55500-chanteraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55358-55500-chanteraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55358-55500-chanteraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55359-55290-morley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55359-55290-morley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55359-55290-morley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55359-55290-morley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55360-55320-mouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55360-55320-mouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55360-55320-mouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55360-55320-mouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55361-55400-moulainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55361-55400-moulainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55361-55400-moulainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55361-55400-moulainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55362-55700-moulins_saint_hubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55362-55700-moulins_saint_hubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55362-55700-moulins_saint_hubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55362-55700-moulins_saint_hubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55363-55160-moulotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55363-55160-moulotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55363-55160-moulotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55363-55160-moulotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55364-55700-mouzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55364-55700-mouzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55364-55700-mouzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55364-55700-mouzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55365-55110-murvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55365-55110-murvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55365-55110-murvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55365-55110-murvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55366-55000-val_d_ornain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55366-55000-val_d_ornain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55366-55000-val_d_ornain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55366-55000-val_d_ornain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55367-55230-muzeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55367-55230-muzeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55367-55230-muzeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55367-55230-muzeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55368-55190-naives_en_blois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55368-55190-naives_en_blois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55368-55190-naives_en_blois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55368-55190-naives_en_blois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55369-55000-naives_rosieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55369-55000-naives_rosieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55369-55000-naives_rosieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55369-55000-naives_rosieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55370-55500-naix_aux_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55370-55500-naix_aux_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55370-55500-naix_aux_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55370-55500-naix_aux_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55371-55500-nancois_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55371-55500-nancois_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55371-55500-nancois_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55371-55500-nancois_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55372-55500-nancois_sur_ornain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55372-55500-nancois_sur_ornain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55372-55500-nancois_sur_ornain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55372-55500-nancois_sur_ornain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55373-55500-nant_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55373-55500-nant_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55373-55500-nant_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55373-55500-nant_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55374-55500-nant_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55374-55500-nant_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55374-55500-nant_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55374-55500-nant_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55375-55270-nantillois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55375-55270-nantillois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55375-55270-nantillois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55375-55270-nantillois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55376-55500-nantois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55376-55500-nantois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55376-55500-nantois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55376-55500-nantois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55377-55700-nepvant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55377-55700-nepvant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55377-55700-nepvant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55377-55700-nepvant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55378-55800-nettancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55378-55800-nettancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55378-55800-nettancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55378-55800-nettancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55379-55120-le_neufour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55379-55120-le_neufour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55379-55120-le_neufour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55379-55120-le_neufour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55380-55260-neuville_en_verdunois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55380-55260-neuville_en_verdunois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55380-55260-neuville_en_verdunois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55380-55260-neuville_en_verdunois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55381-55140-neuville_les_vaucouleurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55381-55140-neuville_les_vaucouleurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55381-55140-neuville_les_vaucouleurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55381-55140-neuville_les_vaucouleurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55382-55800-neuville_sur_ornain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55382-55800-neuville_sur_ornain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55382-55800-neuville_sur_ornain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55382-55800-neuville_sur_ornain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55383-55120-neuvilly_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55383-55120-neuvilly_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55383-55120-neuvilly_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55383-55120-neuvilly_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55384-55260-nicey_sur_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55384-55260-nicey_sur_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55384-55260-nicey_sur_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55384-55260-nicey_sur_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55385-55120-nixeville_blercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55385-55120-nixeville_blercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55385-55120-nixeville_blercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55385-55120-nixeville_blercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55386-55210-nonsard_lamarche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55386-55210-nonsard_lamarche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55386-55210-nonsard_lamarche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55386-55210-nonsard_lamarche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55387-55230-nouillonpont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55387-55230-nouillonpont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55387-55230-nouillonpont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55387-55230-nouillonpont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55388-55800-noyers_auzecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55388-55800-noyers_auzecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55388-55800-noyers_auzecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55388-55800-noyers_auzecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55389-55250-nubecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55389-55250-nubecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55389-55250-nubecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55389-55250-nubecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55391-55700-olizy_sur_chiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55391-55700-olizy_sur_chiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55391-55700-olizy_sur_chiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55391-55700-olizy_sur_chiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55394-55150-ornes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55394-55150-ornes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55394-55150-ornes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55394-55150-ornes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55395-55220-osches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55395-55220-osches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55395-55220-osches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55395-55220-osches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55396-55190-ourches_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55396-55190-ourches_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55396-55190-ourches_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55396-55190-ourches_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55397-55140-pagny_la_blanche_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55397-55140-pagny_la_blanche_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55397-55140-pagny_la_blanche_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55397-55140-pagny_la_blanche_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55398-55190-pagny_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55398-55190-pagny_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55398-55190-pagny_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55398-55190-pagny_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55399-55160-pareid/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55399-55160-pareid/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55399-55160-pareid/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55399-55160-pareid/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55400-55400-parfondrupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55400-55400-parfondrupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55400-55400-parfondrupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55400-55400-parfondrupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55401-55300-les_paroches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55401-55300-les_paroches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55401-55300-les_paroches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55401-55300-les_paroches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55403-55150-peuvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55403-55150-peuvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55403-55150-peuvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55403-55150-peuvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55404-55260-pierrefitte_sur_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55404-55260-pierrefitte_sur_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55404-55260-pierrefitte_sur_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55404-55260-pierrefitte_sur_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55405-55230-pillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55405-55230-pillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55405-55230-pillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55405-55230-pillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55406-55160-pintheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55406-55160-pintheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55406-55160-pintheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55406-55160-pintheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55407-55200-pont_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55407-55200-pont_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55407-55200-pont_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55407-55200-pont_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55408-55700-pouilly_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55408-55700-pouilly_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55408-55700-pouilly_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55408-55700-pouilly_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55409-55250-pretz_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55409-55250-pretz_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55409-55250-pretz_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55409-55250-pretz_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55410-55600-quincy_landzecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55410-55600-quincy_landzecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55410-55600-quincy_landzecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55410-55600-quincy_landzecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55411-55220-rambluzin_et_benoite_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55411-55220-rambluzin_et_benoite_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55411-55220-rambluzin_et_benoite_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55411-55220-rambluzin_et_benoite_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55412-55300-rambucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55412-55300-rambucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55412-55300-rambucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55412-55300-rambucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55414-55800-rancourt_sur_ornain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55414-55800-rancourt_sur_ornain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55414-55800-rancourt_sur_ornain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55414-55800-rancourt_sur_ornain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55415-55300-ranzieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55415-55300-ranzieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55415-55300-ranzieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55415-55300-ranzieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55416-55120-rarecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55416-55120-rarecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55416-55120-rarecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55416-55120-rarecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55419-55120-recicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55419-55120-recicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55419-55120-recicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55419-55120-recicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55420-55220-recourt_le_creux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55420-55220-recourt_le_creux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55420-55220-recourt_le_creux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55420-55220-recourt_le_creux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55421-55190-reffroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55421-55190-reffroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55421-55190-reffroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55421-55190-reffroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55422-55110-regneville_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55422-55110-regneville_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55422-55110-regneville_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55422-55110-regneville_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55423-55250-rembercourt_sommaisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55423-55250-rembercourt_sommaisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55423-55250-rembercourt_sommaisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55423-55250-rembercourt_sommaisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55424-55800-remennecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55424-55800-remennecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55424-55800-remennecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55424-55800-remennecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55425-55600-remoiville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55425-55600-remoiville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55425-55600-remoiville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55425-55600-remoiville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55426-55000-resson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55426-55000-resson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55426-55000-resson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55426-55000-resson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55427-55800-revigny_sur_ornain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55427-55800-revigny_sur_ornain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55427-55800-revigny_sur_ornain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55427-55800-revigny_sur_ornain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55428-55150-reville_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55428-55150-reville_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55428-55150-reville_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55428-55150-reville_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55429-55160-riaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55429-55160-riaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55429-55160-riaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55429-55160-riaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55430-55290-ribeaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55430-55290-ribeaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55430-55290-ribeaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55430-55290-ribeaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55431-55300-richecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55431-55300-richecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55431-55300-richecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55431-55300-richecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55433-55140-rigny_la_salle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55433-55140-rigny_la_salle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55433-55140-rigny_la_salle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55433-55140-rigny_la_salle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55434-55140-rigny_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55434-55140-rigny_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55434-55140-rigny_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55434-55140-rigny_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55435-55000-robert_espagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55435-55000-robert_espagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55435-55000-robert_espagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55435-55000-robert_espagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55436-55130-les_roises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55436-55130-les_roises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55436-55130-les_roises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55436-55130-les_roises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55437-55150-romagne_sous_les_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55437-55150-romagne_sous_les_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55437-55150-romagne_sous_les_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55437-55150-romagne_sous_les_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55438-55110-romagne_sous_montfaucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55438-55110-romagne_sous_montfaucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55438-55110-romagne_sous_montfaucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55438-55110-romagne_sous_montfaucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55439-55160-ronvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55439-55160-ronvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55439-55160-ronvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55439-55160-ronvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55442-55260-raival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55442-55260-raival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55442-55260-raival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55442-55260-raival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55443-55400-rouvres_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55443-55400-rouvres_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55443-55400-rouvres_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55443-55400-rouvres_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55444-55300-rouvrois_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55444-55300-rouvrois_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55444-55300-rouvrois_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55444-55300-rouvrois_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55445-55230-rouvrois_sur_othain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55445-55230-rouvrois_sur_othain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55445-55230-rouvrois_sur_othain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55445-55230-rouvrois_sur_othain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55446-55000-rumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55446-55000-rumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55446-55000-rumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55446-55000-rumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55447-55170-rupt_aux_nonains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55447-55170-rupt_aux_nonains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55447-55170-rupt_aux_nonains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55447-55170-rupt_aux_nonains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55448-55260-rupt_devant_saint_mihiel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55448-55260-rupt_devant_saint_mihiel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55448-55260-rupt_devant_saint_mihiel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55448-55260-rupt_devant_saint_mihiel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55449-55320-rupt_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55449-55320-rupt_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55449-55320-rupt_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55449-55320-rupt_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55450-55150-rupt_sur_othain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55450-55150-rupt_sur_othain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55450-55150-rupt_sur_othain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55450-55150-rupt_sur_othain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55452-55500-saint_amand_sur_ornain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55452-55500-saint_amand_sur_ornain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55452-55500-saint_amand_sur_ornain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55452-55500-saint_amand_sur_ornain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55453-55220-saint_andre_en_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55453-55220-saint_andre_en_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55453-55220-saint_andre_en_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55453-55220-saint_andre_en_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55454-55500-saint_aubin_sur_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55454-55500-saint_aubin_sur_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55454-55500-saint_aubin_sur_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55454-55500-saint_aubin_sur_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55456-55140-saint_germain_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55456-55140-saint_germain_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55456-55140-saint_germain_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55456-55140-saint_germain_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55457-55160-saint_hilaire_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55457-55160-saint_hilaire_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55457-55160-saint_hilaire_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55457-55160-saint_hilaire_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55458-55400-saint_jean_les_buzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55458-55400-saint_jean_les_buzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55458-55400-saint_jean_les_buzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55458-55400-saint_jean_les_buzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55459-55130-saint_joire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55459-55130-saint_joire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55459-55130-saint_joire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55459-55130-saint_joire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55460-55200-saint_julien_sous_les_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55460-55200-saint_julien_sous_les_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55460-55200-saint_julien_sous_les_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55460-55200-saint_julien_sous_les_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55461-55150-saint_laurent_sur_othain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55461-55150-saint_laurent_sur_othain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55461-55150-saint_laurent_sur_othain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55461-55150-saint_laurent_sur_othain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55462-55210-saint_maurice_sous_les_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55462-55210-saint_maurice_sous_les_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55462-55210-saint_maurice_sous_les_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55462-55210-saint_maurice_sous_les_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55463-55300-saint_mihiel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55463-55300-saint_mihiel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55463-55300-saint_mihiel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55463-55300-saint_mihiel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55464-55230-saint_pierrevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55464-55230-saint_pierrevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55464-55230-saint_pierrevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55464-55230-saint_pierrevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55465-55160-saint_remy_la_calonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55465-55160-saint_remy_la_calonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55465-55160-saint_remy_la_calonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55465-55160-saint_remy_la_calonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55466-55000-salmagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55466-55000-salmagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55466-55000-salmagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55466-55000-salmagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55467-55300-sampigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55467-55300-sampigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55467-55300-sampigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55467-55300-sampigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55468-55100-samogneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55468-55100-samogneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55468-55100-samogneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55468-55100-samogneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55469-55110-sassey_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55469-55110-sassey_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55469-55110-sassey_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55469-55110-sassey_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55470-55000-saudrupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55470-55000-saudrupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55470-55000-saudrupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55470-55000-saudrupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55471-55110-saulmory_villefranche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55471-55110-saulmory_villefranche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55471-55110-saulmory_villefranche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55471-55110-saulmory_villefranche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55472-55500-saulvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55472-55500-saulvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55472-55500-saulvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55472-55500-saulvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55473-55160-saulx_les_champlon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55473-55160-saulx_les_champlon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55473-55160-saulx_les_champlon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55473-55160-saulx_les_champlon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55474-55140-sauvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55474-55140-sauvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55474-55140-sauvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55474-55140-sauvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55475-55190-sauvoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55475-55190-sauvoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55475-55190-sauvoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55475-55190-sauvoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55476-55000-savonnieres_devant_bar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55476-55000-savonnieres_devant_bar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55476-55000-savonnieres_devant_bar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55476-55000-savonnieres_devant_bar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55477-55170-savonnieres_en_perthois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55477-55170-savonnieres_en_perthois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55477-55170-savonnieres_en_perthois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55477-55170-savonnieres_en_perthois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55479-55000-seigneulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55479-55000-seigneulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55479-55000-seigneulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55479-55000-seigneulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55481-55230-senon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55481-55230-senon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55481-55230-senon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55481-55230-senon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55482-55220-senoncourt_les_maujouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55482-55220-senoncourt_les_maujouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55482-55220-senoncourt_les_maujouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55482-55220-senoncourt_les_maujouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55484-55270-septsarges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55484-55270-septsarges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55484-55270-septsarges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55484-55270-septsarges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55485-55140-sepvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55485-55140-sepvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55485-55140-sepvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55485-55140-sepvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55487-55300-seuzey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55487-55300-seuzey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55487-55300-seuzey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55487-55300-seuzey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55488-55000-silmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55488-55000-silmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55488-55000-silmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55488-55000-silmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55489-55100-sivry_la_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55489-55100-sivry_la_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55489-55100-sivry_la_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55489-55100-sivry_la_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55490-55110-sivry_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55490-55110-sivry_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55490-55110-sivry_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55490-55110-sivry_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55492-55320-sommedieue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55492-55320-sommedieue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55492-55320-sommedieue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55492-55320-sommedieue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55493-55800-sommeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55493-55800-sommeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55493-55800-sommeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55493-55800-sommeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55494-55170-sommelonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55494-55170-sommelonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55494-55170-sommelonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55494-55170-sommelonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55495-55230-sorbey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55495-55230-sorbey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55495-55230-sorbey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55495-55230-sorbey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55496-55190-sorcy_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55496-55190-sorcy_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55496-55190-sorcy_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55496-55190-sorcy_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55497-55220-les_souhesmes_rampont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55497-55220-les_souhesmes_rampont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55497-55220-les_souhesmes_rampont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55497-55220-les_souhesmes_rampont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55498-55220-souilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55498-55220-souilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55498-55220-souilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55498-55220-souilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55500-55230-spincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55500-55230-spincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55500-55230-spincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55500-55230-spincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55501-55500-stainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55501-55500-stainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55501-55500-stainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55501-55500-stainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55502-55700-stenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55502-55700-stenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55502-55700-stenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55502-55700-stenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55503-55140-taillancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55503-55140-taillancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55503-55140-taillancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55503-55140-taillancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55504-55000-tannois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55504-55000-tannois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55504-55000-tannois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55504-55000-tannois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55505-55840-thierville_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55505-55840-thierville_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55505-55840-thierville_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55505-55840-thierville_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55506-55260-thillombois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55506-55260-thillombois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55506-55260-thillombois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55506-55260-thillombois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55507-55210-thillot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55507-55210-thillot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55507-55210-thillot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55507-55210-thillot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55508-55600-thonne_la_long/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55508-55600-thonne_la_long/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55508-55600-thonne_la_long/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55508-55600-thonne_la_long/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55509-55600-thonne_le_thil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55509-55600-thonne_le_thil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55509-55600-thonne_le_thil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55509-55600-thonne_le_thil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55510-55600-thonne_les_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55510-55600-thonne_les_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55510-55600-thonne_les_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55510-55600-thonne_les_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55511-55600-thonnelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55511-55600-thonnelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55511-55600-thonnelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55511-55600-thonnelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55512-55220-tilly_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55512-55220-tilly_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55512-55220-tilly_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55512-55220-tilly_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55514-55000-tremont_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55514-55000-tremont_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55514-55000-tremont_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55514-55000-tremont_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55515-55160-tresauvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55515-55160-tresauvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55515-55160-tresauvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55515-55160-tresauvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55516-55130-treveray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55516-55130-treveray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55516-55130-treveray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55516-55130-treveray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55517-55250-seuil_d_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55517-55250-seuil_d_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55517-55250-seuil_d_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55517-55250-seuil_d_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55518-55500-cousances_les_triconville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55518-55500-cousances_les_triconville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55518-55500-cousances_les_triconville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55518-55500-cousances_les_triconville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55519-55310-tronville_en_barrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55519-55310-tronville_en_barrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55519-55310-tronville_en_barrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55519-55310-tronville_en_barrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55520-55190-troussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55520-55190-troussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55520-55190-troussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55520-55190-troussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55521-55300-troyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55521-55300-troyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55521-55300-troyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55521-55300-troyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55522-55140-ugny_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55522-55140-ugny_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55522-55140-ugny_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55522-55140-ugny_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55523-55100-vacherauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55523-55100-vacherauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55523-55100-vacherauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55523-55100-vacherauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55525-55220-vadelaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55525-55220-vadelaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55525-55220-vadelaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55525-55220-vadelaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55526-55200-vadonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55526-55200-vadonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55526-55200-vadonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55526-55200-vadonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55527-55270-varennes_en_argonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55527-55270-varennes_en_argonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55527-55270-varennes_en_argonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55527-55270-varennes_en_argonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55528-55300-varneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55528-55300-varneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55528-55300-varneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55528-55300-varneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55530-55300-valbois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55530-55300-valbois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55530-55300-valbois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55530-55300-valbois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55531-55800-vassincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55531-55800-vassincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55531-55800-vassincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55531-55800-vassincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55532-55250-vaubecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55532-55250-vaubecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55532-55250-vaubecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55532-55250-vaubecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55533-55140-vaucouleurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55533-55140-vaucouleurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55533-55140-vaucouleurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55533-55140-vaucouleurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55534-55130-vaudeville_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55534-55130-vaudeville_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55534-55130-vaudeville_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55534-55130-vaudeville_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55535-55230-vaudoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55535-55230-vaudoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55535-55230-vaudoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55535-55230-vaudoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55536-55270-vauquois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55536-55270-vauquois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55536-55270-vauquois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55536-55270-vauquois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55537-55400-douaumont_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55537-55400-douaumont_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55537-55400-douaumont_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55537-55400-douaumont_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55537-55100-douaumont_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55537-55100-douaumont_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55537-55100-douaumont_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55537-55100-douaumont_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55540-55300-vaux_les_palameix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55540-55300-vaux_les_palameix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55540-55300-vaux_les_palameix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55540-55300-vaux_les_palameix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55541-55000-vavincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55541-55000-vavincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55541-55000-vavincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55541-55000-vavincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55543-55500-velaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55543-55500-velaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55543-55500-velaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55543-55500-velaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55544-55600-velosnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55544-55600-velosnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55544-55600-velosnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55544-55600-velosnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55545-55100-verdun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55545-55100-verdun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55545-55100-verdun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55545-55100-verdun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55546-55600-verneuil_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55546-55600-verneuil_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55546-55600-verneuil_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55546-55600-verneuil_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55547-55600-verneuil_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55547-55600-verneuil_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55547-55600-verneuil_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55547-55600-verneuil_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55549-55270-very/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55549-55270-very/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55549-55270-very/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55549-55270-very/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55551-55210-vigneulles_les_hattonchatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55551-55210-vigneulles_les_hattonchatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55551-55210-vigneulles_les_hattonchatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55551-55210-vigneulles_les_hattonchatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55552-55600-vigneul_sous_montmedy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55552-55600-vigneul_sous_montmedy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55552-55600-vigneul_sous_montmedy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55552-55600-vigneul_sous_montmedy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55553-55200-vignot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55553-55200-vignot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55553-55200-vignot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55553-55200-vignot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55554-55600-villecloye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55554-55600-villecloye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55554-55600-villecloye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55554-55600-villecloye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55555-55260-ville_devant_belrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55555-55260-ville_devant_belrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55555-55260-ville_devant_belrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55555-55260-ville_devant_belrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55556-55150-ville_devant_chaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55556-55150-ville_devant_chaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55556-55150-ville_devant_chaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55556-55150-ville_devant_chaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55557-55160-ville_en_woevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55557-55160-ville_en_woevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55557-55160-ville_en_woevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55557-55160-ville_en_woevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55559-55190-villeroy_sur_meholle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55559-55190-villeroy_sur_meholle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55559-55190-villeroy_sur_meholle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55559-55190-villeroy_sur_meholle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55560-55800-villers_aux_vents/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55560-55800-villers_aux_vents/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55560-55800-villers_aux_vents/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55560-55800-villers_aux_vents/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55561-55110-villers_devant_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55561-55110-villers_devant_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55561-55110-villers_devant_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55561-55110-villers_devant_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55562-55500-villers_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55562-55500-villers_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55562-55500-villers_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55562-55500-villers_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55563-55150-villers_les_mangiennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55563-55150-villers_les_mangiennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55563-55150-villers_les_mangiennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55563-55150-villers_les_mangiennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55565-55160-villers_sous_pareid/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55565-55160-villers_sous_pareid/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55565-55160-villers_sous_pareid/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55565-55160-villers_sous_pareid/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55566-55220-villers_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55566-55220-villers_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55566-55220-villers_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55566-55220-villers_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55567-55120-ville_sur_cousances/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55567-55120-ville_sur_cousances/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55567-55120-ville_sur_cousances/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55567-55120-ville_sur_cousances/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55568-55000-ville_sur_saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55568-55000-ville_sur_saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55568-55000-ville_sur_saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55568-55000-ville_sur_saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55569-55250-villotte_devant_louppy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55569-55250-villotte_devant_louppy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55569-55250-villotte_devant_louppy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55569-55250-villotte_devant_louppy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55570-55260-villotte_sur_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55570-55260-villotte_sur_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55570-55260-villotte_sur_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55570-55260-villotte_sur_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55571-55110-vilosnes_haraumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55571-55110-vilosnes_haraumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55571-55110-vilosnes_haraumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55571-55110-vilosnes_haraumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55572-55150-vittarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55572-55150-vittarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55572-55150-vittarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55572-55150-vittarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55573-55190-void_vacon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55573-55190-void_vacon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55573-55190-void_vacon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55573-55190-void_vacon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55574-55130-vouthon_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55574-55130-vouthon_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55574-55130-vouthon_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55574-55130-vouthon_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55575-55130-vouthon_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55575-55130-vouthon_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55575-55130-vouthon_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55575-55130-vouthon_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55577-55250-waly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55577-55250-waly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55577-55250-waly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55577-55250-waly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55578-55400-warcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55578-55400-warcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55578-55400-warcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55578-55400-warcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55579-55160-watronville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55579-55160-watronville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55579-55160-watronville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55579-55160-watronville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55580-55150-wavrille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55580-55150-wavrille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55580-55150-wavrille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55580-55150-wavrille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55581-55500-willeroncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55581-55500-willeroncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55581-55500-willeroncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55581-55500-willeroncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55582-55700-wiseppe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55582-55700-wiseppe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55582-55700-wiseppe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55582-55700-wiseppe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55583-55210-woel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55583-55210-woel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55583-55210-woel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55583-55210-woel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55584-55300-woimbey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55584-55300-woimbey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55584-55300-woimbey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55584-55300-woimbey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55586-55300-xivray_et_marvoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55586-55300-xivray_et_marvoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55586-55300-xivray_et_marvoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt55-meuse/commune55586-55300-xivray_et_marvoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-56.xml
+++ b/public/sitemaps/sitemap-56.xml
@@ -5,510 +5,1016 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56001-56350-allaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56001-56350-allaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56001-56350-allaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56001-56350-allaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56002-56190-ambon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56002-56190-ambon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56002-56190-ambon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56002-56190-ambon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56003-56610-arradon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56003-56610-arradon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56003-56610-arradon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56003-56610-arradon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56004-56190-arzal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56004-56190-arzal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56004-56190-arzal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56004-56190-arzal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56005-56640-arzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56005-56640-arzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56005-56640-arzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56005-56640-arzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56006-56800-augan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56006-56800-augan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56006-56800-augan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56006-56800-augan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56007-56400-auray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56007-56400-auray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56007-56400-auray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56007-56400-auray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56008-56870-baden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56008-56870-baden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56008-56870-baden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56008-56870-baden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56009-56360-bangor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56009-56360-bangor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56009-56360-bangor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56009-56360-bangor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56010-56150-baud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56010-56150-baud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56010-56150-baud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56010-56150-baud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56011-56350-beganne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56011-56350-beganne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56011-56350-beganne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56011-56350-beganne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56012-56380-beignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56012-56380-beignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56012-56380-beignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56012-56380-beignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56013-56550-belz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56013-56550-belz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56013-56550-belz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56013-56550-belz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56014-56240-berne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56014-56240-berne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56014-56240-berne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56014-56240-berne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56015-56230-berric/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56015-56230-berric/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56015-56230-berric/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56015-56230-berric/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56017-56500-bignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56017-56500-bignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56017-56500-bignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56017-56500-bignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56018-56190-billiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56018-56190-billiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56018-56190-billiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56018-56190-billiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56019-56420-billio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56019-56420-billio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56019-56420-billio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56019-56420-billio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56020-56140-bohal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56020-56140-bohal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56020-56140-bohal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56020-56140-bohal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56021-56700-branderion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56021-56700-branderion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56021-56700-branderion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56021-56700-branderion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56022-56390-brandivy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56022-56390-brandivy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56022-56390-brandivy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56022-56390-brandivy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56023-56400-brech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56023-56400-brech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56023-56400-brech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56023-56400-brech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56024-56580-brehan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56024-56580-brehan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56024-56580-brehan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56024-56580-brehan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56025-56430-brignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56025-56430-brignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56025-56430-brignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56025-56430-brignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56026-56310-bubry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56026-56310-bubry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56026-56310-bubry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56026-56310-bubry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56027-56420-buleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56027-56420-buleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56027-56420-buleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56027-56420-buleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56028-56220-caden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56028-56220-caden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56028-56220-caden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56028-56220-caden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56029-56240-calan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56029-56240-calan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56029-56240-calan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56029-56240-calan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56030-56130-camoel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56030-56130-camoel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56030-56130-camoel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56030-56130-camoel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56031-56330-camors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56031-56330-camors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56031-56330-camors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56031-56330-camors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56032-56800-campeneac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56032-56800-campeneac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56032-56800-campeneac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56032-56800-campeneac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56033-56910-carentoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56033-56910-carentoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56033-56910-carentoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56033-56910-carentoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56034-56340-carnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56034-56340-carnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56034-56340-carnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56034-56340-carnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56035-56140-caro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56035-56140-caro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56035-56140-caro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56035-56140-caro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56036-56850-caudan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56036-56850-caudan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56036-56850-caudan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56036-56850-caudan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56039-56500-la_chapelle_neuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56039-56500-la_chapelle_neuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56039-56500-la_chapelle_neuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56039-56500-la_chapelle_neuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56040-56620-cleguer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56040-56620-cleguer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56040-56620-cleguer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56040-56620-cleguer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56041-56480-cleguerec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56041-56480-cleguerec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56041-56480-cleguerec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56041-56480-cleguerec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56042-56390-colpo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56042-56390-colpo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56042-56390-colpo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56042-56390-colpo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56043-56430-concoret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56043-56430-concoret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56043-56430-concoret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56043-56430-concoret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56044-56200-cournon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56044-56200-cournon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56044-56200-cournon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56044-56200-cournon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56045-56230-le_cours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56045-56230-le_cours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56045-56230-le_cours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56045-56230-le_cours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56046-56950-crach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56046-56950-crach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56046-56950-crach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56046-56950-crach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56047-56580-credin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56047-56580-credin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56047-56580-credin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56047-56580-credin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56048-56540-le_croisty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56048-56540-le_croisty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56048-56540-le_croisty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56048-56540-le_croisty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56049-56920-croixanvec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56049-56920-croixanvec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56049-56920-croixanvec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56049-56920-croixanvec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56050-56120-la_croix_hellean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56050-56120-la_croix_hellean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56050-56120-la_croix_hellean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56050-56120-la_croix_hellean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56051-56420-cruguel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56051-56420-cruguel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56051-56420-cruguel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56051-56420-cruguel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56052-56750-damgan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56052-56750-damgan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56052-56750-damgan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56052-56750-damgan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56053-56250-elven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56053-56250-elven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56053-56250-elven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56053-56250-elven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56054-56410-erdeven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56054-56410-erdeven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56054-56410-erdeven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56054-56410-erdeven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56055-56410-etel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56055-56410-etel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56055-56410-etel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56055-56410-etel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56056-56490-evriguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56056-56490-evriguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56056-56490-evriguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56056-56490-evriguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56057-56320-le_faouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56057-56320-le_faouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56057-56320-le_faouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56057-56320-le_faouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56058-56130-ferel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56058-56130-ferel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56058-56130-ferel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56058-56130-ferel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56060-56200-les_fougerets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56060-56200-les_fougerets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56060-56200-les_fougerets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56060-56200-les_fougerets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56061-56200-la_gacilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56061-56200-la_gacilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56061-56200-la_gacilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56061-56200-la_gacilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56062-56680-gavres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56062-56680-gavres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56062-56680-gavres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56062-56680-gavres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56063-56530-gestel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56063-56530-gestel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56063-56530-gestel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56063-56530-gestel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56065-56800-gourhel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56065-56800-gourhel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56065-56800-gourhel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56065-56800-gourhel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56066-56110-gourin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56066-56110-gourin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56066-56110-gourin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56066-56110-gourin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56067-56390-grand_champ/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56067-56390-grand_champ/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56067-56390-grand_champ/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56067-56390-grand_champ/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56068-56120-la_gree_saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56068-56120-la_gree_saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56068-56120-la_gree_saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56068-56120-la_gree_saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56069-56590-groix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56069-56590-groix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56069-56590-groix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56069-56590-groix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56070-56120-guegon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56070-56120-guegon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56070-56120-guegon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56070-56120-guegon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56071-56420-guehenno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56071-56420-guehenno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56071-56420-guehenno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56071-56420-guehenno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56072-56920-gueltas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56072-56920-gueltas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56072-56920-gueltas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56072-56920-gueltas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56073-56160-guemene_sur_scorff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56073-56160-guemene_sur_scorff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56073-56160-guemene_sur_scorff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56073-56160-guemene_sur_scorff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56074-56150-guenin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56074-56150-guenin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56074-56150-guenin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56074-56150-guenin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56075-56380-guer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56075-56380-guer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56075-56380-guer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56075-56380-guer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56076-56310-guern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56076-56310-guern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56076-56310-guern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56076-56310-guern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56077-56190-le_guerno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56077-56190-le_guerno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56077-56190-le_guerno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56077-56190-le_guerno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56078-56520-guidel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56078-56520-guidel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56078-56520-guidel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56078-56520-guidel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56079-56800-guillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56079-56800-guillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56079-56800-guillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56079-56800-guillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56080-56490-guilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56080-56490-guilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56080-56490-guilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56080-56490-guilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56081-56560-guiscriff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56081-56560-guiscriff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56081-56560-guiscriff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56081-56560-guiscriff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56082-56120-hellean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56082-56120-hellean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56082-56120-hellean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56082-56120-hellean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56083-56700-hennebont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56083-56700-hennebont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56083-56700-hennebont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56083-56700-hennebont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56084-56450-le_hezo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56084-56450-le_hezo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56084-56450-le_hezo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56084-56450-le_hezo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56085-56170-hoedic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56085-56170-hoedic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56085-56170-hoedic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56085-56170-hoedic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56086-56170-ile_d_houat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56086-56170-ile_d_houat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56086-56170-ile_d_houat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56086-56170-ile_d_houat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56087-56780-ile_aux_moines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56087-56780-ile_aux_moines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56087-56780-ile_aux_moines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56087-56780-ile_aux_moines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56088-56840-ile_d_arz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56088-56840-ile_d_arz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56088-56840-ile_d_arz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56088-56840-ile_d_arz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56089-56240-inguiniel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56089-56240-inguiniel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56089-56240-inguiniel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56089-56240-inguiniel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56090-56650-inzinzac_lochrist/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56090-56650-inzinzac_lochrist/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56090-56650-inzinzac_lochrist/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56090-56650-inzinzac_lochrist/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56091-56120-josselin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56091-56120-josselin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56091-56120-josselin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56091-56120-josselin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56092-56920-kerfourn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56092-56920-kerfourn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56092-56920-kerfourn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56092-56920-kerfourn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56093-56300-kergrist/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56093-56300-kergrist/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56093-56300-kergrist/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56093-56300-kergrist/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56094-56700-kervignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56094-56700-kervignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56094-56700-kervignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56094-56700-kervignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56096-56690-landaul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56096-56690-landaul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56096-56690-landaul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56096-56690-landaul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56097-56690-landevant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56097-56690-landevant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56097-56690-landevant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56097-56690-landevant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56098-56600-lanester/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56098-56600-lanester/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56098-56600-lanester/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56098-56600-lanester/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56099-56160-langoelan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56099-56160-langoelan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56099-56160-langoelan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56099-56160-langoelan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56100-56630-langonnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56100-56630-langonnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56100-56630-langonnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56100-56630-langonnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56101-56440-languidic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56101-56440-languidic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56101-56440-languidic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56101-56440-languidic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56102-56120-forges_de_lanouee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56102-56120-forges_de_lanouee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56102-56120-forges_de_lanouee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56102-56120-forges_de_lanouee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56103-56120-lantillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56103-56120-lantillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56103-56120-lantillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56103-56120-lantillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56104-56240-lanvaudan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56104-56240-lanvaudan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56104-56240-lanvaudan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56104-56240-lanvaudan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56105-56320-lanvenegen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56105-56320-lanvenegen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56105-56320-lanvenegen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56105-56320-lanvenegen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56106-56870-larmor_baden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56106-56870-larmor_baden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56106-56870-larmor_baden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56106-56870-larmor_baden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56107-56260-larmor_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56107-56260-larmor_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56107-56260-larmor_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56107-56260-larmor_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56108-56230-larre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56108-56230-larre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56108-56230-larre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56108-56230-larre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56109-56190-lauzach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56109-56190-lauzach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56109-56190-lauzach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56109-56190-lauzach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56110-56160-lignol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56110-56160-lignol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56110-56160-lignol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56110-56160-lignol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56111-56220-limerzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56111-56220-limerzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56111-56220-limerzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56111-56220-limerzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56112-56460-lizio/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56112-56460-lizio/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56112-56460-lizio/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56112-56460-lizio/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56113-56160-locmalo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56113-56160-locmalo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56113-56160-locmalo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56113-56160-locmalo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56114-56360-locmaria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56114-56360-locmaria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56114-56360-locmaria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56114-56360-locmaria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56115-56390-locmaria_grand_champ/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56115-56390-locmaria_grand_champ/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56115-56390-locmaria_grand_champ/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56115-56390-locmaria_grand_champ/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56116-56740-locmariaquer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56116-56740-locmariaquer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56116-56740-locmariaquer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56116-56740-locmariaquer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56117-56500-locmine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56117-56500-locmine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56117-56500-locmine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56117-56500-locmine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56118-56570-locmiquelic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56118-56570-locmiquelic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56118-56570-locmiquelic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56118-56570-locmiquelic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56119-56550-locoal_mendon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56119-56550-locoal_mendon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56119-56550-locoal_mendon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56119-56550-locoal_mendon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56120-56390-locqueltas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56120-56390-locqueltas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56120-56390-locqueltas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56120-56390-locqueltas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56121-56100-lorient/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56121-56100-lorient/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56121-56100-lorient/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56121-56100-lorient/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56122-56800-loyat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56122-56800-loyat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56122-56800-loyat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56122-56800-loyat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56123-56220-malansac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56123-56220-malansac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56123-56220-malansac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56123-56220-malansac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56124-56140-malestroit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56124-56140-malestroit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56124-56140-malestroit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56124-56140-malestroit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56125-56300-malguenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56125-56300-malguenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56125-56300-malguenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56125-56300-malguenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56126-56130-marzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56126-56130-marzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56126-56130-marzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56126-56130-marzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56127-56430-mauron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56127-56430-mauron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56127-56430-mauron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56127-56430-mauron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56128-56310-melrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56128-56310-melrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56128-56310-melrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56128-56310-melrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56129-56490-meneac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56129-56490-meneac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56129-56490-meneac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56129-56490-meneac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56130-56700-merlevenez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56130-56700-merlevenez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56130-56700-merlevenez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56130-56700-merlevenez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56131-56320-meslan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56131-56320-meslan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56131-56320-meslan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56131-56320-meslan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56132-56890-meucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56132-56890-meucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56132-56890-meucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56132-56890-meucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56133-56140-missiriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56133-56140-missiriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56133-56140-missiriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56133-56140-missiriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56134-56490-mohon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56134-56490-mohon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56134-56490-mohon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56134-56490-mohon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56135-56230-molac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56135-56230-molac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56135-56230-molac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56135-56230-molac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56136-56380-monteneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56136-56380-monteneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56136-56380-monteneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56136-56380-monteneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56137-56250-monterblanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56137-56250-monterblanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56137-56250-monterblanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56137-56250-monterblanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56139-56800-montertelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56139-56800-montertelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56139-56800-montertelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56139-56800-montertelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56140-56500-moreac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56140-56500-moreac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56140-56500-moreac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56140-56500-moreac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56141-56500-moustoir_ac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56141-56500-moustoir_ac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56141-56500-moustoir_ac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56141-56500-moustoir_ac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56143-56190-muzillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56143-56190-muzillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56143-56190-muzillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56143-56190-muzillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56144-56500-evellys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56144-56500-evellys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56144-56500-evellys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56144-56500-evellys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56145-56430-neant_sur_yvel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56145-56430-neant_sur_yvel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56145-56430-neant_sur_yvel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56145-56430-neant_sur_yvel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56146-56300-neulliac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56146-56300-neulliac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56146-56300-neulliac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56146-56300-neulliac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56147-56130-nivillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56147-56130-nivillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56147-56130-nivillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56147-56130-nivillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56148-56690-nostang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56148-56690-nostang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56148-56690-nostang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56148-56690-nostang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56149-56190-noyal_muzillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56149-56190-noyal_muzillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56149-56190-noyal_muzillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56149-56190-noyal_muzillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56151-56920-noyal_pontivy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56151-56920-noyal_pontivy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56151-56920-noyal_pontivy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56151-56920-noyal_pontivy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56152-56360-le_palais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56152-56360-le_palais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56152-56360-le_palais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56152-56360-le_palais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56153-56130-peaule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56153-56130-peaule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56153-56130-peaule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56153-56130-peaule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56154-56220-peillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56154-56220-peillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56154-56220-peillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56154-56220-peillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56155-56760-penestin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56155-56760-penestin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56155-56760-penestin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56155-56760-penestin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56156-56160-persquen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56156-56160-persquen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56156-56160-persquen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56156-56160-persquen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56157-56420-plaudren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56157-56420-plaudren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56157-56420-plaudren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56157-56420-plaudren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56158-56890-plescop/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56158-56890-plescop/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56158-56890-plescop/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56158-56890-plescop/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56159-56140-pleucadeuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56159-56140-pleucadeuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56159-56140-pleucadeuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56159-56140-pleucadeuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56160-56120-pleugriffet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56160-56120-pleugriffet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56160-56120-pleugriffet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56160-56120-pleugriffet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56161-56400-ploemel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56161-56400-ploemel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56161-56400-ploemel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56161-56400-ploemel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56162-56270-ploemeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56162-56270-ploemeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56162-56270-ploemeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56162-56270-ploemeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56163-56160-ploerdut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56163-56160-ploerdut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56163-56160-ploerdut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56163-56160-ploerdut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56164-56880-ploeren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56164-56880-ploeren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56164-56880-ploeren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56164-56880-ploeren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56165-56800-ploermel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56165-56800-ploermel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56165-56800-ploermel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56165-56800-ploermel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56166-56240-plouay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56166-56240-plouay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56166-56240-plouay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56166-56240-plouay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56167-56400-plougoumelen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56167-56400-plougoumelen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56167-56400-plougoumelen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56167-56400-plougoumelen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56168-56340-plouharnel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56168-56340-plouharnel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56168-56340-plouharnel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56168-56340-plouharnel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56169-56680-plouhinec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56169-56680-plouhinec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56169-56680-plouhinec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56169-56680-plouhinec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56170-56770-plouray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56170-56770-plouray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56170-56770-plouray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56170-56770-plouray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56171-56220-pluherlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56171-56220-pluherlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56171-56220-pluherlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56171-56220-pluherlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56172-56420-plumelec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56172-56420-plumelec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56172-56420-plumelec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56172-56420-plumelec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56173-56930-plumeliau_bieuzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56173-56930-plumeliau_bieuzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56173-56930-plumeliau_bieuzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56173-56930-plumeliau_bieuzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56173-56310-plumeliau_bieuzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56173-56310-plumeliau_bieuzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56173-56310-plumeliau_bieuzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56173-56310-plumeliau_bieuzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56174-56500-plumelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56174-56500-plumelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56174-56500-plumelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56174-56500-plumelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56175-56400-plumergat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56175-56400-plumergat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56175-56400-plumergat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56175-56400-plumergat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56176-56400-pluneret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56176-56400-pluneret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56176-56400-pluneret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56176-56400-pluneret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56177-56330-pluvigner/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56177-56330-pluvigner/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56177-56330-pluvigner/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56177-56330-pluvigner/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56178-56300-pontivy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56178-56300-pontivy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56178-56300-pontivy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56178-56300-pontivy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56179-56620-pont_scorff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56179-56620-pont_scorff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56179-56620-pont_scorff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56179-56620-pont_scorff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56180-56380-porcaro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56180-56380-porcaro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56180-56380-porcaro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56180-56380-porcaro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56181-56290-port_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56181-56290-port_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56181-56290-port_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56181-56290-port_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56182-56320-priziac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56182-56320-priziac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56182-56320-priziac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56182-56320-priziac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56184-56230-questembert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56184-56230-questembert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56184-56230-questembert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56184-56230-questembert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56185-56530-queven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56185-56530-queven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56185-56530-queven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56185-56530-queven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56186-56170-quiberon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56186-56170-quiberon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56186-56170-quiberon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56186-56170-quiberon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56188-56310-quistinic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56188-56310-quistinic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56188-56310-quistinic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56188-56310-quistinic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56189-56500-radenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56189-56500-radenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56189-56500-radenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56189-56500-radenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56190-56500-reguiny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56190-56500-reguiny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56190-56500-reguiny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56190-56500-reguiny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56191-56140-reminiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56191-56140-reminiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56191-56140-reminiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56191-56140-reminiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56193-56670-riantec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56193-56670-riantec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56193-56670-riantec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56193-56670-riantec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56194-56350-rieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56194-56350-rieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56194-56350-rieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56194-56350-rieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56195-56130-la_roche_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56195-56130-la_roche_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56195-56130-la_roche_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56195-56130-la_roche_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56196-56220-rochefort_en_terre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56196-56220-rochefort_en_terre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56196-56220-rochefort_en_terre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56196-56220-rochefort_en_terre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56197-56460-val_d_oust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56197-56460-val_d_oust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56197-56460-val_d_oust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56197-56460-val_d_oust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56197-56800-val_d_oust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56197-56800-val_d_oust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56197-56800-val_d_oust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56197-56800-val_d_oust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56198-56580-rohan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56198-56580-rohan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56198-56580-rohan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56198-56580-rohan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56199-56110-roudouallec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56199-56110-roudouallec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56199-56110-roudouallec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56199-56110-roudouallec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56200-56140-ruffiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56200-56140-ruffiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56200-56140-ruffiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56200-56140-ruffiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56201-56110-le_saint/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56201-56110-le_saint/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56201-56110-le_saint/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56201-56110-le_saint/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56202-56140-saint_abraham/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56202-56140-saint_abraham/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56202-56140-saint_abraham/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56202-56140-saint_abraham/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56203-56480-saint_aignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56203-56480-saint_aignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56203-56480-saint_aignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56203-56480-saint_aignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56204-56500-saint_allouestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56204-56500-saint_allouestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56204-56500-saint_allouestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56204-56500-saint_allouestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56205-56450-saint_armel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56205-56450-saint_armel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56205-56450-saint_armel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56205-56450-saint_armel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56206-56890-saint_ave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56206-56890-saint_ave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56206-56890-saint_ave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56206-56890-saint_ave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56207-56150-saint_barthelemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56207-56150-saint_barthelemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56207-56150-saint_barthelemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56207-56150-saint_barthelemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56208-56430-saint_brieuc_de_mauron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56208-56430-saint_brieuc_de_mauron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56208-56430-saint_brieuc_de_mauron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56208-56430-saint_brieuc_de_mauron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56209-56480-sainte_brigitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56209-56480-sainte_brigitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56209-56480-sainte_brigitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56209-56480-sainte_brigitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56210-56540-saint_caradec_tregomel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56210-56540-saint_caradec_tregomel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56210-56540-saint_caradec_tregomel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56210-56540-saint_caradec_tregomel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56211-56140-saint_congard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56211-56140-saint_congard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56211-56140-saint_congard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56211-56140-saint_congard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56212-56130-saint_dolay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56212-56130-saint_dolay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56212-56130-saint_dolay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56212-56130-saint_dolay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56213-56920-saint_gerand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56213-56920-saint_gerand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56213-56920-saint_gerand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56213-56920-saint_gerand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56214-56730-saint_gildas_de_rhuys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56214-56730-saint_gildas_de_rhuys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56214-56730-saint_gildas_de_rhuys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56214-56730-saint_gildas_de_rhuys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56215-56920-saint_gonnery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56215-56920-saint_gonnery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56215-56920-saint_gonnery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56215-56920-saint_gonnery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56216-56350-saint_gorgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56216-56350-saint_gorgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56216-56350-saint_gorgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56216-56350-saint_gorgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56218-56220-saint_grave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56218-56220-saint_grave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56218-56220-saint_grave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56218-56220-saint_grave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56219-56460-saint_guyomard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56219-56460-saint_guyomard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56219-56460-saint_guyomard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56219-56460-saint_guyomard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56220-56700-sainte_helene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56220-56700-sainte_helene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56220-56700-sainte_helene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56220-56700-sainte_helene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56221-56220-saint_jacut_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56221-56220-saint_jacut_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56221-56220-saint_jacut_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56221-56220-saint_jacut_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56222-56660-saint_jean_brevelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56222-56660-saint_jean_brevelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56222-56660-saint_jean_brevelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56222-56660-saint_jean_brevelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56223-56350-saint_jean_la_poterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56223-56350-saint_jean_la_poterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56223-56350-saint_jean_la_poterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56223-56350-saint_jean_la_poterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56224-56140-saint_laurent_sur_oust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56224-56140-saint_laurent_sur_oust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56224-56140-saint_laurent_sur_oust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56224-56140-saint_laurent_sur_oust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56225-56430-saint_lery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56225-56430-saint_lery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56225-56430-saint_lery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56225-56430-saint_lery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56226-56380-saint_malo_de_beignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56226-56380-saint_malo_de_beignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56226-56380-saint_malo_de_beignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56226-56380-saint_malo_de_beignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56227-56490-saint_malo_des_trois_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56227-56490-saint_malo_des_trois_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56227-56490-saint_malo_des_trois_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56227-56490-saint_malo_des_trois_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56228-56140-saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56228-56140-saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56228-56140-saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56228-56140-saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56229-56200-saint_martin_sur_oust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56229-56200-saint_martin_sur_oust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56229-56200-saint_martin_sur_oust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56229-56200-saint_martin_sur_oust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56230-56910-saint_nicolas_du_tertre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56230-56910-saint_nicolas_du_tertre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56230-56910-saint_nicolas_du_tertre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56230-56910-saint_nicolas_du_tertre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56231-56250-saint_nolff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56231-56250-saint_nolff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56231-56250-saint_nolff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56231-56250-saint_nolff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56232-56350-saint_perreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56232-56350-saint_perreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56232-56350-saint_perreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56232-56350-saint_perreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56233-56470-saint_philibert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56233-56470-saint_philibert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56233-56470-saint_philibert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56233-56470-saint_philibert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56234-56510-saint_pierre_quiberon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56234-56510-saint_pierre_quiberon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56234-56510-saint_pierre_quiberon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56234-56510-saint_pierre_quiberon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56236-56120-saint_servant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56236-56120-saint_servant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56236-56120-saint_servant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56236-56120-saint_servant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56237-56300-saint_thuriau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56237-56300-saint_thuriau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56237-56300-saint_thuriau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56237-56300-saint_thuriau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56238-56540-saint_tugdual/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56238-56540-saint_tugdual/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56238-56540-saint_tugdual/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56238-56540-saint_tugdual/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56239-56350-saint_vincent_sur_oust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56239-56350-saint_vincent_sur_oust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56239-56350-saint_vincent_sur_oust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56239-56350-saint_vincent_sur_oust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56240-56370-sarzeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56240-56370-sarzeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56240-56370-sarzeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56240-56370-sarzeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56241-56360-sauzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56241-56360-sauzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56241-56360-sauzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56241-56360-sauzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56242-56160-seglien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56242-56160-seglien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56242-56160-seglien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56242-56160-seglien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56243-56860-sene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56243-56860-sene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56243-56860-sene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56243-56860-sene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56244-56460-serent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56244-56460-serent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56244-56460-serent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56244-56460-serent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56245-56480-silfiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56245-56480-silfiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56245-56480-silfiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56245-56480-silfiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56246-56300-le_sourn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56246-56300-le_sourn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56246-56300-le_sourn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56246-56300-le_sourn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56247-56250-sulniac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56247-56250-sulniac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56247-56250-sulniac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56247-56250-sulniac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56248-56450-surzur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56248-56450-surzur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56248-56450-surzur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56248-56450-surzur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56249-56800-taupont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56249-56800-taupont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56249-56800-taupont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56249-56800-taupont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56250-56130-thehillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56250-56130-thehillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56250-56130-thehillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56250-56130-thehillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56251-56450-theix_noyalo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56251-56450-theix_noyalo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56251-56450-theix_noyalo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56251-56450-theix_noyalo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56252-56370-le_tour_du_parc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56252-56370-le_tour_du_parc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56252-56370-le_tour_du_parc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56252-56370-le_tour_du_parc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56253-56140-treal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56253-56140-treal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56253-56140-treal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56253-56140-treal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56254-56250-tredion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56254-56250-tredion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56254-56250-tredion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56254-56250-tredion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56255-56250-trefflean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56255-56250-trefflean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56255-56250-trefflean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56255-56250-trefflean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56256-56430-trehorenteuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56256-56430-trehorenteuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56256-56430-trehorenteuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56256-56430-trehorenteuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56257-56490-la_trinite_porhoet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56257-56490-la_trinite_porhoet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56257-56490-la_trinite_porhoet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56257-56490-la_trinite_porhoet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56258-56470-la_trinite_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56258-56470-la_trinite_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56258-56470-la_trinite_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56258-56470-la_trinite_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56259-56190-la_trinite_surzur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56259-56190-la_trinite_surzur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56259-56190-la_trinite_surzur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56259-56190-la_trinite_surzur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56260-56000-vannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56260-56000-vannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56260-56000-vannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56260-56000-vannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56261-56250-la_vraie_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56261-56250-la_vraie_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56261-56250-la_vraie_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56261-56250-la_vraie_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56262-56400-bono/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56262-56400-bono/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56262-56400-bono/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56262-56400-bono/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56263-56400-sainte_anne_d_auray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56263-56400-sainte_anne_d_auray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56263-56400-sainte_anne_d_auray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56263-56400-sainte_anne_d_auray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56264-56540-kernascleden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56264-56540-kernascleden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56264-56540-kernascleden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt56-morbihan/commune56264-56540-kernascleden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-57.xml
+++ b/public/sitemaps/sitemap-57.xml
@@ -5,1470 +5,2936 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57001-57920-aboncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57001-57920-aboncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57001-57920-aboncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57001-57920-aboncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57002-57590-aboncourt_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57002-57590-aboncourt_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57002-57590-aboncourt_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57002-57590-aboncourt_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57003-57560-abreschviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57003-57560-abreschviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57003-57560-abreschviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57003-57560-abreschviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57004-57340-achain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57004-57340-achain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57004-57340-achain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57004-57340-achain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57006-57412-achen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57006-57412-achen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57006-57412-achen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57006-57412-achen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57007-57580-adaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57007-57580-adaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57007-57580-adaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57007-57580-adaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57008-57380-adelange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57008-57380-adelange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57008-57380-adelange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57008-57380-adelange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57009-57590-ajoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57009-57590-ajoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57009-57590-ajoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57009-57590-ajoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57010-57590-alaincourt_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57010-57590-alaincourt_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57010-57590-alaincourt_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57010-57590-alaincourt_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57011-57670-albestroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57011-57670-albestroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57011-57670-albestroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57011-57670-albestroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57012-57440-algrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57012-57440-algrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57012-57440-algrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57012-57440-algrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57013-57515-alsting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57013-57515-alsting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57013-57515-alsting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57013-57515-alsting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57014-57660-altrippe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57014-57660-altrippe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57014-57660-altrippe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57014-57660-altrippe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57015-57730-altviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57015-57730-altviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57015-57730-altviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57015-57730-altviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57016-57320-alzing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57016-57320-alzing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57016-57320-alzing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57016-57320-alzing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57017-57865-amanvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57017-57865-amanvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57017-57865-amanvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57017-57865-amanvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57018-57170-amelecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57018-57170-amelecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57018-57170-amelecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57018-57170-amelecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57019-57360-amneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57019-57360-amneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57019-57360-amneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57019-57360-amneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57020-57580-ancerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57020-57580-ancerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57020-57580-ancerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57020-57580-ancerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57021-57130-ancy_dornot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57021-57130-ancy_dornot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57021-57130-ancy_dornot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57021-57130-ancy_dornot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57022-57440-angevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57022-57440-angevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57022-57440-angevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57022-57440-angevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57024-57640-antilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57024-57640-antilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57024-57640-antilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57024-57640-antilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57025-57320-anzeling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57025-57320-anzeling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57025-57320-anzeling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57025-57320-anzeling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57026-57480-apach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57026-57480-apach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57026-57480-apach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57026-57480-apach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57027-57380-arraincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57027-57380-arraincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57027-57380-arraincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57027-57380-arraincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57028-57640-argancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57028-57640-argancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57028-57640-argancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57028-57640-argancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57028-57140-argancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57028-57140-argancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57028-57140-argancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57028-57140-argancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57029-57580-arriance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57029-57580-arriance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57029-57580-arriance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57029-57580-arriance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57030-57680-arry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57030-57680-arry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57030-57680-arry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57030-57680-arry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57031-57530-ars_laquenexy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57031-57530-ars_laquenexy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57031-57530-ars_laquenexy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57031-57530-ars_laquenexy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57032-57130-ars_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57032-57130-ars_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57032-57130-ars_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57032-57130-ars_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57033-57405-arzviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57033-57405-arzviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57033-57405-arzviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57033-57405-arzviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57034-57790-aspach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57034-57790-aspach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57034-57790-aspach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57034-57790-aspach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57035-57260-assenoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57035-57260-assenoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57035-57260-assenoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57035-57260-assenoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57036-57170-attilloncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57036-57170-attilloncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57036-57170-attilloncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57036-57170-attilloncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57037-57580-aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57037-57580-aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57037-57580-aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57037-57580-aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57038-57390-audun_le_tiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57038-57390-audun_le_tiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57038-57390-audun_le_tiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57038-57390-audun_le_tiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57039-57685-augny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57039-57685-augny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57039-57685-augny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57039-57685-augny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57040-57590-aulnois_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57040-57590-aulnois_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57040-57590-aulnois_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57040-57590-aulnois_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57041-57710-aumetz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57041-57710-aumetz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57041-57710-aumetz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57041-57710-aumetz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57042-57810-avricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57042-57810-avricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57042-57810-avricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57042-57810-avricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57043-57300-ay_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57043-57300-ay_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57043-57300-ay_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57043-57300-ay_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57044-57810-azoudange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57044-57810-azoudange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57044-57810-azoudange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57044-57810-azoudange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57045-57590-bacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57045-57590-bacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57045-57590-bacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57045-57590-bacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57046-57230-baerenthal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57046-57230-baerenthal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57046-57230-baerenthal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57046-57230-baerenthal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57047-57690-bambiderstroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57047-57690-bambiderstroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57047-57690-bambiderstroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57047-57690-bambiderstroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57048-57220-bannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57048-57220-bannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57048-57220-bannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57048-57220-bannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57049-57050-le_ban_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57049-57050-le_ban_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57049-57050-le_ban_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57049-57050-le_ban_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57050-57830-barchain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57050-57830-barchain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57050-57830-barchain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57050-57830-barchain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57051-57340-baronville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57051-57340-baronville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57051-57340-baronville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57051-57340-baronville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57052-57450-barst/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57052-57450-barst/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57052-57450-barst/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57052-57450-barst/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57053-57260-bassing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57053-57260-bassing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57053-57260-bassing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57053-57260-bassing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57054-57580-baudrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57054-57580-baudrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57054-57580-baudrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57054-57580-baudrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57055-57530-bazoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57055-57530-bazoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57055-57530-bazoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57055-57530-bazoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57056-57830-bebing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57056-57830-bebing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57056-57830-bebing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57056-57830-bebing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57057-57580-bechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57057-57580-bechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57057-57580-bechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57057-57580-bechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57058-57460-behren_les_forbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57058-57460-behren_les_forbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57058-57460-behren_les_forbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57058-57460-behren_les_forbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57059-57340-bellange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57059-57340-bellange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57059-57340-bellange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57059-57340-bellange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57060-57670-benestroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57060-57670-benestroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57060-57670-benestroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57060-57670-benestroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57061-57800-bening_les_saint_avold/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57061-57800-bening_les_saint_avold/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57061-57800-bening_les_saint_avold/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57061-57800-bening_les_saint_avold/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57062-57570-berg_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57062-57570-berg_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57062-57570-berg_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57062-57570-berg_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57063-57660-berig_vintrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57063-57660-berig_vintrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57063-57660-berig_vintrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57063-57660-berig_vintrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57064-57370-berling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57064-57370-berling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57064-57370-berling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57064-57370-berling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57065-57340-bermering/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57065-57340-bermering/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57065-57340-bermering/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57065-57340-bermering/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57066-57930-berthelming/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57066-57930-berthelming/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57066-57930-berthelming/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57066-57930-berthelming/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57067-57310-bertrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57067-57310-bertrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57067-57310-bertrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57067-57310-bertrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57069-57550-berviller_en_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57069-57550-berviller_en_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57069-57550-berviller_en_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57069-57550-berviller_en_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57070-57220-bettange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57070-57220-bettange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57070-57220-bettange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57070-57220-bettange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57071-57930-bettborn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57071-57930-bettborn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57071-57930-bettborn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57071-57930-bettborn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57072-57640-bettelainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57072-57640-bettelainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57072-57640-bettelainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57072-57640-bettelainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57073-57800-betting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57073-57800-betting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57073-57800-betting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57073-57800-betting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57074-57410-bettviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57074-57410-bettviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57074-57410-bettviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57074-57410-bettviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57075-57580-beux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57075-57580-beux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57075-57580-beux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57075-57580-beux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57076-57570-beyren_les_sierck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57076-57570-beyren_les_sierck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57076-57570-beyren_les_sierck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57076-57570-beyren_les_sierck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57077-57630-bezange_la_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57077-57630-bezange_la_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57077-57630-bezange_la_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57077-57630-bezange_la_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57079-57320-bibiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57079-57320-bibiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57079-57320-bibiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57079-57320-bibiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57080-57635-bickenholtz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57080-57635-bickenholtz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57080-57635-bickenholtz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57080-57635-bickenholtz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57081-57260-bidestroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57081-57260-bidestroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57081-57260-bidestroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57081-57260-bidestroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57082-57660-biding/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57082-57660-biding/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57082-57660-biding/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57082-57660-biding/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57083-57410-bining/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57083-57410-bining/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57083-57410-bining/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57083-57410-bining/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57084-57170-bioncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57084-57170-bioncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57084-57170-bioncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57084-57170-bioncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57085-57220-bionville_sur_nied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57085-57220-bionville_sur_nied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57085-57220-bionville_sur_nied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57085-57220-bionville_sur_nied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57086-57930-belles_forets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57086-57930-belles_forets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57086-57930-belles_forets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57086-57930-belles_forets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57087-57220-bisten_en_lorraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57087-57220-bisten_en_lorraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57087-57220-bisten_en_lorraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57087-57220-bisten_en_lorraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57088-57660-bistroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57088-57660-bistroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57088-57660-bistroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57088-57660-bistroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57089-57230-bitche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57089-57230-bitche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57089-57230-bitche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57089-57230-bitche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57090-57260-blanche_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57090-57260-blanche_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57090-57260-blanche_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57090-57260-blanche_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57091-57200-bliesbruck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57091-57200-bliesbruck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57091-57200-bliesbruck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57091-57200-bliesbruck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57092-57200-blies_ebersing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57092-57200-blies_ebersing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57092-57200-blies_ebersing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57092-57200-blies_ebersing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57093-57200-blies_guersviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57093-57200-blies_guersviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57093-57200-blies_guersviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57093-57200-blies_guersviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57095-57220-boucheporn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57095-57220-boucheporn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57095-57220-boucheporn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57095-57220-boucheporn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57096-57655-boulange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57096-57655-boulange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57096-57655-boulange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57096-57655-boulange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57097-57220-boulay_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57097-57220-boulay_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57097-57220-boulay_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57097-57220-boulay_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57098-57260-bourgaltroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57098-57260-bourgaltroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57098-57260-bourgaltroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57098-57260-bourgaltroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57099-57810-bourdonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57099-57810-bourdonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57099-57810-bourdonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57099-57810-bourdonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57100-57370-bourscheid/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57100-57370-bourscheid/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57100-57370-bourscheid/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57100-57370-bourscheid/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57101-57460-bousbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57101-57460-bousbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57101-57460-bousbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57101-57460-bousbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57102-57310-bousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57102-57310-bousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57102-57310-bousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57102-57310-bousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57103-57230-bousseviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57103-57230-bousseviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57103-57230-bousseviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57103-57230-bousseviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57104-57570-boust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57104-57570-boust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57104-57570-boust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57104-57570-boust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57105-57380-boustroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57105-57380-boustroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57105-57380-boustroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57105-57380-boustroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57106-57320-bouzonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57106-57320-bouzonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57106-57320-bouzonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57106-57320-bouzonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57107-57340-brehain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57107-57340-brehain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57107-57340-brehain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57107-57340-brehain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57108-57720-breidenbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57108-57720-breidenbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57108-57720-breidenbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57108-57720-breidenbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57109-57570-breistroff_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57109-57570-breistroff_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57109-57570-breistroff_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57109-57570-breistroff_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57110-57320-brettnach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57110-57320-brettnach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57110-57320-brettnach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57110-57320-brettnach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57111-57535-bronvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57111-57535-bronvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57111-57535-bronvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57111-57535-bronvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57112-57220-brouck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57112-57220-brouck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57112-57220-brouck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57112-57220-brouck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57113-57565-brouderdorff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57113-57565-brouderdorff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57113-57565-brouderdorff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57113-57565-brouderdorff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57114-57635-brouviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57114-57635-brouviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57114-57635-brouviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57114-57635-brouviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57115-57340-brulange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57115-57340-brulange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57115-57340-brulange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57115-57340-brulange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57116-57420-buchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57116-57420-buchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57116-57420-buchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57116-57420-buchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57117-57920-buding/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57117-57920-buding/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57117-57920-buding/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57117-57920-buding/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57118-57970-budling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57118-57970-budling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57118-57970-budling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57118-57970-budling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57119-57400-buhl_lorraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57119-57400-buhl_lorraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57119-57400-buhl_lorraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57119-57400-buhl_lorraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57120-57170-burlioncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57120-57170-burlioncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57120-57170-burlioncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57120-57170-burlioncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57121-57220-burtoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57121-57220-burtoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57121-57220-burtoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57121-57220-burtoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57122-57450-cappel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57122-57450-cappel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57122-57450-cappel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57122-57450-cappel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57123-57490-carling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57123-57490-carling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57123-57490-carling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57123-57490-carling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57124-57570-cattenom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57124-57570-cattenom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57124-57570-cattenom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57124-57570-cattenom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57125-57365-chailly_les_ennery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57125-57365-chailly_les_ennery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57125-57365-chailly_les_ennery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57125-57365-chailly_les_ennery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57126-57170-chambrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57126-57170-chambrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57126-57170-chambrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57126-57170-chambrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57127-57580-chanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57127-57580-chanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57127-57580-chanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57127-57580-chanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57128-57220-charleville_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57128-57220-charleville_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57128-57220-charleville_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57128-57220-charleville_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57129-57640-charly_oradour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57129-57640-charly_oradour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57129-57640-charly_oradour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57129-57640-charly_oradour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57130-57340-chateau_brehain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57130-57340-chateau_brehain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57130-57340-chateau_brehain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57130-57340-chateau_brehain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57131-57320-chateau_rouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57131-57320-chateau_rouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57131-57320-chateau_rouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57131-57320-chateau_rouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57132-57170-chateau_salins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57132-57170-chateau_salins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57132-57170-chateau_salins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57132-57170-chateau_salins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57133-57170-chateau_voue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57133-57170-chateau_voue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57133-57170-chateau_voue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57133-57170-chateau_voue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57134-57160-chatel_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57134-57160-chatel_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57134-57160-chatel_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57134-57160-chatel_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57136-57320-chemery_les_deux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57136-57320-chemery_les_deux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57136-57320-chemery_les_deux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57136-57320-chemery_les_deux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57137-57420-cheminot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57137-57420-cheminot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57137-57420-cheminot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57137-57420-cheminot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57138-57580-chenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57138-57580-chenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57138-57580-chenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57138-57580-chenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57139-57420-cherisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57139-57420-cherisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57139-57420-cherisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57139-57420-cherisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57140-57245-chesny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57140-57245-chesny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57140-57245-chesny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57140-57245-chesny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57141-57590-chicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57141-57590-chicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57141-57590-chicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57141-57590-chicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57142-57070-chieulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57142-57070-chieulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57142-57070-chieulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57142-57070-chieulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57143-57185-clouange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57143-57185-clouange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57143-57185-clouange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57143-57185-clouange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57144-57800-cocheren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57144-57800-cocheren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57144-57800-cocheren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57144-57800-cocheren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57145-57530-coincy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57145-57530-coincy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57145-57530-coincy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57145-57530-coincy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57146-57420-coin_les_cuvry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57146-57420-coin_les_cuvry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57146-57420-coin_les_cuvry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57146-57420-coin_les_cuvry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57147-57420-coin_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57147-57420-coin_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57147-57420-coin_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57147-57420-coin_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57148-57530-colligny_maizery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57148-57530-colligny_maizery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57148-57530-colligny_maizery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57148-57530-colligny_maizery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57149-57320-colmen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57149-57320-colmen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57149-57320-colmen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57149-57320-colmen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57150-57220-conde_northen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57150-57220-conde_northen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57150-57220-conde_northen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57150-57220-conde_northen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57151-57340-conthil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57151-57340-conthil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57151-57340-conthil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57151-57340-conthil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57152-57480-contz_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57152-57480-contz_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57152-57480-contz_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57152-57480-contz_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57153-57680-corny_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57153-57680-corny_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57153-57680-corny_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57153-57680-corny_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57154-57220-coume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57154-57220-coume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57154-57220-coume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57154-57220-coume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57155-57530-courcelles_chaussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57155-57530-courcelles_chaussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57155-57530-courcelles_chaussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57155-57530-courcelles_chaussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57156-57530-courcelles_sur_nied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57156-57530-courcelles_sur_nied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57156-57530-courcelles_sur_nied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57156-57530-courcelles_sur_nied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57158-57590-craincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57158-57590-craincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57158-57590-craincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57158-57590-craincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57159-57690-crehange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57159-57690-crehange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57159-57690-crehange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57159-57690-crehange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57160-57150-creutzwald/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57160-57150-creutzwald/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57160-57150-creutzwald/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57160-57150-creutzwald/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57161-57260-cutting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57161-57260-cutting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57161-57260-cutting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57161-57260-cutting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57162-57420-cuvry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57162-57420-cuvry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57162-57420-cuvry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57162-57420-cuvry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57163-57850-dabo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57163-57850-dabo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57163-57850-dabo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57163-57850-dabo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57165-57550-dalem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57165-57550-dalem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57165-57550-dalem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57165-57550-dalem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57166-57340-dalhain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57166-57340-dalhain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57166-57340-dalhain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57166-57340-dalhain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57167-57320-dalstein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57167-57320-dalstein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57167-57320-dalstein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57167-57320-dalstein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57168-57370-danne_et_quatre_vents/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57168-57370-danne_et_quatre_vents/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57168-57370-danne_et_quatre_vents/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57168-57370-danne_et_quatre_vents/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57169-57820-dannelbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57169-57820-dannelbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57169-57820-dannelbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57169-57820-dannelbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57171-57590-delme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57171-57590-delme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57171-57590-delme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57171-57590-delme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57172-57220-denting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57172-57220-denting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57172-57220-denting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57172-57220-denting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57173-57260-desseling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57173-57260-desseling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57173-57260-desseling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57173-57260-desseling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57174-57340-destry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57174-57340-destry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57174-57340-destry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57174-57340-destry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57175-57830-diane_capelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57175-57830-diane_capelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57175-57830-diane_capelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57175-57830-diane_capelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57176-57980-diebling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57176-57980-diebling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57176-57980-diebling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57176-57980-diebling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57177-57260-dieuze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57177-57260-dieuze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57177-57260-dieuze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57177-57260-dieuze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57178-57660-diffembach_les_hellimer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57178-57660-diffembach_les_hellimer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57178-57660-diffembach_les_hellimer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57178-57660-diffembach_les_hellimer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57179-57925-distroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57179-57925-distroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57179-57925-distroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57179-57925-distroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57180-57400-dolving/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57180-57400-dolving/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57180-57400-dolving/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57180-57400-dolving/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57181-57260-domnom_les_dieuze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57181-57260-domnom_les_dieuze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57181-57260-domnom_les_dieuze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57181-57260-domnom_les_dieuze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57182-57590-donjeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57182-57590-donjeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57182-57590-donjeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57182-57590-donjeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57183-57810-donnelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57183-57810-donnelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57183-57810-donnelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57183-57810-donnelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57186-57320-ebersviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57186-57320-ebersviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57186-57320-ebersviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57186-57320-ebersviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57187-57220-eblange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57187-57220-eblange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57187-57220-eblange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57187-57220-eblange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57188-57230-eguelshardt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57188-57230-eguelshardt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57188-57230-eguelshardt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57188-57230-eguelshardt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57189-57340-eincheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57189-57340-eincheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57189-57340-eincheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57189-57340-eincheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57190-57690-elvange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57190-57690-elvange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57190-57690-elvange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57190-57690-elvange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57191-57970-elzange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57191-57970-elzange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57191-57970-elzange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57191-57970-elzange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57192-57415-enchenberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57192-57415-enchenberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57192-57415-enchenberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57192-57415-enchenberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57193-57365-ennery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57193-57365-ennery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57193-57365-ennery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57193-57365-ennery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57194-57330-entrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57194-57330-entrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57194-57330-entrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57194-57330-entrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57195-57720-epping/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57195-57720-epping/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57195-57720-epping/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57195-57720-epping/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57196-57720-erching/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57196-57720-erching/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57196-57720-erching/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57196-57720-erching/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57197-57510-ernestviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57197-57510-ernestviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57197-57510-ernestviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57197-57510-ernestviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57198-57660-erstroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57198-57660-erstroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57198-57660-erstroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57198-57660-erstroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57199-57330-escherange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57199-57330-escherange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57199-57330-escherange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57199-57330-escherange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57200-57530-les_etangs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57200-57530-les_etangs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57200-57530-les_etangs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57200-57530-les_etangs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57201-57412-etting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57201-57412-etting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57201-57412-etting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57201-57412-etting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57202-57460-etzling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57202-57460-etzling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57202-57460-etzling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57202-57460-etzling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57203-57570-evrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57203-57570-evrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57203-57570-evrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57203-57570-evrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57204-57640-failly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57204-57640-failly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57204-57640-failly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57204-57640-failly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57205-57550-falck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57205-57550-falck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57205-57550-falck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57205-57550-falck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57206-57290-fameck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57206-57290-fameck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57206-57290-fameck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57206-57290-fameck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57207-57450-farebersviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57207-57450-farebersviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57207-57450-farebersviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57207-57450-farebersviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57208-57450-farschviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57208-57450-farschviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57208-57450-farschviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57208-57450-farschviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57209-57380-faulquemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57209-57380-faulquemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57209-57380-faulquemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57209-57380-faulquemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57210-57930-fenetrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57210-57930-fenetrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57210-57930-fenetrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57210-57930-fenetrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57211-57280-feves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57211-57280-feves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57211-57280-feves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57211-57280-feves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57212-57420-fey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57212-57420-fey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57212-57420-fey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57212-57420-fey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57213-57320-filstroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57213-57320-filstroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57213-57320-filstroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57213-57320-filstroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57214-57570-fixem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57214-57570-fixem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57214-57570-fixem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57214-57570-fixem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57215-57320-flastroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57215-57320-flastroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57215-57320-flastroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57215-57320-flastroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57216-57635-fleisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57216-57635-fleisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57216-57635-fleisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57216-57635-fleisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57217-57690-fletrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57217-57690-fletrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57217-57690-fletrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57217-57690-fletrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57218-57420-fleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57218-57420-fleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57218-57420-fleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57218-57420-fleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57219-57365-flevy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57219-57365-flevy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57219-57365-flevy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57219-57365-flevy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57220-57580-flocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57220-57580-flocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57220-57580-flocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57220-57580-flocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57221-57190-florange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57221-57190-florange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57221-57190-florange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57221-57190-florange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57222-57600-folkling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57222-57600-folkling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57222-57600-folkling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57222-57600-folkling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57224-57730-folschviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57224-57730-folschviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57224-57730-folschviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57224-57730-folschviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57225-57590-fonteny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57225-57590-fonteny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57225-57590-fonteny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57225-57590-fonteny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57226-57650-fontoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57226-57650-fontoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57226-57650-fontoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57226-57650-fontoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57227-57600-forbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57227-57600-forbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57227-57600-forbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57227-57600-forbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57228-57590-fossieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57228-57590-fossieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57228-57590-fossieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57228-57590-fossieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57229-57830-foulcrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57229-57830-foulcrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57229-57830-foulcrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57229-57830-foulcrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57230-57220-fouligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57230-57220-fouligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57230-57220-fouligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57230-57220-fouligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57231-57420-foville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57231-57420-foville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57231-57420-foville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57231-57420-foville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57232-57670-francaltroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57232-57670-francaltroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57232-57670-francaltroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57232-57670-francaltroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57233-57790-fraquelfing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57233-57790-fraquelfing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57233-57790-fraquelfing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57233-57790-fraquelfing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57234-57200-frauenberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57234-57200-frauenberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57234-57200-frauenberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57234-57200-frauenberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57235-57320-freistroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57235-57320-freistroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57235-57320-freistroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57235-57320-freistroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57236-57590-fremery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57236-57590-fremery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57236-57590-fremery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57236-57590-fremery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57237-57660-fremestroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57237-57660-fremestroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57237-57660-fremestroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57237-57660-fremestroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57238-57170-fresnes_en_saulnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57238-57170-fresnes_en_saulnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57238-57170-fresnes_en_saulnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57238-57170-fresnes_en_saulnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57239-57660-freybouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57239-57660-freybouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57239-57660-freybouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57239-57660-freybouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57240-57800-freyming_merlebach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57240-57800-freyming_merlebach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57240-57800-freyming_merlebach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57240-57800-freyming_merlebach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57241-57810-fribourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57241-57810-fribourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57241-57810-fribourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57241-57810-fribourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57242-57175-gandrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57242-57175-gandrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57242-57175-gandrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57242-57175-gandrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57244-57820-garrebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57244-57820-garrebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57244-57820-garrebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57244-57820-garrebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57245-57570-gavisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57245-57570-gavisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57245-57570-gavisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57245-57570-gavisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57246-57260-gelucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57246-57260-gelucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57246-57260-gelucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57246-57260-gelucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57247-57170-gerbecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57247-57170-gerbecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57247-57170-gerbecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57247-57170-gerbecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57248-57670-givrycourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57248-57670-givrycourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57248-57670-givrycourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57248-57670-givrycourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57249-57530-glatigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57249-57530-glatigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57249-57530-glatigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57249-57530-glatigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57250-57620-goetzenbruck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57250-57620-goetzenbruck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57250-57620-goetzenbruck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57250-57620-goetzenbruck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57251-57420-goin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57251-57420-goin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57251-57420-goin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57251-57420-goin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57252-57220-gomelange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57252-57220-gomelange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57252-57220-gomelange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57252-57220-gomelange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57253-57815-gondrexange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57253-57815-gondrexange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57253-57815-gondrexange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57253-57815-gondrexange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57254-57680-gorze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57254-57680-gorze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57254-57680-gorze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57254-57680-gorze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57255-57930-gosselming/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57255-57930-gosselming/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57255-57930-gosselming/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57255-57930-gosselming/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57256-57130-gravelotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57256-57130-gravelotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57256-57130-gravelotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57256-57130-gravelotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57257-57170-gremecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57257-57170-gremecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57257-57170-gremecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57257-57170-gremecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57258-57660-grening/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57258-57660-grening/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57258-57660-grening/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57258-57660-grening/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57259-57480-grindorff_bizing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57259-57480-grindorff_bizing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57259-57480-grindorff_bizing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57259-57480-grindorff_bizing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57260-57520-grosbliederstroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57260-57520-grosbliederstroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57260-57520-grosbliederstroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57260-57520-grosbliederstroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57261-57410-gros_rederching/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57261-57410-gros_rederching/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57261-57410-gros_rederching/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57261-57410-gros_rederching/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57262-57660-grostenquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57262-57660-grostenquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57262-57660-grostenquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57262-57660-grostenquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57263-57510-grundviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57263-57510-grundviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57263-57510-grundviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57263-57510-grundviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57264-57510-guebenhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57264-57510-guebenhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57264-57510-guebenhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57264-57510-guebenhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57265-57260-guebestroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57265-57260-guebestroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57265-57260-guebestroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57265-57260-guebestroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57266-57260-gueblange_les_dieuze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57266-57260-gueblange_les_dieuze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57266-57260-gueblange_les_dieuze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57266-57260-gueblange_les_dieuze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57267-57430-le_val_de_gueblange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57267-57430-le_val_de_gueblange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57267-57430-le_val_de_gueblange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57267-57430-le_val_de_gueblange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57268-57260-guebling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57268-57260-guebling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57268-57260-guebling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57268-57260-guebling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57269-57310-guenange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57269-57310-guenange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57269-57310-guenange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57269-57310-guenange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57270-57260-val_de_bride/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57270-57260-val_de_bride/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57270-57260-val_de_bride/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57270-57260-val_de_bride/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57271-57470-guenviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57271-57470-guenviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57271-57470-guenviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57271-57470-guenviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57272-57260-guermange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57272-57260-guermange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57272-57260-guermange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57272-57260-guermange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57273-57320-guerstling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57273-57320-guerstling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57273-57320-guerstling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57273-57320-guerstling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57274-57880-guerting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57274-57880-guerting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57274-57880-guerting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57274-57880-guerting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57275-57380-guessling_hemering/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57275-57380-guessling_hemering/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57275-57380-guessling_hemering/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57275-57380-guessling_hemering/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57276-57690-guinglange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57276-57690-guinglange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57276-57690-guinglange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57276-57690-guinglange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57277-57220-guinkirchen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57277-57220-guinkirchen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57277-57220-guinkirchen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57277-57220-guinkirchen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57278-57670-guinzeling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57278-57670-guinzeling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57278-57670-guinzeling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57278-57670-guinzeling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57280-57405-guntzviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57280-57405-guntzviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57280-57405-guntzviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57280-57405-guntzviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57281-57340-haboudange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57281-57340-haboudange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57281-57340-haboudange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57281-57340-haboudange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57282-57570-hagen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57282-57570-hagen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57282-57570-hagen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57282-57570-hagen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57283-57300-hagondange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57283-57300-hagondange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57283-57300-hagondange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57283-57300-hagondange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57284-57690-hallering/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57284-57690-hallering/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57284-57690-hallering/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57284-57690-hallering/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57286-57480-halstroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57286-57480-halstroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57286-57480-halstroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57286-57480-halstroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57287-57970-basse_ham/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57287-57970-basse_ham/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57287-57970-basse_ham/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57287-57970-basse_ham/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57288-57880-ham_sous_varsberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57288-57880-ham_sous_varsberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57288-57880-ham_sous_varsberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57288-57880-ham_sous_varsberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57289-57910-hambach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57289-57910-hambach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57289-57910-hambach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57289-57910-hambach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57290-57170-hampont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57290-57170-hampont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57290-57170-hampont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57290-57170-hampont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57291-57370-hangviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57291-57370-hangviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57291-57370-hangviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57291-57370-hangviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57292-57590-hannocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57292-57590-hannocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57292-57590-hannocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57292-57590-hannocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57293-57580-han_sur_nied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57293-57580-han_sur_nied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57293-57580-han_sur_nied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57293-57580-han_sur_nied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57294-57230-hanviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57294-57230-hanviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57294-57230-hanviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57294-57230-hanviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57295-57630-haraucourt_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57295-57630-haraucourt_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57295-57630-haraucourt_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57295-57630-haraucourt_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57296-57550-hargarten_aux_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57296-57550-hargarten_aux_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57296-57550-hargarten_aux_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57296-57550-hargarten_aux_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57297-57340-harprich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57297-57340-harprich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57297-57340-harprich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57297-57340-harprich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57298-57870-harreberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57298-57870-harreberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57298-57870-harreberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57298-57870-harreberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57299-57870-hartzviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57299-57870-hartzviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57299-57870-hartzviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57299-57870-hartzviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57300-57850-haselbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57300-57850-haselbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57300-57850-haselbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57300-57850-haselbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57301-57230-haspelschiedt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57301-57230-haspelschiedt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57301-57230-haspelschiedt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57301-57230-haspelschiedt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57302-57790-hattigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57302-57790-hattigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57302-57790-hattigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57302-57790-hattigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57303-57280-hauconcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57303-57280-hauconcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57303-57280-hauconcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57303-57280-hauconcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57304-57400-haut_clocher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57304-57400-haut_clocher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57304-57400-haut_clocher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57304-57400-haut_clocher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57305-57650-havange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57305-57650-havange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57305-57650-havange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57305-57650-havange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57306-57700-hayange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57306-57700-hayange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57306-57700-hayange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57306-57700-hayange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57307-57530-hayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57307-57530-hayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57307-57530-hayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57307-57530-hayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57308-57430-hazembourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57308-57430-hazembourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57308-57430-hazembourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57308-57430-hazembourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57309-57320-heining_les_bouzonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57309-57320-heining_les_bouzonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57309-57320-heining_les_bouzonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57309-57320-heining_les_bouzonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57310-57930-hellering_les_fenetrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57310-57930-hellering_les_fenetrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57310-57930-hellering_les_fenetrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57310-57930-hellering_les_fenetrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57311-57660-hellimer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57311-57660-hellimer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57311-57660-hellimer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57311-57660-hellimer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57312-57220-helstroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57312-57220-helstroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57312-57220-helstroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57312-57220-helstroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57313-57690-hemilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57313-57690-hemilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57313-57690-hemilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57313-57690-hemilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57314-57830-heming/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57314-57830-heming/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57314-57830-heming/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57314-57830-heming/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57315-57820-henridorff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57315-57820-henridorff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57315-57820-henridorff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57315-57820-henridorff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57316-57450-henriville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57316-57450-henriville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57316-57450-henriville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57316-57450-henriville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57317-57635-herange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57317-57635-herange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57317-57635-herange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57317-57635-herange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57318-57790-hermelange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57318-57790-hermelange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57318-57790-hermelange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57318-57790-hermelange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57319-57580-herny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57319-57580-herny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57319-57580-herny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57319-57580-herny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57320-57830-hertzing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57320-57830-hertzing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57320-57830-hertzing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57320-57830-hertzing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57321-57400-hesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57321-57400-hesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57321-57400-hesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57321-57400-hesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57322-57320-hestroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57322-57320-hestroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57322-57320-hestroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57322-57320-hestroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57323-57330-hettange_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57323-57330-hettange_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57323-57330-hettange_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57323-57330-hettange_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57324-57400-hilbesheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57324-57400-hilbesheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57324-57400-hilbesheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57324-57400-hilbesheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57325-57510-hilsprich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57325-57510-hilsprich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57325-57510-hilsprich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57325-57510-hilsprich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57326-57220-hinckange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57326-57220-hinckange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57326-57220-hinckange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57326-57220-hinckange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57328-57380-holacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57328-57380-holacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57328-57380-holacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57328-57380-holacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57329-57220-holling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57329-57220-holling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57329-57220-holling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57329-57220-holling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57330-57510-holving/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57330-57510-holving/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57330-57510-holving/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57330-57510-holving/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57331-57920-hombourg_budange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57331-57920-hombourg_budange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57331-57920-hombourg_budange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57331-57920-hombourg_budange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57332-57470-hombourg_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57332-57470-hombourg_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57332-57470-hombourg_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57332-57470-hombourg_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57333-57405-hommarting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57333-57405-hommarting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57333-57405-hommarting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57333-57405-hommarting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57334-57870-hommert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57334-57870-hommert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57334-57870-hommert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57334-57870-hommert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57335-57670-honskirch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57335-57670-honskirch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57335-57670-honskirch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57335-57670-honskirch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57336-57490-l_hopital/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57336-57490-l_hopital/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57336-57490-l_hopital/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57336-57490-l_hopital/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57337-57510-hoste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57337-57510-hoste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57337-57510-hoste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57337-57510-hoste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57338-57720-hottviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57338-57720-hottviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57338-57720-hottviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57338-57720-hottviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57339-57820-hultehouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57339-57820-hultehouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57339-57820-hultehouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57339-57820-hultehouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57340-57990-hundling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57340-57990-hundling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57340-57990-hundling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57340-57990-hundling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57341-57480-hunting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57341-57480-hunting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57341-57480-hunting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57341-57480-hunting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57342-57830-ibigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57342-57830-ibigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57342-57830-ibigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57342-57830-ibigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57343-57970-illange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57343-57970-illange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57343-57970-illange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57343-57970-illange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57344-57400-imling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57344-57400-imling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57344-57400-imling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57344-57400-imling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57345-57970-inglange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57345-57970-inglange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57345-57970-inglange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57345-57970-inglange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57346-57670-insming/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57346-57670-insming/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57346-57670-insming/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57346-57670-insming/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57347-57670-insviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57347-57670-insviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57347-57670-insviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57347-57670-insviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57348-57990-ippling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57348-57990-ippling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57348-57990-ippling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57348-57990-ippling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57349-57590-jallaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57349-57590-jallaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57349-57590-jallaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57349-57590-jallaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57350-57130-jouy_aux_arches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57350-57130-jouy_aux_arches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57350-57130-jouy_aux_arches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57350-57130-jouy_aux_arches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57351-57245-jury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57351-57245-jury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57351-57245-jury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57351-57245-jury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57352-57130-jussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57352-57130-jussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57352-57130-jussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57352-57130-jussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57353-57630-juvelize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57353-57630-juvelize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57353-57630-juvelize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57353-57630-juvelize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57354-57590-juville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57354-57590-juville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57354-57590-juville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57354-57590-juville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57355-57412-kalhausen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57355-57412-kalhausen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57355-57412-kalhausen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57355-57412-kalhausen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57356-57330-kanfen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57356-57330-kanfen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57356-57330-kanfen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57356-57330-kanfen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57357-57430-kappelkinger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57357-57430-kappelkinger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57357-57430-kappelkinger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57357-57430-kappelkinger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57358-57920-kedange_sur_canner/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57358-57920-kedange_sur_canner/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57358-57920-kedange_sur_canner/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57358-57920-kedange_sur_canner/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57359-57920-kemplich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57359-57920-kemplich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57359-57920-kemplich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57359-57920-kemplich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57360-57460-kerbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57360-57460-kerbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57360-57460-kerbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57360-57460-kerbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57361-57480-kerling_les_sierck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57361-57480-kerling_les_sierck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57361-57480-kerling_les_sierck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57361-57480-kerling_les_sierck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57362-57830-kerprich_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57362-57830-kerprich_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57362-57830-kerprich_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57362-57830-kerprich_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57364-57480-kirsch_les_sierck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57364-57480-kirsch_les_sierck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57364-57480-kirsch_les_sierck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57364-57480-kirsch_les_sierck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57365-57480-kirschnaumen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57365-57480-kirschnaumen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57365-57480-kirschnaumen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57365-57480-kirschnaumen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57366-57430-kirviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57366-57430-kirviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57366-57430-kirviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57366-57430-kirviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57367-57920-klang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57367-57920-klang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57367-57920-klang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57367-57920-klang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57368-57240-knutange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57368-57240-knutange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57368-57240-knutange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57368-57240-knutange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57370-57970-koenigsmacker/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57370-57970-koenigsmacker/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57370-57970-koenigsmacker/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57370-57970-koenigsmacker/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57371-57480-haute_kontz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57371-57480-haute_kontz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57371-57480-haute_kontz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57371-57480-haute_kontz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57372-57970-kuntzig/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57372-57970-kuntzig/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57372-57970-kuntzig/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57372-57970-kuntzig/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57373-57730-lachambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57373-57730-lachambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57373-57730-lachambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57373-57730-lachambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57374-57560-lafrimbolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57374-57560-lafrimbolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57374-57560-lafrimbolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57374-57560-lafrimbolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57375-57810-lagarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57375-57810-lagarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57375-57810-lagarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57375-57810-lagarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57376-57410-lambach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57376-57410-lambach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57376-57410-lambach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57376-57410-lambach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57377-57830-landange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57377-57830-landange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57377-57830-landange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57377-57830-landange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57379-57340-landroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57379-57340-landroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57379-57340-landroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57379-57340-landroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57380-57790-laneuveville_les_lorquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57380-57790-laneuveville_les_lorquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57380-57790-laneuveville_les_lorquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57380-57790-laneuveville_les_lorquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57381-57590-laneuveville_en_saulnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57381-57590-laneuveville_en_saulnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57381-57590-laneuveville_en_saulnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57381-57590-laneuveville_en_saulnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57382-57400-langatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57382-57400-langatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57382-57400-langatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57382-57400-langatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57383-57810-languimberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57383-57810-languimberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57383-57810-languimberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57383-57810-languimberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57384-57660-laning/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57384-57660-laning/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57384-57660-laning/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57384-57660-laning/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57385-57530-laquenexy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57385-57530-laquenexy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57385-57530-laquenexy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57385-57530-laquenexy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57386-57385-laudrefang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57386-57385-laudrefang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57386-57385-laudrefang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57386-57385-laudrefang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57387-57480-laumesfeld/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57387-57480-laumesfeld/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57387-57480-laumesfeld/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57387-57480-laumesfeld/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57388-57480-launstroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57388-57480-launstroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57388-57480-launstroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57388-57480-launstroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57389-57660-lelling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57389-57660-lelling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57389-57660-lelling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57389-57660-lelling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57390-57620-lemberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57390-57620-lemberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57390-57620-lemberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57390-57620-lemberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57391-57590-lemoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57391-57590-lemoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57391-57590-lemoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57391-57590-lemoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57392-57580-lemud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57392-57580-lemud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57392-57580-lemud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57392-57580-lemud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57393-57720-lengelsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57393-57720-lengelsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57393-57720-lengelsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57393-57720-lengelsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57394-57670-lening/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57394-57670-lening/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57394-57670-lening/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57394-57670-lening/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57395-57580-lesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57395-57580-lesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57395-57580-lesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57395-57580-lesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57396-57160-lessy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57396-57160-lessy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57396-57160-lessy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57396-57160-lessy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57397-57810-ley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57397-57810-ley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57397-57810-ley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57397-57810-ley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57398-57660-leyviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57398-57660-leyviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57398-57660-leyviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57398-57660-leyviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57399-57630-lezey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57399-57630-lezey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57399-57630-lezey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57399-57630-lezey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57401-57340-lidrezing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57401-57340-lidrezing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57401-57340-lidrezing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57401-57340-lidrezing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57402-57230-liederschiedt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57402-57230-liederschiedt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57402-57230-liederschiedt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57402-57230-liederschiedt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57403-57420-liehon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57403-57420-liehon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57403-57420-liehon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57403-57420-liehon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57404-57260-lindre_basse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57404-57260-lindre_basse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57404-57260-lindre_basse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57404-57260-lindre_basse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57405-57260-lindre_haute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57405-57260-lindre_haute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57405-57260-lindre_haute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57405-57260-lindre_haute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57406-57590-liocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57406-57590-liocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57406-57590-liocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57406-57590-liocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57407-57635-lixheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57407-57635-lixheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57407-57635-lixheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57407-57635-lixheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57408-57520-lixing_les_rouhling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57408-57520-lixing_les_rouhling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57408-57520-lixing_les_rouhling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57408-57520-lixing_les_rouhling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57409-57660-lixing_les_saint_avold/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57409-57660-lixing_les_saint_avold/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57409-57660-lixing_les_saint_avold/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57409-57660-lixing_les_saint_avold/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57410-57670-lhor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57410-57670-lhor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57410-57670-lhor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57410-57670-lhor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57411-57650-lommerange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57411-57650-lommerange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57411-57650-lommerange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57411-57650-lommerange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57412-57050-longeville_les_metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57412-57050-longeville_les_metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57412-57050-longeville_les_metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57412-57050-longeville_les_metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57413-57740-longeville_les_saint_avold/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57413-57740-longeville_les_saint_avold/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57413-57740-longeville_les_saint_avold/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57413-57740-longeville_les_saint_avold/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57414-57790-lorquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57414-57790-lorquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57414-57790-lorquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57414-57790-lorquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57415-57050-lorry_les_metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57415-57050-lorry_les_metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57415-57050-lorry_les_metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57415-57050-lorry_les_metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57416-57420-lorry_mardigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57416-57420-lorry_mardigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57416-57420-lorry_mardigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57416-57420-lorry_mardigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57417-57670-lostroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57417-57670-lostroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57417-57670-lostroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57417-57670-lostroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57418-57670-loudrefing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57418-57670-loudrefing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57418-57670-loudrefing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57418-57670-loudrefing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57419-57510-loupershouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57419-57510-loupershouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57419-57510-loupershouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57419-57510-loupershouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57421-57720-loutzviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57421-57720-loutzviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57421-57720-loutzviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57421-57720-loutzviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57422-57420-louvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57422-57420-louvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57422-57420-louvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57422-57420-louvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57423-57170-lubecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57423-57170-lubecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57423-57170-lubecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57423-57170-lubecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57424-57590-lucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57424-57590-lucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57424-57590-lucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57424-57590-lucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57425-57580-luppy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57425-57580-luppy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57425-57580-luppy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57425-57580-luppy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57426-57935-luttange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57426-57935-luttange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57426-57935-luttange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57426-57935-luttange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57427-57820-lutzelbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57427-57820-lutzelbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57427-57820-lutzelbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57427-57820-lutzelbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57428-57730-macheren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57428-57730-macheren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57428-57730-macheren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57428-57730-macheren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57430-57380-mainvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57430-57380-mainvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57430-57380-mainvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57430-57380-mainvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57431-57530-maizeroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57431-57530-maizeroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57431-57530-maizeroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57431-57530-maizeroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57433-57280-maizieres_les_metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57433-57280-maizieres_les_metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57433-57280-maizieres_les_metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57433-57280-maizieres_les_metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57434-57810-maizieres_les_vic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57434-57810-maizieres_les_vic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57434-57810-maizieres_les_vic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57434-57810-maizieres_les_vic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57436-57590-malaucourt_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57436-57590-malaucourt_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57436-57590-malaucourt_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57436-57590-malaucourt_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57437-57480-malling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57437-57480-malling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57437-57480-malling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57437-57480-malling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57438-57640-malroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57438-57640-malroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57438-57640-malroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57438-57640-malroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57439-57480-manderen_ritzing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57439-57480-manderen_ritzing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57439-57480-manderen_ritzing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57439-57480-manderen_ritzing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57440-57590-manhoue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57440-57590-manhoue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57440-57590-manhoue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57440-57590-manhoue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57441-57100-manom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57441-57100-manom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57441-57100-manom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57441-57100-manom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57442-57380-many/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57442-57380-many/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57442-57380-many/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57442-57380-many/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57443-57535-marange_silvange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57443-57535-marange_silvange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57443-57535-marange_silvange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57443-57535-marange_silvange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57444-57690-marange_zondrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57444-57690-marange_zondrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57444-57690-marange_zondrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57444-57690-marange_zondrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57445-57420-marieulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57445-57420-marieulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57445-57420-marieulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57445-57420-marieulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57446-57670-marimont_les_benestroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57446-57670-marimont_les_benestroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57446-57670-marimont_les_benestroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57446-57670-marimont_les_benestroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57447-57155-marly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57447-57155-marly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57447-57155-marly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57447-57155-marly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57448-57630-marsal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57448-57630-marsal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57448-57630-marsal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57448-57630-marsal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57449-57530-marsilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57449-57530-marsilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57449-57530-marsilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57449-57530-marsilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57451-57340-marthille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57451-57340-marthille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57451-57340-marthille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57451-57340-marthille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57452-57140-la_maxe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57452-57140-la_maxe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57452-57140-la_maxe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57452-57140-la_maxe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57453-57660-maxstadt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57453-57660-maxstadt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57453-57660-maxstadt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57453-57660-maxstadt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57454-57245-mecleuves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57454-57245-mecleuves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57454-57245-mecleuves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57454-57245-mecleuves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57455-57220-megange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57455-57220-megange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57455-57220-megange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57455-57220-megange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57456-57960-meisenthal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57456-57960-meisenthal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57456-57960-meisenthal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57456-57960-meisenthal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57457-57320-menskirch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57457-57320-menskirch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57457-57320-menskirch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57457-57320-menskirch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57459-57480-merschweiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57459-57480-merschweiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57459-57480-merschweiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57459-57480-merschweiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57460-57550-merten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57460-57550-merten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57460-57550-merten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57460-57550-merten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57461-57560-metairies_saint_quirin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57461-57560-metairies_saint_quirin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57461-57560-metairies_saint_quirin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57461-57560-metairies_saint_quirin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57462-57370-metting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57462-57370-metting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57462-57370-metting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57462-57370-metting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57000-metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57000-metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57000-metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57000-metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57050-metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57050-metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57050-metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57050-metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57070-metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57070-metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57070-metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57070-metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57140-metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57140-metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57140-metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57463-57140-metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57464-57920-metzeresche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57464-57920-metzeresche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57464-57920-metzeresche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57464-57920-metzeresche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57465-57940-metzervisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57465-57940-metzervisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57465-57940-metzervisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57465-57940-metzervisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57466-57980-metzing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57466-57980-metzing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57466-57980-metzing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57466-57980-metzing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57467-57070-mey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57467-57070-mey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57467-57070-mey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57467-57070-mey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57468-57370-mittelbronn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57468-57370-mittelbronn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57468-57370-mittelbronn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57468-57370-mittelbronn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57469-57930-mittersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57469-57930-mittersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57469-57930-mittersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57469-57930-mittersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57470-57670-molring/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57470-57670-molring/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57470-57670-molring/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57470-57670-molring/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57471-57220-momerstroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57471-57220-momerstroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57471-57220-momerstroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57471-57220-momerstroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57472-57420-moncheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57472-57420-moncheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57472-57420-moncheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57472-57420-moncheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57473-57810-moncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57473-57810-moncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57473-57810-moncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57473-57810-moncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57474-57300-mondelange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57474-57300-mondelange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57474-57300-mondelange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57474-57300-mondelange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57475-57570-mondorff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57475-57570-mondorff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57475-57570-mondorff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57475-57570-mondorff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57476-57920-monneren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57476-57920-monneren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57476-57920-monneren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57476-57920-monneren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57477-57415-montbronn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57477-57415-montbronn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57477-57415-montbronn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57477-57415-montbronn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57478-57670-montdidier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57478-57670-montdidier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57478-57670-montdidier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57478-57670-montdidier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57479-57480-montenach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57479-57480-montenach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57479-57480-montenach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57479-57480-montenach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57480-57950-montigny_les_metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57480-57950-montigny_les_metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57480-57950-montigny_les_metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57480-57950-montigny_les_metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57481-57860-montois_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57481-57860-montois_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57481-57860-montois_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57481-57860-montois_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57482-57645-ogy_montoy_flanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57482-57645-ogy_montoy_flanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57482-57645-ogy_montoy_flanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57482-57645-ogy_montoy_flanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57482-57530-ogy_montoy_flanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57482-57530-ogy_montoy_flanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57482-57530-ogy_montoy_flanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57482-57530-ogy_montoy_flanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57483-57340-morhange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57483-57340-morhange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57483-57340-morhange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57483-57340-morhange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57484-57600-morsbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57484-57600-morsbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57484-57600-morsbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57484-57600-morsbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57485-57170-morville_les_vic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57485-57170-morville_les_vic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57485-57170-morville_les_vic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57485-57170-morville_les_vic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57486-57590-morville_sur_nied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57486-57590-morville_sur_nied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57486-57590-morville_sur_nied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57486-57590-morville_sur_nied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57487-57160-moulins_les_metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57487-57160-moulins_les_metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57487-57160-moulins_les_metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57487-57160-moulins_les_metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57488-57770-moussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57488-57770-moussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57488-57770-moussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57488-57770-moussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57489-57620-mouterhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57489-57620-mouterhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57489-57620-mouterhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57489-57620-mouterhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57490-57630-moyenvic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57490-57630-moyenvic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57490-57630-moyenvic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57490-57630-moyenvic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57491-57250-moyeuvre_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57491-57250-moyeuvre_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57491-57250-moyeuvre_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57491-57250-moyeuvre_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57492-57250-moyeuvre_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57492-57250-moyeuvre_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57492-57250-moyeuvre_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57492-57250-moyeuvre_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57493-57260-mulcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57493-57260-mulcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57493-57260-mulcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57493-57260-mulcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57494-57670-munster/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57494-57670-munster/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57494-57670-munster/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57494-57670-munster/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57495-57220-narbefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57495-57220-narbefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57495-57220-narbefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57495-57220-narbefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57496-57670-nebing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57496-57670-nebing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57496-57670-nebing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57496-57670-nebing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57497-57670-nelling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57497-57670-nelling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57497-57670-nelling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57497-57670-nelling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57498-57700-neufchef/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57498-57700-neufchef/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57498-57700-neufchef/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57498-57700-neufchef/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57499-57910-neufgrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57499-57910-neufgrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57499-57910-neufgrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57499-57910-neufgrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57500-57830-neufmoulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57500-57830-neufmoulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57500-57830-neufmoulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57500-57830-neufmoulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57501-57670-neufvillage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57501-57670-neufvillage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57501-57670-neufvillage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57501-57670-neufvillage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57502-57320-neunkirchen_les_bouzonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57502-57320-neunkirchen_les_bouzonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57502-57320-neunkirchen_les_bouzonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57502-57320-neunkirchen_les_bouzonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57504-57560-niderhoff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57504-57560-niderhoff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57504-57560-niderhoff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57504-57560-niderhoff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57505-57565-niderviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57505-57565-niderviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57505-57565-niderviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57505-57565-niderviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57506-57930-niederstinzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57506-57930-niederstinzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57506-57930-niederstinzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57506-57930-niederstinzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57507-57220-niedervisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57507-57220-niedervisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57507-57220-niedervisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57507-57220-niedervisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57508-57240-nilvange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57508-57240-nilvange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57508-57240-nilvange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57508-57240-nilvange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57509-57790-nitting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57509-57790-nitting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57509-57790-nitting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57509-57790-nitting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57510-57645-noisseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57510-57645-noisseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57510-57645-noisseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57510-57645-noisseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57511-57140-norroy_le_veneur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57511-57140-norroy_le_veneur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57511-57140-norroy_le_veneur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57511-57140-norroy_le_veneur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57511-57855-norroy_le_veneur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57511-57855-norroy_le_veneur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57511-57855-norroy_le_veneur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57511-57855-norroy_le_veneur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57512-57645-nouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57512-57645-nouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57512-57645-nouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57512-57645-nouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57513-57720-nousseviller_les_bitche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57513-57720-nousseviller_les_bitche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57513-57720-nousseviller_les_bitche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57513-57720-nousseviller_les_bitche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57514-57990-nousseviller_saint_nabor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57514-57990-nousseviller_saint_nabor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57514-57990-nousseviller_saint_nabor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57514-57990-nousseviller_saint_nabor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57515-57680-noveant_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57515-57680-noveant_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57515-57680-noveant_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57515-57680-noveant_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57516-57320-oberdorff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57516-57320-oberdorff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57516-57320-oberdorff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57516-57320-oberdorff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57517-57720-obergailbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57517-57720-obergailbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57517-57720-obergailbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57517-57720-obergailbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57518-57930-oberstinzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57518-57930-oberstinzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57518-57930-oberstinzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57518-57930-oberstinzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57519-57220-obervisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57519-57220-obervisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57519-57220-obervisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57519-57220-obervisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57520-57170-obreck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57520-57170-obreck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57520-57170-obreck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57520-57170-obreck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57521-57600-oeting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57521-57600-oeting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57521-57600-oeting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57521-57600-oeting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57524-57810-ommeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57524-57810-ommeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57524-57810-ommeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57524-57810-ommeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57525-57590-oriocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57525-57590-oriocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57525-57590-oriocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57525-57590-oriocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57526-57720-ormersviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57526-57720-ormersviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57526-57720-ormersviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57526-57720-ormersviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57527-57420-orny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57527-57420-orny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57527-57420-orny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57527-57420-orny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57528-57590-oron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57528-57590-oron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57528-57590-oron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57528-57590-oron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57529-57840-ottange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57529-57840-ottange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57529-57840-ottange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57529-57840-ottange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57530-57220-ottonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57530-57220-ottonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57530-57220-ottonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57530-57220-ottonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57531-57970-oudrenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57531-57970-oudrenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57531-57970-oudrenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57531-57970-oudrenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57532-57420-pagny_les_goin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57532-57420-pagny_les_goin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57532-57420-pagny_les_goin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57532-57420-pagny_les_goin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57533-57530-pange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57533-57530-pange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57533-57530-pange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57533-57530-pange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57534-57245-peltre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57534-57245-peltre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57534-57245-peltre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57534-57245-peltre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57535-57410-petit_rederching/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57535-57410-petit_rederching/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57535-57410-petit_rederching/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57535-57410-petit_rederching/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57536-57660-petit_tenquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57536-57660-petit_tenquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57536-57660-petit_tenquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57536-57660-petit_tenquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57537-57540-petite_rosselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57537-57540-petite_rosselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57537-57540-petite_rosselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57537-57540-petite_rosselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57538-57170-pettoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57538-57170-pettoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57538-57170-pettoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57538-57170-pettoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57539-57340-pevange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57539-57340-pevange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57539-57340-pevange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57539-57340-pevange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57540-57370-phalsbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57540-57370-phalsbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57540-57370-phalsbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57540-57370-phalsbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57541-57230-philippsbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57541-57230-philippsbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57541-57230-philippsbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57541-57230-philippsbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57542-57220-piblange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57542-57220-piblange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57542-57220-piblange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57542-57220-piblange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57543-57120-pierrevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57543-57120-pierrevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57543-57120-pierrevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57543-57120-pierrevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57544-57870-plaine_de_walsch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57544-57870-plaine_de_walsch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57544-57870-plaine_de_walsch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57544-57870-plaine_de_walsch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57545-57050-plappeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57545-57050-plappeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57545-57050-plappeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57545-57050-plappeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57546-57140-plesnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57546-57140-plesnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57546-57140-plesnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57546-57140-plesnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57547-57420-pommerieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57547-57420-pommerieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57547-57420-pommerieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57547-57420-pommerieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57548-57420-pontoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57548-57420-pontoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57548-57420-pontoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57548-57420-pontoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57549-57380-pontpierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57549-57380-pontpierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57549-57380-pontpierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57549-57380-pontpierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57550-57890-porcelette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57550-57890-porcelette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57550-57890-porcelette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57550-57890-porcelette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57551-57930-postroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57551-57930-postroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57551-57930-postroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57551-57930-postroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57552-57420-pouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57552-57420-pouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57552-57420-pouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57552-57420-pouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57553-57420-pournoy_la_chetive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57553-57420-pournoy_la_chetive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57553-57420-pournoy_la_chetive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57553-57420-pournoy_la_chetive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57554-57420-pournoy_la_grasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57554-57420-pournoy_la_grasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57554-57420-pournoy_la_grasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57554-57420-pournoy_la_grasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57555-57590-prevocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57555-57590-prevocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57555-57590-prevocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57555-57590-prevocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57556-57510-puttelange_aux_lacs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57556-57510-puttelange_aux_lacs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57556-57510-puttelange_aux_lacs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57556-57510-puttelange_aux_lacs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57557-57570-puttelange_les_thionville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57557-57570-puttelange_les_thionville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57557-57570-puttelange_les_thionville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57557-57570-puttelange_les_thionville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57558-57170-puttigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57558-57170-puttigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57558-57170-puttigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57558-57170-puttigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57559-57590-puzieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57559-57590-puzieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57559-57590-puzieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57559-57590-puzieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57560-57340-racrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57560-57340-racrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57560-57340-racrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57560-57340-racrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57561-57410-rahling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57561-57410-rahling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57561-57410-rahling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57561-57410-rahling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57562-57700-ranguevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57562-57700-ranguevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57562-57700-ranguevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57562-57700-ranguevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57563-57530-raville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57563-57530-raville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57563-57530-raville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57563-57530-raville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57564-57810-rechicourt_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57564-57810-rechicourt_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57564-57810-rechicourt_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57564-57810-rechicourt_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57565-57390-redange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57565-57390-redange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57565-57390-redange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57565-57390-redange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57566-57445-reding/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57566-57445-reding/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57566-57445-reding/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57566-57445-reding/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57567-57320-remelfang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57567-57320-remelfang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57567-57320-remelfang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57567-57320-remelfang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57568-57200-remelfing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57568-57200-remelfing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57568-57200-remelfing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57568-57200-remelfing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57569-57480-remeling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57569-57480-remeling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57569-57480-remeling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57569-57480-remeling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57570-57550-remering/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57570-57550-remering/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57570-57550-remering/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57570-57550-remering/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57571-57510-remering_les_puttelange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57571-57510-remering_les_puttelange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57571-57510-remering_les_puttelange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57571-57510-remering_les_puttelange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57572-57580-remilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57572-57580-remilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57572-57580-remilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57572-57580-remilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57573-57670-rening/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57573-57670-rening/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57573-57670-rening/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57573-57670-rening/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57574-57570-basse_rentgen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57574-57570-basse_rentgen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57574-57570-basse_rentgen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57574-57570-basse_rentgen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57575-57645-retonfey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57575-57645-retonfey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57575-57645-retonfey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57575-57645-retonfey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57576-57480-rettel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57576-57480-rettel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57576-57480-rettel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57576-57480-rettel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57577-57230-reyersviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57577-57230-reyersviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57577-57230-reyersviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57577-57230-reyersviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57578-57130-rezonville_vionville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57578-57130-rezonville_vionville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57578-57130-rezonville_vionville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57578-57130-rezonville_vionville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57579-57810-rhodes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57579-57810-rhodes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57579-57810-rhodes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57579-57810-rhodes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57580-57340-riche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57580-57340-riche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57580-57340-riche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57580-57340-riche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57581-57510-richeling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57581-57510-richeling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57581-57510-richeling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57581-57510-richeling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57582-57270-richemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57582-57270-richemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57582-57270-richemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57582-57270-richemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57583-57830-richeval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57583-57830-richeval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57583-57830-richeval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57583-57830-richeval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57584-57720-rimling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57584-57720-rimling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57584-57720-rimling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57584-57720-rimling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57586-57840-rochonvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57586-57840-rochonvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57586-57840-rochonvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57586-57840-rochonvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57587-57340-rodalbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57587-57340-rodalbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57587-57340-rodalbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57587-57340-rodalbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57588-57570-rodemack/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57588-57570-rodemack/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57588-57570-rodemack/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57588-57570-rodemack/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57589-57410-rohrbach_les_bitche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57589-57410-rohrbach_les_bitche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57589-57410-rohrbach_les_bitche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57589-57410-rohrbach_les_bitche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57590-57720-rolbing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57590-57720-rolbing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57590-57720-rolbing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57590-57720-rolbing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57591-57120-rombas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57591-57120-rombas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57591-57120-rombas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57591-57120-rombas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57592-57930-romelfing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57592-57930-romelfing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57592-57930-romelfing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57592-57930-romelfing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57593-57860-roncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57593-57860-roncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57593-57860-roncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57593-57860-roncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57594-57230-roppeviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57594-57230-roppeviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57594-57230-roppeviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57594-57230-roppeviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57595-57260-rorbach_les_dieuze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57595-57260-rorbach_les_dieuze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57595-57260-rorbach_les_dieuze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57595-57260-rorbach_les_dieuze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57596-57800-rosbruck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57596-57800-rosbruck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57596-57800-rosbruck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57596-57800-rosbruck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57597-57780-rosselange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57597-57780-rosselange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57597-57780-rosselange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57597-57780-rosselange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57598-57520-rouhling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57598-57520-rouhling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57598-57520-rouhling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57598-57520-rouhling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57599-57220-roupeldange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57599-57220-roupeldange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57599-57220-roupeldange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57599-57220-roupeldange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57600-57330-roussy_le_village/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57600-57330-roussy_le_village/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57600-57330-roussy_le_village/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57600-57330-roussy_le_village/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57601-57160-rozerieulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57601-57160-rozerieulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57601-57160-rozerieulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57601-57160-rozerieulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57602-57310-rurange_les_thionville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57602-57310-rurange_les_thionville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57602-57310-rurange_les_thionville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57602-57310-rurange_les_thionville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57603-57390-russange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57603-57390-russange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57603-57390-russange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57603-57390-russange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57604-57480-rustroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57604-57480-rustroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57604-57480-rustroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57604-57480-rustroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57605-57420-sailly_achatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57605-57420-sailly_achatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57605-57420-sailly_achatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57605-57420-sailly_achatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57606-57500-saint_avold/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57606-57500-saint_avold/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57606-57500-saint_avold/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57606-57500-saint_avold/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57607-57640-sainte_barbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57607-57640-sainte_barbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57607-57640-sainte_barbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57607-57640-sainte_barbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57607-57530-sainte_barbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57607-57530-sainte_barbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57607-57530-sainte_barbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57607-57530-sainte_barbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57609-57580-saint_epvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57609-57580-saint_epvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57609-57580-saint_epvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57609-57580-saint_epvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57610-57320-saint_francois_lacroix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57610-57320-saint_francois_lacroix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57610-57320-saint_francois_lacroix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57610-57320-saint_francois_lacroix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57611-57830-saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57611-57830-saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57611-57830-saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57611-57830-saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57612-57640-saint_hubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57612-57640-saint_hubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57612-57640-saint_hubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57612-57640-saint_hubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57613-57930-saint_jean_de_bassel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57613-57930-saint_jean_de_bassel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57613-57930-saint_jean_de_bassel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57613-57930-saint_jean_de_bassel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57614-57370-saint_jean_kourtzerode/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57614-57370-saint_jean_kourtzerode/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57614-57370-saint_jean_kourtzerode/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57614-57370-saint_jean_kourtzerode/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57615-57510-saint_jean_rohrbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57615-57510-saint_jean_rohrbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57615-57510-saint_jean_rohrbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57615-57510-saint_jean_rohrbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57616-57070-saint_julien_les_metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57616-57070-saint_julien_les_metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57616-57070-saint_julien_les_metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57616-57070-saint_julien_les_metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57617-57420-saint_jure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57617-57420-saint_jure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57617-57420-saint_jure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57617-57420-saint_jure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57618-57820-saint_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57618-57820-saint_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57618-57820-saint_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57618-57820-saint_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57619-57620-saint_louis_les_bitche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57619-57620-saint_louis_les_bitche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57619-57620-saint_louis_les_bitche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57619-57620-saint_louis_les_bitche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57620-57255-sainte_marie_aux_chenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57620-57255-sainte_marie_aux_chenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57620-57255-sainte_marie_aux_chenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57620-57255-sainte_marie_aux_chenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57621-57260-saint_medard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57621-57260-saint_medard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57621-57260-saint_medard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57621-57260-saint_medard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57622-57855-saint_privat_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57622-57855-saint_privat_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57622-57855-saint_privat_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57622-57855-saint_privat_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57623-57560-saint_quirin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57623-57560-saint_quirin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57623-57560-saint_quirin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57623-57560-saint_quirin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57624-57130-sainte_ruffine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57624-57130-sainte_ruffine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57624-57130-sainte_ruffine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57624-57130-sainte_ruffine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57625-57170-salonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57625-57170-salonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57625-57170-salonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57625-57170-salonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57626-57640-sanry_les_vigy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57626-57640-sanry_les_vigy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57626-57640-sanry_les_vigy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57626-57640-sanry_les_vigy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57627-57530-sanry_sur_nied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57627-57530-sanry_sur_nied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57627-57530-sanry_sur_nied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57627-57530-sanry_sur_nied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57628-57430-sarralbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57628-57430-sarralbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57628-57430-sarralbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57628-57430-sarralbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57629-57400-sarraltroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57629-57400-sarraltroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57629-57400-sarraltroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57629-57400-sarraltroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57630-57400-sarrebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57630-57400-sarrebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57630-57400-sarrebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57630-57400-sarrebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57631-57200-sarreguemines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57631-57200-sarreguemines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57631-57200-sarreguemines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57631-57200-sarreguemines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57633-57905-sarreinsming/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57633-57905-sarreinsming/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57633-57905-sarreinsming/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57633-57905-sarreinsming/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57634-57140-saulny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57634-57140-saulny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57634-57140-saulny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57634-57140-saulny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57635-57370-schalbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57635-57370-schalbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57635-57370-schalbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57635-57370-schalbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57636-57412-schmittviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57636-57412-schmittviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57636-57412-schmittviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57636-57412-schmittviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57637-57400-schneckenbusch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57637-57400-schneckenbusch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57637-57400-schneckenbusch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57637-57400-schneckenbusch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57638-57350-schoeneck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57638-57350-schoeneck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57638-57350-schoeneck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57638-57350-schoeneck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57639-57230-schorbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57639-57230-schorbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57639-57230-schorbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57639-57230-schorbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57640-57320-schwerdorff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57640-57320-schwerdorff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57640-57320-schwerdorff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57640-57320-schwerdorff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57641-57720-schweyen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57641-57720-schweyen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57641-57720-schweyen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57641-57720-schweyen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57642-57160-scy_chazelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57642-57160-scy_chazelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57642-57160-scy_chazelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57642-57160-scy_chazelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57643-57420-secourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57643-57420-secourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57643-57420-secourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57643-57420-secourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57644-57455-seingbouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57644-57455-seingbouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57644-57455-seingbouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57644-57455-seingbouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57645-57280-semecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57645-57280-semecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57645-57280-semecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57645-57280-semecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57647-57290-seremange_erzange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57647-57290-seremange_erzange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57647-57290-seremange_erzange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57647-57290-seremange_erzange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57648-57530-servigny_les_raville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57648-57530-servigny_les_raville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57648-57530-servigny_les_raville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57648-57530-servigny_les_raville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57649-57640-servigny_les_sainte_barbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57649-57640-servigny_les_sainte_barbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57649-57640-servigny_les_sainte_barbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57649-57640-servigny_les_sainte_barbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57650-57480-sierck_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57650-57480-sierck_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57650-57480-sierck_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57650-57480-sierck_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57651-57410-siersthal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57651-57410-siersthal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57651-57410-siersthal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57651-57410-siersthal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57652-57420-sillegny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57652-57420-sillegny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57652-57420-sillegny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57652-57420-sillegny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57653-57420-silly_en_saulnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57653-57420-silly_en_saulnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57653-57420-silly_en_saulnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57653-57420-silly_en_saulnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57654-57530-silly_sur_nied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57654-57530-silly_sur_nied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57654-57530-silly_sur_nied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57654-57530-silly_sur_nied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57655-57420-solgne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57655-57420-solgne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57655-57420-solgne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57655-57420-solgne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57656-57580-sorbey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57656-57580-sorbey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57656-57580-sorbey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57656-57580-sorbey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57657-57170-sotzeling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57657-57170-sotzeling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57657-57170-sotzeling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57657-57170-sotzeling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57658-57960-soucht/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57658-57960-soucht/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57658-57960-soucht/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57658-57960-soucht/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57659-57350-spicheren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57659-57350-spicheren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57659-57350-spicheren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57659-57350-spicheren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57660-57350-stiring_wendel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57660-57350-stiring_wendel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57660-57350-stiring_wendel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57660-57350-stiring_wendel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57661-57230-sturzelbronn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57661-57230-sturzelbronn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57661-57230-sturzelbronn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57661-57230-sturzelbronn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57662-57340-suisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57662-57340-suisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57662-57340-suisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57662-57340-suisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57663-57525-talange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57663-57525-talange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57663-57525-talange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57663-57525-talange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57664-57260-tarquimpol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57664-57260-tarquimpol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57664-57260-tarquimpol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57664-57260-tarquimpol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57665-57980-tenteling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57665-57980-tenteling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57665-57980-tenteling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57665-57980-tenteling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57666-57180-terville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57666-57180-terville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57666-57180-terville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57666-57180-terville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57667-57220-teterchen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57667-57220-teterchen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57667-57220-teterchen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57667-57220-teterchen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57668-57385-teting_sur_nied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57668-57385-teting_sur_nied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57668-57385-teting_sur_nied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57668-57385-teting_sur_nied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57669-57450-theding/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57669-57450-theding/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57669-57450-theding/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57669-57450-theding/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57670-57380-thicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57670-57380-thicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57670-57380-thicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57670-57380-thicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57671-57580-thimonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57671-57580-thimonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57671-57580-thimonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57671-57580-thimonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57672-57100-thionville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57672-57100-thionville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57672-57100-thionville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57672-57100-thionville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57673-57380-thonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57673-57380-thonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57673-57380-thonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57673-57380-thonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57674-57590-tincry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57674-57590-tincry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57674-57590-tincry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57674-57590-tincry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57675-57670-torcheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57675-57670-torcheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57675-57670-torcheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57675-57670-torcheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57676-57580-tragny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57676-57580-tragny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57676-57580-tragny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57676-57580-tragny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57677-57300-tremery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57677-57300-tremery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57677-57300-tremery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57677-57300-tremery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57678-57710-tressange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57678-57710-tressange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57678-57710-tressange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57678-57710-tressange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57679-57385-tritteling_redlach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57679-57385-tritteling_redlach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57679-57385-tritteling_redlach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57679-57385-tritteling_redlach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57680-57870-troisfontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57680-57870-troisfontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57680-57870-troisfontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57680-57870-troisfontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57681-57320-tromborn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57681-57320-tromborn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57681-57320-tromborn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57681-57320-tromborn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57682-57560-turquestein_blancrupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57682-57560-turquestein_blancrupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57682-57560-turquestein_blancrupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57682-57560-turquestein_blancrupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57683-57270-uckange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57683-57270-uckange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57683-57270-uckange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57683-57270-uckange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57684-57660-vahl_ebersing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57684-57660-vahl_ebersing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57684-57660-vahl_ebersing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57684-57660-vahl_ebersing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57685-57670-vahl_les_benestroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57685-57670-vahl_les_benestroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57685-57670-vahl_les_benestroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57685-57670-vahl_les_benestroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57686-57380-vahl_les_faulquemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57686-57380-vahl_les_faulquemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57686-57380-vahl_les_faulquemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57686-57380-vahl_les_faulquemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57687-57340-vallerange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57687-57340-vallerange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57687-57340-vallerange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57687-57340-vallerange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57689-57970-valmestroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57689-57970-valmestroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57689-57970-valmestroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57689-57970-valmestroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57690-57730-valmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57690-57730-valmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57690-57730-valmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57690-57730-valmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57691-57220-valmunster/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57691-57220-valmunster/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57691-57220-valmunster/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57691-57220-valmunster/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57692-57340-vannecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57692-57340-vannecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57692-57340-vannecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57692-57340-vannecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57693-57070-vantoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57693-57070-vantoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57693-57070-vantoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57693-57070-vantoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57694-57070-vany/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57694-57070-vany/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57694-57070-vany/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57694-57070-vany/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57695-57220-varize_vaudoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57695-57220-varize_vaudoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57695-57220-varize_vaudoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57695-57220-varize_vaudoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57696-57880-varsberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57696-57880-varsberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57696-57880-varsberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57696-57880-varsberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57697-57560-vasperviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57697-57560-vasperviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57697-57560-vasperviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57697-57560-vasperviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57698-57580-vatimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57698-57580-vatimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57698-57580-vatimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57698-57580-vatimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57700-57320-vaudreching/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57700-57320-vaudreching/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57700-57320-vaudreching/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57700-57320-vaudreching/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57701-57130-vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57701-57130-vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57701-57130-vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57701-57130-vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57702-57170-vaxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57702-57170-vaxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57702-57170-vaxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57702-57170-vaxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57703-57370-veckersviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57703-57370-veckersviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57703-57370-veckersviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57703-57370-veckersviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57704-57920-veckring/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57704-57920-veckring/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57704-57920-veckring/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57704-57920-veckring/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57705-57220-velving/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57705-57220-velving/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57705-57220-velving/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57705-57220-velving/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57706-57260-vergaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57706-57260-vergaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57706-57260-vergaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57706-57260-vergaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57707-57130-verneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57707-57130-verneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57707-57130-verneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57707-57130-verneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57708-57420-verny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57708-57420-verny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57708-57420-verny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57708-57420-verny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57709-57370-vescheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57709-57370-vescheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57709-57370-vescheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57709-57370-vescheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57711-57670-vibersviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57711-57670-vibersviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57711-57670-vibersviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57711-57670-vibersviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57712-57630-vic_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57712-57630-vic_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57712-57630-vic_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57712-57630-vic_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57713-57635-vieux_lixheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57713-57635-vieux_lixheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57713-57635-vieux_lixheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57713-57635-vieux_lixheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57714-57690-haute_vigneulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57714-57690-haute_vigneulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57714-57690-haute_vigneulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57714-57690-haute_vigneulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57715-57420-vigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57715-57420-vigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57715-57420-vigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57715-57420-vigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57716-57640-vigy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57716-57640-vigy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57716-57640-vigy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57716-57640-vigy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57717-57340-viller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57717-57340-viller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57717-57340-viller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57717-57340-viller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57718-57530-villers_stoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57718-57530-villers_stoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57718-57530-villers_stoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57718-57530-villers_stoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57719-57340-villers_sur_nied/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57719-57340-villers_sur_nied/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57719-57340-villers_sur_nied/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57719-57340-villers_sur_nied/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57720-57550-villing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57720-57550-villing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57720-57550-villing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57720-57550-villing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57721-57370-vilsberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57721-57370-vilsberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57721-57370-vilsberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57721-57370-vilsberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57723-57340-virming/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57723-57340-virming/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57723-57340-virming/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57723-57340-virming/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57724-57185-vitry_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57724-57185-vitry_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57724-57185-vitry_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57724-57185-vitry_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57725-57670-vittersbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57725-57670-vittersbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57725-57670-vittersbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57725-57670-vittersbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57726-57580-vittoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57726-57580-vittoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57726-57580-vittoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57726-57580-vittoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57727-57590-viviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57727-57590-viviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57727-57590-viviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57727-57590-viviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57728-57580-voimhaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57728-57580-voimhaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57728-57580-voimhaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57728-57580-voimhaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57730-57220-volmerange_les_boulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57730-57220-volmerange_les_boulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57730-57220-volmerange_les_boulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57730-57220-volmerange_les_boulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57731-57330-volmerange_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57731-57330-volmerange_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57731-57330-volmerange_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57731-57330-volmerange_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57732-57720-volmunster/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57732-57720-volmunster/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57732-57720-volmunster/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57732-57720-volmunster/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57733-57940-volstroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57733-57940-volstroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57733-57940-volstroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57733-57940-volstroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57734-57560-voyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57734-57560-voyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57734-57560-voyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57734-57560-voyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57736-57640-vry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57736-57640-vry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57736-57640-vry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57736-57640-vry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57737-57420-vulmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57737-57420-vulmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57737-57420-vulmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57737-57420-vulmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57738-57720-waldhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57738-57720-waldhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57738-57720-waldhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57738-57720-waldhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57739-57320-waldweistroff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57739-57320-waldweistroff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57739-57320-waldweistroff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57739-57320-waldweistroff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57740-57480-waldwisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57740-57480-waldwisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57740-57480-waldwisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57740-57480-waldwisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57741-57720-walschbronn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57741-57720-walschbronn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57741-57720-walschbronn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57741-57720-walschbronn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57742-57870-walscheid/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57742-57870-walscheid/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57742-57870-walscheid/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57742-57870-walscheid/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57743-57370-waltembourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57743-57370-waltembourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57743-57370-waltembourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57743-57370-waltembourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57745-57200-wiesviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57745-57200-wiesviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57745-57200-wiesviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57745-57200-wiesviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57746-57430-willerwald/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57746-57430-willerwald/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57746-57430-willerwald/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57746-57430-willerwald/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57747-57635-wintersbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57747-57635-wintersbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57747-57635-wintersbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57747-57635-wintersbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57748-57905-wittring/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57748-57905-wittring/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57748-57905-wittring/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57748-57905-wittring/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57749-57320-voelfling_les_bouzonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57749-57320-voelfling_les_bouzonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57749-57320-voelfling_les_bouzonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57749-57320-voelfling_les_bouzonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57750-57200-woelfling_les_sarreguemines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57750-57200-woelfling_les_sarreguemines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57750-57200-woelfling_les_sarreguemines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57750-57200-woelfling_les_sarreguemines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57751-57140-woippy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57751-57140-woippy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57751-57140-woippy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57751-57140-woippy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57752-57915-woustviller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57752-57915-woustviller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57752-57915-woustviller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57752-57915-woustviller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57753-57170-wuisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57753-57170-wuisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57753-57170-wuisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57753-57170-wuisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57754-57630-xanrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57754-57630-xanrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57754-57630-xanrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57754-57630-xanrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57755-57590-xocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57755-57590-xocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57755-57590-xocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57755-57590-xocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57756-57830-xouaxange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57756-57830-xouaxange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57756-57830-xouaxange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57756-57830-xouaxange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57757-57970-yutz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57757-57970-yutz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57757-57970-yutz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57757-57970-yutz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57759-57340-zarbeling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57759-57340-zarbeling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57759-57340-zarbeling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57759-57340-zarbeling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57760-57905-zetting/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57760-57905-zetting/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57760-57905-zetting/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57760-57905-zetting/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57761-57370-zilling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57761-57370-zilling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57761-57370-zilling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57761-57370-zilling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57762-57690-zimming/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57762-57690-zimming/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57762-57690-zimming/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57762-57690-zimming/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57763-57260-zommange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57763-57260-zommange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57763-57260-zommange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57763-57260-zommange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57764-57330-zoufftgen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57764-57330-zoufftgen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57764-57330-zoufftgen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57764-57330-zoufftgen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57765-57890-diesen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57765-57890-diesen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57765-57890-diesen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57765-57890-diesen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57767-57970-stuckange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57767-57970-stuckange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57767-57970-stuckange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt57-moselle/commune57767-57970-stuckange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-58.xml
+++ b/public/sitemaps/sitemap-58.xml
@@ -5,624 +5,1244 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58001-58110-achun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58001-58110-achun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58001-58110-achun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58001-58110-achun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58002-58200-alligny_cosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58002-58200-alligny_cosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58002-58200-alligny_cosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58002-58200-alligny_cosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58003-58230-alligny_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58003-58230-alligny_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58003-58230-alligny_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58003-58230-alligny_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58004-58110-alluy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58004-58110-alluy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58004-58110-alluy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58004-58110-alluy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58005-58190-amazy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58005-58190-amazy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58005-58190-amazy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58005-58190-amazy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58006-58270-anlezy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58006-58270-anlezy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58006-58270-anlezy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58006-58270-anlezy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58007-58450-annay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58007-58450-annay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58007-58450-annay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58007-58450-annay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58008-58800-anthien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58008-58800-anthien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58008-58800-anthien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58008-58800-anthien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58009-58350-arbourse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58009-58350-arbourse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58009-58350-arbourse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58009-58350-arbourse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58010-58430-arleuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58010-58430-arleuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58010-58430-arleuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58010-58430-arleuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58011-58500-armes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58011-58500-armes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58011-58500-armes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58011-58500-armes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58012-58310-arquian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58012-58310-arquian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58012-58310-arquian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58012-58310-arquian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58013-58700-arthel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58013-58700-arthel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58013-58700-arthel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58013-58700-arthel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58014-58700-arzembouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58014-58700-arzembouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58014-58700-arzembouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58014-58700-arzembouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58015-58420-asnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58015-58420-asnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58015-58420-asnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58015-58420-asnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58016-58190-asnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58016-58190-asnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58016-58190-asnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58016-58190-asnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58017-58110-aunay_en_bazois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58017-58110-aunay_en_bazois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58017-58110-aunay_en_bazois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58017-58110-aunay_en_bazois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58018-58700-authiou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58018-58700-authiou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58018-58700-authiou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58018-58700-authiou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58019-58170-avree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58019-58170-avree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58019-58170-avree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58019-58170-avree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58020-58300-avril_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58020-58300-avril_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58020-58300-avril_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58020-58300-avril_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58021-58240-azy_le_vif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58021-58240-azy_le_vif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58021-58240-azy_le_vif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58021-58240-azy_le_vif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58023-58190-bazoches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58023-58190-bazoches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58023-58190-bazoches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58023-58190-bazoches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58024-58110-bazolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58024-58110-bazolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58024-58110-bazolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58024-58110-bazolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58025-58160-beard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58025-58160-beard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58025-58160-beard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58025-58160-beard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58026-58420-beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58026-58420-beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58026-58420-beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58026-58420-beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58027-58700-beaumont_la_ferriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58027-58700-beaumont_la_ferriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58027-58700-beaumont_la_ferriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58027-58700-beaumont_la_ferriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58028-58270-beaumont_sardolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58028-58270-beaumont_sardolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58028-58270-beaumont_sardolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58028-58270-beaumont_sardolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58029-58210-beuvron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58029-58210-beuvron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58029-58210-beuvron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58029-58210-beuvron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58030-58110-biches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58030-58110-biches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58030-58110-biches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58030-58110-biches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58031-58270-billy_chevannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58031-58270-billy_chevannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58031-58270-billy_chevannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58031-58270-billy_chevannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58032-58500-billy_sur_oisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58032-58500-billy_sur_oisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58032-58500-billy_sur_oisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58032-58500-billy_sur_oisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58033-58310-bitry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58033-58310-bitry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58033-58310-bitry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58033-58310-bitry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58034-58120-blismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58034-58120-blismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58034-58120-blismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58034-58120-blismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58035-58330-bona/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58035-58330-bona/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58035-58330-bona/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58035-58330-bona/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58036-58310-bouhy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58036-58310-bouhy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58036-58310-bouhy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58036-58310-bouhy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58037-58140-brassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58037-58140-brassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58037-58140-brassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58037-58140-brassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58038-58460-breugnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58038-58460-breugnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58038-58460-breugnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58038-58460-breugnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58039-58530-breves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58039-58530-breves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58039-58530-breves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58039-58530-breves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58040-58110-brinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58040-58110-brinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58040-58110-brinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58040-58110-brinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58041-58420-brinon_sur_beuvron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58041-58420-brinon_sur_beuvron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58041-58420-brinon_sur_beuvron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58041-58420-brinon_sur_beuvron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58042-58400-bulcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58042-58400-bulcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58042-58400-bulcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58042-58400-bulcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58043-58420-bussy_la_pesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58043-58420-bussy_la_pesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58043-58420-bussy_la_pesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58043-58420-bussy_la_pesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58044-58440-la_celle_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58044-58440-la_celle_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58044-58440-la_celle_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58044-58440-la_celle_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58045-58700-la_celle_sur_nievre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58045-58700-la_celle_sur_nievre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58045-58700-la_celle_sur_nievre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58045-58700-la_celle_sur_nievre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58046-58340-cercy_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58046-58340-cercy_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58046-58340-cercy_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58046-58340-cercy_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58047-58800-cervon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58047-58800-cervon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58047-58800-cervon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58047-58800-cervon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58048-58220-cessy_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58048-58220-cessy_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58048-58220-cessy_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58048-58220-cessy_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58049-58140-chalaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58049-58140-chalaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58049-58140-chalaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58049-58140-chalaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58050-58420-challement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58050-58420-challement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58050-58420-challement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58050-58420-challement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58051-58000-challuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58051-58000-challuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58051-58000-challuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58051-58000-challuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58052-58420-champallement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58052-58420-champallement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58052-58420-champallement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58052-58420-champallement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58053-58210-champlemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58053-58210-champlemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58053-58210-champlemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58053-58210-champlemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58054-58700-champlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58054-58700-champlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58054-58700-champlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58054-58700-champlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58055-58300-champvert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58055-58300-champvert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58055-58300-champvert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58055-58300-champvert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58056-58400-champvoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58056-58400-champvoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58056-58400-champvoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58056-58400-champvoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58057-58240-chantenay_saint_imbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58057-58240-chantenay_saint_imbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58057-58240-chantenay_saint_imbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58057-58240-chantenay_saint_imbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58058-58210-la_chapelle_saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58058-58210-la_chapelle_saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58058-58210-la_chapelle_saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58058-58210-la_chapelle_saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58059-58400-la_charite_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58059-58400-la_charite_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58059-58400-la_charite_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58059-58400-la_charite_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58060-58300-charrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58060-58300-charrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58060-58300-charrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58060-58300-charrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58061-58350-chasnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58061-58350-chasnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58061-58350-chasnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58061-58350-chasnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58062-58120-chateau_chinon_(ville)/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58062-58120-chateau_chinon_(ville)/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58062-58120-chateau_chinon_(ville)/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58062-58120-chateau_chinon_(ville)/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58063-58120-chateau_chinon_(campagne)/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58063-58120-chateau_chinon_(campagne)/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58063-58120-chateau_chinon_(campagne)/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58063-58120-chateau_chinon_(campagne)/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58064-58350-chateauneuf_val_de_bargis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58064-58350-chateauneuf_val_de_bargis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58064-58350-chateauneuf_val_de_bargis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58064-58350-chateauneuf_val_de_bargis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58065-58110-chatillon_en_bazois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58065-58110-chatillon_en_bazois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58065-58110-chatillon_en_bazois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58065-58110-chatillon_en_bazois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58066-58120-chatin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58066-58120-chatin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58066-58120-chatin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58066-58120-chatin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58067-58400-chaulgnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58067-58400-chaulgnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58067-58400-chaulgnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58067-58400-chaulgnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58068-58120-chaumard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58068-58120-chaumard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58068-58120-chaumard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58068-58120-chaumard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58069-58800-chaumot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58069-58800-chaumot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58069-58800-chaumot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58069-58800-chaumot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58070-58700-chazeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58070-58700-chazeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58070-58700-chazeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58070-58700-chazeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58071-58420-chevannes_changy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58071-58420-chevannes_changy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58071-58420-chevannes_changy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58071-58420-chevannes_changy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58072-58160-chevenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58072-58160-chevenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58072-58160-chevenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58072-58160-chevenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58073-58500-chevroches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58073-58500-chevroches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58073-58500-chevroches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58073-58500-chevroches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58074-58170-chiddes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58074-58170-chiddes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58074-58170-chiddes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58074-58170-chiddes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58075-58800-chitry_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58075-58800-chitry_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58075-58800-chitry_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58075-58800-chitry_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58076-58110-chougny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58076-58110-chougny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58076-58110-chougny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58076-58110-chougny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58077-58220-ciez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58077-58220-ciez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58077-58220-ciez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58077-58220-ciez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58078-58270-cizely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58078-58270-cizely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58078-58270-cizely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58078-58270-cizely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58079-58500-clamecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58079-58500-clamecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58079-58500-clamecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58079-58500-clamecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58080-58800-la_collancelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58080-58800-la_collancelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58080-58800-la_collancelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58080-58800-la_collancelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58081-58350-colmery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58081-58350-colmery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58081-58350-colmery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58081-58350-colmery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58082-58120-corancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58082-58120-corancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58082-58120-corancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58082-58120-corancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58083-58800-corbigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58083-58800-corbigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58083-58800-corbigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58083-58800-corbigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58084-58210-corvol_d_embernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58084-58210-corvol_d_embernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58084-58210-corvol_d_embernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58084-58210-corvol_d_embernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58085-58460-corvol_l_orgueilleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58085-58460-corvol_l_orgueilleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58085-58460-corvol_l_orgueilleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58085-58460-corvol_l_orgueilleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58086-58200-cosne_cours_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58086-58200-cosne_cours_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58086-58200-cosne_cours_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58086-58200-cosne_cours_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58087-58300-cossaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58087-58300-cossaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58087-58300-cossaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58087-58300-cossaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58088-58660-coulanges_les_nevers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58088-58660-coulanges_les_nevers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58088-58660-coulanges_les_nevers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58088-58660-coulanges_les_nevers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58089-58220-couloutre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58089-58220-couloutre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58089-58220-couloutre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58089-58220-couloutre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58090-58210-courcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58090-58210-courcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58090-58210-courcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58090-58210-courcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58092-58330-crux_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58092-58330-crux_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58092-58330-crux_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58092-58330-crux_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58093-58210-cuncy_les_varzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58093-58210-cuncy_les_varzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58093-58210-cuncy_les_varzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58093-58210-cuncy_les_varzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58094-58310-dampierre_sous_bouhy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58094-58310-dampierre_sous_bouhy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58094-58310-dampierre_sous_bouhy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58094-58310-dampierre_sous_bouhy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58095-58300-decize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58095-58300-decize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58095-58300-decize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58095-58300-decize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58096-58300-devay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58096-58300-devay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58096-58300-devay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58096-58300-devay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58097-58340-diennes_aubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58097-58340-diennes_aubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58097-58340-diennes_aubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58097-58340-diennes_aubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58098-58190-dirol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58098-58190-dirol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58098-58190-dirol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58098-58190-dirol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58099-58120-dommartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58099-58120-dommartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58099-58120-dommartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58099-58120-dommartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58101-58350-dompierre_sur_nievre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58101-58350-dompierre_sur_nievre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58101-58350-dompierre_sur_nievre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58101-58350-dompierre_sur_nievre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58102-58220-donzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58102-58220-donzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58102-58220-donzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58102-58220-donzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58103-58530-dornecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58103-58530-dornecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58103-58530-dornecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58103-58530-dornecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58104-58390-dornes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58104-58390-dornes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58104-58390-dornes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58104-58390-dornes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58105-58160-druy_parigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58105-58160-druy_parigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58105-58160-druy_parigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58105-58160-druy_parigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58106-58230-dun_les_places/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58106-58230-dun_les_places/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58106-58230-dun_les_places/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58106-58230-dun_les_places/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58107-58110-dun_sur_grandry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58107-58110-dun_sur_grandry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58107-58110-dun_sur_grandry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58107-58110-dun_sur_grandry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58108-58140-empury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58108-58140-empury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58108-58140-empury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58108-58140-empury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58109-58410-entrains_sur_nohain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58109-58410-entrains_sur_nohain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58109-58410-entrains_sur_nohain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58109-58410-entrains_sur_nohain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58110-58800-epiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58110-58800-epiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58110-58800-epiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58110-58800-epiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58111-58430-fachin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58111-58430-fachin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58111-58430-fachin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58111-58430-fachin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58112-58160-la_fermete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58112-58160-la_fermete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58112-58160-la_fermete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58112-58160-la_fermete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58113-58270-fertreve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58113-58270-fertreve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58113-58270-fertreve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58113-58270-fertreve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58114-58170-flety/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58114-58170-flety/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58114-58170-flety/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58114-58170-flety/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58115-58240-fleury_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58115-58240-fleury_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58115-58240-fleury_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58115-58240-fleury_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58116-58190-flez_cuzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58116-58190-flez_cuzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58116-58190-flez_cuzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58116-58190-flez_cuzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58117-58600-fourchambault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58117-58600-fourchambault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58117-58600-fourchambault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58117-58600-fourchambault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58118-58250-fours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58118-58250-fours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58118-58250-fours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58118-58250-fours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58119-58270-frasnay_reugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58119-58270-frasnay_reugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58119-58270-frasnay_reugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58119-58270-frasnay_reugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58120-58140-gacogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58120-58140-gacogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58120-58140-gacogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58120-58140-gacogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58121-58600-garchizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58121-58600-garchizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58121-58600-garchizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58121-58600-garchizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58122-58150-garchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58122-58150-garchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58122-58150-garchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58122-58150-garchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58123-58800-germenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58123-58800-germenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58123-58800-germenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58123-58800-germenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58124-58320-germigny_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58124-58320-germigny_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58124-58320-germigny_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58124-58320-germigny_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58125-58230-gien_sur_cure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58125-58230-gien_sur_cure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58125-58230-gien_sur_cure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58125-58230-gien_sur_cure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58126-58470-gimouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58126-58470-gimouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58126-58470-gimouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58126-58470-gimouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58127-58700-giry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58127-58700-giry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58127-58700-giry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58127-58700-giry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58128-58370-glux_en_glenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58128-58370-glux_en_glenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58128-58370-glux_en_glenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58128-58370-glux_en_glenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58129-58230-gouloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58129-58230-gouloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58129-58230-gouloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58129-58230-gouloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58130-58420-grenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58130-58420-grenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58130-58420-grenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58130-58420-grenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58131-58130-guerigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58131-58130-guerigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58131-58130-guerigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58131-58130-guerigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58132-58420-guipy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58132-58420-guipy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58132-58420-guipy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58132-58420-guipy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58133-58800-hery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58133-58800-hery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58133-58800-hery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58133-58800-hery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58134-58160-imphy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58134-58160-imphy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58134-58160-imphy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58134-58160-imphy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58135-58290-isenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58135-58290-isenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58135-58290-isenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58135-58290-isenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58136-58330-jailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58136-58330-jailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58136-58330-jailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58136-58330-jailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58137-58300-lamenay_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58137-58300-lamenay_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58137-58300-lamenay_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58137-58300-lamenay_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58138-58240-langeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58138-58240-langeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58138-58240-langeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58138-58240-langeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58139-58250-lanty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58139-58250-lanty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58139-58250-lanty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58139-58250-lanty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58140-58370-larochemillay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58140-58370-larochemillay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58140-58370-larochemillay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58140-58370-larochemillay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58141-58230-lavault_de_fretoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58141-58230-lavault_de_fretoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58141-58230-lavault_de_fretoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58141-58230-lavault_de_fretoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58142-58290-limanton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58142-58290-limanton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58142-58290-limanton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58142-58290-limanton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58143-58270-limon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58143-58270-limon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58143-58270-limon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58143-58270-limon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58144-58240-livry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58144-58240-livry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58144-58240-livry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58144-58240-livry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58145-58140-lormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58145-58140-lormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58145-58140-lormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58145-58140-lormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58146-58380-lucenay_les_aix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58146-58380-lucenay_les_aix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58146-58380-lucenay_les_aix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58146-58380-lucenay_les_aix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58147-58700-lurcy_le_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58147-58700-lurcy_le_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58147-58700-lurcy_le_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58147-58700-lurcy_le_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58148-58240-luthenay_uxeloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58148-58240-luthenay_uxeloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58148-58240-luthenay_uxeloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58148-58240-luthenay_uxeloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58149-58170-luzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58149-58170-luzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58149-58170-luzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58149-58170-luzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58150-58190-lys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58150-58190-lys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58150-58190-lys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58150-58190-lys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58151-58260-la_machine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58151-58260-la_machine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58151-58260-la_machine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58151-58260-la_machine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58152-58470-magny_cours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58152-58470-magny_cours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58152-58470-magny_cours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58152-58470-magny_cours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58153-58800-magny_lormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58153-58800-magny_lormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58153-58800-magny_lormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58153-58800-magny_lormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58154-58190-la_maison_dieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58154-58190-la_maison_dieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58154-58190-la_maison_dieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58154-58190-la_maison_dieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58155-58400-la_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58155-58400-la_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58155-58400-la_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58155-58400-la_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58156-58210-marcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58156-58210-marcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58156-58210-marcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58156-58210-marcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58157-58140-marigny_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58157-58140-marigny_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58157-58140-marigny_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58157-58140-marigny_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58158-58240-mars_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58158-58240-mars_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58158-58240-mars_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58158-58240-mars_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58159-58800-marigny_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58159-58800-marigny_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58159-58800-marigny_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58159-58800-marigny_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58160-58180-marzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58160-58180-marzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58160-58180-marzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58160-58180-marzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58161-58290-maux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58161-58290-maux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58161-58290-maux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58161-58290-maux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58162-58410-menestreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58162-58410-menestreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58162-58410-menestreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58162-58410-menestreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58163-58210-menou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58163-58210-menou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58163-58210-menou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58163-58210-menou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58164-58400-mesves_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58164-58400-mesves_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58164-58400-mesves_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58164-58400-mesves_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58165-58190-metz_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58165-58190-metz_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58165-58190-metz_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58165-58190-metz_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58166-58140-mhere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58166-58140-mhere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58166-58140-mhere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58166-58140-mhere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58168-58170-millay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58168-58170-millay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58168-58170-millay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58168-58170-millay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58169-58190-moissy_moulinot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58169-58190-moissy_moulinot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58169-58190-moissy_moulinot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58169-58190-moissy_moulinot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58170-58190-monceaux_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58170-58190-monceaux_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58170-58190-monceaux_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58170-58190-monceaux_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58171-58110-montapas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58171-58110-montapas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58171-58110-montapas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58171-58110-montapas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58172-58250-montambert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58172-58250-montambert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58172-58250-montambert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58172-58250-montambert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58173-58250-montaron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58173-58250-montaron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58173-58250-montaron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58173-58250-montaron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58174-58700-montenoison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58174-58700-montenoison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58174-58700-montenoison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58174-58700-montenoison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58175-58110-mont_et_marre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58175-58110-mont_et_marre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58175-58110-mont_et_marre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58175-58110-mont_et_marre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58176-58130-montigny_aux_amognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58176-58130-montigny_aux_amognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58176-58130-montigny_aux_amognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58176-58130-montigny_aux_amognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58177-58120-montigny_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58177-58120-montigny_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58177-58120-montigny_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58177-58120-montigny_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58178-58340-montigny_sur_canne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58178-58340-montigny_sur_canne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58178-58340-montigny_sur_canne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58178-58340-montigny_sur_canne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58179-58800-montreuillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58179-58800-montreuillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58179-58800-montreuillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58179-58800-montreuillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58180-58230-montsauche_les_settons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58180-58230-montsauche_les_settons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58180-58230-montsauche_les_settons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58180-58230-montsauche_les_settons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58181-58420-moraches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58181-58420-moraches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58181-58420-moraches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58181-58420-moraches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58182-58290-moulins_engilbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58182-58290-moulins_engilbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58182-58290-moulins_engilbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58182-58290-moulins_engilbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58183-58800-mouron_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58183-58800-mouron_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58183-58800-mouron_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58183-58800-mouron_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58184-58700-moussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58184-58700-moussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58184-58700-moussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58184-58700-moussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58185-58230-moux_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58185-58230-moux_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58185-58230-moux_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58185-58230-moux_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58186-58700-murlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58186-58700-murlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58186-58700-murlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58186-58700-murlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58187-58440-myennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58187-58440-myennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58187-58440-myennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58187-58440-myennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58188-58350-nannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58188-58350-nannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58188-58350-nannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58188-58350-nannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58189-58400-narcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58189-58400-narcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58189-58400-narcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58189-58400-narcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58190-58190-neuffontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58190-58190-neuffontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58190-58190-neuffontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58190-58190-neuffontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58191-58420-neuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58191-58420-neuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58191-58420-neuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58191-58420-neuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58192-58300-neuville_les_decize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58192-58300-neuville_les_decize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58192-58300-neuville_les_decize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58192-58300-neuville_les_decize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58193-58450-neuvy_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58193-58450-neuvy_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58193-58450-neuvy_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58193-58450-neuvy_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58194-58000-nevers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58194-58000-nevers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58194-58000-nevers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58194-58000-nevers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58195-58250-la_nocle_maulaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58195-58250-la_nocle_maulaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58195-58250-la_nocle_maulaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58195-58250-la_nocle_maulaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58196-58700-nolay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58196-58700-nolay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58196-58700-nolay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58196-58700-nolay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58197-58190-nuars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58197-58190-nuars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58197-58190-nuars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58197-58190-nuars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58198-58500-oisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58198-58500-oisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58198-58500-oisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58198-58500-oisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58199-58370-onlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58199-58370-onlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58199-58370-onlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58199-58370-onlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58200-58500-ouagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58200-58500-ouagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58200-58500-ouagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58200-58500-ouagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58201-58210-oudan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58201-58210-oudan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58201-58210-oudan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58201-58210-oudan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58202-58110-ougny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58202-58110-ougny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58202-58110-ougny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58202-58110-ougny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58203-58700-oulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58203-58700-oulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58203-58700-oulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58203-58700-oulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58204-58130-vaux_d_amognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58204-58130-vaux_d_amognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58204-58130-vaux_d_amognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58204-58130-vaux_d_amognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58205-58230-ouroux_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58205-58230-ouroux_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58205-58230-ouroux_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58205-58230-ouroux_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58206-58210-parigny_la_rose/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58206-58210-parigny_la_rose/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58206-58210-parigny_la_rose/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58206-58210-parigny_la_rose/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58207-58320-parigny_les_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58207-58320-parigny_les_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58207-58320-parigny_les_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58207-58320-parigny_les_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58208-58800-pazy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58208-58800-pazy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58208-58800-pazy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58208-58800-pazy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58209-58220-perroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58209-58220-perroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58209-58220-perroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58209-58220-perroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58210-58230-planchez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58210-58230-planchez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58210-58230-planchez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58210-58230-planchez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58211-58170-poil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58211-58170-poil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58211-58170-poil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58211-58170-poil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58212-58130-poiseux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58212-58130-poiseux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58212-58130-poiseux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58212-58130-poiseux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58213-58200-pougny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58213-58200-pougny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58213-58200-pougny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58213-58200-pougny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58214-58320-pougues_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58214-58320-pougues_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58214-58320-pougues_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58214-58320-pougues_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58215-58150-pouilly_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58215-58150-pouilly_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58215-58150-pouilly_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58215-58150-pouilly_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58216-58140-pouques_lormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58216-58140-pouques_lormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58216-58140-pouques_lormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58216-58140-pouques_lormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58217-58500-pousseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58217-58500-pousseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58217-58500-pousseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58217-58500-pousseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58218-58700-premery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58218-58700-premery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58218-58700-premery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58218-58700-premery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58219-58360-preporche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58219-58360-preporche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58219-58360-preporche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58219-58360-preporche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58220-58400-raveau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58220-58400-raveau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58220-58400-raveau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58220-58400-raveau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58221-58250-remilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58221-58250-remilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58221-58250-remilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58221-58250-remilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58222-58500-rix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58222-58500-rix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58222-58500-rix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58222-58500-rix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58223-58110-rouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58223-58110-rouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58223-58110-rouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58223-58110-rouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58224-58190-ruages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58224-58190-ruages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58224-58190-ruages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58224-58190-ruages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58225-58470-saincaize_meauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58225-58470-saincaize_meauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58225-58470-saincaize_meauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58225-58470-saincaize_meauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58226-58230-saint_agnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58226-58230-saint_agnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58226-58230-saint_agnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58226-58230-saint_agnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58227-58310-saint_amand_en_puisaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58227-58310-saint_amand_en_puisaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58227-58310-saint_amand_en_puisaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58227-58310-saint_amand_en_puisaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58228-58150-saint_andelain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58228-58150-saint_andelain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58228-58150-saint_andelain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58228-58150-saint_andelain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58229-58140-saint_andre_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58229-58140-saint_andre_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58229-58140-saint_andre_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58229-58140-saint_andre_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58230-58190-saint_aubin_des_chaumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58230-58190-saint_aubin_des_chaumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58230-58190-saint_aubin_des_chaumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58230-58190-saint_aubin_des_chaumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58231-58130-saint_aubin_les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58231-58130-saint_aubin_les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58231-58130-saint_aubin_les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58231-58130-saint_aubin_les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58232-58270-saint_benin_d_azy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58232-58270-saint_benin_d_azy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58232-58270-saint_benin_d_azy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58232-58270-saint_benin_d_azy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58233-58330-saint_benin_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58233-58330-saint_benin_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58233-58330-saint_benin_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58233-58330-saint_benin_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58234-58700-saint_bonnot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58234-58700-saint_bonnot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58234-58700-saint_bonnot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58234-58700-saint_bonnot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58235-58230-saint_brisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58235-58230-saint_brisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58235-58230-saint_brisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58235-58230-saint_brisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58236-58220-sainte_colombe_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58236-58220-sainte_colombe_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58236-58220-sainte_colombe_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58236-58220-sainte_colombe_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58237-58190-saint_didier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58237-58190-saint_didier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58237-58190-saint_didier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58237-58190-saint_didier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58238-58000-saint_eloi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58238-58000-saint_eloi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58238-58000-saint_eloi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58238-58000-saint_eloi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58239-58270-saint_firmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58239-58270-saint_firmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58239-58270-saint_firmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58239-58270-saint_firmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58240-58330-saint_franchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58240-58330-saint_franchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58240-58330-saint_franchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58240-58330-saint_franchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58241-58300-saint_germain_chassenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58241-58300-saint_germain_chassenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58241-58300-saint_germain_chassenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58241-58300-saint_germain_chassenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58242-58210-saint_germain_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58242-58210-saint_germain_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58242-58210-saint_germain_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58242-58210-saint_germain_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58243-58340-saint_gratien_savigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58243-58340-saint_gratien_savigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58243-58340-saint_gratien_savigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58243-58340-saint_gratien_savigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58244-58120-saint_hilaire_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58244-58120-saint_hilaire_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58244-58120-saint_hilaire_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58244-58120-saint_hilaire_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58245-58300-saint_hilaire_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58245-58300-saint_hilaire_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58245-58300-saint_hilaire_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58245-58300-saint_hilaire_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58246-58360-saint_honore_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58246-58360-saint_honore_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58246-58360-saint_honore_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58246-58360-saint_honore_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58247-58270-saint_jean_aux_amognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58247-58270-saint_jean_aux_amognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58247-58270-saint_jean_aux_amognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58247-58270-saint_jean_aux_amognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58248-58150-saint_laurent_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58248-58150-saint_laurent_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58248-58150-saint_laurent_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58248-58150-saint_laurent_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58249-58120-saint_leger_de_fougeret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58249-58120-saint_leger_de_fougeret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58249-58120-saint_leger_de_fougeret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58249-58120-saint_leger_de_fougeret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58250-58300-saint_leger_des_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58250-58300-saint_leger_des_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58250-58300-saint_leger_des_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58250-58300-saint_leger_des_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58251-58200-saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58251-58200-saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58251-58200-saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58251-58200-saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58252-58350-saint_malo_en_donziois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58252-58350-saint_malo_en_donziois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58252-58350-saint_malo_en_donziois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58252-58350-saint_malo_en_donziois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58253-58330-sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58253-58330-sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58253-58330-sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58253-58330-sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58254-58130-saint_martin_d_heuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58254-58130-saint_martin_d_heuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58254-58130-saint_martin_d_heuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58254-58130-saint_martin_d_heuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58255-58140-saint_martin_du_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58255-58140-saint_martin_du_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58255-58140-saint_martin_du_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58255-58140-saint_martin_du_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58256-58150-saint_martin_sur_nohain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58256-58150-saint_martin_sur_nohain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58256-58150-saint_martin_sur_nohain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58256-58150-saint_martin_sur_nohain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58257-58330-saint_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58257-58330-saint_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58257-58330-saint_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58257-58330-saint_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58258-58160-saint_ouen_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58258-58160-saint_ouen_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58258-58160-saint_ouen_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58258-58160-saint_ouen_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58259-58300-saint_parize_en_viry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58259-58300-saint_parize_en_viry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58259-58300-saint_parize_en_viry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58259-58300-saint_parize_en_viry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58260-58490-saint_parize_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58260-58490-saint_parize_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58260-58490-saint_parize_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58260-58490-saint_parize_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58261-58200-saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58261-58200-saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58261-58200-saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58261-58200-saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58262-58110-saint_pereuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58262-58110-saint_pereuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58262-58110-saint_pereuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58262-58110-saint_pereuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58263-58210-saint_pierre_du_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58263-58210-saint_pierre_du_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58263-58210-saint_pierre_du_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58263-58210-saint_pierre_du_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58264-58240-saint_pierre_le_moutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58264-58240-saint_pierre_le_moutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58264-58240-saint_pierre_le_moutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58264-58240-saint_pierre_le_moutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58265-58150-saint_quentin_sur_nohain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58265-58150-saint_quentin_sur_nohain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58265-58150-saint_quentin_sur_nohain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58265-58150-saint_quentin_sur_nohain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58266-58420-saint_reverien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58266-58420-saint_reverien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58266-58420-saint_reverien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58266-58420-saint_reverien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58267-58330-saint_saulge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58267-58330-saint_saulge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58267-58330-saint_saulge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58267-58330-saint_saulge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58268-58250-saint_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58268-58250-saint_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58268-58250-saint_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58268-58250-saint_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58269-58270-saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58269-58270-saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58269-58270-saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58269-58270-saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58270-58310-saint_verain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58270-58310-saint_verain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58270-58310-saint_verain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58270-58310-saint_verain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58271-58190-saizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58271-58190-saizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58271-58190-saizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58271-58190-saizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58272-58800-sardy_les_epiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58272-58800-sardy_les_epiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58272-58800-sardy_les_epiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58272-58800-sardy_les_epiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58273-58160-sauvigny_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58273-58160-sauvigny_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58273-58160-sauvigny_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58273-58160-sauvigny_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58274-58170-savigny_poil_fol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58274-58170-savigny_poil_fol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58274-58170-savigny_poil_fol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58274-58170-savigny_poil_fol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58275-58330-saxi_bourdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58275-58330-saxi_bourdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58275-58330-saxi_bourdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58275-58330-saxi_bourdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58276-58360-semelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58276-58360-semelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58276-58360-semelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58276-58360-semelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58277-58290-sermages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58277-58290-sermages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58277-58290-sermages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58277-58290-sermages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58278-58000-sermoise_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58278-58000-sermoise_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58278-58000-sermoise_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58278-58000-sermoise_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58279-58700-sichamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58279-58700-sichamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58279-58700-sichamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58279-58700-sichamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58280-58300-sougy_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58280-58300-sougy_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58280-58300-sougy_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58280-58300-sougy_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58281-58150-suilly_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58281-58150-suilly_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58281-58150-suilly_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58281-58150-suilly_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58282-58500-surgy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58282-58500-surgy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58282-58500-surgy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58282-58500-surgy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58283-58420-taconnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58283-58420-taconnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58283-58420-taconnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58283-58420-taconnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58284-58190-talon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58284-58190-talon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58284-58190-talon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58284-58190-talon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58285-58110-tamnay_en_bazois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58285-58110-tamnay_en_bazois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58285-58110-tamnay_en_bazois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58285-58110-tamnay_en_bazois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58286-58190-tannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58286-58190-tannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58286-58190-tannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58286-58190-tannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58287-58170-tazilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58287-58170-tazilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58287-58170-tazilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58287-58170-tazilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58288-58190-teigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58288-58190-teigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58288-58190-teigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58288-58190-teigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58289-58250-ternant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58289-58250-ternant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58289-58250-ternant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58289-58250-ternant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58290-58250-thaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58290-58250-thaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58290-58250-thaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58290-58250-thaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58291-58260-thianges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58291-58260-thianges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58291-58260-thianges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58291-58260-thianges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58292-58110-tintury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58292-58110-tintury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58292-58110-tintury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58292-58110-tintury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58293-58300-toury_lurcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58293-58300-toury_lurcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58293-58300-toury_lurcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58293-58300-toury_lurcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58294-58240-toury_sur_jour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58294-58240-toury_sur_jour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58294-58240-toury_sur_jour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58294-58240-toury_sur_jour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58295-58150-tracy_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58295-58150-tracy_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58295-58150-tracy_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58295-58150-tracy_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58296-58240-tresnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58296-58240-tresnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58296-58240-tresnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58296-58240-tresnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58297-58260-trois_vevres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58297-58260-trois_vevres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58297-58260-trois_vevres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58297-58260-trois_vevres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58298-58400-tronsanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58298-58400-tronsanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58298-58400-tronsanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58298-58400-tronsanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58299-58460-trucy_l_orgueilleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58299-58460-trucy_l_orgueilleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58299-58460-trucy_l_orgueilleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58299-58460-trucy_l_orgueilleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58300-58130-urzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58300-58130-urzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58300-58130-urzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58300-58130-urzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58301-58290-vandenesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58301-58290-vandenesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58301-58290-vandenesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58301-58290-vandenesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58302-58400-varennes_les_narcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58302-58400-varennes_les_narcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58302-58400-varennes_les_narcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58302-58400-varennes_les_narcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58303-58640-varennes_vauzelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58303-58640-varennes_vauzelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58303-58640-varennes_vauzelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58303-58640-varennes_vauzelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58304-58210-varzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58304-58210-varzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58304-58210-varzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58304-58210-varzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58305-58140-vauclaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58305-58140-vauclaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58305-58140-vauclaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58305-58140-vauclaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58306-58300-verneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58306-58300-verneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58306-58300-verneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58306-58300-verneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58307-58150-vielmanay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58307-58150-vielmanay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58307-58150-vielmanay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58307-58150-vielmanay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58308-58190-vignol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58308-58190-vignol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58308-58190-vignol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58308-58190-vignol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58309-58370-villapourcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58309-58370-villapourcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58309-58370-villapourcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58309-58370-villapourcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58310-58210-villiers_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58310-58210-villiers_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58310-58210-villiers_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58310-58210-villiers_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58311-58270-ville_langy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58311-58270-ville_langy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58311-58270-ville_langy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58311-58270-ville_langy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58312-58500-villiers_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58312-58500-villiers_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58312-58500-villiers_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58312-58500-villiers_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58313-58420-vitry_lache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58313-58420-vitry_lache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58313-58420-vitry_lache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt58-nievre/commune58313-58420-vitry_lache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-59.xml
+++ b/public/sitemaps/sitemap-59.xml
@@ -5,1338 +5,2672 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59001-59268-abancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59001-59268-abancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59001-59268-abancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59001-59268-abancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59002-59215-abscon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59002-59215-abscon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59002-59215-abscon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59002-59215-abscon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59003-59149-aibes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59003-59149-aibes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59003-59149-aibes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59003-59149-aibes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59004-59310-aix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59004-59310-aix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59004-59310-aix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59004-59310-aix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59005-59251-allennes_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59005-59251-allennes_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59005-59251-allennes_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59005-59251-allennes_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59006-59144-amfroipret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59006-59144-amfroipret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59006-59144-amfroipret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59006-59144-amfroipret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59007-59194-anhiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59007-59194-anhiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59007-59194-anhiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59007-59194-anhiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59008-59580-aniche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59008-59580-aniche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59008-59580-aniche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59008-59580-aniche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59650-villeneuve_d_ascq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59650-villeneuve_d_ascq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59650-villeneuve_d_ascq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59650-villeneuve_d_ascq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59491-villeneuve_d_ascq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59491-villeneuve_d_ascq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59491-villeneuve_d_ascq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59491-villeneuve_d_ascq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59493-villeneuve_d_ascq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59493-villeneuve_d_ascq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59493-villeneuve_d_ascq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59009-59493-villeneuve_d_ascq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59010-59400-anneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59010-59400-anneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59010-59400-anneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59010-59400-anneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59011-59112-annoeullin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59011-59112-annoeullin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59011-59112-annoeullin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59011-59112-annoeullin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59012-59186-anor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59012-59186-anor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59012-59186-anor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59012-59186-anor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59013-59152-anstaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59013-59152-anstaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59013-59152-anstaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59013-59152-anstaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59014-59410-anzin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59014-59410-anzin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59014-59410-anzin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59014-59410-anzin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59015-59151-arleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59015-59151-arleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59015-59151-arleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59015-59151-arleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59016-59380-armbouts_cappel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59016-59380-armbouts_cappel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59016-59380-armbouts_cappel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59016-59380-armbouts_cappel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59017-59280-armentieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59017-59280-armentieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59017-59280-armentieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59017-59280-armentieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59018-59285-arneke/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59018-59285-arneke/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59018-59285-arneke/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59018-59285-arneke/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59019-59269-artres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59019-59269-artres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59019-59269-artres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59019-59269-artres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59021-59600-assevent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59021-59600-assevent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59021-59600-assevent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59021-59600-assevent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59022-59551-attiches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59022-59551-attiches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59022-59551-attiches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59022-59551-attiches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59023-59265-aubencheul_au_bac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59023-59265-aubencheul_au_bac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59023-59265-aubencheul_au_bac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59023-59265-aubencheul_au_bac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59024-59165-auberchicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59024-59165-auberchicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59024-59165-auberchicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59024-59165-auberchicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59025-59249-aubers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59025-59249-aubers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59025-59249-aubers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59025-59249-aubers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59026-59265-aubigny_au_bac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59026-59265-aubigny_au_bac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59026-59265-aubigny_au_bac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59026-59265-aubigny_au_bac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59027-59494-aubry_du_hainaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59027-59494-aubry_du_hainaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59027-59494-aubry_du_hainaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59027-59494-aubry_du_hainaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59027-59590-aubry_du_hainaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59027-59590-aubry_du_hainaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59027-59590-aubry_du_hainaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59027-59590-aubry_du_hainaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59028-59950-auby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59028-59950-auby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59028-59950-auby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59028-59950-auby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59029-59310-auchy_lez_orchies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59029-59310-auchy_lez_orchies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59029-59310-auchy_lez_orchies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59029-59310-auchy_lez_orchies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59031-59570-audignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59031-59570-audignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59031-59570-audignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59031-59570-audignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59032-59300-aulnoy_lez_valenciennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59032-59300-aulnoy_lez_valenciennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59032-59300-aulnoy_lez_valenciennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59032-59300-aulnoy_lez_valenciennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59033-59620-aulnoye_aymeries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59033-59620-aulnoye_aymeries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59033-59620-aulnoye_aymeries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59033-59620-aulnoye_aymeries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59034-59710-avelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59034-59710-avelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59034-59710-avelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59034-59710-avelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59035-59440-avesnelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59035-59440-avesnelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59035-59440-avesnelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59035-59440-avesnelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59036-59440-avesnes_sur_helpe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59036-59440-avesnes_sur_helpe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59036-59440-avesnes_sur_helpe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59036-59440-avesnes_sur_helpe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59037-59129-avesnes_les_aubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59037-59129-avesnes_les_aubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59037-59129-avesnes_les_aubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59037-59129-avesnes_les_aubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59038-59296-avesnes_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59038-59296-avesnes_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59038-59296-avesnes_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59038-59296-avesnes_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59039-59400-awoingt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59039-59400-awoingt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59039-59400-awoingt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59039-59400-awoingt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59041-59138-bachant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59041-59138-bachant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59041-59138-bachant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59041-59138-bachant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59042-59830-bachy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59042-59830-bachy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59042-59830-bachy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59042-59830-bachy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59043-59270-bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59043-59270-bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59043-59270-bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59043-59270-bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59044-59780-baisieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59044-59780-baisieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59044-59780-baisieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59044-59780-baisieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59045-59132-baives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59045-59132-baives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59045-59132-baives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59045-59132-baives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59046-59470-bambecque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59046-59470-bambecque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59046-59470-bambecque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59046-59470-bambecque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59047-59266-banteux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59047-59266-banteux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59047-59266-banteux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59047-59266-banteux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59048-59554-bantigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59048-59554-bantigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59048-59554-bantigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59048-59554-bantigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59049-59266-bantouzelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59049-59266-bantouzelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59049-59266-bantouzelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59049-59266-bantouzelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59050-59440-bas_lieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59050-59440-bas_lieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59050-59440-bas_lieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59050-59440-bas_lieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59051-59480-la_bassee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59051-59480-la_bassee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59051-59480-la_bassee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59051-59480-la_bassee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59052-59221-bauvin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59052-59221-bauvin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59052-59221-bauvin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59052-59221-bauvin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59053-59570-bavay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59053-59570-bavay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59053-59570-bavay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59053-59570-bavay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59054-59670-bavinchove/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59054-59670-bavinchove/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59054-59670-bavinchove/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59054-59670-bavinchove/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59055-59360-bazuel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59055-59360-bazuel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59055-59360-bazuel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59055-59360-bazuel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59056-59134-beaucamps_ligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59056-59134-beaucamps_ligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59056-59134-beaucamps_ligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59056-59134-beaucamps_ligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59057-59530-beaudignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59057-59530-beaudignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59057-59530-beaudignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59057-59530-beaudignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59058-59330-beaufort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59058-59330-beaufort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59058-59330-beaufort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59058-59330-beaufort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59059-59540-beaumont_en_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59059-59540-beaumont_en_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59059-59540-beaumont_en_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59059-59540-beaumont_en_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59060-59730-beaurain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59060-59730-beaurain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59060-59730-beaurain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59060-59730-beaurain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59061-59550-beaurepaire_sur_sambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59061-59550-beaurepaire_sur_sambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59061-59550-beaurepaire_sur_sambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59061-59550-beaurepaire_sur_sambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59062-59740-beaurieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59062-59740-beaurieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59062-59740-beaurieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59062-59740-beaurieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59063-59157-beauvois_en_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59063-59157-beauvois_en_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59063-59157-beauvois_en_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59063-59157-beauvois_en_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59064-59135-bellaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59064-59135-bellaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59064-59135-bellaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59064-59135-bellaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59065-59570-bellignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59065-59570-bellignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59065-59570-bellignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59065-59570-bellignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59066-59740-berelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59066-59740-berelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59066-59740-berelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59066-59740-berelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59067-59380-bergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59067-59380-bergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59067-59380-bergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59067-59380-bergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59068-59145-berlaimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59068-59145-berlaimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59068-59145-berlaimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59068-59145-berlaimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59069-59213-bermerain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59069-59213-bermerain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59069-59213-bermerain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59069-59213-bermerain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59070-59570-bermeries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59070-59570-bermeries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59070-59570-bermeries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59070-59570-bermeries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59071-59235-bersee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59071-59235-bersee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59071-59235-bersee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59071-59235-bersee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59072-59600-bersillies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59072-59600-bersillies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59072-59600-bersillies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59072-59600-bersillies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59073-59270-berthen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59073-59270-berthen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59073-59270-berthen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59073-59270-berthen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59074-59980-bertry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59074-59980-bertry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59074-59980-bertry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59074-59980-bertry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59075-59540-bethencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59075-59540-bethencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59075-59540-bethencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59075-59540-bethencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59076-59600-bettignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59076-59600-bettignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59076-59600-bettignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59076-59600-bettignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59077-59570-bettrechies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59077-59570-bettrechies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59077-59570-bettrechies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59077-59570-bettrechies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59078-59216-beugnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59078-59216-beugnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59078-59216-beugnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59078-59216-beugnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59079-59192-beuvrages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59079-59192-beuvrages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59079-59192-beuvrages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59079-59192-beuvrages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59080-59310-beuvry_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59080-59310-beuvry_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59080-59310-beuvry_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59080-59310-beuvry_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59081-59217-bevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59081-59217-bevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59081-59217-bevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59081-59217-bevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59082-59380-bierne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59082-59380-bierne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59082-59380-bierne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59082-59380-bierne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59083-59380-bissezeele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59083-59380-bissezeele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59083-59380-bissezeele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59083-59380-bissezeele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59084-59173-blaringhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59084-59173-blaringhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59084-59173-blaringhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59084-59173-blaringhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59085-59268-blecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59085-59268-blecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59085-59268-blecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59085-59268-blecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59086-59299-boeschepe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59086-59299-boeschepe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59086-59299-boeschepe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59086-59299-boeschepe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59087-59189-boeseghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59087-59189-boeseghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59087-59189-boeseghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59087-59189-boeseghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59088-59280-bois_grenier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59088-59280-bois_grenier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59088-59280-bois_grenier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59088-59280-bois_grenier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59089-59470-bollezeele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59089-59470-bollezeele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59089-59470-bollezeele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59089-59470-bollezeele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59090-59910-bondues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59090-59910-bondues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59090-59910-bondues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59090-59910-bondues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59091-59190-borre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59091-59190-borre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59091-59190-borre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59091-59190-borre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59092-59111-bouchain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59092-59111-bouchain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59092-59111-bouchain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59092-59111-bouchain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59093-59440-boulogne_sur_helpe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59093-59440-boulogne_sur_helpe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59093-59440-boulogne_sur_helpe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59093-59440-boulogne_sur_helpe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59094-59630-bourbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59094-59630-bourbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59094-59630-bourbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59094-59630-bourbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59096-59830-bourghelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59096-59830-bourghelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59096-59830-bourghelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59096-59830-bourghelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59097-59400-boursies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59097-59400-boursies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59097-59400-boursies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59097-59400-boursies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59098-59166-bousbecque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59098-59166-bousbecque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59098-59166-bousbecque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59098-59166-bousbecque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59099-59222-bousies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59099-59222-bousies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59099-59222-bousies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59099-59222-bousies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59100-59178-bousignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59100-59178-bousignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59100-59178-bousignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59100-59178-bousignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59101-59149-bousignies_sur_roc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59101-59149-bousignies_sur_roc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59101-59149-bousignies_sur_roc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59101-59149-bousignies_sur_roc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59102-59217-boussieres_en_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59102-59217-boussieres_en_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59102-59217-boussieres_en_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59102-59217-boussieres_en_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59103-59330-boussieres_sur_sambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59103-59330-boussieres_sur_sambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59103-59330-boussieres_sur_sambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59103-59330-boussieres_sur_sambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59104-59168-boussois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59104-59168-boussois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59104-59168-boussois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59104-59168-boussois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59105-59870-bouvignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59105-59870-bouvignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59105-59870-bouvignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59105-59870-bouvignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59106-59830-bouvines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59106-59830-bouvines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59106-59830-bouvines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59106-59830-bouvines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59107-59123-bray_dunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59107-59123-bray_dunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59107-59123-bray_dunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59107-59123-bray_dunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59108-59730-briastre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59108-59730-briastre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59108-59730-briastre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59108-59730-briastre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59109-59178-brillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59109-59178-brillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59109-59178-brillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59109-59178-brillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59110-59630-brouckerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59110-59630-brouckerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59110-59630-brouckerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59110-59630-brouckerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59111-59470-broxeele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59111-59470-broxeele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59111-59470-broxeele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59111-59470-broxeele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59112-59860-bruay_sur_l_escaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59112-59860-bruay_sur_l_escaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59112-59860-bruay_sur_l_escaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59112-59860-bruay_sur_l_escaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59113-59490-bruille_lez_marchiennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59113-59490-bruille_lez_marchiennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59113-59490-bruille_lez_marchiennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59113-59490-bruille_lez_marchiennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59114-59199-bruille_saint_amand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59114-59199-bruille_saint_amand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59114-59199-bruille_saint_amand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59114-59199-bruille_saint_amand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59115-59151-brunemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59115-59151-brunemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59115-59151-brunemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59115-59151-brunemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59116-59144-bry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59116-59144-bry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59116-59144-bry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59116-59144-bry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59117-59151-bugnicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59117-59151-bugnicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59117-59151-bugnicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59117-59151-bugnicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59118-59137-busigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59118-59137-busigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59118-59137-busigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59118-59137-busigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59119-59285-buysscheure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59119-59285-buysscheure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59119-59285-buysscheure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59119-59285-buysscheure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59120-59190-caestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59120-59190-caestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59120-59190-caestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59120-59190-caestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59121-59161-cagnoncles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59121-59161-cagnoncles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59121-59161-cagnoncles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59121-59161-cagnoncles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59122-59400-cambrai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59122-59400-cambrai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59122-59400-cambrai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59122-59400-cambrai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59123-59133-camphin_en_carembault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59123-59133-camphin_en_carembault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59123-59133-camphin_en_carembault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59123-59133-camphin_en_carembault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59124-59780-camphin_en_pevele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59124-59780-camphin_en_pevele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59124-59780-camphin_en_pevele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59124-59780-camphin_en_pevele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59125-59267-cantaing_sur_escaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59125-59267-cantaing_sur_escaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59125-59267-cantaing_sur_escaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59125-59267-cantaing_sur_escaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59126-59169-cantin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59126-59169-cantin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59126-59169-cantin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59126-59169-cantin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59127-59213-capelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59127-59213-capelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59127-59213-capelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59127-59213-capelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59128-59160-capinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59128-59160-capinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59128-59160-capinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59128-59160-capinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59129-59242-cappelle_en_pevele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59129-59242-cappelle_en_pevele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59129-59242-cappelle_en_pevele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59129-59242-cappelle_en_pevele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59130-59630-cappelle_brouck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59130-59630-cappelle_brouck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59130-59630-cappelle_brouck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59130-59630-cappelle_brouck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59131-59180-cappelle_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59131-59180-cappelle_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59131-59180-cappelle_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59131-59180-cappelle_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59132-59217-carnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59132-59217-carnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59132-59217-carnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59132-59217-carnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59133-59112-carnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59133-59112-carnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59133-59112-carnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59133-59112-carnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59134-59244-cartignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59134-59244-cartignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59134-59244-cartignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59134-59244-cartignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59135-59670-cassel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59135-59670-cassel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59135-59670-cassel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59135-59670-cassel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59136-59360-le_cateau_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59136-59360-le_cateau_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59136-59360-le_cateau_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59136-59360-le_cateau_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59137-59360-catillon_sur_sambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59137-59360-catillon_sur_sambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59137-59360-catillon_sur_sambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59137-59360-catillon_sur_sambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59138-59217-cattenieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59138-59217-cattenieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59138-59217-cattenieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59138-59217-cattenieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59139-59540-caudry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59139-59540-caudry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59139-59540-caudry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59139-59540-caudry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59140-59191-caullery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59140-59191-caullery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59140-59191-caullery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59140-59191-caullery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59141-59400-cauroir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59141-59400-cauroir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59141-59400-cauroir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59141-59400-cauroir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59142-59680-cerfontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59142-59680-cerfontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59142-59680-cerfontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59142-59680-cerfontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59143-59930-la_chapelle_d_armentieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59143-59930-la_chapelle_d_armentieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59143-59930-la_chapelle_d_armentieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59143-59930-la_chapelle_d_armentieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59144-59230-chateau_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59144-59230-chateau_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59144-59230-chateau_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59144-59230-chateau_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59145-59147-chemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59145-59147-chemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59145-59147-chemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59145-59147-chemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59146-59152-chereng/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59146-59152-chereng/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59146-59152-chereng/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59146-59152-chereng/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59147-59740-choisies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59147-59740-choisies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59147-59740-choisies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59147-59740-choisies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59148-59740-clairfayts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59148-59740-clairfayts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59148-59740-clairfayts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59148-59740-clairfayts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59149-59225-clary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59149-59225-clary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59149-59225-clary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59149-59225-clary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59150-59830-cobrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59150-59830-cobrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59150-59830-cobrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59150-59830-cobrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59151-59680-colleret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59151-59680-colleret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59151-59680-colleret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59151-59680-colleret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59152-59560-comines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59152-59560-comines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59152-59560-comines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59152-59560-comines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59153-59163-conde_sur_l_escaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59153-59163-conde_sur_l_escaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59153-59163-conde_sur_l_escaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59153-59163-conde_sur_l_escaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59155-59210-coudekerque_branche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59155-59210-coudekerque_branche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59155-59210-coudekerque_branche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59155-59210-coudekerque_branche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59156-59552-courchelettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59156-59552-courchelettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59156-59552-courchelettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59156-59552-courchelettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59157-59149-cousolre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59157-59149-cousolre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59157-59149-cousolre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59157-59149-cousolre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59158-59310-coutiches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59158-59310-coutiches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59158-59310-coutiches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59158-59310-coutiches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59159-59279-craywick/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59159-59279-craywick/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59159-59279-craywick/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59159-59279-craywick/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59160-59154-crespin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59160-59154-crespin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59160-59154-crespin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59160-59154-crespin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59161-59258-crevecoeur_sur_l_escaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59161-59258-crevecoeur_sur_l_escaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59161-59258-crevecoeur_sur_l_escaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59161-59258-crevecoeur_sur_l_escaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59162-59380-crochte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59162-59380-crochte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59162-59380-crochte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59162-59380-crochte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59163-59170-croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59163-59170-croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59163-59170-croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59163-59170-croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59164-59222-croix_caluyau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59164-59222-croix_caluyau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59164-59222-croix_caluyau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59164-59222-croix_caluyau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59165-59553-cuincy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59165-59553-cuincy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59165-59553-cuincy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59165-59553-cuincy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59166-59990-curgies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59166-59990-curgies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59166-59990-curgies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59166-59990-curgies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59167-59268-cuvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59167-59268-cuvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59167-59268-cuvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59167-59268-cuvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59168-59830-cysoing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59168-59830-cysoing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59168-59830-cysoing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59168-59830-cysoing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59169-59680-damousies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59169-59680-damousies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59169-59680-damousies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59169-59680-damousies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59170-59187-dechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59170-59187-dechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59170-59187-dechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59170-59187-dechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59171-59127-deheries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59171-59127-deheries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59171-59127-deheries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59171-59127-deheries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59172-59220-denain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59172-59220-denain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59172-59220-denain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59172-59220-denain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59173-59890-deulemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59173-59890-deulemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59173-59890-deulemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59173-59890-deulemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59174-59740-dimechaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59174-59740-dimechaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59174-59740-dimechaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59174-59740-dimechaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59175-59216-dimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59175-59216-dimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59175-59216-dimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59175-59216-dimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59176-59400-doignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59176-59400-doignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59176-59400-doignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59176-59400-doignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59177-59440-dompierre_sur_helpe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59177-59440-dompierre_sur_helpe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59177-59440-dompierre_sur_helpe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59177-59440-dompierre_sur_helpe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59178-59500-douai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59178-59500-douai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59178-59500-douai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59178-59500-douai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59179-59282-douchy_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59179-59282-douchy_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59179-59282-douchy_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59179-59282-douchy_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59180-59940-le_doulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59180-59940-le_doulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59180-59940-le_doulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59180-59940-le_doulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59181-59440-dourlers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59181-59440-dourlers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59181-59440-dourlers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59181-59440-dourlers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59182-59630-drincham/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59182-59630-drincham/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59182-59630-drincham/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59182-59630-drincham/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59640-dunkerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59640-dunkerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59640-dunkerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59640-dunkerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59140-dunkerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59140-dunkerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59140-dunkerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59140-dunkerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59240-dunkerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59240-dunkerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59240-dunkerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59240-dunkerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59430-dunkerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59430-dunkerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59430-dunkerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59430-dunkerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59279-dunkerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59279-dunkerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59279-dunkerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59183-59279-dunkerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59184-59173-ebblinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59184-59173-ebblinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59184-59173-ebblinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59184-59173-ebblinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59185-59176-ecaillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59185-59176-ecaillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59185-59176-ecaillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59185-59176-ecaillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59186-59740-eccles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59186-59740-eccles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59186-59740-eccles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59186-59740-eccles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59187-59330-eclaibes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59187-59330-eclaibes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59187-59330-eclaibes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59187-59330-eclaibes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59188-59620-ecuelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59188-59620-ecuelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59188-59620-ecuelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59188-59620-ecuelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59189-59114-eecke/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59189-59114-eecke/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59189-59114-eecke/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59189-59114-eecke/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59190-59600-elesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59190-59600-elesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59190-59600-elesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59190-59600-elesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59191-59127-elincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59191-59127-elincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59191-59127-elincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59191-59127-elincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59192-59580-emerchicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59192-59580-emerchicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59192-59580-emerchicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59192-59580-emerchicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59193-59320-emmerin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59193-59320-emmerin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59193-59320-emmerin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59193-59320-emmerin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59194-59530-englefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59194-59530-englefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59194-59530-englefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59194-59530-englefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59195-59320-englos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59195-59320-englos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59195-59320-englos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59195-59320-englos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59196-59320-ennetieres_en_weppes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59196-59320-ennetieres_en_weppes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59196-59320-ennetieres_en_weppes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59196-59320-ennetieres_en_weppes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59197-59710-ennevelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59197-59710-ennevelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59197-59710-ennevelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59197-59710-ennevelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59198-59132-eppe_sauvage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59198-59132-eppe_sauvage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59198-59132-eppe_sauvage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59198-59132-eppe_sauvage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59199-59169-erchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59199-59169-erchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59199-59169-erchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59199-59169-erchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59200-59470-eringhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59200-59470-eringhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59200-59470-eringhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59200-59470-eringhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59201-59320-erquinghem_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59201-59320-erquinghem_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59201-59320-erquinghem_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59201-59320-erquinghem_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59202-59193-erquinghem_lys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59202-59193-erquinghem_lys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59202-59193-erquinghem_lys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59202-59193-erquinghem_lys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59203-59171-erre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59203-59171-erre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59203-59171-erre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59203-59171-erre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59204-59213-escarmain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59204-59213-escarmain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59204-59213-escarmain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59204-59213-escarmain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59205-59124-escaudain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59205-59124-escaudain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59205-59124-escaudain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59205-59124-escaudain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59206-59161-escaudoeuvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59206-59161-escaudoeuvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59206-59161-escaudoeuvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59206-59161-escaudoeuvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59207-59278-escautpont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59207-59278-escautpont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59207-59278-escautpont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59207-59278-escautpont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59208-59320-escobecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59208-59320-escobecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59208-59320-escobecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59208-59320-escobecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59209-59127-esnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59209-59127-esnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59209-59127-esnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59209-59127-esnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59210-59470-esquelbecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59210-59470-esquelbecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59210-59470-esquelbecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59210-59470-esquelbecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59211-59553-esquerchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59211-59553-esquerchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59211-59553-esquerchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59211-59553-esquerchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59212-59940-estaires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59212-59940-estaires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59212-59940-estaires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59212-59940-estaires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59213-59400-estourmel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59213-59400-estourmel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59213-59400-estourmel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59213-59400-estourmel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59214-59151-estrees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59214-59151-estrees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59214-59151-estrees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59214-59151-estrees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59215-59990-estreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59215-59990-estreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59215-59990-estreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59215-59990-estreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59216-59161-eswars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59216-59161-eswars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59216-59161-eswars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59216-59161-eswars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59217-59144-eth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59217-59144-eth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59217-59144-eth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59217-59144-eth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59218-59219-etroeungt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59218-59219-etroeungt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59218-59219-etroeungt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59218-59219-etroeungt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59219-59295-estrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59219-59295-estrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59219-59295-estrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59219-59295-estrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59220-59155-faches_thumesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59220-59155-faches_thumesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59220-59155-faches_thumesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59220-59155-faches_thumesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59221-59300-famars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59221-59300-famars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59221-59300-famars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59221-59300-famars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59222-59310-faumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59222-59310-faumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59222-59310-faumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59222-59310-faumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59223-59550-le_favril/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59223-59550-le_favril/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59223-59550-le_favril/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59223-59550-le_favril/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59224-59247-fechain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59224-59247-fechain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59224-59247-fechain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59224-59247-fechain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59225-59750-feignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59225-59750-feignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59225-59750-feignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59225-59750-feignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59226-59740-felleries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59226-59740-felleries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59226-59740-felleries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59226-59740-felleries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59227-59179-fenain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59227-59179-fenain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59227-59179-fenain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59227-59179-fenain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59228-59169-ferin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59228-59169-ferin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59228-59169-ferin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59228-59169-ferin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59229-59610-feron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59229-59610-feron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59229-59610-feron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59229-59610-feron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59230-59680-ferriere_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59230-59680-ferriere_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59230-59680-ferriere_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59230-59680-ferriere_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59231-59680-ferriere_la_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59231-59680-ferriere_la_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59231-59680-ferriere_la_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59231-59680-ferriere_la_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59232-59570-la_flamengrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59232-59570-la_flamengrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59232-59570-la_flamengrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59232-59570-la_flamengrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59233-59440-flaumont_waudrechies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59233-59440-flaumont_waudrechies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59233-59440-flaumont_waudrechies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59233-59440-flaumont_waudrechies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59234-59128-flers_en_escrebieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59234-59128-flers_en_escrebieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59234-59128-flers_en_escrebieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59234-59128-flers_en_escrebieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59236-59267-flesquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59236-59267-flesquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59236-59267-flesquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59236-59267-flesquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59237-59270-fletre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59237-59270-fletre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59237-59270-fletre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59237-59270-fletre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59238-59158-flines_les_mortagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59238-59158-flines_les_mortagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59238-59158-flines_les_mortagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59238-59158-flines_les_mortagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59239-59148-flines_lez_raches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59239-59148-flines_lez_raches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59239-59148-flines_lez_raches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59239-59148-flines_lez_raches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59240-59440-floursies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59240-59440-floursies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59240-59440-floursies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59240-59440-floursies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59241-59219-floyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59241-59219-floyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59241-59219-floyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59241-59219-floyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59242-59550-fontaine_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59242-59550-fontaine_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59242-59550-fontaine_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59242-59550-fontaine_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59243-59157-fontaine_au_pire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59243-59157-fontaine_au_pire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59243-59157-fontaine_au_pire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59243-59157-fontaine_au_pire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59244-59400-fontaine_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59244-59400-fontaine_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59244-59400-fontaine_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59244-59400-fontaine_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59246-59222-forest_en_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59246-59222-forest_en_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59246-59222-forest_en_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59246-59222-forest_en_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59247-59510-forest_sur_marque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59247-59510-forest_sur_marque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59247-59510-forest_sur_marque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59247-59510-forest_sur_marque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59249-59610-fourmies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59249-59610-fourmies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59249-59610-fourmies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59249-59610-fourmies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59250-59134-fournes_en_weppes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59250-59134-fournes_en_weppes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59250-59134-fournes_en_weppes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59250-59134-fournes_en_weppes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59251-59530-frasnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59251-59530-frasnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59251-59530-frasnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59251-59530-frasnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59252-59236-frelinghien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59252-59236-frelinghien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59252-59236-frelinghien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59252-59236-frelinghien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59253-59970-fresnes_sur_escaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59253-59970-fresnes_sur_escaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59253-59970-fresnes_sur_escaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59253-59970-fresnes_sur_escaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59254-59234-fressain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59254-59234-fressain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59254-59234-fressain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59254-59234-fressain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59255-59268-fressies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59255-59268-fressies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59255-59268-fressies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59255-59268-fressies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59256-59273-fretin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59256-59273-fretin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59256-59273-fretin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59256-59273-fretin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59257-59249-fromelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59257-59249-fromelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59257-59249-fromelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59257-59249-fromelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59258-59242-genech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59258-59242-genech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59258-59242-genech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59258-59242-genech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59259-59530-ghissignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59259-59530-ghissignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59259-59530-ghissignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59259-59530-ghissignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59260-59122-ghyvelde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59260-59122-ghyvelde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59260-59122-ghyvelde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59260-59122-ghyvelde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59260-59254-ghyvelde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59260-59254-ghyvelde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59260-59254-ghyvelde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59260-59254-ghyvelde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59261-59132-glageon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59261-59132-glageon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59261-59132-glageon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59261-59132-glageon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59262-59270-godewaersvelde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59262-59270-godewaersvelde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59262-59270-godewaersvelde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59262-59270-godewaersvelde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59263-59169-goeulzin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59263-59169-goeulzin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59263-59169-goeulzin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59263-59169-goeulzin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59264-59600-gognies_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59264-59600-gognies_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59264-59600-gognies_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59264-59600-gognies_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59265-59144-gommegnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59265-59144-gommegnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59265-59144-gommegnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59265-59144-gommegnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59266-59147-gondecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59266-59147-gondecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59266-59147-gondecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59266-59147-gondecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59267-59231-gonnelieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59267-59231-gonnelieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59267-59231-gonnelieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59267-59231-gonnelieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59268-59253-la_gorgue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59268-59253-la_gorgue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59268-59253-la_gorgue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59268-59253-la_gorgue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59269-59231-gouzeaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59269-59231-gouzeaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59269-59231-gouzeaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59269-59231-gouzeaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59270-59244-grand_fayt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59270-59244-grand_fayt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59270-59244-grand_fayt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59270-59244-grand_fayt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59271-59760-grande_synthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59271-59760-grande_synthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59271-59760-grande_synthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59271-59760-grande_synthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59272-59153-grand_fort_philippe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59272-59153-grand_fort_philippe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59272-59153-grand_fort_philippe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59272-59153-grand_fort_philippe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59273-59820-gravelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59273-59820-gravelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59273-59820-gravelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59273-59820-gravelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59274-59360-la_groise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59274-59360-la_groise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59274-59360-la_groise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59274-59360-la_groise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59275-59152-gruson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59275-59152-gruson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59275-59152-gruson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59275-59152-gruson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59276-59287-guesnain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59276-59287-guesnain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59276-59287-guesnain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59276-59287-guesnain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59277-59570-gussignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59277-59570-gussignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59277-59570-gussignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59277-59570-gussignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59278-59320-hallennes_lez_haubourdin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59278-59320-hallennes_lez_haubourdin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59278-59320-hallennes_lez_haubourdin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59278-59320-hallennes_lez_haubourdin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59279-59250-halluin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59279-59250-halluin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59279-59250-halluin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59279-59250-halluin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59280-59151-hamel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59280-59151-hamel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59280-59151-hamel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59280-59151-hamel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59281-59496-hantay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59281-59496-hantay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59281-59496-hantay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59281-59496-hantay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59282-59670-hardifort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59282-59670-hardifort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59282-59670-hardifort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59282-59670-hardifort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59283-59138-hargnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59283-59138-hargnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59283-59138-hargnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59283-59138-hargnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59284-59178-hasnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59284-59178-hasnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59284-59178-hasnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59284-59178-hasnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59285-59198-haspres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59285-59198-haspres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59285-59198-haspres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59285-59198-haspres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59286-59320-haubourdin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59286-59320-haubourdin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59286-59320-haubourdin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59286-59320-haubourdin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59287-59191-haucourt_en_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59287-59191-haucourt_en_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59287-59191-haucourt_en_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59287-59191-haucourt_en_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59288-59121-haulchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59288-59121-haulchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59288-59121-haulchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59288-59121-haulchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59289-59294-haussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59289-59294-haussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59289-59294-haussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59289-59294-haussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59290-59440-haut_lieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59290-59440-haut_lieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59290-59440-haut_lieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59290-59440-haut_lieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59291-59330-hautmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59291-59330-hautmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59291-59330-hautmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59291-59330-hautmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59292-59255-haveluy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59292-59255-haveluy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59292-59255-haveluy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59292-59255-haveluy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59293-59660-haverskerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59293-59660-haverskerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59293-59660-haverskerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59293-59660-haverskerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59294-59268-haynecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59294-59268-haynecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59294-59268-haynecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59294-59268-haynecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59294-59341-haynecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59294-59341-haynecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59294-59341-haynecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59294-59341-haynecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59295-59190-hazebrouck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59295-59190-hazebrouck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59295-59190-hazebrouck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59295-59190-hazebrouck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59296-59530-hecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59296-59530-hecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59296-59530-hecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59296-59530-hecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59297-59171-helesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59297-59171-helesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59297-59171-helesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59297-59171-helesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59299-59510-hem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59299-59510-hem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59299-59510-hem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59299-59510-hem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59300-59247-hem_lenglet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59300-59247-hem_lenglet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59300-59247-hem_lenglet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59300-59247-hem_lenglet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59301-59199-hergnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59301-59199-hergnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59301-59199-hergnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59301-59199-hergnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59302-59195-herin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59302-59195-herin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59302-59195-herin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59302-59195-herin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59303-59134-herlies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59303-59134-herlies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59303-59134-herlies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59303-59134-herlies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59304-59147-herrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59304-59147-herrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59304-59147-herrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59304-59147-herrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59305-59470-herzeele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59305-59470-herzeele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59305-59470-herzeele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59305-59470-herzeele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59306-59740-hestrud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59306-59740-hestrud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59306-59740-hestrud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59306-59740-hestrud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59307-59143-holque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59307-59143-holque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59307-59143-holque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59307-59143-holque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59308-59190-hondeghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59308-59190-hondeghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59308-59190-hondeghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59308-59190-hondeghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59309-59122-hondschoote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59309-59122-hondschoote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59309-59122-hondschoote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59309-59122-hondschoote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59310-59570-hon_hergies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59310-59570-hon_hergies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59310-59570-hon_hergies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59310-59570-hon_hergies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59311-59980-honnechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59311-59980-honnechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59311-59980-honnechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59311-59980-honnechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59312-59266-honnecourt_sur_escaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59312-59266-honnecourt_sur_escaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59312-59266-honnecourt_sur_escaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59312-59266-honnecourt_sur_escaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59313-59111-hordain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59313-59111-hordain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59313-59111-hordain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59313-59111-hordain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59314-59171-hornaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59314-59171-hornaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59314-59171-hornaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59314-59171-hornaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59315-59570-houdain_lez_bavay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59315-59570-houdain_lez_bavay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59315-59570-houdain_lez_bavay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59315-59570-houdain_lez_bavay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59316-59263-houplin_ancoisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59316-59263-houplin_ancoisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59316-59263-houplin_ancoisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59316-59263-houplin_ancoisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59317-59116-houplines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59317-59116-houplines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59317-59116-houplines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59317-59116-houplines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59318-59470-houtkerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59318-59470-houtkerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59318-59470-houtkerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59318-59470-houtkerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59319-59492-hoymille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59319-59492-hoymille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59319-59492-hoymille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59319-59492-hoymille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59320-59480-illies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59320-59480-illies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59320-59480-illies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59320-59480-illies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59321-59540-inchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59321-59540-inchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59321-59540-inchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59321-59540-inchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59322-59141-iwuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59322-59141-iwuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59322-59141-iwuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59322-59141-iwuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59323-59144-jenlain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59323-59144-jenlain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59323-59144-jenlain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59323-59144-jenlain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59324-59460-jeumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59324-59460-jeumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59324-59460-jeumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59324-59460-jeumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59325-59530-jolimetz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59325-59530-jolimetz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59325-59530-jolimetz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59325-59530-jolimetz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59326-59122-killem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59326-59122-killem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59326-59122-killem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59326-59122-killem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59327-59167-lallaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59327-59167-lallaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59327-59167-lallaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59327-59167-lallaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59328-59130-lambersart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59328-59130-lambersart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59328-59130-lambersart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59328-59130-lambersart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59329-59552-lambres_lez_douai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59329-59552-lambres_lez_douai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59329-59552-lambres_lez_douai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59329-59552-lambres_lez_douai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59330-59310-landas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59330-59310-landas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59330-59310-landas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59330-59310-landas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59331-59550-landrecies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59331-59550-landrecies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59331-59550-landrecies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59331-59550-landrecies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59332-59390-lannoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59332-59390-lannoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59332-59390-lannoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59332-59390-lannoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59333-59219-larouillies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59333-59219-larouillies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59333-59219-larouillies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59333-59219-larouillies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59334-59553-lauwin_planque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59334-59553-lauwin_planque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59334-59553-lauwin_planque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59334-59553-lauwin_planque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59335-59226-lecelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59335-59226-lecelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59335-59226-lecelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59335-59226-lecelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59336-59259-lecluse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59336-59259-lecluse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59336-59259-lecluse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59336-59259-lecluse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59337-59143-lederzeele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59337-59143-lederzeele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59337-59143-lederzeele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59337-59143-lederzeele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59338-59470-ledringhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59338-59470-ledringhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59338-59470-ledringhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59338-59470-ledringhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59339-59115-leers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59339-59115-leers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59339-59115-leers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59339-59115-leers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59340-59495-leffrinckoucke/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59340-59495-leffrinckoucke/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59340-59495-leffrinckoucke/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59340-59495-leffrinckoucke/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59341-59258-lesdain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59341-59258-lesdain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59341-59258-lesdain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59341-59258-lesdain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59342-59740-lez_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59342-59740-lez_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59342-59740-lez_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59342-59740-lez_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59343-59810-lesquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59343-59810-lesquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59343-59810-lesquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59343-59810-lesquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59344-59620-leval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59344-59620-leval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59344-59620-leval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59344-59620-leval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59345-59287-lewarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59345-59287-lewarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59345-59287-lewarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59345-59287-lewarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59346-59260-lezennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59346-59260-lezennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59346-59260-lezennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59346-59260-lezennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59347-59740-liessies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59347-59740-liessies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59347-59740-liessies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59347-59740-liessies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59348-59111-lieu_saint_amand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59348-59111-lieu_saint_amand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59348-59111-lieu_saint_amand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59348-59111-lieu_saint_amand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59349-59191-ligny_en_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59349-59191-ligny_en_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59349-59191-ligny_en_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59349-59191-ligny_en_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59800-lille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59800-lille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59800-lille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59800-lille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59000-lille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59000-lille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59000-lille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59000-lille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59260-lille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59260-lille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59260-lille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59260-lille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59777-lille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59777-lille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59777-lille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59777-lille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59160-lille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59160-lille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59160-lille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59350-59160-lille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59351-59330-limont_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59351-59330-limont_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59351-59330-limont_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59351-59330-limont_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59352-59126-linselles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59352-59126-linselles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59352-59126-linselles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59352-59126-linselles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59353-59530-locquignol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59353-59530-locquignol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59353-59530-locquignol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59353-59530-locquignol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59354-59182-loffre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59354-59182-loffre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59354-59182-loffre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59354-59182-loffre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59356-59840-lompret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59356-59840-lompret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59356-59840-lompret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59356-59840-lompret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59357-59570-la_longueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59357-59570-la_longueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59357-59570-la_longueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59357-59570-la_longueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59358-59630-looberghe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59358-59630-looberghe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59358-59630-looberghe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59358-59630-looberghe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59359-59279-loon_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59359-59279-loon_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59359-59279-loon_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59359-59279-loon_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59360-59120-loos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59360-59120-loos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59360-59120-loos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59360-59120-loos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59361-59156-lourches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59361-59156-lourches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59361-59156-lourches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59361-59156-lourches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59363-59530-louvignies_quesnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59363-59530-louvignies_quesnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59363-59530-louvignies_quesnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59363-59530-louvignies_quesnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59364-59830-louvil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59364-59830-louvil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59364-59830-louvil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59364-59830-louvil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59365-59720-louvroil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59365-59720-louvroil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59365-59720-louvroil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59365-59720-louvroil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59366-59173-lynde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59366-59173-lynde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59366-59173-lynde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59366-59173-lynde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59367-59390-lys_lez_lannoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59367-59390-lys_lez_lannoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59367-59390-lys_lez_lannoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59367-59390-lys_lez_lannoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59368-59110-la_madeleine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59368-59110-la_madeleine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59368-59110-la_madeleine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59368-59110-la_madeleine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59369-59233-maing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59369-59233-maing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59369-59233-maing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59369-59233-maing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59370-59600-mairieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59370-59600-mairieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59370-59600-mairieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59370-59600-mairieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59371-59134-le_maisnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59371-59134-le_maisnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59371-59134-le_maisnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59371-59134-le_maisnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59372-59127-malincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59372-59127-malincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59372-59127-malincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59372-59127-malincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59374-59440-marbaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59374-59440-marbaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59374-59440-marbaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59374-59440-marbaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59375-59870-marchiennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59375-59870-marchiennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59375-59870-marchiennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59375-59870-marchiennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59377-59159-marcoing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59377-59159-marcoing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59377-59159-marcoing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59377-59159-marcoing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59378-59700-marcq_en_baroeul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59378-59700-marcq_en_baroeul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59378-59700-marcq_en_baroeul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59378-59700-marcq_en_baroeul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59379-59252-marcq_en_ostrevent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59379-59252-marcq_en_ostrevent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59379-59252-marcq_en_ostrevent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59379-59252-marcq_en_ostrevent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59381-59990-maresches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59381-59990-maresches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59381-59990-maresches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59381-59990-maresches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59382-59238-maretz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59382-59238-maretz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59382-59238-maretz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59382-59238-maretz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59383-59770-marly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59383-59770-marly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59383-59770-marly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59383-59770-marly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59384-59550-maroilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59384-59550-maroilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59384-59550-maroilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59384-59550-maroilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59385-59164-marpent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59385-59164-marpent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59385-59164-marpent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59385-59164-marpent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59386-59520-marquette_lez_lille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59386-59520-marquette_lez_lille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59386-59520-marquette_lez_lille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59386-59520-marquette_lez_lille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59387-59252-marquette_en_ostrevant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59387-59252-marquette_en_ostrevant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59387-59252-marquette_en_ostrevant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59387-59252-marquette_en_ostrevant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59388-59274-marquillies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59388-59274-marquillies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59388-59274-marquillies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59388-59274-marquillies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59389-59241-masnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59389-59241-masnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59389-59241-masnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59389-59241-masnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59390-59176-masny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59390-59176-masny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59390-59176-masny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59390-59176-masny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59391-59172-mastaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59391-59172-mastaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59391-59172-mastaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59391-59172-mastaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59392-59600-maubeuge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59392-59600-maubeuge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59392-59600-maubeuge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59392-59600-maubeuge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59393-59158-maulde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59393-59158-maulde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59393-59158-maulde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59393-59158-maulde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59394-59980-maurois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59394-59980-maurois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59394-59980-maurois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59394-59980-maurois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59395-59360-mazinghien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59395-59360-mazinghien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59395-59360-mazinghien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59395-59360-mazinghien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59396-59570-mecquignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59396-59570-mecquignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59396-59570-mecquignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59396-59570-mecquignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59397-59470-merckeghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59397-59470-merckeghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59397-59470-merckeghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59397-59470-merckeghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59398-59710-merignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59398-59710-merignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59398-59710-merignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59398-59710-merignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59399-59270-merris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59399-59270-merris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59399-59270-merris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59399-59270-merris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59400-59660-merville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59400-59660-merville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59400-59660-merville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59400-59660-merville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59401-59270-meteren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59401-59270-meteren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59401-59270-meteren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59401-59270-meteren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59402-59143-millam/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59402-59143-millam/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59402-59143-millam/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59402-59143-millam/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59403-59178-millonfosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59403-59178-millonfosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59403-59178-millonfosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59403-59178-millonfosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59405-59400-moeuvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59405-59400-moeuvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59405-59400-moeuvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59405-59400-moeuvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59406-59620-monceau_saint_waast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59406-59620-monceau_saint_waast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59406-59620-monceau_saint_waast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59406-59620-monceau_saint_waast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59407-59224-monchaux_sur_ecaillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59407-59224-monchaux_sur_ecaillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59407-59224-monchaux_sur_ecaillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59407-59224-monchaux_sur_ecaillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59408-59283-moncheaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59408-59283-moncheaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59408-59283-moncheaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59408-59283-moncheaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59409-59234-monchecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59409-59234-monchecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59409-59234-monchecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59409-59234-monchecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59410-59370-mons_en_baroeul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59410-59370-mons_en_baroeul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59410-59370-mons_en_baroeul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59410-59370-mons_en_baroeul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59411-59246-mons_en_pevele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59411-59246-mons_en_pevele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59411-59246-mons_en_pevele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59411-59246-mons_en_pevele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59412-59360-montay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59412-59360-montay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59412-59360-montay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59412-59360-montay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59413-59225-montigny_en_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59413-59225-montigny_en_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59413-59225-montigny_en_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59413-59225-montigny_en_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59414-59182-montigny_en_ostrevent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59414-59182-montigny_en_ostrevent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59414-59182-montigny_en_ostrevent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59414-59182-montigny_en_ostrevent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59415-59227-montrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59415-59227-montrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59415-59227-montrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59415-59227-montrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59416-59190-morbecque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59416-59190-morbecque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59416-59190-morbecque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59416-59190-morbecque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59418-59158-mortagne_du_nord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59418-59158-mortagne_du_nord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59418-59158-mortagne_du_nord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59418-59158-mortagne_du_nord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59419-59310-mouchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59419-59310-mouchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59419-59310-mouchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59419-59310-mouchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59420-59132-moustier_en_fagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59420-59132-moustier_en_fagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59420-59132-moustier_en_fagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59420-59132-moustier_en_fagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59421-59420-mouvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59421-59420-mouvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59421-59420-mouvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59421-59420-mouvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59422-59161-naves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59422-59161-naves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59422-59161-naves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59422-59161-naves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59423-59940-neuf_berquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59423-59940-neuf_berquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59423-59940-neuf_berquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59423-59940-neuf_berquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59424-59330-neuf_mesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59424-59330-neuf_mesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59424-59330-neuf_mesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59424-59330-neuf_mesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59425-59218-neuville_en_avesnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59425-59218-neuville_en_avesnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59425-59218-neuville_en_avesnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59425-59218-neuville_en_avesnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59426-59960-neuville_en_ferrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59426-59960-neuville_en_ferrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59426-59960-neuville_en_ferrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59426-59960-neuville_en_ferrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59427-59239-la_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59427-59239-la_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59427-59239-la_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59427-59239-la_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59428-59554-neuville_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59428-59554-neuville_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59428-59554-neuville_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59428-59554-neuville_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59429-59293-neuville_sur_escaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59429-59293-neuville_sur_escaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59429-59293-neuville_sur_escaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59429-59293-neuville_sur_escaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59430-59360-neuvilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59430-59360-neuvilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59430-59360-neuvilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59430-59360-neuvilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59431-59850-nieppe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59431-59850-nieppe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59431-59850-nieppe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59431-59850-nieppe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59432-59400-niergnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59432-59400-niergnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59432-59400-niergnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59432-59400-niergnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59433-59143-nieurlet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59433-59143-nieurlet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59433-59143-nieurlet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59433-59143-nieurlet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59434-59230-nivelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59434-59230-nivelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59434-59230-nivelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59434-59230-nivelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59435-59310-nomain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59435-59310-nomain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59435-59310-nomain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59435-59310-nomain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59436-59670-noordpeene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59436-59670-noordpeene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59436-59670-noordpeene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59436-59670-noordpeene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59437-59139-noyelles_les_seclin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59437-59139-noyelles_les_seclin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59437-59139-noyelles_les_seclin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59437-59139-noyelles_les_seclin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59438-59159-noyelles_sur_escaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59438-59159-noyelles_sur_escaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59438-59159-noyelles_sur_escaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59438-59159-noyelles_sur_escaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59439-59550-noyelles_sur_sambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59439-59550-noyelles_sur_sambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59439-59550-noyelles_sur_sambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59439-59550-noyelles_sur_sambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59440-59282-noyelles_sur_selle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59440-59282-noyelles_sur_selle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59440-59282-noyelles_sur_selle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59440-59282-noyelles_sur_selle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59441-59570-obies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59441-59570-obies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59441-59570-obies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59441-59570-obies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59442-59680-obrechies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59442-59680-obrechies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59442-59680-obrechies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59442-59680-obrechies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59443-59670-ochtezeele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59443-59670-ochtezeele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59443-59670-ochtezeele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59443-59670-ochtezeele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59444-59970-odomez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59444-59970-odomez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59444-59970-odomez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59444-59970-odomez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59445-59132-ohain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59445-59132-ohain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59445-59132-ohain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59445-59132-ohain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59446-59195-oisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59446-59195-oisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59446-59195-oisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59446-59195-oisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59447-59264-onnaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59447-59264-onnaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59447-59264-onnaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59447-59264-onnaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59448-59122-oost_cappel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59448-59122-oost_cappel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59448-59122-oost_cappel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59448-59122-oost_cappel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59449-59310-orchies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59449-59310-orchies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59449-59310-orchies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59449-59310-orchies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59450-59360-ors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59450-59360-ors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59450-59360-ors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59450-59360-ors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59451-59530-orsinval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59451-59530-orsinval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59451-59530-orsinval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59451-59530-orsinval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59452-59162-ostricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59452-59162-ostricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59452-59162-ostricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59452-59162-ostricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59453-59670-oudezeele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59453-59670-oudezeele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59453-59670-oudezeele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59453-59670-oudezeele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59454-59670-oxelaere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59454-59670-oxelaere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59454-59670-oxelaere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59454-59670-oxelaere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59455-59295-paillencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59455-59295-paillencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59455-59295-paillencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59455-59295-paillencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59456-59146-pecquencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59456-59146-pecquencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59456-59146-pecquencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59456-59146-pecquencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59457-59840-perenchies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59457-59840-perenchies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59457-59840-perenchies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59457-59840-perenchies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59458-59273-peronne_en_melantois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59458-59273-peronne_en_melantois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59458-59273-peronne_en_melantois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59458-59273-peronne_en_melantois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59459-59494-petite_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59459-59494-petite_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59459-59494-petite_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59459-59494-petite_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59461-59244-petit_fayt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59461-59244-petit_fayt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59461-59244-petit_fayt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59461-59244-petit_fayt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59462-59133-phalempin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59462-59133-phalempin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59462-59133-phalempin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59462-59133-phalempin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59463-59284-pitgam/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59463-59284-pitgam/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59463-59284-pitgam/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59463-59284-pitgam/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59464-59218-poix_du_nord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59464-59218-poix_du_nord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59464-59218-poix_du_nord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59464-59218-poix_du_nord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59465-59360-pommereuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59465-59360-pommereuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59465-59360-pommereuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59465-59360-pommereuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59466-59710-pont_a_marcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59466-59710-pont_a_marcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59466-59710-pont_a_marcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59466-59710-pont_a_marcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59467-59138-pont_sur_sambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59467-59138-pont_sur_sambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59467-59138-pont_sur_sambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59467-59138-pont_sur_sambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59468-59530-potelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59468-59530-potelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59468-59530-potelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59468-59530-potelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59469-59190-pradelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59469-59190-pradelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59469-59190-pradelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59469-59190-pradelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59470-59840-premesques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59470-59840-premesques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59470-59840-premesques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59470-59840-premesques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59471-59990-preseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59471-59990-preseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59471-59990-preseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59471-59990-preseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59472-59288-preux_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59472-59288-preux_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59472-59288-preux_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59472-59288-preux_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59473-59144-preux_au_sart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59473-59144-preux_au_sart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59473-59144-preux_au_sart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59473-59144-preux_au_sart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59474-59550-prisches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59474-59550-prisches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59474-59550-prisches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59474-59550-prisches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59475-59121-prouvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59475-59121-prouvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59475-59121-prouvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59475-59121-prouvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59476-59267-proville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59476-59267-proville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59476-59267-proville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59476-59267-proville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59477-59185-provin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59477-59185-provin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59477-59185-provin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59477-59185-provin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59478-59380-quaedypre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59478-59380-quaedypre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59478-59380-quaedypre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59478-59380-quaedypre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59479-59243-quarouble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59479-59243-quarouble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59479-59243-quarouble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59479-59243-quarouble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59480-59269-querenaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59480-59269-querenaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59480-59269-querenaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59480-59269-querenaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59481-59530-le_quesnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59481-59530-le_quesnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59481-59530-le_quesnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59481-59530-le_quesnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59482-59890-quesnoy_sur_deule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59482-59890-quesnoy_sur_deule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59482-59890-quesnoy_sur_deule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59482-59890-quesnoy_sur_deule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59483-59680-quievelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59483-59680-quievelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59483-59680-quievelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59483-59680-quievelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59484-59920-quievrechain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59484-59920-quievrechain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59484-59920-quievrechain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59484-59920-quievrechain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59485-59214-quievy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59485-59214-quievy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59485-59214-quievy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59485-59214-quievy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59486-59194-raches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59486-59194-raches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59486-59194-raches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59486-59194-raches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59487-59320-radinghem_en_weppes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59487-59320-radinghem_en_weppes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59487-59320-radinghem_en_weppes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59487-59320-radinghem_en_weppes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59488-59554-raillencourt_sainte_olle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59488-59554-raillencourt_sainte_olle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59488-59554-raillencourt_sainte_olle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59488-59554-raillencourt_sainte_olle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59489-59283-raimbeaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59489-59283-raimbeaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59489-59283-raimbeaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59489-59283-raimbeaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59490-59177-rainsars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59490-59177-rainsars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59490-59177-rainsars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59490-59177-rainsars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59590-raismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59590-raismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59590-raismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59590-raismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59278-raismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59278-raismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59278-raismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59278-raismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59860-raismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59860-raismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59860-raismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59860-raismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59135-raismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59135-raismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59135-raismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59491-59135-raismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59492-59161-ramillies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59492-59161-ramillies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59492-59161-ramillies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59492-59161-ramillies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59493-59177-ramousies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59493-59177-ramousies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59493-59177-ramousies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59493-59177-ramousies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59494-59530-raucourt_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59494-59530-raucourt_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59494-59530-raucourt_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59494-59530-raucourt_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59495-59245-recquignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59495-59245-recquignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59495-59245-recquignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59495-59245-recquignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59496-59360-rejet_de_beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59496-59360-rejet_de_beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59496-59360-rejet_de_beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59496-59360-rejet_de_beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59497-59173-renescure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59497-59173-renescure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59497-59173-renescure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59497-59173-renescure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59498-59980-reumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59498-59980-reumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59498-59980-reumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59498-59980-reumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59499-59122-rexpoede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59499-59122-rexpoede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59499-59122-rexpoede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59499-59122-rexpoede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59500-59159-ribecourt_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59500-59159-ribecourt_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59500-59159-ribecourt_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59500-59159-ribecourt_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59501-59870-rieulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59501-59870-rieulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59501-59870-rieulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59501-59870-rieulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59502-59277-rieux_en_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59502-59277-rieux_en_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59502-59277-rieux_en_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59502-59277-rieux_en_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59503-59550-robersart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59503-59550-robersart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59503-59550-robersart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59503-59550-robersart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59504-59172-roeulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59504-59172-roeulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59504-59172-roeulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59504-59172-roeulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59505-59990-rombies_et_marchipont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59505-59990-rombies_et_marchipont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59505-59990-rombies_et_marchipont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59505-59990-rombies_et_marchipont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59506-59730-romeries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59506-59730-romeries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59506-59730-romeries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59506-59730-romeries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59507-59790-ronchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59507-59790-ronchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59507-59790-ronchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59507-59790-ronchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59507-59000-ronchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59507-59000-ronchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59507-59000-ronchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59507-59000-ronchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59508-59223-roncq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59508-59223-roncq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59508-59223-roncq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59508-59223-roncq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59509-59286-roost_warendin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59509-59286-roost_warendin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59509-59286-roost_warendin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59509-59286-roost_warendin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59511-59230-rosult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59511-59230-rosult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59511-59230-rosult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59511-59230-rosult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59512-59100-roubaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59512-59100-roubaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59512-59100-roubaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59512-59100-roubaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59513-59169-roucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59513-59169-roucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59513-59169-roucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59513-59169-roucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59514-59131-rousies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59514-59131-rousies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59514-59131-rousies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59514-59131-rousies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59515-59220-rouvignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59515-59220-rouvignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59515-59220-rouvignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59515-59220-rouvignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59516-59285-rubrouck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59516-59285-rubrouck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59516-59285-rubrouck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59516-59285-rubrouck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59517-59258-les_rues_des_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59517-59258-les_rues_des_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59517-59258-les_rues_des_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59517-59258-les_rues_des_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59518-59530-ruesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59518-59530-ruesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59518-59530-ruesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59518-59530-ruesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59519-59226-rumegies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59519-59226-rumegies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59519-59226-rumegies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59519-59226-rumegies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59520-59281-rumilly_en_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59520-59281-rumilly_en_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59520-59281-rumilly_en_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59520-59281-rumilly_en_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59521-59554-sailly_lez_cambrai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59521-59554-sailly_lez_cambrai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59521-59554-sailly_lez_cambrai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59521-59554-sailly_lez_cambrai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59522-59390-sailly_lez_lannoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59522-59390-sailly_lez_lannoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59522-59390-sailly_lez_lannoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59522-59390-sailly_lez_lannoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59523-59262-sainghin_en_melantois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59523-59262-sainghin_en_melantois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59523-59262-sainghin_en_melantois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59523-59262-sainghin_en_melantois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59524-59184-sainghin_en_weppes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59524-59184-sainghin_en_weppes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59524-59184-sainghin_en_weppes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59524-59184-sainghin_en_weppes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59525-59177-sains_du_nord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59525-59177-sains_du_nord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59525-59177-sains_du_nord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59525-59177-sains_du_nord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59526-59230-saint_amand_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59526-59230-saint_amand_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59526-59230-saint_amand_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59526-59230-saint_amand_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59527-59350-saint_andre_lez_lille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59527-59350-saint_andre_lez_lille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59527-59350-saint_andre_lez_lille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59527-59350-saint_andre_lez_lille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59528-59188-saint_aubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59528-59188-saint_aubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59528-59188-saint_aubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59528-59188-saint_aubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59529-59440-saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59529-59440-saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59529-59440-saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59529-59440-saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59530-59163-saint_aybert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59530-59163-saint_aybert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59530-59163-saint_aybert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59530-59163-saint_aybert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59531-59360-saint_benin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59531-59360-saint_benin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59531-59360-saint_benin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59531-59360-saint_benin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59532-59820-saint_georges_sur_l_aa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59532-59820-saint_georges_sur_l_aa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59532-59820-saint_georges_sur_l_aa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59532-59820-saint_georges_sur_l_aa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59533-59292-saint_hilaire_lez_cambrai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59533-59292-saint_hilaire_lez_cambrai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59533-59292-saint_hilaire_lez_cambrai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59533-59292-saint_hilaire_lez_cambrai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59534-59440-saint_hilaire_sur_helpe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59534-59440-saint_hilaire_sur_helpe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59534-59440-saint_hilaire_sur_helpe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59534-59440-saint_hilaire_sur_helpe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59535-59270-saint_jans_cappel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59535-59270-saint_jans_cappel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59535-59270-saint_jans_cappel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59535-59270-saint_jans_cappel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59536-59670-sainte_marie_cappel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59536-59670-sainte_marie_cappel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59536-59670-sainte_marie_cappel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59536-59670-sainte_marie_cappel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59537-59213-saint_martin_sur_ecaillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59537-59213-saint_martin_sur_ecaillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59537-59213-saint_martin_sur_ecaillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59537-59213-saint_martin_sur_ecaillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59538-59143-saint_momelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59538-59143-saint_momelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59538-59143-saint_momelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59538-59143-saint_momelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59539-59630-saint_pierre_brouck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59539-59630-saint_pierre_brouck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59539-59630-saint_pierre_brouck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59539-59630-saint_pierre_brouck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59541-59730-saint_python/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59541-59730-saint_python/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59541-59730-saint_python/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59541-59730-saint_python/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59542-59620-saint_remy_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59542-59620-saint_remy_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59542-59620-saint_remy_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59542-59620-saint_remy_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59543-59330-saint_remy_du_nord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59543-59330-saint_remy_du_nord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59543-59330-saint_remy_du_nord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59543-59330-saint_remy_du_nord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59544-59880-saint_saulve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59544-59880-saint_saulve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59544-59880-saint_saulve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59544-59880-saint_saulve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59545-59360-saint_souplet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59545-59360-saint_souplet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59545-59360-saint_souplet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59545-59360-saint_souplet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59546-59114-saint_sylvestre_cappel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59546-59114-saint_sylvestre_cappel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59546-59114-saint_sylvestre_cappel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59546-59114-saint_sylvestre_cappel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59547-59188-saint_vaast_en_cambresis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59547-59188-saint_vaast_en_cambresis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59547-59188-saint_vaast_en_cambresis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59547-59188-saint_vaast_en_cambresis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59548-59570-saint_waast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59548-59570-saint_waast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59548-59570-saint_waast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59548-59570-saint_waast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59549-59218-salesches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59549-59218-salesches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59549-59218-salesches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59549-59218-salesches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59550-59496-salome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59550-59496-salome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59550-59496-salome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59550-59496-salome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59551-59310-sameon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59551-59310-sameon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59551-59310-sameon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59551-59310-sameon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59552-59268-sancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59552-59268-sancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59552-59268-sancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59552-59268-sancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59553-59211-santes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59553-59211-santes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59553-59211-santes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59553-59211-santes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59554-59230-sars_et_rosieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59554-59230-sars_et_rosieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59554-59230-sars_et_rosieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59554-59230-sars_et_rosieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59555-59216-sars_poteries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59555-59216-sars_poteries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59555-59216-sars_poteries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59555-59216-sars_poteries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59556-59145-sassegnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59556-59145-sassegnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59556-59145-sassegnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59556-59145-sassegnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59557-59990-saultain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59557-59990-saultain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59557-59990-saultain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59557-59990-saultain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59558-59227-saulzoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59558-59227-saulzoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59558-59227-saulzoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59558-59227-saulzoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59559-59990-sebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59559-59990-sebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59559-59990-sebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59559-59990-sebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59560-59113-seclin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59560-59113-seclin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59560-59113-seclin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59560-59113-seclin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59562-59440-semeries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59562-59440-semeries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59562-59440-semeries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59562-59440-semeries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59563-59440-semousies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59563-59440-semousies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59563-59440-semousies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59563-59440-semousies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59564-59174-la_sentinelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59564-59174-la_sentinelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59564-59174-la_sentinelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59564-59174-la_sentinelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59565-59269-sepmeries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59565-59269-sepmeries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59565-59269-sepmeries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59565-59269-sepmeries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59566-59320-sequedin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59566-59320-sequedin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59566-59320-sequedin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59566-59320-sequedin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59567-59400-seranvillers_forenville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59567-59400-seranvillers_forenville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59567-59400-seranvillers_forenville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59567-59400-seranvillers_forenville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59568-59173-sercus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59568-59173-sercus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59568-59173-sercus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59568-59173-sercus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59569-59450-sin_le_noble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59569-59450-sin_le_noble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59569-59450-sin_le_noble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59569-59450-sin_le_noble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59570-59380-socx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59570-59380-socx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59570-59380-socx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59570-59380-socx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59571-59730-solesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59571-59730-solesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59571-59730-solesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59571-59730-solesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59572-59740-solre_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59572-59740-solre_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59572-59740-solre_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59572-59740-solre_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59573-59740-solrinnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59573-59740-solrinnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59573-59740-solrinnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59573-59740-solrinnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59574-59490-somain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59574-59490-somain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59574-59490-somain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59574-59490-somain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59575-59213-sommaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59575-59213-sommaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59575-59213-sommaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59575-59213-sommaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59576-59380-spycker/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59576-59380-spycker/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59576-59380-spycker/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59576-59380-spycker/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59577-59190-staple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59577-59190-staple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59577-59190-staple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59577-59190-staple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59578-59189-steenbecque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59578-59189-steenbecque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59578-59189-steenbecque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59578-59189-steenbecque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59579-59380-steene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59579-59380-steene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59579-59380-steene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59579-59380-steene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59580-59114-steenvoorde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59580-59114-steenvoorde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59580-59114-steenvoorde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59580-59114-steenvoorde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59581-59181-steenwerck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59581-59181-steenwerck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59581-59181-steenwerck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59581-59181-steenwerck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59582-59270-strazeele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59582-59270-strazeele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59582-59270-strazeele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59582-59270-strazeele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59583-59550-taisnieres_en_thierache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59583-59550-taisnieres_en_thierache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59583-59550-taisnieres_en_thierache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59583-59550-taisnieres_en_thierache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59584-59570-taisnieres_sur_hon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59584-59570-taisnieres_sur_hon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59584-59570-taisnieres_sur_hon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59584-59570-taisnieres_sur_hon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59585-59175-templemars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59585-59175-templemars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59585-59175-templemars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59585-59175-templemars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59586-59242-templeuve_en_pevele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59586-59242-templeuve_en_pevele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59586-59242-templeuve_en_pevele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59586-59242-templeuve_en_pevele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59587-59114-terdeghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59587-59114-terdeghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59587-59114-terdeghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59587-59114-terdeghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59588-59229-teteghem_coudekerque_village/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59588-59229-teteghem_coudekerque_village/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59588-59229-teteghem_coudekerque_village/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59588-59229-teteghem_coudekerque_village/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59588-59380-teteghem_coudekerque_village/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59588-59380-teteghem_coudekerque_village/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59588-59380-teteghem_coudekerque_village/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59588-59380-teteghem_coudekerque_village/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59589-59224-thiant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59589-59224-thiant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59589-59224-thiant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59589-59224-thiant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59590-59189-thiennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59590-59189-thiennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59590-59189-thiennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59590-59189-thiennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59591-59163-thivencelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59591-59163-thivencelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59591-59163-thivencelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59591-59163-thivencelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59592-59239-thumeries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59592-59239-thumeries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59592-59239-thumeries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59592-59239-thumeries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59593-59141-thun_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59593-59141-thun_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59593-59141-thun_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59593-59141-thun_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59594-59158-thun_saint_amand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59594-59158-thun_saint_amand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59594-59158-thun_saint_amand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59594-59158-thun_saint_amand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59595-59141-thun_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59595-59141-thun_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59595-59141-thun_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59595-59141-thun_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59596-59870-tilloy_lez_marchiennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59596-59870-tilloy_lez_marchiennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59596-59870-tilloy_lez_marchiennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59596-59870-tilloy_lez_marchiennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59597-59554-tilloy_lez_cambrai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59597-59554-tilloy_lez_cambrai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59597-59554-tilloy_lez_cambrai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59597-59554-tilloy_lez_cambrai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59598-59390-toufflers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59598-59390-toufflers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59598-59390-toufflers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59598-59390-toufflers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59599-59200-tourcoing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59599-59200-tourcoing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59599-59200-tourcoing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59599-59200-tourcoing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59600-59551-tourmignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59600-59551-tourmignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59600-59551-tourmignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59600-59551-tourmignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59601-59132-trelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59601-59132-trelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59601-59132-trelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59601-59132-trelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59602-59152-tressin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59602-59152-tressin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59602-59152-tressin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59602-59152-tressin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59603-59125-trith_saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59603-59125-trith_saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59603-59125-trith_saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59603-59125-trith_saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59604-59980-troisvilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59604-59980-troisvilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59604-59980-troisvilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59604-59980-troisvilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59605-59229-uxem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59605-59229-uxem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59605-59229-uxem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59605-59229-uxem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59606-59300-valenciennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59606-59300-valenciennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59606-59300-valenciennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59606-59300-valenciennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59607-59218-vendegies_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59607-59218-vendegies_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59607-59218-vendegies_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59607-59218-vendegies_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59608-59213-vendegies_sur_ecaillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59608-59213-vendegies_sur_ecaillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59608-59213-vendegies_sur_ecaillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59608-59213-vendegies_sur_ecaillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59609-59175-vendeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59609-59175-vendeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59609-59175-vendeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59609-59175-vendeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59610-59227-verchain_maugre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59610-59227-verchain_maugre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59610-59227-verchain_maugre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59610-59227-verchain_maugre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59611-59237-verlinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59611-59237-verlinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59611-59237-verlinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59611-59237-verlinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59612-59730-vertain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59612-59730-vertain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59612-59730-vertain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59612-59730-vertain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59613-59970-vicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59613-59970-vicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59613-59970-vicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59613-59970-vicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59614-59271-viesly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59614-59271-viesly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59614-59271-viesly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59614-59271-viesly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59615-59232-vieux_berquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59615-59232-vieux_berquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59615-59232-vieux_berquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59615-59232-vieux_berquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59616-59690-vieux_conde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59616-59690-vieux_conde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59616-59690-vieux_conde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59616-59690-vieux_conde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59617-59138-vieux_mesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59617-59138-vieux_mesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59617-59138-vieux_mesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59617-59138-vieux_mesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59618-59600-vieux_reng/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59618-59600-vieux_reng/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59618-59600-vieux_reng/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59618-59600-vieux_reng/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59619-59530-villereau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59619-59530-villereau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59619-59530-villereau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59619-59530-villereau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59620-59234-villers_au_tertre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59620-59234-villers_au_tertre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59620-59234-villers_au_tertre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59620-59234-villers_au_tertre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59622-59188-villers_en_cauchies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59622-59188-villers_en_cauchies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59622-59188-villers_en_cauchies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59622-59188-villers_en_cauchies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59623-59297-villers_guislain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59623-59297-villers_guislain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59623-59297-villers_guislain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59623-59297-villers_guislain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59624-59142-villers_outreaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59624-59142-villers_outreaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59624-59142-villers_outreaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59624-59142-villers_outreaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59625-59231-villers_plouich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59625-59231-villers_plouich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59625-59231-villers_plouich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59625-59231-villers_plouich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59626-59530-villers_pol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59626-59530-villers_pol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59626-59530-villers_pol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59626-59530-villers_pol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59627-59600-villers_sire_nicole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59627-59600-villers_sire_nicole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59627-59600-villers_sire_nicole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59627-59600-villers_sire_nicole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59628-59470-volckerinckhove/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59628-59470-volckerinckhove/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59628-59470-volckerinckhove/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59628-59470-volckerinckhove/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59629-59870-vred/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59629-59870-vred/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59629-59870-vred/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59629-59870-vred/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59630-59261-wahagnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59630-59261-wahagnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59630-59261-wahagnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59630-59261-wahagnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59631-59127-walincourt_selvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59631-59127-walincourt_selvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59631-59127-walincourt_selvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59631-59127-walincourt_selvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59632-59135-wallers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59632-59135-wallers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59632-59135-wallers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59632-59135-wallers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59633-59132-wallers_en_fagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59633-59132-wallers_en_fagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59633-59132-wallers_en_fagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59633-59132-wallers_en_fagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59634-59190-wallon_cappel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59634-59190-wallon_cappel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59634-59190-wallon_cappel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59634-59190-wallon_cappel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59635-59400-wambaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59635-59400-wambaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59635-59400-wambaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59635-59400-wambaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59636-59118-wambrechies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59636-59118-wambrechies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59636-59118-wambrechies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59636-59118-wambrechies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59637-59870-wandignies_hamage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59637-59870-wandignies_hamage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59637-59870-wandignies_hamage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59637-59870-wandignies_hamage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59638-59830-wannehain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59638-59830-wannehain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59638-59830-wannehain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59638-59830-wannehain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59639-59144-wargnies_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59639-59144-wargnies_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59639-59144-wargnies_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59639-59144-wargnies_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59640-59144-wargnies_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59640-59144-wargnies_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59640-59144-wargnies_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59640-59144-wargnies_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59641-59380-warhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59641-59380-warhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59641-59380-warhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59641-59380-warhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59642-59870-warlaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59642-59870-warlaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59642-59870-warlaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59642-59870-warlaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59643-59560-warneton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59643-59560-warneton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59643-59560-warneton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59643-59560-warneton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59645-59252-wasnes_au_bac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59645-59252-wasnes_au_bac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59645-59252-wasnes_au_bac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59645-59252-wasnes_au_bac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59646-59290-wasquehal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59646-59290-wasquehal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59646-59290-wasquehal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59646-59290-wasquehal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59647-59143-watten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59647-59143-watten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59647-59143-watten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59647-59143-watten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59648-59139-wattignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59648-59139-wattignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59648-59139-wattignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59648-59139-wattignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59649-59680-wattignies_la_victoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59649-59680-wattignies_la_victoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59649-59680-wattignies_la_victoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59649-59680-wattignies_la_victoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59650-59150-wattrelos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59650-59150-wattrelos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59650-59150-wattrelos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59650-59150-wattrelos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59651-59220-wavrechain_sous_denain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59651-59220-wavrechain_sous_denain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59651-59220-wavrechain_sous_denain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59651-59220-wavrechain_sous_denain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59652-59111-wavrechain_sous_faulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59652-59111-wavrechain_sous_faulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59652-59111-wavrechain_sous_faulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59652-59111-wavrechain_sous_faulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59653-59136-wavrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59653-59136-wavrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59653-59136-wavrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59653-59136-wavrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59654-59119-waziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59654-59119-waziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59654-59119-waziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59654-59119-waziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59655-59670-wemaers_cappel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59655-59670-wemaers_cappel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59655-59670-wemaers_cappel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59655-59670-wemaers_cappel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59656-59117-wervicq_sud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59656-59117-wervicq_sud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59656-59117-wervicq_sud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59656-59117-wervicq_sud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59657-59380-west_cappel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59657-59380-west_cappel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59657-59380-west_cappel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59657-59380-west_cappel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59658-59134-wicres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59658-59134-wicres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59658-59134-wicres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59658-59134-wicres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59659-59212-wignehies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59659-59212-wignehies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59659-59212-wignehies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59659-59212-wignehies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59660-59780-willems/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59660-59780-willems/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59660-59780-willems/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59660-59780-willems/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59661-59740-willies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59661-59740-willies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59661-59740-willies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59661-59740-willies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59662-59670-winnezeele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59662-59670-winnezeele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59662-59670-winnezeele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59662-59670-winnezeele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59663-59470-wormhout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59663-59470-wormhout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59663-59470-wormhout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59663-59470-wormhout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59664-59143-wulverdinghe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59664-59143-wulverdinghe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59664-59143-wulverdinghe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59664-59143-wulverdinghe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59665-59380-wylder/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59665-59380-wylder/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59665-59380-wylder/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59665-59380-wylder/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59666-59470-zegerscappel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59666-59470-zegerscappel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59666-59470-zegerscappel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59666-59470-zegerscappel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59667-59670-zermezeele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59667-59670-zermezeele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59667-59670-zermezeele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59667-59670-zermezeele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59668-59123-zuydcoote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59668-59123-zuydcoote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59668-59123-zuydcoote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59668-59123-zuydcoote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59669-59670-zuytpeene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59669-59670-zuytpeene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59669-59670-zuytpeene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59669-59670-zuytpeene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59670-59272-don/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59670-59272-don/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59670-59272-don/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt59-nord/commune59670-59272-don/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-60.xml
+++ b/public/sitemaps/sitemap-60.xml
@@ -5,1382 +5,2760 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60001-60220-abancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60001-60220-abancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60001-60220-abancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60001-60220-abancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60002-60430-abbecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60002-60430-abbecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60002-60430-abbecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60002-60430-abbecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60003-60480-abbeville_saint_lucien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60003-60480-abbeville_saint_lucien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60003-60480-abbeville_saint_lucien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60003-60480-abbeville_saint_lucien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60004-60690-achy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60004-60690-achy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60004-60690-achy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60004-60690-achy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60005-60620-acy_en_multien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60005-60620-acy_en_multien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60005-60620-acy_en_multien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60005-60620-acy_en_multien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60006-60700-les_ageux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60006-60700-les_ageux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60006-60700-les_ageux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60006-60700-les_ageux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60007-60600-agnetz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60007-60600-agnetz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60007-60600-agnetz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60007-60600-agnetz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60008-60600-airion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60008-60600-airion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60008-60600-airion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60008-60600-airion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60009-60000-allonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60009-60000-allonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60009-60000-allonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60009-60000-allonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60010-60110-amblainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60010-60110-amblainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60010-60110-amblainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60010-60110-amblainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60011-60310-amy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60011-60310-amy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60011-60310-amy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60011-60310-amy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60012-60570-andeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60012-60570-andeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60012-60570-andeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60012-60570-andeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60013-60940-angicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60013-60940-angicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60013-60940-angicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60013-60940-angicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60014-60130-angivillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60014-60130-angivillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60014-60130-angivillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60014-60130-angivillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60015-60250-angy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60015-60250-angy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60015-60250-angy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60015-60250-angy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60016-60250-ansacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60016-60250-ansacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60016-60250-ansacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60016-60250-ansacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60017-60120-ansauvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60017-60120-ansauvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60017-60120-ansauvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60017-60120-ansauvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60019-60162-antheuil_portes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60019-60162-antheuil_portes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60019-60162-antheuil_portes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60019-60162-antheuil_portes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60020-60620-antilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60020-60620-antilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60020-60620-antilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60020-60620-antilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60021-60400-appilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60021-60400-appilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60021-60400-appilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60021-60400-appilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60022-60300-apremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60022-60300-apremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60022-60300-apremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60022-60300-apremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60023-60880-armancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60023-60880-armancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60023-60880-armancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60023-60880-armancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60024-60190-arsy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60024-60190-arsy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60024-60190-arsy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60024-60190-arsy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60025-60350-attichy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60025-60350-attichy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60025-60350-attichy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60025-60350-attichy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60026-60360-auchy_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60026-60360-auchy_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60026-60360-auchy_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60026-60360-auchy_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60027-60800-auger_saint_vincent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60027-60800-auger_saint_vincent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60027-60800-auger_saint_vincent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60027-60800-auger_saint_vincent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60028-60300-aumont_en_halatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60028-60300-aumont_en_halatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60028-60300-aumont_en_halatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60028-60300-aumont_en_halatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60029-60390-auneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60029-60390-auneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60029-60390-auneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60029-60390-auneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60030-60390-auteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60030-60390-auteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60030-60390-auteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60030-60390-auteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60031-60890-autheuil_en_valois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60031-60890-autheuil_en_valois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60031-60890-autheuil_en_valois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60031-60890-autheuil_en_valois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60032-60350-autreches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60032-60350-autreches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60032-60350-autreches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60032-60350-autreches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60033-60300-avilly_saint_leonard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60033-60300-avilly_saint_leonard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60033-60300-avilly_saint_leonard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60033-60300-avilly_saint_leonard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60034-60130-avrechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60034-60130-avrechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60034-60130-avrechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60034-60130-avrechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60034-60600-avrechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60034-60600-avrechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60034-60600-avrechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60034-60600-avrechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60035-60310-avricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60035-60310-avricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60035-60310-avricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60035-60310-avricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60036-60190-avrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60036-60190-avrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60036-60190-avrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60036-60190-avrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60037-60400-baboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60037-60400-baboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60037-60400-baboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60037-60400-baboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60039-60120-bacouel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60039-60120-bacouel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60039-60120-bacouel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60039-60120-bacouel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60040-60190-bailleul_le_soc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60040-60190-bailleul_le_soc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60040-60190-bailleul_le_soc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60040-60190-bailleul_le_soc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60041-60930-bailleul_sur_therain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60041-60930-bailleul_sur_therain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60041-60930-bailleul_sur_therain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60041-60930-bailleul_sur_therain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60042-60140-bailleval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60042-60140-bailleval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60042-60140-bailleval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60042-60140-bailleval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60043-60170-bailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60043-60170-bailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60043-60170-bailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60043-60170-bailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60044-60250-balagny_sur_therain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60044-60250-balagny_sur_therain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60044-60250-balagny_sur_therain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60044-60250-balagny_sur_therain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60045-60810-barbery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60045-60810-barbery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60045-60810-barbery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60045-60810-barbery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60046-60620-bargny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60046-60620-bargny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60046-60620-bargny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60046-60620-bargny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60047-60300-baron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60047-60300-baron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60047-60300-baron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60047-60300-baron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60048-60113-baugy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60048-60113-baugy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60048-60113-baugy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60048-60113-baugy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60049-60380-bazancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60049-60380-bazancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60049-60380-bazancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60049-60380-bazancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60050-60700-bazicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60050-60700-bazicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60050-60700-bazicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60050-60700-bazicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60051-60210-beaudeduit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60051-60210-beaudeduit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60051-60210-beaudeduit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60051-60210-beaudeduit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60052-60640-beaugies_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60052-60640-beaugies_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60052-60640-beaugies_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60052-60640-beaugies_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60053-60310-beaulieu_les_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60053-60310-beaulieu_les_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60053-60310-beaulieu_les_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60053-60310-beaulieu_les_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60054-60390-les_hauts_talican/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60054-60390-les_hauts_talican/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60054-60390-les_hauts_talican/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60054-60390-les_hauts_talican/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60055-60400-beaurains_les_noyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60055-60400-beaurains_les_noyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60055-60400-beaurains_les_noyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60055-60400-beaurains_les_noyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60056-60700-beaurepaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60056-60700-beaurepaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60056-60700-beaurepaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60056-60700-beaurepaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60057-60000-beauvais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60057-60000-beauvais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60057-60000-beauvais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60057-60000-beauvais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60058-60120-beauvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60058-60120-beauvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60058-60120-beauvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60058-60120-beauvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60059-60400-behericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60059-60400-behericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60059-60400-behericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60059-60400-behericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60060-60540-belle_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60060-60540-belle_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60060-60540-belle_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60060-60540-belle_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60061-60490-belloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60061-60490-belloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60061-60490-belloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60061-60490-belloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60062-60640-berlancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60062-60640-berlancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60062-60640-berlancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60062-60640-berlancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60063-60390-berneuil_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60063-60390-berneuil_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60063-60390-berneuil_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60063-60390-berneuil_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60064-60350-berneuil_sur_aisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60064-60350-berneuil_sur_aisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60064-60350-berneuil_sur_aisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60064-60350-berneuil_sur_aisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60065-60370-berthecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60065-60370-berthecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60065-60370-berthecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60065-60370-berthecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60066-60129-bethancourt_en_valois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60066-60129-bethancourt_en_valois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60066-60129-bethancourt_en_valois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60066-60129-bethancourt_en_valois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60067-60320-bethisy_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60067-60320-bethisy_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60067-60320-bethisy_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60067-60320-bethisy_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60068-60320-bethisy_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60068-60320-bethisy_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60068-60320-bethisy_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60068-60320-bethisy_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60069-60620-betz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60069-60620-betz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60069-60620-betz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60069-60620-betz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60070-60280-bienville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60070-60280-bienville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60070-60280-bienville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60070-60280-bienville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60071-60490-biermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60071-60490-biermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60071-60490-biermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60071-60490-biermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60072-60350-bitry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60072-60350-bitry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60072-60350-bitry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60072-60350-bitry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60073-60650-blacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60073-60650-blacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60073-60650-blacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60073-60650-blacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60074-60460-blaincourt_les_precy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60074-60460-blaincourt_les_precy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60074-60460-blaincourt_les_precy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60074-60460-blaincourt_les_precy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60075-60120-blancfosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60075-60120-blancfosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60075-60120-blancfosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60075-60120-blancfosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60076-60220-blargies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60076-60220-blargies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60076-60220-blargies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60076-60220-blargies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60077-60860-blicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60077-60860-blicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60077-60860-blicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60077-60860-blicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60078-60190-blincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60078-60190-blincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60078-60190-blincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60078-60190-blincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60079-60440-boissy_fresnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60079-60440-boissy_fresnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60079-60440-boissy_fresnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60079-60440-boissy_fresnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60081-60510-bonlier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60081-60510-bonlier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60081-60510-bonlier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60081-60510-bonlier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60082-60120-bonneuil_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60082-60120-bonneuil_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60082-60120-bonneuil_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60082-60120-bonneuil_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60083-60123-bonneuil_en_valois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60083-60123-bonneuil_en_valois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60083-60123-bonneuil_en_valois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60083-60123-bonneuil_en_valois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60084-60112-bonnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60084-60112-bonnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60084-60112-bonnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60084-60112-bonnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60085-60120-bonvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60085-60120-bonvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60085-60120-bonvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60085-60120-bonvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60086-60820-boran_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60086-60820-boran_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60086-60820-boran_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60086-60820-boran_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60087-60300-borest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60087-60300-borest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60087-60300-borest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60087-60300-borest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60088-60540-bornel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60088-60540-bornel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60088-60540-bornel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60088-60540-bornel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60089-60240-boubiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60089-60240-boubiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60089-60240-boubiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60089-60240-boubiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60090-60240-bouconvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60090-60240-bouconvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60090-60240-bouconvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60090-60240-bouconvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60091-60620-bouillancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60091-60620-bouillancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60091-60620-bouillancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60091-60620-bouillancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60092-60620-boullarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60092-60620-boullarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60092-60620-boullarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60092-60620-boullarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60093-60490-boulogne_la_grasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60093-60490-boulogne_la_grasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60093-60490-boulogne_la_grasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60093-60490-boulogne_la_grasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60094-60141-boursonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60094-60141-boursonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60094-60141-boursonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60094-60141-boursonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60095-60240-boury_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60095-60240-boury_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60095-60240-boury_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60095-60240-boury_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60097-60590-boutencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60097-60590-boutencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60097-60590-boutencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60097-60590-boutencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60098-60220-bouvresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60098-60220-bouvresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60098-60220-bouvresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60098-60220-bouvresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60099-60113-braisnes_sur_aronde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60099-60113-braisnes_sur_aronde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60099-60113-braisnes_sur_aronde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60099-60113-braisnes_sur_aronde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60100-60810-brasseuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60100-60810-brasseuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60100-60810-brasseuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60100-60810-brasseuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60101-60440-bregy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60101-60440-bregy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60101-60440-bregy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60101-60440-bregy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60102-60870-brenouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60102-60870-brenouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60102-60870-brenouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60102-60870-brenouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60103-60510-bresles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60103-60510-bresles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60103-60510-bresles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60103-60510-bresles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60104-60120-breteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60104-60120-breteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60104-60120-breteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60104-60120-breteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60105-60400-bretigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60105-60400-bretigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60105-60400-bretigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60105-60400-bretigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60106-60840-breuil_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60106-60840-breuil_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60106-60840-breuil_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60106-60840-breuil_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60107-60600-breuil_le_vert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60107-60600-breuil_le_vert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60107-60600-breuil_le_vert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60107-60600-breuil_le_vert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60108-60210-briot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60108-60210-briot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60108-60210-briot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60108-60210-briot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60109-60210-brombos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60109-60210-brombos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60109-60210-brombos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60109-60210-brombos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60110-60220-broquiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60110-60220-broquiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60110-60220-broquiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60110-60220-broquiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60111-60120-broyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60111-60120-broyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60111-60120-broyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60111-60120-broyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60112-60130-brunvillers_la_motte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60112-60130-brunvillers_la_motte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60112-60130-brunvillers_la_motte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60112-60130-brunvillers_la_motte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60113-60480-bucamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60113-60480-bucamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60113-60480-bucamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60113-60480-bucamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60114-60380-buicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60114-60380-buicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60114-60380-buicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60114-60380-buicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60115-60130-bulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60115-60130-bulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60115-60130-bulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60115-60130-bulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60116-60250-bury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60116-60250-bury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60116-60250-bury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60116-60250-bury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60117-60400-bussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60117-60400-bussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60117-60400-bussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60117-60400-bussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60118-60400-caisnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60118-60400-caisnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60118-60400-caisnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60118-60400-caisnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60119-60170-cambronne_les_ribecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60119-60170-cambronne_les_ribecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60119-60170-cambronne_les_ribecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60119-60170-cambronne_les_ribecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60120-60290-cambronne_les_clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60120-60290-cambronne_les_clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60120-60290-cambronne_les_clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60120-60290-cambronne_les_clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60121-60640-campagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60121-60640-campagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60121-60640-campagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60121-60640-campagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60122-60220-campeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60122-60220-campeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60122-60220-campeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60122-60220-campeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60122-60380-campeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60122-60380-campeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60122-60380-campeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60122-60380-campeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60123-60480-campremy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60123-60480-campremy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60123-60480-campremy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60123-60480-campremy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60124-60310-candor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60124-60310-candor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60124-60310-candor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60124-60310-candor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60125-60680-canly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60125-60680-canly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60125-60680-canly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60125-60680-canly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60126-60310-cannectancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60126-60310-cannectancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60126-60310-cannectancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60126-60310-cannectancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60127-60310-canny_sur_matz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60127-60310-canny_sur_matz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60127-60310-canny_sur_matz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60127-60310-canny_sur_matz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60128-60220-canny_sur_therain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60128-60220-canny_sur_therain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60128-60220-canny_sur_therain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60128-60220-canny_sur_therain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60129-60170-carlepont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60129-60170-carlepont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60129-60170-carlepont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60129-60170-carlepont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60130-60840-catenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60130-60840-catenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60130-60840-catenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60130-60840-catenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60131-60360-catheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60131-60360-catheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60131-60360-catheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60131-60360-catheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60132-60640-catigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60132-60640-catigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60132-60640-catigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60132-60640-catigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60133-60130-catillon_fumechon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60133-60130-catillon_fumechon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60133-60130-catillon_fumechon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60133-60130-catillon_fumechon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60134-60290-cauffry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60134-60290-cauffry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60134-60290-cauffry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60134-60290-cauffry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60135-60730-cauvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60135-60730-cauvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60135-60730-cauvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60135-60730-cauvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60136-60210-cempuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60136-60210-cempuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60136-60210-cempuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60136-60210-cempuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60137-60190-cernoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60137-60190-cernoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60137-60190-cernoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60137-60190-cernoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60138-60300-chamant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60138-60300-chamant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60138-60300-chamant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60138-60300-chamant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60139-60230-chambly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60139-60230-chambly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60139-60230-chambly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60139-60230-chambly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60140-60240-chambors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60140-60240-chambors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60140-60240-chambors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60140-60240-chambors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60141-60500-chantilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60141-60500-chantilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60141-60500-chantilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60141-60500-chantilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60142-60520-la_chapelle_en_serval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60142-60520-la_chapelle_en_serval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60142-60520-la_chapelle_en_serval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60142-60520-la_chapelle_en_serval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60143-60240-chaumont_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60143-60240-chaumont_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60143-60240-chaumont_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60143-60240-chaumont_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60144-60240-chavencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60144-60240-chavencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60144-60240-chavencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60144-60240-chavencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60145-60350-chelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60145-60350-chelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60145-60350-chelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60145-60350-chelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60146-60120-chepoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60146-60120-chepoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60146-60120-chepoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60146-60120-chepoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60147-60150-chevincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60147-60150-chevincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60147-60150-chevincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60147-60150-chevincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60148-60440-chevreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60148-60440-chevreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60148-60440-chevreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60148-60440-chevreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60149-60710-chevrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60149-60710-chevrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60149-60710-chevrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60149-60710-chevrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60150-60138-chiry_ourscamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60150-60138-chiry_ourscamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60150-60138-chiry_ourscamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60150-60138-chiry_ourscamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60151-60750-choisy_au_bac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60151-60750-choisy_au_bac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60151-60750-choisy_au_bac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60151-60750-choisy_au_bac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60152-60190-choisy_la_victoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60152-60190-choisy_la_victoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60152-60190-choisy_la_victoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60152-60190-choisy_la_victoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60153-60360-choqueuse_les_benards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60153-60360-choqueuse_les_benards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60153-60360-choqueuse_les_benards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60153-60360-choqueuse_les_benards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60154-60940-cinqueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60154-60940-cinqueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60154-60940-cinqueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60154-60940-cinqueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60155-60660-cires_les_mello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60155-60660-cires_les_mello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60155-60660-cires_les_mello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60155-60660-cires_les_mello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60156-60280-clairoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60156-60280-clairoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60156-60280-clairoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60156-60280-clairoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60157-60600-clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60157-60600-clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60157-60600-clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60157-60600-clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60158-60420-coivrel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60158-60420-coivrel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60158-60420-coivrel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60158-60420-coivrel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60159-60200-compiegne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60159-60200-compiegne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60159-60200-compiegne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60159-60200-compiegne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60160-60490-conchy_les_pots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60160-60490-conchy_les_pots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60160-60490-conchy_les_pots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60160-60490-conchy_les_pots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60161-60360-conteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60161-60360-conteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60161-60360-conteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60161-60360-conteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60162-60110-corbeil_cerf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60162-60110-corbeil_cerf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60162-60110-corbeil_cerf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60162-60110-corbeil_cerf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60163-60120-cormeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60163-60120-cormeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60163-60120-cormeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60163-60120-cormeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60164-60850-le_coudray_saint_germer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60164-60850-le_coudray_saint_germer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60164-60850-le_coudray_saint_germer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60164-60850-le_coudray_saint_germer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60165-60430-le_coudray_sur_thelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60165-60430-le_coudray_sur_thelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60165-60430-le_coudray_sur_thelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60165-60430-le_coudray_sur_thelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60166-60150-coudun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60166-60150-coudun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60166-60150-coudun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60166-60150-coudun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60167-60350-couloisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60167-60350-couloisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60167-60350-couloisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60167-60350-couloisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60168-60420-courcelles_epayelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60168-60420-courcelles_epayelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60168-60420-courcelles_epayelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60168-60420-courcelles_epayelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60169-60240-courcelles_les_gisors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60169-60240-courcelles_les_gisors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60169-60240-courcelles_les_gisors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60169-60240-courcelles_les_gisors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60170-60300-courteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60170-60300-courteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60170-60300-courteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60170-60300-courteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60171-60350-courtieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60171-60350-courtieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60171-60350-courtieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60171-60350-courtieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60172-60580-coye_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60172-60580-coye_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60172-60580-coye_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60172-60580-coye_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60173-60660-cramoisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60173-60660-cramoisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60173-60660-cramoisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60173-60660-cramoisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60174-60310-crapeaumesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60174-60310-crapeaumesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60174-60310-crapeaumesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60174-60310-crapeaumesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60175-60100-creil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60175-60100-creil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60175-60100-creil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60175-60100-creil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60176-60800-crepy_en_valois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60176-60800-crepy_en_valois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60176-60800-crepy_en_valois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60176-60800-crepy_en_valois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60177-60190-cressonsacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60177-60190-cressonsacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60177-60190-cressonsacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60177-60190-cressonsacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60178-60360-crevecoeur_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60178-60360-crevecoeur_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60178-60360-crevecoeur_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60178-60360-crevecoeur_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60179-60420-crevecoeur_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60179-60420-crevecoeur_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60179-60420-crevecoeur_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60179-60420-crevecoeur_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60180-60112-crillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60180-60112-crillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60180-60112-crillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60180-60112-crillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60181-60400-crisolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60181-60400-crisolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60181-60400-crisolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60181-60400-crisolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60182-60120-le_crocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60182-60120-le_crocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60182-60120-le_crocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60182-60120-le_crocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60183-60120-croissy_sur_celle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60183-60120-croissy_sur_celle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60183-60120-croissy_sur_celle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60183-60120-croissy_sur_celle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60184-60350-croutoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60184-60350-croutoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60184-60350-croutoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60184-60350-croutoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60185-60530-crouy_en_thelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60185-60530-crouy_en_thelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60185-60530-crouy_en_thelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60185-60530-crouy_en_thelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60186-60130-cuignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60186-60130-cuignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60186-60130-cuignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60186-60130-cuignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60187-60850-cuigy_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60187-60850-cuigy_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60187-60850-cuigy_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60187-60850-cuigy_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60188-60350-cuise_la_motte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60188-60350-cuise_la_motte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60188-60350-cuise_la_motte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60188-60350-cuise_la_motte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60189-60400-cuts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60189-60400-cuts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60189-60400-cuts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60189-60400-cuts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60190-60620-cuvergnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60190-60620-cuvergnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60190-60620-cuvergnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60190-60620-cuvergnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60191-60490-cuvilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60191-60490-cuvilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60191-60490-cuvilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60191-60490-cuvilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60192-60310-cuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60192-60310-cuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60192-60310-cuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60192-60310-cuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60193-60210-dameraucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60193-60210-dameraucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60193-60210-dameraucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60193-60210-dameraucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60194-60210-dargies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60194-60210-dargies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60194-60210-dargies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60194-60210-dargies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60195-60240-delincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60195-60240-delincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60195-60240-delincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60195-60240-delincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60196-60790-la_drenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60196-60790-la_drenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60196-60790-la_drenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60196-60790-la_drenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60197-60530-dieudonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60197-60530-dieudonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60197-60530-dieudonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60197-60530-dieudonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60198-60310-dives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60198-60310-dives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60198-60310-dives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60198-60310-dives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60199-60360-domeliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60199-60360-domeliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60199-60360-domeliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60199-60360-domeliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60200-60420-domfront/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60200-60420-domfront/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60200-60420-domfront/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60200-60420-domfront/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60201-60420-dompierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60201-60420-dompierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60201-60420-dompierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60201-60420-dompierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60203-60800-duvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60203-60800-duvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60203-60800-duvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60203-60800-duvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60204-60310-ecuvilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60204-60310-ecuvilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60204-60310-ecuvilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60204-60310-ecuvilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60205-60210-elencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60205-60210-elencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60205-60210-elencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60205-60210-elencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60206-60157-elincourt_sainte_marguerite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60206-60157-elincourt_sainte_marguerite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60206-60157-elincourt_sainte_marguerite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60206-60157-elincourt_sainte_marguerite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60207-60123-emeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60207-60123-emeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60207-60123-emeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60207-60123-emeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60208-60590-enencourt_leage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60208-60590-enencourt_leage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60208-60590-enencourt_leage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60208-60590-enencourt_leage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60209-60240-la_corne_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60209-60240-la_corne_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60209-60240-la_corne_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60209-60240-la_corne_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60210-60190-epineuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60210-60190-epineuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60210-60190-epineuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60210-60190-epineuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60211-60590-eragny_sur_epte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60211-60590-eragny_sur_epte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60211-60590-eragny_sur_epte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60211-60590-eragny_sur_epte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60212-60530-ercuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60212-60530-ercuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60212-60530-ercuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60212-60530-ercuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60213-60950-ermenonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60213-60950-ermenonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60213-60950-ermenonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60213-60950-ermenonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60214-60380-ernemont_boutavent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60214-60380-ernemont_boutavent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60214-60380-ernemont_boutavent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60214-60380-ernemont_boutavent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60215-60600-erquery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60215-60600-erquery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60215-60600-erquery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60215-60600-erquery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60216-60130-erquinvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60216-60130-erquinvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60216-60130-erquinvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60216-60130-erquinvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60217-60380-escames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60217-60380-escames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60217-60380-escames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60217-60380-escames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60218-60110-esches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60218-60110-esches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60218-60110-esches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60218-60110-esches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60219-60220-escles_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60219-60220-escles_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60219-60220-escles_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60219-60220-escles_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60220-60650-espaubourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60220-60650-espaubourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60220-60650-espaubourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60220-60650-espaubourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60221-60120-esquennoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60221-60120-esquennoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60221-60120-esquennoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60221-60120-esquennoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60222-60510-essuiles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60222-60510-essuiles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60222-60510-essuiles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60222-60510-essuiles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60223-60190-estrees_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60223-60190-estrees_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60223-60190-estrees_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60223-60190-estrees_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60224-60620-etavigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60224-60620-etavigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60224-60620-etavigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60224-60620-etavigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60225-60600-etouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60225-60600-etouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60225-60600-etouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60225-60600-etouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60226-60330-eve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60226-60330-eve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60226-60330-eve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60226-60330-eve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60227-60310-evricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60227-60310-evricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60227-60310-evricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60227-60310-evricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60228-60240-fay_les_etangs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60228-60240-fay_les_etangs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60228-60240-fay_les_etangs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60228-60240-fay_les_etangs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60229-60680-le_fayel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60229-60680-le_fayel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60229-60680-le_fayel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60229-60680-le_fayel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60230-60510-le_fay_saint_quentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60230-60510-le_fay_saint_quentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60230-60510-le_fay_saint_quentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60230-60510-le_fay_saint_quentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60231-60800-feigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60231-60800-feigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60231-60800-feigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60231-60800-feigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60232-60420-ferrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60232-60420-ferrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60232-60420-ferrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60232-60420-ferrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60233-60960-feuquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60233-60960-feuquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60233-60960-feuquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60233-60960-feuquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60234-60600-fitz_james/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60234-60600-fitz_james/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60234-60600-fitz_james/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60234-60600-fitz_james/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60235-60590-flavacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60235-60590-flavacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60235-60590-flavacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60235-60590-flavacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60236-60640-flavy_le_meldeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60236-60640-flavy_le_meldeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60236-60640-flavy_le_meldeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60236-60640-flavy_le_meldeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60237-60120-flechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60237-60120-flechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60237-60120-flechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60237-60120-flechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60238-60700-fleurines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60238-60700-fleurines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60238-60700-fleurines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60238-60700-fleurines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60239-60240-fleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60239-60240-fleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60239-60240-fleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60239-60240-fleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60240-60360-fontaine_bonneleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60240-60360-fontaine_bonneleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60240-60360-fontaine_bonneleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60240-60360-fontaine_bonneleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60241-60300-fontaine_chaalis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60241-60300-fontaine_chaalis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60241-60300-fontaine_chaalis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60241-60300-fontaine_chaalis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60242-60690-fontaine_lavaganne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60242-60690-fontaine_lavaganne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60242-60690-fontaine_lavaganne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60242-60690-fontaine_lavaganne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60243-60480-fontaine_saint_lucien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60243-60480-fontaine_saint_lucien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60243-60480-fontaine_saint_lucien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60243-60480-fontaine_saint_lucien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60244-60380-fontenay_torcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60244-60380-fontenay_torcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60244-60380-fontenay_torcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60244-60380-fontenay_torcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60245-60220-formerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60245-60220-formerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60245-60220-formerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60245-60220-formerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60247-60190-fouilleuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60247-60190-fouilleuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60247-60190-fouilleuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60247-60190-fouilleuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60248-60220-fouilloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60248-60220-fouilloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60248-60220-fouilloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60248-60220-fouilloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60249-60250-foulangues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60249-60250-foulangues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60249-60250-foulangues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60249-60250-foulangues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60250-60000-fouquenies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60250-60000-fouquenies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60250-60000-fouquenies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60250-60000-fouquenies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60251-60510-fouquerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60251-60510-fouquerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60251-60510-fouquerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60251-60510-fouquerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60252-60130-fournival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60252-60130-fournival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60252-60130-fournival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60252-60130-fournival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60253-60480-francastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60253-60480-francastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60253-60480-francastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60253-60480-francastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60254-60190-francieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60254-60190-francieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60254-60190-francieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60254-60190-francieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60255-60640-freniches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60255-60640-freniches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60255-60640-freniches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60255-60640-freniches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60256-60240-montchevreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60256-60240-montchevreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60256-60240-montchevreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60256-60240-montchevreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60257-60240-fresne_leguillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60257-60240-fresne_leguillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60257-60240-fresne_leguillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60257-60240-fresne_leguillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60258-60310-fresnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60258-60310-fresnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60258-60310-fresnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60258-60310-fresnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60259-60530-fresnoy_en_thelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60259-60530-fresnoy_en_thelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60259-60530-fresnoy_en_thelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60259-60530-fresnoy_en_thelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60260-60127-fresnoy_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60260-60127-fresnoy_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60260-60127-fresnoy_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60260-60127-fresnoy_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60261-60800-fresnoy_le_luat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60261-60800-fresnoy_le_luat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60261-60800-fresnoy_le_luat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60261-60800-fresnoy_le_luat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60262-60420-le_frestoy_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60262-60420-le_frestoy_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60262-60420-le_frestoy_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60262-60420-le_frestoy_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60263-60640-fretoy_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60263-60640-fretoy_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60263-60640-fretoy_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60263-60640-fretoy_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60264-60000-frocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60264-60000-frocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60264-60000-frocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60264-60000-frocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60265-60480-froissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60265-60480-froissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60265-60480-froissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60265-60480-froissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60267-60360-le_gallet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60267-60360-le_gallet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60267-60360-le_gallet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60267-60360-le_gallet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60268-60120-gannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60268-60120-gannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60268-60120-gannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60268-60120-gannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60269-60210-gaudechart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60269-60210-gaudechart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60269-60210-gaudechart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60269-60210-gaudechart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60270-60400-genvry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60270-60400-genvry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60270-60400-genvry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60270-60400-genvry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60271-60380-gerberoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60271-60380-gerberoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60271-60380-gerberoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60271-60380-gerberoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60272-60129-gilocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60272-60129-gilocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60272-60129-gilocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60272-60129-gilocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60273-60150-giraumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60273-60150-giraumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60273-60150-giraumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60273-60150-giraumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60274-60129-glaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60274-60129-glaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60274-60129-glaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60274-60129-glaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60275-60650-glatigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60275-60650-glatigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60275-60650-glatigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60275-60650-glatigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60276-60420-godenvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60276-60420-godenvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60276-60420-godenvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60276-60420-godenvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60277-60000-goincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60277-60000-goincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60277-60000-goincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60277-60000-goincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60278-60640-golancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60278-60640-golancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60278-60640-golancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60278-60640-golancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60279-60117-gondreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60279-60117-gondreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60279-60117-gondreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60279-60117-gondreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60280-60220-gourchelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60280-60220-gourchelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60280-60220-gourchelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60280-60220-gourchelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60281-60190-gournay_sur_aronde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60281-60190-gournay_sur_aronde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60281-60190-gournay_sur_aronde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60281-60190-gournay_sur_aronde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60500-gouvieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60500-gouvieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60500-gouvieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60500-gouvieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60270-gouvieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60270-gouvieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60270-gouvieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60270-gouvieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60260-gouvieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60260-gouvieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60260-gouvieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60260-gouvieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60740-gouvieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60740-gouvieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60740-gouvieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60282-60740-gouvieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60283-60120-gouy_les_groseillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60283-60120-gouy_les_groseillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60283-60120-gouy_les_groseillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60283-60120-gouy_les_groseillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60284-60680-grandfresnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60284-60680-grandfresnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60284-60680-grandfresnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60284-60680-grandfresnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60285-60190-grandvillers_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60285-60190-grandvillers_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60285-60190-grandvillers_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60285-60190-grandvillers_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60286-60210-grandvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60286-60210-grandvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60286-60210-grandvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60286-60210-grandvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60287-60400-grandru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60287-60400-grandru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60287-60400-grandru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60287-60400-grandru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60288-60380-gremevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60288-60380-gremevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60288-60380-gremevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60288-60380-gremevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60289-60210-grez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60289-60210-grez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60289-60210-grez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60289-60210-grez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60290-60480-guignecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60290-60480-guignecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60290-60480-guignecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60290-60480-guignecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60291-60640-guiscard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60291-60640-guiscard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60291-60640-guiscard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60291-60640-guiscard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60292-60310-gury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60292-60310-gury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60292-60310-gury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60292-60310-gury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60293-60240-hadancourt_le_haut_clocher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60293-60240-hadancourt_le_haut_clocher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60293-60240-hadancourt_le_haut_clocher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60293-60240-hadancourt_le_haut_clocher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60294-60490-hainvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60294-60490-hainvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60294-60490-hainvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60294-60490-hainvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60295-60210-halloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60295-60210-halloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60295-60210-halloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60295-60210-halloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60296-60650-hannaches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60296-60650-hannaches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60296-60650-hannaches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60296-60650-hannaches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60297-60210-le_hamel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60297-60210-le_hamel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60297-60210-le_hamel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60297-60210-le_hamel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60298-60650-hanvoile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60298-60650-hanvoile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60298-60650-hanvoile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60298-60650-hanvoile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60299-60120-hardivillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60299-60120-hardivillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60299-60120-hardivillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60299-60120-hardivillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60301-60112-haucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60301-60112-haucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60301-60112-haucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60301-60112-haucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60302-60510-haudivillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60302-60510-haudivillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60302-60510-haudivillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60302-60510-haudivillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60303-60210-hautbos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60303-60210-hautbos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60303-60210-hautbos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60303-60210-hautbos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60304-60690-haute_epine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60304-60690-haute_epine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60304-60690-haute_epine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60304-60690-haute_epine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60305-60350-hautefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60305-60350-hautefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60305-60350-hautefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60305-60350-hautefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60306-60380-hecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60306-60380-hecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60306-60380-hecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60306-60380-hecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60307-60250-heilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60307-60250-heilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60307-60250-heilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60307-60250-heilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60308-60190-hemevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60308-60190-hemevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60308-60190-hemevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60308-60190-hemevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60309-60119-henonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60309-60119-henonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60309-60119-henonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60309-60119-henonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60310-60112-herchies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60310-60112-herchies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60310-60112-herchies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60310-60112-herchies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60311-60120-la_herelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60311-60120-la_herelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60311-60120-la_herelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60311-60120-la_herelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60312-60380-hericourt_sur_therain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60312-60380-hericourt_sur_therain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60312-60380-hericourt_sur_therain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60312-60380-hericourt_sur_therain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60313-60370-hermes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60313-60370-hermes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60313-60370-hermes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60313-60370-hermes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60314-60360-hetomesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60314-60360-hetomesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60314-60360-hetomesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60314-60360-hetomesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60315-60650-hodenc_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60315-60650-hodenc_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60315-60650-hodenc_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60315-60650-hodenc_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60316-60430-hodenc_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60316-60430-hodenc_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60316-60430-hodenc_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60316-60430-hodenc_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60317-60250-hondainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60317-60250-hondainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60317-60250-hondainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60317-60250-hondainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60318-60710-houdancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60318-60710-houdancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60318-60710-houdancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60318-60710-houdancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60319-60390-la_houssoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60319-60390-la_houssoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60319-60390-la_houssoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60319-60390-la_houssoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60320-60141-ivors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60320-60141-ivors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60320-60141-ivors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60320-60141-ivors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60321-60173-ivry_le_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60321-60173-ivry_le_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60321-60173-ivry_le_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60321-60173-ivry_le_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60322-60240-jamericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60322-60240-jamericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60322-60240-jamericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60322-60240-jamericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60323-60150-janville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60323-60150-janville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60323-60150-janville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60323-60150-janville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60324-60350-jaulzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60324-60350-jaulzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60324-60350-jaulzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60324-60350-jaulzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60325-60880-jaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60325-60880-jaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60325-60880-jaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60325-60880-jaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60326-60680-jonquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60326-60680-jonquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60326-60680-jonquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60326-60680-jonquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60327-60240-jouy_sous_thelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60327-60240-jouy_sous_thelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60327-60240-jouy_sous_thelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60327-60240-jouy_sous_thelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60328-60112-juvignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60328-60112-juvignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60328-60112-juvignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60328-60112-juvignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60329-60310-laberliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60329-60310-laberliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60329-60310-laberliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60329-60310-laberliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60330-60570-laboissiere_en_thelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60330-60570-laboissiere_en_thelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60330-60570-laboissiere_en_thelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60330-60570-laboissiere_en_thelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60331-60590-labosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60331-60590-labosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60331-60590-labosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60331-60590-labosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60332-60140-labruyere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60332-60140-labruyere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60332-60140-labruyere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60332-60140-labruyere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60333-60650-lachapelle_aux_pots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60333-60650-lachapelle_aux_pots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60333-60650-lachapelle_aux_pots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60333-60650-lachapelle_aux_pots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60334-60730-lachapelle_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60334-60730-lachapelle_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60334-60730-lachapelle_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60334-60730-lachapelle_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60335-60380-lachapelle_sous_gerberoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60335-60380-lachapelle_sous_gerberoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60335-60380-lachapelle_sous_gerberoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60335-60380-lachapelle_sous_gerberoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60336-60480-lachaussee_du_bois_d_ecu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60336-60480-lachaussee_du_bois_d_ecu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60336-60480-lachaussee_du_bois_d_ecu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60336-60480-lachaussee_du_bois_d_ecu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60337-60190-lachelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60337-60190-lachelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60337-60190-lachelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60337-60190-lachelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60338-60610-lacroix_saint_ouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60338-60610-lacroix_saint_ouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60338-60610-lacroix_saint_ouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60338-60610-lacroix_saint_ouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60339-60510-lafraye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60339-60510-lafraye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60339-60510-lafraye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60339-60510-lafraye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60340-60310-lagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60340-60310-lagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60340-60310-lagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60340-60310-lagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60341-60330-lagny_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60341-60330-lagny_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60341-60330-lagny_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60341-60330-lagny_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60342-60290-laigneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60342-60290-laigneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60342-60290-laigneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60342-60290-laigneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60343-60590-lalande_en_son/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60343-60590-lalande_en_son/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60343-60590-lalande_en_son/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60343-60590-lalande_en_son/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60344-60850-lalandelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60344-60850-lalandelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60344-60850-lalandelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60344-60850-lalandelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60345-60600-lamecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60345-60600-lamecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60345-60600-lamecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60345-60600-lamecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60346-60260-lamorlaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60346-60260-lamorlaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60346-60260-lamorlaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60346-60260-lamorlaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60347-60220-lannoy_cuillere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60347-60220-lannoy_cuillere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60347-60220-lannoy_cuillere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60347-60220-lannoy_cuillere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60348-60400-larbroye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60348-60400-larbroye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60348-60400-larbroye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60348-60400-larbroye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60350-60310-lassigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60350-60310-lassigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60350-60310-lassigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60350-60310-lassigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60351-60490-lataule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60351-60490-lataule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60351-60490-lataule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60351-60490-lataule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60352-60240-lattainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60352-60240-lattainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60352-60240-lattainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60352-60240-lattainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60353-60120-lavacquerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60353-60120-lavacquerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60353-60120-lavacquerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60353-60120-lavacquerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60354-60210-laverriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60354-60210-laverriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60354-60210-laverriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60354-60210-laverriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60355-60510-laversines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60355-60510-laversines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60355-60510-laversines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60355-60510-laversines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60356-60240-lavilletertre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60356-60240-lavilletertre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60356-60240-lavilletertre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60356-60240-lavilletertre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60357-60420-leglantiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60357-60420-leglantiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60357-60420-leglantiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60357-60420-leglantiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60358-60800-levignen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60358-60800-levignen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60358-60800-levignen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60358-60800-levignen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60359-60650-lheraule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60359-60650-lheraule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60359-60650-lheraule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60359-60650-lheraule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60360-60140-liancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60360-60140-liancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60360-60140-liancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60360-60140-liancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60361-60240-liancourt_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60361-60240-liancourt_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60361-60240-liancourt_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60361-60240-liancourt_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60362-60640-libermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60362-60640-libermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60362-60640-libermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60362-60640-libermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60363-60240-lierville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60363-60240-lierville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60363-60240-lierville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60363-60240-lierville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60364-60130-lieuvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60364-60130-lieuvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60364-60130-lieuvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60364-60130-lieuvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60365-60360-lihus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60365-60360-lihus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60365-60360-lihus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60365-60360-lihus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60366-60510-litz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60366-60510-litz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60366-60510-litz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60366-60510-litz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60367-60240-loconville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60367-60240-loconville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60367-60240-loconville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60367-60240-loconville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60368-60150-longueil_annel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60368-60150-longueil_annel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60368-60150-longueil_annel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60368-60150-longueil_annel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60369-60126-longueil_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60369-60126-longueil_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60369-60126-longueil_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60369-60126-longueil_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60370-60110-lormaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60370-60110-lormaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60370-60110-lormaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60370-60110-lormaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60371-60380-loueuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60371-60380-loueuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60371-60380-loueuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60371-60380-loueuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60372-60360-luchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60372-60360-luchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60372-60360-luchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60372-60360-luchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60373-60150-machemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60373-60150-machemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60373-60150-machemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60373-60150-machemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60374-60420-maignelay_montigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60374-60420-maignelay_montigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60374-60420-maignelay_montigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60374-60420-maignelay_montigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60375-60600-maimbeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60375-60600-maimbeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60375-60600-maimbeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60375-60600-maimbeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60376-60112-maisoncelle_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60376-60112-maisoncelle_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60376-60112-maisoncelle_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60376-60112-maisoncelle_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60377-60480-maisoncelle_tuilerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60377-60480-maisoncelle_tuilerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60377-60480-maisoncelle_tuilerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60377-60480-maisoncelle_tuilerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60378-60490-marest_sur_matz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60378-60490-marest_sur_matz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60378-60490-marest_sur_matz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60378-60490-marest_sur_matz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60379-60490-mareuil_la_motte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60379-60490-mareuil_la_motte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60379-60490-mareuil_la_motte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60379-60490-mareuil_la_motte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60380-60890-mareuil_sur_ourcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60380-60890-mareuil_sur_ourcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60380-60890-mareuil_sur_ourcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60380-60890-mareuil_sur_ourcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60381-60310-margny_aux_cerises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60381-60310-margny_aux_cerises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60381-60310-margny_aux_cerises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60381-60310-margny_aux_cerises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60382-60280-margny_les_compiegne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60382-60280-margny_les_compiegne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60382-60280-margny_les_compiegne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60382-60280-margny_les_compiegne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60383-60490-margny_sur_matz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60383-60490-margny_sur_matz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60383-60490-margny_sur_matz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60383-60490-margny_sur_matz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60385-60890-marolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60385-60890-marolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60385-60890-marolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60385-60890-marolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60386-60490-marqueglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60386-60490-marqueglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60386-60490-marqueglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60386-60490-marqueglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60387-60690-marseille_en_beauvaisis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60387-60690-marseille_en_beauvaisis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60387-60690-marseille_en_beauvaisis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60387-60690-marseille_en_beauvaisis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60388-60112-martincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60388-60112-martincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60388-60112-martincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60388-60112-martincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60389-60640-maucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60389-60640-maucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60389-60640-maucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60389-60640-maucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60390-60480-maulers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60390-60480-maulers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60390-60480-maulers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60390-60480-maulers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60391-60660-maysel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60391-60660-maysel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60391-60660-maysel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60391-60660-maysel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60392-60150-melicocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60392-60150-melicocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60392-60150-melicocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60392-60150-melicocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60393-60660-mello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60393-60660-mello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60393-60660-mello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60393-60660-mello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60394-60420-menevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60394-60420-menevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60394-60420-menevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60394-60420-menevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60395-60110-meru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60395-60110-meru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60395-60110-meru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60395-60110-meru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60396-60420-mery_la_bataille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60396-60420-mery_la_bataille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60396-60420-mery_la_bataille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60396-60420-mery_la_bataille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60397-60210-le_mesnil_conteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60397-60210-le_mesnil_conteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60397-60210-le_mesnil_conteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60397-60210-le_mesnil_conteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60398-60530-le_mesnil_en_thelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60398-60530-le_mesnil_en_thelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60398-60530-le_mesnil_en_thelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60398-60530-le_mesnil_en_thelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60399-60120-le_mesnil_saint_firmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60399-60120-le_mesnil_saint_firmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60399-60120-le_mesnil_saint_firmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60399-60120-le_mesnil_saint_firmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60400-60130-le_mesnil_sur_bulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60400-60130-le_mesnil_sur_bulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60400-60130-le_mesnil_sur_bulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60400-60130-le_mesnil_sur_bulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60401-60240-le_mesnil_theribus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60401-60240-le_mesnil_theribus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60401-60240-le_mesnil_theribus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60401-60240-le_mesnil_theribus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60402-60880-le_meux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60402-60880-le_meux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60402-60880-le_meux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60402-60880-le_meux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60403-60112-milly_sur_therain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60403-60112-milly_sur_therain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60403-60112-milly_sur_therain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60403-60112-milly_sur_therain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60404-60140-mogneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60404-60140-mogneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60404-60140-mogneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60404-60140-mogneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60405-60220-moliens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60405-60220-moliens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60405-60220-moliens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60405-60220-moliens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60406-60940-monceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60406-60940-monceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60406-60940-monceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60406-60940-monceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60407-60220-monceaux_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60407-60220-monceaux_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60407-60220-monceaux_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60407-60220-monceaux_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60408-60113-monchy_humieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60408-60113-monchy_humieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60408-60113-monchy_humieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60408-60113-monchy_humieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60409-60290-monchy_saint_eloi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60409-60290-monchy_saint_eloi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60409-60290-monchy_saint_eloi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60409-60290-monchy_saint_eloi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60410-60400-mondescourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60410-60400-mondescourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60410-60400-mondescourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60410-60400-mondescourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60411-60240-monneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60411-60240-monneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60411-60240-monneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60411-60240-monneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60412-60240-montagny_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60412-60240-montagny_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60412-60240-montagny_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60412-60240-montagny_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60413-60950-montagny_sainte_felicite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60413-60950-montagny_sainte_felicite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60413-60950-montagny_sainte_felicite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60413-60950-montagny_sainte_felicite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60414-60160-montataire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60414-60160-montataire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60414-60160-montataire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60414-60160-montataire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60415-60810-montepilloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60415-60810-montepilloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60415-60810-montepilloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60415-60810-montepilloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60416-60420-montgerain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60416-60420-montgerain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60416-60420-montgerain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60416-60420-montgerain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60418-60190-montiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60418-60190-montiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60418-60190-montiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60418-60190-montiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60420-60240-montjavoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60420-60240-montjavoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60420-60240-montjavoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60420-60240-montjavoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60421-60300-mont_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60421-60300-mont_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60421-60300-mont_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60421-60300-mont_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60422-60300-montlognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60422-60300-montlognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60422-60300-montlognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60422-60300-montlognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60423-60150-montmacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60423-60150-montmacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60423-60150-montmacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60423-60150-montmacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60424-60190-montmartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60424-60190-montmartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60424-60190-montmartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60424-60190-montmartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60425-60480-montreuil_sur_breche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60425-60480-montreuil_sur_breche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60425-60480-montreuil_sur_breche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60425-60480-montreuil_sur_breche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60426-60134-montreuil_sur_therain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60426-60134-montreuil_sur_therain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60426-60134-montreuil_sur_therain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60426-60134-montreuil_sur_therain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60427-60119-monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60427-60119-monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60427-60119-monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60427-60119-monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60428-60650-le_mont_saint_adrien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60428-60650-le_mont_saint_adrien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60428-60650-le_mont_saint_adrien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60428-60650-le_mont_saint_adrien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60429-60530-morangles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60429-60530-morangles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60429-60530-morangles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60429-60530-morangles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60430-60127-morienval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60430-60127-morienval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60430-60127-morienval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60430-60127-morienval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60431-60400-morlincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60431-60400-morlincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60431-60400-morlincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60431-60400-morlincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60432-60128-mortefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60432-60128-mortefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60432-60128-mortefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60432-60128-mortefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60433-60570-mortefontaine_en_thelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60433-60570-mortefontaine_en_thelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60433-60570-mortefontaine_en_thelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60433-60570-mortefontaine_en_thelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60434-60490-mortemer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60434-60490-mortemer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60434-60490-mortemer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60434-60490-mortemer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60435-60380-morvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60435-60380-morvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60435-60380-morvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60435-60380-morvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60436-60120-mory_montcrux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60436-60120-mory_montcrux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60436-60120-mory_montcrux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60436-60120-mory_montcrux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60437-60250-mouchy_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60437-60250-mouchy_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60437-60250-mouchy_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60437-60250-mouchy_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60438-60350-moulin_sous_touvent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60438-60350-moulin_sous_touvent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60438-60350-moulin_sous_touvent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60438-60350-moulin_sous_touvent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60439-60250-mouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60439-60250-mouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60439-60250-mouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60439-60250-mouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60440-60190-moyenneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60440-60190-moyenneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60440-60190-moyenneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60440-60190-moyenneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60441-60190-moyvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60441-60190-moyvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60441-60190-moyvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60441-60190-moyvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60442-60480-muidorge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60442-60480-muidorge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60442-60480-muidorge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60442-60480-muidorge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60443-60640-muirancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60443-60640-muirancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60443-60640-muirancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60443-60640-muirancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60444-60220-mureaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60444-60220-mureaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60444-60220-mureaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60444-60220-mureaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60445-60400-nampcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60445-60400-nampcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60445-60400-nampcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60445-60400-nampcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60446-60440-nanteuil_le_haudouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60446-60440-nanteuil_le_haudouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60446-60440-nanteuil_le_haudouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60446-60440-nanteuil_le_haudouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60447-60320-nery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60447-60320-nery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60447-60320-nery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60447-60320-nery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60448-60890-neufchelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60448-60890-neufchelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60448-60890-neufchelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60448-60890-neufchelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60448-60620-neufchelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60448-60620-neufchelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60448-60620-neufchelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60448-60620-neufchelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60449-60190-neufvy_sur_aronde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60449-60190-neufvy_sur_aronde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60449-60190-neufvy_sur_aronde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60449-60190-neufvy_sur_aronde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60450-60530-neuilly_en_thelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60450-60530-neuilly_en_thelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60450-60530-neuilly_en_thelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60450-60530-neuilly_en_thelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60451-60290-neuilly_sous_clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60451-60290-neuilly_sous_clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60451-60290-neuilly_sous_clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60451-60290-neuilly_sous_clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60452-60119-neuville_bosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60452-60119-neuville_bosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60452-60119-neuville_bosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60452-60119-neuville_bosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60454-60510-la_neuville_en_hez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60454-60510-la_neuville_en_hez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60454-60510-la_neuville_en_hez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60454-60510-la_neuville_en_hez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60456-60190-la_neuville_roy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60456-60190-la_neuville_roy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60456-60190-la_neuville_roy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60456-60190-la_neuville_roy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60457-60480-la_neuville_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60457-60480-la_neuville_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60457-60480-la_neuville_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60457-60480-la_neuville_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60458-60690-la_neuville_sur_oudeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60458-60690-la_neuville_sur_oudeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60458-60690-la_neuville_sur_oudeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60458-60690-la_neuville_sur_oudeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60459-60490-la_neuville_sur_ressons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60459-60490-la_neuville_sur_ressons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60459-60490-la_neuville_sur_ressons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60459-60490-la_neuville_sur_ressons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60460-60112-la_neuville_vault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60460-60112-la_neuville_vault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60460-60112-la_neuville_vault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60460-60112-la_neuville_vault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60461-60510-nivillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60461-60510-nivillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60461-60510-nivillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60461-60510-nivillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60462-60430-noailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60462-60430-noailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60462-60430-noailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60462-60430-noailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60463-60180-nogent_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60463-60180-nogent_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60463-60180-nogent_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60463-60180-nogent_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60464-60840-nointel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60464-60840-nointel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60464-60840-nointel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60464-60840-nointel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60465-60480-noiremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60465-60480-noiremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60465-60480-noiremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60465-60480-noiremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60466-60130-noroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60466-60130-noroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60466-60130-noroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60466-60130-noroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60468-60130-nourard_le_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60468-60130-nourard_le_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60468-60130-nourard_le_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60468-60130-nourard_le_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60469-60730-novillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60469-60730-novillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60469-60730-novillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60469-60730-novillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60470-60480-noyers_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60470-60480-noyers_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60470-60480-noyers_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60470-60480-noyers_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60471-60400-noyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60471-60400-noyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60471-60400-noyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60471-60400-noyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60472-60210-offoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60472-60210-offoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60472-60210-offoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60472-60210-offoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60473-60440-ognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60473-60440-ognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60473-60440-ognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60473-60440-ognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60474-60310-ognolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60474-60310-ognolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60474-60310-ognolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60474-60310-ognolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60476-60220-omecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60476-60220-omecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60476-60220-omecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60476-60220-omecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60477-60650-ons_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60477-60650-ons_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60477-60650-ons_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60477-60650-ons_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60478-60620-ormoy_le_davien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60478-60620-ormoy_le_davien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60478-60620-ormoy_le_davien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60478-60620-ormoy_le_davien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60479-60800-ormoy_villers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60479-60800-ormoy_villers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60479-60800-ormoy_villers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60479-60800-ormoy_villers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60480-60510-oroer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60480-60510-oroer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60480-60510-oroer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60480-60510-oroer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60481-60129-orrouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60481-60129-orrouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60481-60129-orrouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60481-60129-orrouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60482-60560-orry_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60482-60560-orry_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60482-60560-orry_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60482-60560-orry_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60483-60490-orvillers_sorel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60483-60490-orvillers_sorel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60483-60490-orvillers_sorel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60483-60490-orvillers_sorel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60484-60860-oudeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60484-60860-oudeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60484-60860-oudeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60484-60860-oudeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60485-60480-oursel_maison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60485-60480-oursel_maison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60485-60480-oursel_maison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60485-60480-oursel_maison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60486-60120-paillart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60486-60120-paillart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60486-60120-paillart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60486-60120-paillart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60487-60240-parnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60487-60240-parnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60487-60240-parnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60487-60240-parnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60488-60400-passel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60488-60400-passel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60488-60400-passel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60488-60400-passel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60489-60440-peroy_les_gombries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60489-60440-peroy_les_gombries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60489-60440-peroy_les_gombries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60489-60440-peroy_les_gombries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60490-60112-pierrefitte_en_beauvaisis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60490-60112-pierrefitte_en_beauvaisis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60490-60112-pierrefitte_en_beauvaisis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60490-60112-pierrefitte_en_beauvaisis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60491-60350-pierrefonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60491-60350-pierrefonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60491-60350-pierrefonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60491-60350-pierrefonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60492-60170-pimprez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60492-60170-pimprez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60492-60170-pimprez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60492-60170-pimprez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60493-60860-pisseleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60493-60860-pisseleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60493-60860-pisseleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60493-60860-pisseleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60494-60128-plailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60494-60128-plailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60494-60128-plailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60494-60128-plailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60495-60130-plainval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60495-60130-plainval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60495-60130-plainval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60495-60130-plainval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60496-60120-plainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60496-60120-plainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60496-60120-plainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60496-60120-plainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60497-60130-le_plessier_sur_bulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60497-60130-le_plessier_sur_bulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60497-60130-le_plessier_sur_bulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60497-60130-le_plessier_sur_bulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60498-60130-le_plessier_sur_saint_just/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60498-60130-le_plessier_sur_saint_just/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60498-60130-le_plessier_sur_saint_just/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60498-60130-le_plessier_sur_saint_just/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60499-60310-plessis_de_roye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60499-60310-plessis_de_roye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60499-60310-plessis_de_roye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60499-60310-plessis_de_roye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60500-60330-le_plessis_belleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60500-60330-le_plessis_belleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60500-60330-le_plessis_belleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60500-60330-le_plessis_belleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60501-60150-le_plessis_brion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60501-60150-le_plessis_brion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60501-60150-le_plessis_brion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60501-60150-le_plessis_brion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60502-60640-le_plessis_patte_d_oie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60502-60640-le_plessis_patte_d_oie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60502-60640-le_plessis_patte_d_oie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60502-60640-le_plessis_patte_d_oie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60503-60420-le_ployron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60503-60420-le_ployron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60503-60420-le_ployron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60503-60420-le_ployron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60504-60430-ponchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60504-60430-ponchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60504-60430-ponchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60504-60430-ponchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60505-60520-pontarme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60505-60520-pontarme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60505-60520-pontarme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60505-60520-pontarme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60506-60400-pont_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60506-60400-pont_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60506-60400-pont_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60506-60400-pont_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60507-60400-pontoise_les_noyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60507-60400-pontoise_les_noyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60507-60400-pontoise_les_noyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60507-60400-pontoise_les_noyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60508-60700-pontpoint/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60508-60700-pontpoint/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60508-60700-pontpoint/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60508-60700-pontpoint/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60509-60700-pont_sainte_maxence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60509-60700-pont_sainte_maxence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60509-60700-pont_sainte_maxence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60509-60700-pont_sainte_maxence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60510-60390-porcheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60510-60390-porcheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60510-60390-porcheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60510-60390-porcheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60511-60400-porquericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60511-60400-porquericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60511-60400-porquericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60511-60400-porquericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60512-60790-pouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60512-60790-pouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60512-60790-pouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60512-60790-pouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60513-60460-precy_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60513-60460-precy_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60513-60460-precy_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60513-60460-precy_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60514-60360-previllers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60514-60360-previllers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60514-60360-previllers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60514-60360-previllers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60515-60190-pronleroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60515-60190-pronleroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60515-60190-pronleroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60515-60190-pronleroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60516-60850-puiseux_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60516-60850-puiseux_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60516-60850-puiseux_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60516-60850-puiseux_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60517-60540-puiseux_le_hauberger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60517-60540-puiseux_le_hauberger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60517-60540-puiseux_le_hauberger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60517-60540-puiseux_le_hauberger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60518-60480-puits_la_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60518-60480-puits_la_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60518-60480-puits_la_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60518-60480-puits_la_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60519-60640-quesmy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60519-60640-quesmy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60519-60640-quesmy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60519-60640-quesmy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60520-60480-le_quesnel_aubry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60520-60480-le_quesnel_aubry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60520-60480-le_quesnel_aubry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60520-60480-le_quesnel_aubry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60521-60220-quincampoix_fleuzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60521-60220-quincampoix_fleuzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60521-60220-quincampoix_fleuzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60521-60220-quincampoix_fleuzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60522-60130-quinquempoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60522-60130-quinquempoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60522-60130-quinquempoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60522-60130-quinquempoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60155-rainvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60155-rainvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60155-rainvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60155-rainvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60390-rainvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60390-rainvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60390-rainvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60390-rainvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60650-rainvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60650-rainvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60650-rainvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60523-60650-rainvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60524-60290-rantigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60524-60290-rantigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60524-60290-rantigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60524-60290-rantigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60525-60810-raray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60525-60810-raray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60525-60810-raray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60525-60810-raray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60526-60130-ravenel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60526-60130-ravenel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60526-60130-ravenel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60526-60130-ravenel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60527-60620-reez_fosse_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60527-60620-reez_fosse_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60527-60620-reez_fosse_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60527-60620-reez_fosse_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60528-60240-reilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60528-60240-reilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60528-60240-reilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60528-60240-reilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60529-60600-remecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60529-60600-remecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60529-60600-remecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60529-60600-remecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60530-60510-remerangles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60530-60510-remerangles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60530-60510-remerangles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60530-60510-remerangles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60531-60190-remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60531-60190-remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60531-60190-remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60531-60190-remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60533-60490-ressons_sur_matz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60533-60490-ressons_sur_matz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60533-60490-ressons_sur_matz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60533-60490-ressons_sur_matz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60534-60153-rethondes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60534-60153-rethondes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60534-60153-rethondes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60534-60153-rethondes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60535-60480-reuil_sur_breche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60535-60480-reuil_sur_breche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60535-60480-reuil_sur_breche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60535-60480-reuil_sur_breche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60536-60410-rhuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60536-60410-rhuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60536-60410-rhuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60536-60410-rhuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60537-60170-ribecourt_dreslincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60537-60170-ribecourt_dreslincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60537-60170-ribecourt_dreslincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60537-60170-ribecourt_dreslincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60538-60490-ricquebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60538-60490-ricquebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60538-60490-ricquebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60538-60490-ricquebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60539-60870-rieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60539-60870-rieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60539-60870-rieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60539-60870-rieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60540-60126-rivecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60540-60126-rivecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60540-60126-rivecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60540-60126-rivecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60541-60410-roberval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60541-60410-roberval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60541-60410-roberval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60541-60410-roberval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60542-60510-rochy_conde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60542-60510-rochy_conde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60542-60510-rochy_conde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60542-60510-rochy_conde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60543-60800-rocquemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60543-60800-rocquemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60543-60800-rocquemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60543-60800-rocquemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60544-60120-rocquencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60544-60120-rocquencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60544-60120-rocquencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60544-60120-rocquencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60545-60220-romescamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60545-60220-romescamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60545-60220-romescamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60545-60220-romescamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60546-60440-rosieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60546-60440-rosieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60546-60440-rosieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60546-60440-rosieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60547-60140-rosoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60547-60140-rosoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60547-60140-rosoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60547-60140-rosoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60548-60620-rosoy_en_multien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60548-60620-rosoy_en_multien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60548-60620-rosoy_en_multien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60548-60620-rosoy_en_multien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60549-60360-rotangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60549-60360-rotangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60549-60360-rotangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60549-60360-rotangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60550-60690-rothois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60550-60690-rothois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60550-60690-rothois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60550-60690-rothois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60551-60660-rousseloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60551-60660-rousseloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60551-60660-rousseloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60551-60660-rousseloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60552-60800-rouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60552-60800-rouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60552-60800-rouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60552-60800-rouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60553-60190-rouvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60553-60190-rouvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60553-60190-rouvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60553-60190-rouvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60554-60620-rouvres_en_multien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60554-60620-rouvres_en_multien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60554-60620-rouvres_en_multien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60554-60620-rouvres_en_multien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60555-60120-rouvroy_les_merles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60555-60120-rouvroy_les_merles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60555-60120-rouvroy_les_merles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60555-60120-rouvroy_les_merles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60556-60420-royaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60556-60420-royaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60556-60420-royaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60556-60420-royaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60557-60690-roy_boissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60557-60690-roy_boissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60557-60690-roy_boissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60557-60690-roy_boissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60558-60310-roye_sur_matz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60558-60310-roye_sur_matz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60558-60310-roye_sur_matz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60558-60310-roye_sur_matz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60559-60510-la_rue_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60559-60510-la_rue_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60559-60510-la_rue_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60559-60510-la_rue_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60560-60810-rully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60560-60810-rully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60560-60810-rully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60560-60810-rully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60561-60117-russy_bemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60561-60117-russy_bemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60561-60117-russy_bemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60561-60117-russy_bemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60562-60700-sacy_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60562-60700-sacy_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60562-60700-sacy_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60562-60700-sacy_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60563-60190-sacy_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60563-60190-sacy_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60563-60190-sacy_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60563-60190-sacy_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60564-60420-sains_morainvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60564-60420-sains_morainvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60564-60420-sains_morainvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60564-60420-sains_morainvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60565-60480-saint_andre_farivillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60565-60480-saint_andre_farivillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60565-60480-saint_andre_farivillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60565-60480-saint_andre_farivillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60566-60220-saint_arnoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60566-60220-saint_arnoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60566-60220-saint_arnoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60566-60220-saint_arnoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60567-60650-saint_aubin_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60567-60650-saint_aubin_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60567-60650-saint_aubin_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60567-60650-saint_aubin_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60568-60600-saint_aubin_sous_erquery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60568-60600-saint_aubin_sous_erquery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60568-60600-saint_aubin_sous_erquery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60568-60600-saint_aubin_sous_erquery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60569-60170-saint_crepin_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60569-60170-saint_crepin_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60569-60170-saint_crepin_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60569-60170-saint_crepin_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60570-60149-saint_crepin_ibouvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60570-60149-saint_crepin_ibouvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60570-60149-saint_crepin_ibouvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60570-60149-saint_crepin_ibouvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60571-60380-saint_deniscourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60571-60380-saint_deniscourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60571-60380-saint_deniscourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60571-60380-saint_deniscourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60572-60350-saint_etienne_roilaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60572-60350-saint_etienne_roilaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60572-60350-saint_etienne_roilaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60572-60350-saint_etienne_roilaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60573-60480-sainte_eusoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60573-60480-sainte_eusoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60573-60480-sainte_eusoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60573-60480-sainte_eusoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60574-60370-saint_felix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60574-60370-saint_felix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60574-60370-saint_felix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60574-60370-saint_felix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60575-60730-sainte_genevieve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60575-60730-sainte_genevieve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60575-60730-sainte_genevieve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60575-60730-sainte_genevieve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60576-60650-saint_germain_la_poterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60576-60650-saint_germain_la_poterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60576-60650-saint_germain_la_poterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60576-60650-saint_germain_la_poterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60577-60850-saint_germer_de_fly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60577-60850-saint_germer_de_fly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60577-60850-saint_germer_de_fly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60577-60850-saint_germer_de_fly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60578-60410-saintines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60578-60410-saintines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60578-60410-saintines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60578-60410-saintines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60579-60350-saint_jean_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60579-60350-saint_jean_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60579-60350-saint_jean_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60579-60350-saint_jean_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60581-60130-saint_just_en_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60581-60130-saint_just_en_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60581-60130-saint_just_en_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60581-60130-saint_just_en_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60582-60170-saint_leger_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60582-60170-saint_leger_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60582-60170-saint_leger_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60582-60170-saint_leger_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60583-60155-saint_leger_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60583-60155-saint_leger_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60583-60155-saint_leger_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60583-60155-saint_leger_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60584-60340-saint_leu_d_esserent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60584-60340-saint_leu_d_esserent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60584-60340-saint_leu_d_esserent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60584-60340-saint_leu_d_esserent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60585-60420-saint_martin_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60585-60420-saint_martin_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60585-60420-saint_martin_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60585-60420-saint_martin_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60586-60000-saint_martin_le_noeud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60586-60000-saint_martin_le_noeud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60586-60000-saint_martin_le_noeud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60586-60000-saint_martin_le_noeud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60587-60700-saint_martin_longueau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60587-60700-saint_martin_longueau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60587-60700-saint_martin_longueau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60587-60700-saint_martin_longueau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60588-60210-saint_maur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60588-60210-saint_maur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60588-60210-saint_maur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60588-60210-saint_maur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60589-60740-saint_maximin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60589-60740-saint_maximin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60589-60740-saint_maximin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60589-60740-saint_maximin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60590-60860-saint_omer_en_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60590-60860-saint_omer_en_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60590-60860-saint_omer_en_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60590-60860-saint_omer_en_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60591-60650-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60591-60650-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60591-60650-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60591-60650-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60592-60850-saint_pierre_es_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60592-60850-saint_pierre_es_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60592-60850-saint_pierre_es_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60592-60850-saint_pierre_es_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60593-60350-saint_pierre_les_bitry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60593-60350-saint_pierre_les_bitry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60593-60350-saint_pierre_les_bitry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60593-60350-saint_pierre_les_bitry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60594-60380-saint_quentin_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60594-60380-saint_quentin_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60594-60380-saint_quentin_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60594-60380-saint_quentin_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60595-60130-saint_remy_en_l_eau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60595-60130-saint_remy_en_l_eau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60595-60130-saint_remy_en_l_eau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60595-60130-saint_remy_en_l_eau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60596-60220-saint_samson_la_poterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60596-60220-saint_samson_la_poterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60596-60220-saint_samson_la_poterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60596-60220-saint_samson_la_poterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60597-60320-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60597-60320-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60597-60320-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60597-60320-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60598-60430-saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60598-60430-saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60598-60430-saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60598-60430-saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60599-60210-saint_thibault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60599-60210-saint_thibault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60599-60210-saint_thibault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60599-60210-saint_thibault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60600-60410-saint_vaast_de_longmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60600-60410-saint_vaast_de_longmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60600-60410-saint_vaast_de_longmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60600-60410-saint_vaast_de_longmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60601-60660-saint_vaast_les_mello/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60601-60660-saint_vaast_les_mello/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60601-60660-saint_vaast_les_mello/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60601-60660-saint_vaast_les_mello/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60602-60220-saint_valery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60602-60220-saint_valery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60602-60220-saint_valery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60602-60220-saint_valery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60603-60400-salency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60603-60400-salency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60603-60400-salency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60603-60400-salency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60604-60210-sarcus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60604-60210-sarcus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60604-60210-sarcus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60604-60210-sarcus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60605-60210-sarnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60605-60210-sarnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60605-60210-sarnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60605-60210-sarnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60608-60360-le_saulchoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60608-60360-le_saulchoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60608-60360-le_saulchoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60608-60360-le_saulchoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60609-60650-savignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60609-60650-savignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60609-60650-savignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60609-60650-savignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60610-60400-sempigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60610-60400-sempigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60610-60400-sempigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60610-60400-sempigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60611-60650-senantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60611-60650-senantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60611-60650-senantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60611-60650-senantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60612-60300-senlis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60612-60300-senlis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60612-60300-senlis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60612-60300-senlis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60613-60240-senots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60613-60240-senots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60613-60240-senots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60613-60240-senots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60614-60240-serans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60614-60240-serans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60614-60240-serans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60614-60240-serans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60615-60120-serevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60615-60120-serevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60615-60120-serevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60615-60120-serevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60616-60590-serifontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60616-60590-serifontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60616-60590-serifontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60616-60590-serifontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60617-60400-sermaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60617-60400-sermaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60617-60400-sermaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60617-60400-sermaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60618-60800-sery_magneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60618-60800-sery_magneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60618-60800-sery_magneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60618-60800-sery_magneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60619-60330-silly_le_long/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60619-60330-silly_le_long/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60619-60330-silly_le_long/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60619-60330-silly_le_long/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60620-60430-silly_tillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60620-60430-silly_tillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60620-60430-silly_tillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60620-60430-silly_tillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60621-60310-solente/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60621-60310-solente/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60621-60310-solente/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60621-60310-solente/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60622-60210-sommereux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60622-60210-sommereux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60622-60210-sommereux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60622-60210-sommereux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60623-60380-songeons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60623-60380-songeons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60623-60380-songeons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60623-60380-songeons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60624-60380-sully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60624-60380-sully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60624-60380-sully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60624-60380-sully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60625-60400-suzoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60625-60400-suzoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60625-60400-suzoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60625-60400-suzoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60626-60590-talmontiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60626-60590-talmontiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60626-60590-talmontiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60626-60590-talmontiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60627-60120-tartigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60627-60120-tartigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60627-60120-tartigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60627-60120-tartigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60628-60510-therdonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60628-60510-therdonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60628-60510-therdonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60628-60510-therdonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60629-60380-therines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60629-60380-therines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60629-60380-therines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60629-60380-therines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60630-60240-thibivillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60630-60240-thibivillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60630-60240-thibivillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60630-60240-thibivillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60631-60520-thiers_sur_theve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60631-60520-thiers_sur_theve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60631-60520-thiers_sur_theve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60631-60520-thiers_sur_theve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60632-60310-thiescourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60632-60310-thiescourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60632-60310-thiescourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60632-60310-thiescourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60633-60210-thieuloy_saint_antoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60633-60210-thieuloy_saint_antoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60633-60210-thieuloy_saint_antoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60633-60210-thieuloy_saint_antoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60634-60480-thieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60634-60480-thieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60634-60480-thieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60634-60480-thieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60635-60160-thiverny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60635-60160-thiverny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60635-60160-thiverny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60635-60160-thiverny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60636-60150-thourotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60636-60150-thourotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60636-60150-thourotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60636-60150-thourotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60637-60890-thury_en_valois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60637-60890-thury_en_valois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60637-60890-thury_en_valois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60637-60890-thury_en_valois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60638-60250-thury_sous_clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60638-60250-thury_sous_clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60638-60250-thury_sous_clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60638-60250-thury_sous_clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60639-60000-tille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60639-60000-tille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60639-60000-tille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60639-60000-tille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60640-60240-tourly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60640-60240-tourly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60640-60240-tourly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60640-60240-tourly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60641-60170-tracy_le_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60641-60170-tracy_le_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60641-60170-tracy_le_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60641-60170-tracy_le_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60642-60170-tracy_le_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60642-60170-tracy_le_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60642-60170-tracy_le_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60642-60170-tracy_le_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60643-60420-tricot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60643-60420-tricot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60643-60420-tricot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60643-60420-tricot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60644-60590-trie_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60644-60590-trie_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60644-60590-trie_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60644-60590-trie_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60645-60590-trie_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60645-60590-trie_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60645-60590-trie_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60645-60590-trie_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60646-60112-troissereux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60646-60112-troissereux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60646-60112-troissereux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60646-60112-troissereux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60647-60350-trosly_breuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60647-60350-trosly_breuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60647-60350-trosly_breuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60647-60350-trosly_breuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60648-60120-troussencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60648-60120-troussencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60648-60120-troussencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60648-60120-troussencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60650-60800-trumilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60650-60800-trumilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60650-60800-trumilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60650-60800-trumilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60651-60730-ully_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60651-60730-ully_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60651-60730-ully_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60651-60730-ully_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60652-60790-valdampierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60652-60790-valdampierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60652-60790-valdampierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60652-60790-valdampierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60653-60130-valescourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60653-60130-valescourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60653-60130-valescourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60653-60130-valescourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60654-60490-vandelicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60654-60490-vandelicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60654-60490-vandelicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60654-60490-vandelicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60655-60400-varesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60655-60400-varesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60655-60400-varesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60655-60400-varesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60656-60890-varinfroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60656-60890-varinfroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60656-60890-varinfroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60656-60890-varinfroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60657-60400-vauchelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60657-60400-vauchelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60657-60400-vauchelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60657-60400-vauchelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60658-60117-vauciennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60658-60117-vauciennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60658-60117-vauciennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60658-60117-vauciennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60659-60240-vaudancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60659-60240-vaudancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60659-60240-vaudancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60659-60240-vaudancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60660-60590-le_vaumain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60660-60590-le_vaumain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60660-60590-le_vaumain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60660-60590-le_vaumain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60661-60117-vaumoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60661-60117-vaumoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60661-60117-vaumoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60661-60117-vaumoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60662-60390-le_vauroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60662-60390-le_vauroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60662-60390-le_vauroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60662-60390-le_vauroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60663-60510-velennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60663-60510-velennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60663-60510-velennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60663-60510-velennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60664-60120-vendeuil_caply/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60664-60120-vendeuil_caply/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60664-60120-vendeuil_caply/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60664-60120-vendeuil_caply/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60665-60280-venette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60665-60280-venette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60665-60280-venette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60665-60280-venette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60666-60950-ver_sur_launette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60666-60950-ver_sur_launette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60666-60950-ver_sur_launette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60666-60950-ver_sur_launette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60667-60410-verberie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60667-60410-verberie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60667-60410-verberie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60667-60410-verberie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60668-60112-verderel_les_sauqueuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60668-60112-verderel_les_sauqueuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60668-60112-verderel_les_sauqueuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60668-60112-verderel_les_sauqueuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60669-60140-verderonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60669-60140-verderonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60669-60140-verderonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60669-60140-verderonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60670-60550-verneuil_en_halatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60670-60550-verneuil_en_halatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60670-60550-verneuil_en_halatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60670-60550-verneuil_en_halatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60671-60440-versigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60671-60440-versigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60671-60440-versigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60671-60440-versigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60672-60117-vez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60672-60117-vez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60672-60117-vez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60672-60117-vez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60673-60360-viefvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60673-60360-viefvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60673-60360-viefvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60673-60360-viefvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60674-60350-vieux_moulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60674-60350-vieux_moulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60674-60350-vieux_moulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60674-60350-vieux_moulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60675-60162-vignemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60675-60162-vignemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60675-60162-vignemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60675-60162-vignemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60676-60400-ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60676-60400-ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60676-60400-ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60676-60400-ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60677-60650-villembray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60677-60650-villembray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60677-60650-villembray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60677-60650-villembray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60678-60175-villeneuve_les_sablons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60678-60175-villeneuve_les_sablons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60678-60175-villeneuve_les_sablons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60678-60175-villeneuve_les_sablons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60679-60890-la_villeneuve_sous_thury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60679-60890-la_villeneuve_sous_thury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60679-60890-la_villeneuve_sous_thury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60679-60890-la_villeneuve_sous_thury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60680-60410-villeneuve_sur_verberie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60680-60410-villeneuve_sur_verberie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60680-60410-villeneuve_sur_verberie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60680-60410-villeneuve_sur_verberie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60681-60390-villers_saint_barthelemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60681-60390-villers_saint_barthelemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60681-60390-villers_saint_barthelemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60681-60390-villers_saint_barthelemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60681-60650-villers_saint_barthelemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60681-60650-villers_saint_barthelemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60681-60650-villers_saint_barthelemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60681-60650-villers_saint_barthelemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60682-60810-villers_saint_frambourg_ognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60682-60810-villers_saint_frambourg_ognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60682-60810-villers_saint_frambourg_ognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60682-60810-villers_saint_frambourg_ognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60683-60620-villers_saint_genest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60683-60620-villers_saint_genest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60683-60620-villers_saint_genest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60683-60620-villers_saint_genest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60684-60870-villers_saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60684-60870-villers_saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60684-60870-villers_saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60684-60870-villers_saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60685-60134-villers_saint_sepulcre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60685-60134-villers_saint_sepulcre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60685-60134-villers_saint_sepulcre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60685-60134-villers_saint_sepulcre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60686-60340-villers_sous_saint_leu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60686-60340-villers_sous_saint_leu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60686-60340-villers_sous_saint_leu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60686-60340-villers_sous_saint_leu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60687-60650-villers_sur_auchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60687-60650-villers_sur_auchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60687-60650-villers_sur_auchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60687-60650-villers_sur_auchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60688-60860-villers_sur_bonnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60688-60860-villers_sur_bonnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60688-60860-villers_sur_bonnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60688-60860-villers_sur_bonnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60689-60150-villers_sur_coudun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60689-60150-villers_sur_coudun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60689-60150-villers_sur_coudun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60689-60150-villers_sur_coudun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60691-60380-villers_vermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60691-60380-villers_vermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60691-60380-villers_vermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60691-60380-villers_vermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60692-60120-villers_vicomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60692-60120-villers_vicomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60692-60120-villers_vicomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60692-60120-villers_vicomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60693-60640-villeselve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60693-60640-villeselve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60693-60640-villeselve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60693-60640-villeselve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60695-60500-vineuil_saint_firmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60695-60500-vineuil_saint_firmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60695-60500-vineuil_saint_firmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60695-60500-vineuil_saint_firmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60697-60112-vrocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60697-60112-vrocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60697-60112-vrocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60697-60112-vrocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60698-60420-wacquemoulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60698-60420-wacquemoulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60698-60420-wacquemoulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60698-60420-wacquemoulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60699-60380-wambez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60699-60380-wambez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60699-60380-wambez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60699-60380-wambez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60700-60430-warluis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60700-60430-warluis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60700-60430-warluis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60700-60430-warluis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60701-60130-wavignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60701-60130-wavignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60701-60130-wavignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60701-60130-wavignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60702-60420-welles_perennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60702-60420-welles_perennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60702-60420-welles_perennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60702-60420-welles_perennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60703-60000-aux_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60703-60000-aux_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60703-60000-aux_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt60-oise/commune60703-60000-aux_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-61.xml
+++ b/public/sitemaps/sitemap-61.xml
@@ -5,810 +5,1616 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61001-61000-alencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61001-61000-alencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61001-61000-alencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61001-61000-alencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61002-61570-almeneches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61002-61570-almeneches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61002-61570-almeneches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61002-61570-almeneches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61005-61130-appenai_sous_belleme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61005-61130-appenai_sous_belleme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61005-61130-appenai_sous_belleme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61005-61130-appenai_sous_belleme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61006-61200-argentan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61006-61200-argentan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61006-61200-argentan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61006-61200-argentan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61007-61430-athis_val_de_rouvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61007-61430-athis_val_de_rouvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61007-61430-athis_val_de_rouvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61007-61430-athis_val_de_rouvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61007-61100-athis_val_de_rouvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61007-61100-athis_val_de_rouvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61007-61100-athis_val_de_rouvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61007-61100-athis_val_de_rouvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61008-61270-aube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61008-61270-aube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61008-61270-aube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61008-61270-aube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61010-61120-aubry_le_panthou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61010-61120-aubry_le_panthou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61010-61120-aubry_le_panthou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61010-61120-aubry_le_panthou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61011-61100-aubusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61011-61100-aubusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61011-61100-aubusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61011-61100-aubusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61012-61270-auguaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61012-61270-auguaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61012-61270-auguaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61012-61270-auguaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61013-61500-aunay_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61013-61500-aunay_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61013-61500-aunay_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61013-61500-aunay_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61014-61200-aunou_le_faucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61014-61200-aunou_le_faucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61014-61200-aunou_le_faucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61014-61200-aunou_le_faucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61015-61500-aunou_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61015-61500-aunou_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61015-61500-aunou_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61015-61500-aunou_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61017-61240-les_authieux_du_puits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61017-61240-les_authieux_du_puits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61017-61240-les_authieux_du_puits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61017-61240-les_authieux_du_puits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61018-61470-avernes_saint_gourgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61018-61470-avernes_saint_gourgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61018-61470-avernes_saint_gourgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61018-61470-avernes_saint_gourgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61020-61150-avoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61020-61150-avoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61020-61150-avoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61020-61150-avoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61021-61700-avrilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61021-61700-avrilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61021-61700-avrilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61021-61700-avrilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61023-61160-bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61023-61160-bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61023-61160-bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61023-61160-bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61024-61450-banvou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61024-61450-banvou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61024-61450-banvou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61024-61450-banvou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61026-61170-barville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61026-61170-barville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61026-61170-barville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61026-61170-barville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61028-61210-bazoches_au_houlme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61028-61210-bazoches_au_houlme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61028-61210-bazoches_au_houlme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61028-61210-bazoches_au_houlme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61029-61560-bazoches_sur_hoene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61029-61560-bazoches_sur_hoene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61029-61560-bazoches_sur_hoene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61029-61560-bazoches_sur_hoene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61030-61100-la_bazoque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61030-61100-la_bazoque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61030-61100-la_bazoque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61030-61100-la_bazoque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61032-61270-beaufai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61032-61270-beaufai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61032-61270-beaufai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61032-61270-beaufai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61034-61190-beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61034-61190-beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61034-61190-beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61034-61190-beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61035-61600-beauvain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61035-61600-beauvain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61035-61600-beauvain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61035-61600-beauvain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61036-61500-belfonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61036-61500-belfonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61036-61500-belfonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61036-61500-belfonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61037-61360-bellavilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61037-61360-bellavilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61037-61360-bellavilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61037-61360-bellavilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61038-61130-belleme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61038-61130-belleme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61038-61130-belleme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61038-61130-belleme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61039-61570-la_belliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61039-61570-la_belliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61039-61570-la_belliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61039-61570-la_belliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61040-61220-bellou_en_houlme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61040-61220-bellou_en_houlme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61040-61220-bellou_en_houlme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61040-61220-bellou_en_houlme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61041-61130-bellou_le_trichard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61041-61130-bellou_le_trichard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61041-61130-bellou_le_trichard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61041-61130-bellou_le_trichard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61043-61340-berd_huis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61043-61340-berd_huis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61043-61340-berd_huis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61043-61340-berd_huis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61044-61430-berjou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61044-61430-berjou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61044-61430-berjou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61044-61430-berjou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61046-61290-bizou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61046-61290-bizou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61046-61290-bizou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61046-61290-bizou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61048-61560-boece/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61048-61560-boece/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61048-61560-boece/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61048-61560-boece/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61049-61570-boissei_la_lande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61049-61570-boissei_la_lande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61049-61570-boissei_la_lande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61049-61570-boissei_la_lande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61050-61110-cour_maugis_sur_huisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61050-61110-cour_maugis_sur_huisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61050-61110-cour_maugis_sur_huisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61050-61110-cour_maugis_sur_huisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61050-61340-cour_maugis_sur_huisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61050-61340-cour_maugis_sur_huisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61050-61340-cour_maugis_sur_huisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61050-61340-cour_maugis_sur_huisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61051-61500-boitron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61051-61500-boitron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61051-61500-boitron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61051-61500-boitron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61052-61270-bonnefoi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61052-61270-bonnefoi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61052-61270-bonnefoi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61052-61270-bonnefoi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61053-61380-bonsmoulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61053-61380-bonsmoulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61053-61380-bonsmoulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61053-61380-bonsmoulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61054-61470-le_bosc_renoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61054-61470-le_bosc_renoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61054-61470-le_bosc_renoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61054-61470-le_bosc_renoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61055-61570-bouce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61055-61570-bouce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61055-61570-bouce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61055-61570-bouce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61056-61500-le_bouillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61056-61500-le_bouillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61056-61500-le_bouillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61056-61500-le_bouillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61060-61270-brethel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61060-61270-brethel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61060-61270-brethel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61060-61270-brethel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61061-61110-bretoncelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61061-61110-bretoncelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61061-61110-bretoncelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61061-61110-bretoncelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61062-61160-brieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61062-61160-brieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61062-61160-brieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61062-61160-brieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61063-61220-briouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61063-61220-briouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61063-61220-briouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61063-61220-briouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61064-61390-brullemail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61064-61390-brullemail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61064-61390-brullemail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61064-61390-brullemail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61066-61170-bure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61066-61170-bure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61066-61170-bure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61066-61170-bure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61067-61170-bures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61067-61170-bures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61067-61170-bures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61067-61170-bures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61068-61500-bursard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61068-61500-bursard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61068-61500-bursard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61068-61500-bursard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61069-61430-cahan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61069-61430-cahan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61069-61430-cahan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61069-61430-cahan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61070-61100-caligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61070-61100-caligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61070-61100-caligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61070-61100-caligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61071-61120-camembert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61071-61120-camembert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61071-61120-camembert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61071-61120-camembert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61072-61120-canapville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61072-61120-canapville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61072-61120-canapville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61072-61120-canapville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61074-61320-carrouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61074-61320-carrouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61074-61320-carrouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61074-61320-carrouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61075-61330-ceauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61075-61330-ceauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61075-61330-ceauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61075-61330-ceauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61076-61500-le_cercueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61076-61500-le_cercueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61076-61500-le_cercueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61076-61500-le_cercueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61077-61000-cerise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61077-61000-cerise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61077-61000-cerise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61077-61000-cerise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61078-61100-cerisy_belle_etoile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61078-61100-cerisy_belle_etoile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61078-61100-cerisy_belle_etoile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61078-61100-cerisy_belle_etoile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61079-61260-ceton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61079-61260-ceton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61079-61260-ceton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61079-61260-ceton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61080-61320-chahains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61080-61320-chahains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61080-61320-chahains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61080-61320-chahains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61081-61500-chailloue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61081-61500-chailloue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61081-61500-chailloue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61081-61500-chailloue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61081-61240-chailloue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61081-61240-chailloue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61081-61240-chailloue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61081-61240-chailloue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61082-61390-le_chalange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61082-61390-le_chalange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61082-61390-le_chalange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61082-61390-le_chalange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61084-61210-champcerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61084-61210-champcerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61084-61210-champcerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61084-61210-champcerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61085-61320-le_champ_de_la_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61085-61320-le_champ_de_la_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61085-61320-le_champ_de_la_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61085-61320-le_champ_de_la_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61086-61120-les_champeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61086-61120-les_champeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61086-61120-les_champeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61086-61120-les_champeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61087-61560-champeaux_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61087-61560-champeaux_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61087-61560-champeaux_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61087-61560-champeaux_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61088-61240-champ_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61088-61240-champ_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61088-61240-champ_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61088-61240-champ_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61089-61120-champosoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61089-61120-champosoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61089-61120-champosoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61089-61120-champosoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61091-61700-champsecret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61091-61700-champsecret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61091-61700-champsecret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61091-61700-champsecret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61092-61300-chandai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61092-61300-chandai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61092-61300-chandai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61092-61300-chandai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61093-61800-chanu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61093-61800-chanu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61093-61800-chanu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61093-61800-chanu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61094-61100-la_chapelle_au_moine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61094-61100-la_chapelle_au_moine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61094-61100-la_chapelle_au_moine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61094-61100-la_chapelle_au_moine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61095-61100-la_chapelle_biche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61095-61100-la_chapelle_biche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61095-61100-la_chapelle_biche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61095-61100-la_chapelle_biche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61096-61140-rives_d_andaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61096-61140-rives_d_andaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61096-61140-rives_d_andaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61096-61140-rives_d_andaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61096-61410-rives_d_andaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61096-61410-rives_d_andaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61096-61410-rives_d_andaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61096-61410-rives_d_andaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61097-61400-la_chapelle_montligeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61097-61400-la_chapelle_montligeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61097-61400-la_chapelle_montligeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61097-61400-la_chapelle_montligeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61098-61500-la_chapelle_pres_sees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61098-61500-la_chapelle_pres_sees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61098-61500-la_chapelle_pres_sees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61098-61500-la_chapelle_pres_sees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61099-61130-la_chapelle_souef/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61099-61130-la_chapelle_souef/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61099-61130-la_chapelle_souef/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61099-61130-la_chapelle_souef/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61100-61270-la_chapelle_viel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61100-61270-la_chapelle_viel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61100-61270-la_chapelle_viel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61100-61270-la_chapelle_viel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61101-61570-le_chateau_d_almeneches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61101-61570-le_chateau_d_almeneches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61101-61570-le_chateau_d_almeneches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61101-61570-le_chateau_d_almeneches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61102-61450-le_chatellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61102-61450-le_chatellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61102-61450-le_chatellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61102-61450-le_chatellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61103-61230-chaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61103-61230-chaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61103-61230-chaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61103-61230-chaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61104-61600-la_chaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61104-61600-la_chaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61104-61600-la_chaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61104-61600-la_chaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61105-61360-chemilli/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61105-61360-chemilli/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61105-61360-chemilli/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61105-61360-chemilli/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61107-61320-ciral/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61107-61320-ciral/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61107-61320-ciral/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61107-61320-ciral/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61108-61230-cisai_saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61108-61230-cisai_saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61108-61230-cisai_saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61108-61230-cisai_saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61111-61250-colombiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61111-61250-colombiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61111-61250-colombiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61111-61250-colombiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61113-61400-comblot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61113-61400-comblot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61113-61400-comblot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61113-61400-comblot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61114-61200-commeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61114-61200-commeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61114-61200-commeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61114-61200-commeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61116-61110-sablons_sur_huisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61116-61110-sablons_sur_huisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61116-61110-sablons_sur_huisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61116-61110-sablons_sur_huisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61117-61250-conde_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61117-61250-conde_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61117-61250-conde_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61117-61250-conde_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61118-61400-corbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61118-61400-corbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61118-61400-corbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61118-61400-corbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61120-61160-coudehard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61120-61160-coudehard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61120-61160-coudehard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61120-61160-coudehard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61121-61360-coulimer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61121-61360-coulimer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61121-61360-coulimer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61121-61360-coulimer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61122-61230-coulmer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61122-61230-coulmer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61122-61230-coulmer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61122-61230-coulmer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61123-61160-coulonces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61123-61160-coulonces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61123-61160-coulonces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61123-61160-coulonces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61124-61220-la_coulonche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61124-61220-la_coulonche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61124-61220-la_coulonche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61124-61220-la_coulonche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61126-61170-coulonges_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61126-61170-coulonges_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61126-61170-coulonges_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61126-61170-coulonges_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61129-61400-courgeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61129-61400-courgeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61129-61400-courgeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61129-61400-courgeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61130-61560-courgeout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61130-61560-courgeout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61130-61560-courgeout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61130-61560-courgeout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61133-61390-courtomer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61133-61390-courtomer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61133-61390-courtomer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61133-61390-courtomer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61137-61220-cramenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61137-61220-cramenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61137-61220-cramenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61137-61220-cramenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61138-61230-croisilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61138-61230-croisilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61138-61230-croisilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61138-61230-croisilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61139-61120-crouttes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61139-61120-crouttes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61139-61120-crouttes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61139-61120-crouttes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61140-61300-crulai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61140-61300-crulai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61140-61300-crulai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61140-61300-crulai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61141-61250-cuissai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61141-61250-cuissai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61141-61250-cuissai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61141-61250-cuissai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61142-61130-dame_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61142-61130-dame_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61142-61130-dame_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61142-61130-dame_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61143-61250-damigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61143-61250-damigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61143-61250-damigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61143-61250-damigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61145-61700-domfront_en_poiraie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61145-61700-domfront_en_poiraie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61145-61700-domfront_en_poiraie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61145-61700-domfront_en_poiraie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61146-61700-dompierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61146-61700-dompierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61146-61700-dompierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61146-61700-dompierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61148-61100-durcet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61148-61100-durcet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61148-61100-durcet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61148-61100-durcet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61149-61440-echalou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61149-61440-echalou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61149-61440-echalou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61149-61440-echalou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61150-61370-echauffour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61150-61370-echauffour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61150-61370-echauffour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61150-61370-echauffour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61151-61270-ecorcei/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61151-61270-ecorcei/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61151-61270-ecorcei/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61151-61270-ecorcei/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61152-61160-ecorches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61152-61160-ecorches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61152-61160-ecorches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61152-61160-ecorches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61153-61150-ecouche_les_vallees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61153-61150-ecouche_les_vallees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61153-61150-ecouche_les_vallees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61153-61150-ecouche_les_vallees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61156-61500-essay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61156-61500-essay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61156-61500-essay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61156-61500-essay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61158-61600-faverolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61158-61600-faverolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61158-61600-faverolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61158-61600-faverolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61159-61390-fay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61159-61390-fay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61159-61390-fay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61159-61390-fay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61160-61400-feings/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61160-61400-feings/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61160-61400-feings/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61160-61400-feings/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61162-61380-la_ferriere_au_doyen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61162-61380-la_ferriere_au_doyen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61162-61380-la_ferriere_au_doyen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61162-61380-la_ferriere_au_doyen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61163-61450-la_ferriere_aux_etangs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61163-61450-la_ferriere_aux_etangs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61163-61450-la_ferriere_aux_etangs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61163-61450-la_ferriere_aux_etangs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61164-61500-la_ferriere_bechet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61164-61500-la_ferriere_bechet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61164-61500-la_ferriere_bechet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61164-61500-la_ferriere_bechet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61165-61420-la_ferriere_bochard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61165-61420-la_ferriere_bochard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61165-61420-la_ferriere_bochard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61165-61420-la_ferriere_bochard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61166-61390-ferrieres_la_verrerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61166-61390-ferrieres_la_verrerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61166-61390-ferrieres_la_verrerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61166-61390-ferrieres_la_verrerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61167-61550-la_ferte_en_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61167-61550-la_ferte_en_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61167-61550-la_ferte_en_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61167-61550-la_ferte_en_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61167-61470-la_ferte_en_ouche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61167-61470-la_ferte_en_ouche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61167-61470-la_ferte_en_ouche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61167-61470-la_ferte_en_ouche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61168-61600-la_ferte_mace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61168-61600-la_ferte_mace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61168-61600-la_ferte_mace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61168-61600-la_ferte_mace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61168-61410-la_ferte_mace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61168-61410-la_ferte_mace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61168-61410-la_ferte_mace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61168-61410-la_ferte_mace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61169-61100-flers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61169-61100-flers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61169-61100-flers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61169-61100-flers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61170-61200-fleure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61170-61200-fleure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61170-61200-fleure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61170-61200-fleure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61171-61160-fontaine_les_bassets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61171-61160-fontaine_les_bassets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61171-61160-fontaine_les_bassets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61171-61160-fontaine_les_bassets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61176-61570-francheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61176-61570-francheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61176-61570-francheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61176-61570-francheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61178-61230-la_fresnaie_fayel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61178-61230-la_fresnaie_fayel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61178-61230-la_fresnaie_fayel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61178-61230-la_fresnaie_fayel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61180-61120-fresnay_le_samson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61180-61120-fresnay_le_samson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61180-61120-fresnay_le_samson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61180-61120-fresnay_le_samson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61181-61230-gace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61181-61230-gace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61181-61230-gace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61181-61230-gace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61182-61420-gandelain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61182-61420-gandelain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61182-61420-gandelain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61182-61420-gandelain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61183-61390-gapree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61183-61390-gapree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61183-61390-gapree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61183-61390-gapree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61187-61270-les_genettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61187-61270-les_genettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61187-61270-les_genettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61187-61270-les_genettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61188-61240-la_genevraie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61188-61240-la_genevraie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61188-61240-la_genevraie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61188-61240-la_genevraie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61189-61210-giel_courteilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61189-61210-giel_courteilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61189-61210-giel_courteilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61189-61210-giel_courteilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61190-61310-ginai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61190-61310-ginai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61190-61310-ginai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61190-61310-ginai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61192-61240-godisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61192-61240-godisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61192-61240-godisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61192-61240-godisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61193-61550-la_gonfriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61193-61550-la_gonfriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61193-61550-la_gonfriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61193-61550-la_gonfriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61194-61150-monts_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61194-61150-monts_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61194-61150-monts_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61194-61150-monts_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61195-61600-le_grais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61195-61600-le_grais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61195-61600-le_grais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61195-61600-le_grais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61130-belforet_en_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61130-belforet_en_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61130-belforet_en_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61130-belforet_en_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61360-belforet_en_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61360-belforet_en_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61360-belforet_en_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61360-belforet_en_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61400-belforet_en_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61400-belforet_en_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61400-belforet_en_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61196-61400-belforet_en_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61197-61160-gueprei/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61197-61160-gueprei/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61197-61160-gueprei/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61197-61160-gueprei/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61198-61120-guerquesalles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61198-61120-guerquesalles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61198-61120-guerquesalles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61198-61120-guerquesalles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61199-61210-habloville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61199-61210-habloville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61199-61210-habloville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61199-61210-habloville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61202-61250-hauterive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61202-61250-hauterive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61202-61250-hauterive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61202-61250-hauterive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61203-61250-heloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61203-61250-heloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61203-61250-heloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61203-61250-heloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61206-61290-l_home_chamondot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61206-61290-l_home_chamondot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61206-61290-l_home_chamondot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61206-61290-l_home_chamondot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61207-61130-ige/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61207-61130-ige/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61207-61130-ige/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61207-61130-ige/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61208-61190-irai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61208-61190-irai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61208-61190-irai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61208-61190-irai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61209-61320-joue_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61209-61320-joue_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61209-61320-joue_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61209-61320-joue_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61210-61150-joue_du_plain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61210-61150-joue_du_plain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61210-61150-joue_du_plain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61210-61150-joue_du_plain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61211-61140-juvigny_val_d_andaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61211-61140-juvigny_val_d_andaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61211-61140-juvigny_val_d_andaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61211-61140-juvigny_val_d_andaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61211-61330-juvigny_val_d_andaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61211-61330-juvigny_val_d_andaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61211-61330-juvigny_val_d_andaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61211-61330-juvigny_val_d_andaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61212-61200-juvigny_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61212-61200-juvigny_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61212-61200-juvigny_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61212-61200-juvigny_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61213-61320-lalacelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61213-61320-lalacelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61213-61320-lalacelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61213-61320-lalacelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61214-61300-l_aigle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61214-61300-l_aigle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61214-61300-l_aigle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61214-61300-l_aigle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61215-61170-laleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61215-61170-laleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61215-61170-laleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61215-61170-laleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61216-61320-la_lande_de_goult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61216-61320-la_lande_de_goult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61216-61320-la_lande_de_goult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61216-61320-la_lande_de_goult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61217-61210-la_lande_de_louge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61217-61210-la_lande_de_louge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61217-61210-la_lande_de_louge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61217-61210-la_lande_de_louge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61218-61100-la_lande_patry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61218-61100-la_lande_patry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61218-61100-la_lande_patry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61218-61100-la_lande_patry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61219-61100-la_lande_saint_simeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61219-61100-la_lande_saint_simeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61219-61100-la_lande_saint_simeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61219-61100-la_lande_saint_simeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61221-61100-landigou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61221-61100-landigou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61221-61100-landigou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61221-61100-landigou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61222-61100-landisacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61222-61100-landisacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61222-61100-landisacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61222-61100-landisacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61224-61250-larre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61224-61250-larre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61224-61250-larre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61224-61250-larre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61225-61240-ligneres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61225-61240-ligneres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61225-61240-ligneres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61225-61240-ligneres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61227-61220-lignou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61227-61220-lignou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61227-61220-lignou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61227-61220-lignou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61228-61420-l’oree_d’ecouves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61228-61420-l’oree_d’ecouves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61228-61420-l’oree_d’ecouves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61228-61420-l’oree_d’ecouves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61228-61320-l’oree_d’ecouves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61228-61320-l’oree_d’ecouves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61228-61320-l’oree_d’ecouves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61228-61320-l’oree_d’ecouves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61229-61400-loisail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61229-61400-loisail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61229-61400-loisail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61229-61400-loisail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61230-61290-longny_les_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61230-61290-longny_les_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61230-61290-longny_les_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61230-61290-longny_les_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61232-61700-lonlay_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61232-61700-lonlay_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61232-61700-lonlay_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61232-61700-lonlay_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61233-61600-lonlay_le_tesson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61233-61600-lonlay_le_tesson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61233-61600-lonlay_le_tesson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61233-61600-lonlay_le_tesson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61234-61250-lonrai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61234-61250-lonrai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61234-61250-lonrai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61234-61250-lonrai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61237-61150-louge_sur_maire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61237-61150-louge_sur_maire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61237-61150-louge_sur_maire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61237-61150-louge_sur_maire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61238-61160-louvieres_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61238-61160-louvieres_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61238-61160-louvieres_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61238-61160-louvieres_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61240-61500-mace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61240-61500-mace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61240-61500-mace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61240-61500-mace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61241-61110-la_madeleine_bouvet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61241-61110-la_madeleine_bouvet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61241-61110-la_madeleine_bouvet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61241-61110-la_madeleine_bouvet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61242-61290-le_mage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61242-61290-le_mage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61242-61290-le_mage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61242-61290-le_mage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61243-61600-magny_le_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61243-61600-magny_le_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61243-61600-magny_le_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61243-61600-magny_le_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61244-61380-maheru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61244-61380-maheru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61244-61380-maheru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61244-61380-maheru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61248-61350-mantilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61248-61350-mantilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61248-61350-mantilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61248-61350-mantilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61251-61170-marchemaisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61251-61170-marchemaisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61251-61170-marchemaisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61251-61170-marchemaisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61252-61230-mardilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61252-61230-mardilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61252-61230-mardilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61252-61230-mardilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61255-61400-mauves_sur_huisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61255-61400-mauves_sur_huisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61255-61400-mauves_sur_huisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61255-61400-mauves_sur_huisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61256-61570-medavy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61256-61570-medavy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61256-61570-medavy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61256-61570-medavy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61257-61410-mehoudin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61257-61410-mehoudin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61257-61410-mehoudin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61257-61410-mehoudin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61258-61170-le_mele_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61258-61170-le_mele_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61258-61170-le_mele_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61258-61170-le_mele_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61259-61270-le_menil_berard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61259-61270-le_menil_berard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61259-61270-le_menil_berard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61259-61270-le_menil_berard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61260-61220-le_menil_de_briouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61260-61220-le_menil_de_briouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61260-61220-le_menil_de_briouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61260-61220-le_menil_de_briouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61261-61250-le_menil_brout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61261-61250-le_menil_brout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61261-61250-le_menil_brout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61261-61250-le_menil_brout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61262-61800-le_menil_ciboult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61262-61800-le_menil_ciboult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61262-61800-le_menil_ciboult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61262-61800-le_menil_ciboult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61263-61250-menil_erreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61263-61250-menil_erreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61263-61250-menil_erreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61263-61250-menil_erreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61264-61240-menil_froger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61264-61240-menil_froger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61264-61240-menil_froger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61264-61240-menil_froger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61265-61210-menil_gondouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61265-61210-menil_gondouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61265-61210-menil_gondouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61265-61210-menil_gondouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61266-61170-le_menil_guyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61266-61170-le_menil_guyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61266-61170-le_menil_guyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61266-61170-le_menil_guyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61267-61210-menil_hermei/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61267-61210-menil_hermei/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61267-61210-menil_hermei/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61267-61210-menil_hermei/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61268-61230-menil_hubert_en_exmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61268-61230-menil_hubert_en_exmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61268-61230-menil_hubert_en_exmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61268-61230-menil_hubert_en_exmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61269-61430-menil_hubert_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61269-61430-menil_hubert_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61269-61430-menil_hubert_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61269-61430-menil_hubert_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61271-61320-le_menil_scelleur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61271-61320-le_menil_scelleur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61271-61320-le_menil_scelleur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61271-61320-le_menil_scelleur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61272-61240-le_menil_vicomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61272-61240-le_menil_vicomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61272-61240-le_menil_vicomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61272-61240-le_menil_vicomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61273-61210-menil_vin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61273-61210-menil_vin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61273-61210-menil_vin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61273-61210-menil_vin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61274-61290-les_menus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61274-61290-les_menus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61274-61290-les_menus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61274-61290-les_menus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61275-61240-le_merlerault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61275-61240-le_merlerault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61275-61240-le_merlerault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61275-61240-le_merlerault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61276-61160-merri/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61276-61160-merri/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61276-61160-merri/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61276-61160-merri/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61277-61560-la_mesniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61277-61560-la_mesniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61277-61560-la_mesniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61277-61560-la_mesniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61278-61440-messei/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61278-61440-messei/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61278-61440-messei/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61278-61440-messei/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61279-61250-mieuxce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61279-61250-mieuxce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61279-61250-mieuxce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61279-61250-mieuxce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61281-61800-moncy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61281-61800-moncy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61281-61800-moncy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61281-61800-moncy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61283-61160-montabard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61283-61160-montabard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61283-61160-montabard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61283-61160-montabard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61284-61170-montchevrel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61284-61170-montchevrel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61284-61170-montchevrel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61284-61170-montchevrel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61286-61360-montgaudry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61286-61360-montgaudry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61286-61360-montgaudry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61286-61360-montgaudry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61287-61100-montilly_sur_noireau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61287-61100-montilly_sur_noireau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61287-61100-montilly_sur_noireau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61287-61100-montilly_sur_noireau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61288-61570-montmerrei/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61288-61570-montmerrei/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61288-61570-montmerrei/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61288-61570-montmerrei/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61289-61160-mont_ormel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61289-61160-mont_ormel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61289-61160-mont_ormel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61289-61160-mont_ormel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61290-61210-montreuil_au_houlme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61290-61210-montreuil_au_houlme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61290-61210-montreuil_au_houlme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61290-61210-montreuil_au_houlme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61291-61160-montreuil_la_cambe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61291-61160-montreuil_la_cambe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61291-61160-montreuil_la_cambe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61291-61160-montreuil_la_cambe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61292-61800-montsecret_clairefougere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61292-61800-montsecret_clairefougere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61292-61800-montsecret_clairefougere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61292-61800-montsecret_clairefougere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61293-61400-mortagne_au_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61293-61400-mortagne_au_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61293-61400-mortagne_au_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61293-61400-mortagne_au_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61294-61570-mortree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61294-61570-mortree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61294-61570-mortree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61294-61570-mortree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61294-61500-mortree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61294-61500-mortree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61294-61500-mortree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61294-61500-mortree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61295-61600-la_motte_fouquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61295-61600-la_motte_fouquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61295-61600-la_motte_fouquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61295-61600-la_motte_fouquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61297-61380-moulins_la_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61297-61380-moulins_la_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61297-61380-moulins_la_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61297-61380-moulins_la_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61298-61200-moulins_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61298-61200-moulins_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61298-61200-moulins_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61298-61200-moulins_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61300-61110-moutiers_au_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61300-61110-moutiers_au_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61300-61110-moutiers_au_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61300-61110-moutiers_au_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61301-61500-neauphe_sous_essai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61301-61500-neauphe_sous_essai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61301-61500-neauphe_sous_essai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61301-61500-neauphe_sous_essai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61302-61160-neauphe_sur_dive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61302-61160-neauphe_sur_dive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61302-61160-neauphe_sur_dive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61302-61160-neauphe_sur_dive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61303-61160-necy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61303-61160-necy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61303-61160-necy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61303-61160-necy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61304-61250-neuilly_le_bisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61304-61250-neuilly_le_bisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61304-61250-neuilly_le_bisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61304-61250-neuilly_le_bisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61307-61120-neuville_sur_touques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61307-61120-neuville_sur_touques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61307-61120-neuville_sur_touques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61307-61120-neuville_sur_touques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61308-61210-neuvy_au_houlme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61308-61210-neuvy_au_houlme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61308-61210-neuvy_au_houlme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61308-61210-neuvy_au_houlme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61309-61340-perche_en_noce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61309-61340-perche_en_noce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61309-61340-perche_en_noce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61309-61340-perche_en_noce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61310-61240-nonant_le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61310-61240-nonant_le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61310-61240-nonant_le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61310-61240-nonant_le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61314-61200-occagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61314-61200-occagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61314-61200-occagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61314-61200-occagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61316-61160-ommoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61316-61160-ommoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61316-61160-ommoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61316-61160-ommoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61317-61230-orgeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61317-61230-orgeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61317-61230-orgeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61317-61230-orgeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61319-61130-origny_le_roux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61319-61130-origny_le_roux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61319-61130-origny_le_roux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61319-61130-origny_le_roux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61321-61250-pace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61321-61250-pace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61321-61250-pace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61321-61250-pace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61322-61400-parfondeval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61322-61400-parfondeval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61322-61400-parfondeval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61322-61400-parfondeval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61323-61290-le_pas_saint_l_homer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61323-61290-le_pas_saint_l_homer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61323-61290-le_pas_saint_l_homer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61323-61290-le_pas_saint_l_homer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61324-61350-passais_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61324-61350-passais_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61324-61350-passais_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61324-61350-passais_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61326-61700-perrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61326-61700-perrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61326-61700-perrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61326-61700-perrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61327-61360-pervencheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61327-61360-pervencheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61327-61360-pervencheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61327-61360-pervencheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61328-61310-le_pin_au_haras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61328-61310-le_pin_au_haras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61328-61310-le_pin_au_haras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61328-61310-le_pin_au_haras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61329-61400-le_pin_la_garenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61329-61400-le_pin_la_garenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61329-61400-le_pin_la_garenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61329-61400-le_pin_la_garenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61330-61370-planches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61330-61370-planches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61330-61370-planches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61330-61370-planches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61331-61170-le_plantis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61331-61170-le_plantis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61331-61170-le_plantis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61331-61170-le_plantis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61332-61220-pointel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61332-61220-pointel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61332-61220-pointel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61332-61220-pointel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61333-61120-pontchardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61333-61120-pontchardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61333-61120-pontchardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61333-61120-pontchardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61336-61130-pouvrai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61336-61130-pouvrai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61336-61130-pouvrai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61336-61130-pouvrai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61339-61210-putanges_le_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61339-61210-putanges_le_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61339-61210-putanges_le_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61339-61210-putanges_le_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61341-61250-ecouves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61341-61250-ecouves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61341-61250-ecouves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61341-61250-ecouves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61342-61270-rai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61342-61270-rai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61342-61270-rai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61342-61270-rai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61344-61150-ranes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61344-61150-ranes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61344-61150-ranes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61344-61150-ranes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61345-61110-remalard_en_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61345-61110-remalard_en_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61345-61110-remalard_en_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61345-61110-remalard_en_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61346-61120-le_renouard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61346-61120-le_renouard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61346-61120-le_renouard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61346-61120-le_renouard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61347-61230-resenlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61347-61230-resenlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61347-61230-resenlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61347-61230-resenlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61348-61400-reveillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61348-61400-reveillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61348-61400-reveillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61348-61400-reveillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61349-61210-ri/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61349-61210-ri/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61349-61210-ri/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61349-61210-ri/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61350-61420-la_roche_mabile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61350-61420-la_roche_mabile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61350-61420-la_roche_mabile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61350-61420-la_roche_mabile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61351-61120-roiville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61351-61120-roiville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61351-61120-roiville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61351-61120-roiville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61352-61160-ronai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61352-61160-ronai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61352-61160-ronai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61352-61160-ronai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61357-61320-rouperroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61357-61320-rouperroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61357-61320-rouperroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61357-61320-rouperroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61358-61200-sai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61358-61200-sai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61358-61200-sai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61358-61200-sai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61360-61170-saint_agnan_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61360-61170-saint_agnan_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61360-61170-saint_agnan_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61360-61170-saint_agnan_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61361-61220-saint_andre_de_briouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61361-61220-saint_andre_de_briouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61361-61220-saint_andre_de_briouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61361-61220-saint_andre_de_briouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61362-61440-saint_andre_de_messei/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61362-61440-saint_andre_de_messei/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61362-61440-saint_andre_de_messei/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61362-61440-saint_andre_de_messei/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61363-61380-saint_aquilin_de_corbion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61363-61380-saint_aquilin_de_corbion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61363-61380-saint_aquilin_de_corbion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61363-61380-saint_aquilin_de_corbion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61365-61170-saint_aubin_d_appenai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61365-61170-saint_aubin_d_appenai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61365-61170-saint_aubin_d_appenai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61365-61170-saint_aubin_d_appenai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61366-61470-saint_aubin_de_bonneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61366-61470-saint_aubin_de_bonneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61366-61470-saint_aubin_de_bonneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61366-61470-saint_aubin_de_bonneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61367-61560-saint_aubin_de_courteraie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61367-61560-saint_aubin_de_courteraie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61367-61560-saint_aubin_de_courteraie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61367-61560-saint_aubin_de_courteraie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61369-61700-saint_bomer_les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61369-61700-saint_bomer_les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61369-61700-saint_bomer_les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61369-61700-saint_bomer_les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61370-61700-saint_brice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61370-61700-saint_brice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61370-61700-saint_brice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61370-61700-saint_brice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61371-61150-saint_brice_sous_ranes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61371-61150-saint_brice_sous_ranes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61371-61150-saint_brice_sous_ranes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61371-61150-saint_brice_sous_ranes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61372-61250-saint_ceneri_le_gerei/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61372-61250-saint_ceneri_le_gerei/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61372-61250-saint_ceneri_le_gerei/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61372-61250-saint_ceneri_le_gerei/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61373-61380-sainte_ceronne_les_mortagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61373-61380-sainte_ceronne_les_mortagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61373-61380-sainte_ceronne_les_mortagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61373-61380-sainte_ceronne_les_mortagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61374-61800-saint_christophe_de_chaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61374-61800-saint_christophe_de_chaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61374-61800-saint_christophe_de_chaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61374-61800-saint_christophe_de_chaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61375-61570-boischampre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61375-61570-boischampre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61375-61570-boischampre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61375-61570-boischampre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61376-61490-saint_clair_de_halouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61376-61490-saint_clair_de_halouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61376-61490-saint_clair_de_halouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61376-61490-saint_clair_de_halouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61379-61130-saint_cyr_la_rosiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61379-61130-saint_cyr_la_rosiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61379-61130-saint_cyr_la_rosiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61379-61130-saint_cyr_la_rosiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61381-61400-saint_denis_sur_huisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61381-61400-saint_denis_sur_huisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61381-61400-saint_denis_sur_huisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61381-61400-saint_denis_sur_huisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61382-61420-saint_denis_sur_sarthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61382-61420-saint_denis_sur_sarthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61382-61420-saint_denis_sur_sarthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61382-61420-saint_denis_sur_sarthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61384-61320-saint_ellier_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61384-61320-saint_ellier_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61384-61320-saint_ellier_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61384-61320-saint_ellier_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61385-61230-saint_evroult_de_montfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61385-61230-saint_evroult_de_montfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61385-61230-saint_evroult_de_montfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61385-61230-saint_evroult_de_montfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61386-61550-saint_evroult_notre_dame_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61386-61550-saint_evroult_notre_dame_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61386-61550-saint_evroult_notre_dame_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61386-61550-saint_evroult_notre_dame_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61387-61350-saint_fraimbault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61387-61350-saint_fraimbault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61387-61350-saint_fraimbault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61387-61350-saint_fraimbault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61388-61130-saint_fulgent_des_ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61388-61130-saint_fulgent_des_ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61388-61130-saint_fulgent_des_ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61388-61130-saint_fulgent_des_ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61389-61370-sainte_gauburge_sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61389-61370-sainte_gauburge_sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61389-61370-sainte_gauburge_sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61389-61370-sainte_gauburge_sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61390-61600-saint_georges_d_annebecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61390-61600-saint_georges_d_annebecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61390-61600-saint_georges_d_annebecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61390-61600-saint_georges_d_annebecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61391-61100-saint_georges_des_groseillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61391-61100-saint_georges_des_groseillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61391-61100-saint_georges_des_groseillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61391-61100-saint_georges_des_groseillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61392-61470-saint_germain_d_aunay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61392-61470-saint_germain_d_aunay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61392-61470-saint_germain_d_aunay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61392-61470-saint_germain_d_aunay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61393-61240-saint_germain_de_clairefeuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61393-61240-saint_germain_de_clairefeuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61393-61240-saint_germain_de_clairefeuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61393-61240-saint_germain_de_clairefeuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61394-61130-saint_germain_de_la_coudre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61394-61130-saint_germain_de_la_coudre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61394-61130-saint_germain_de_la_coudre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61394-61130-saint_germain_de_la_coudre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61395-61110-saint_germain_des_grois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61395-61110-saint_germain_des_grois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61395-61110-saint_germain_des_grois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61395-61110-saint_germain_des_grois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61396-61560-saint_germain_de_martigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61396-61560-saint_germain_de_martigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61396-61560-saint_germain_de_martigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61396-61560-saint_germain_de_martigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61397-61000-saint_germain_du_corbeis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61397-61000-saint_germain_du_corbeis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61397-61000-saint_germain_du_corbeis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61397-61000-saint_germain_du_corbeis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61398-61390-saint_germain_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61398-61390-saint_germain_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61398-61390-saint_germain_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61398-61390-saint_germain_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61399-61160-saint_gervais_des_sablons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61399-61160-saint_gervais_des_sablons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61399-61160-saint_gervais_des_sablons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61399-61160-saint_gervais_des_sablons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61400-61500-saint_gervais_du_perron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61400-61500-saint_gervais_du_perron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61400-61500-saint_gervais_du_perron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61400-61500-saint_gervais_du_perron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61401-61700-saint_gilles_des_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61401-61700-saint_gilles_des_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61401-61700-saint_gilles_des_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61401-61700-saint_gilles_des_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61402-61220-saint_hilaire_de_briouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61402-61220-saint_hilaire_de_briouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61402-61220-saint_hilaire_de_briouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61402-61220-saint_hilaire_de_briouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61404-61400-saint_hilaire_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61404-61400-saint_hilaire_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61404-61400-saint_hilaire_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61404-61400-saint_hilaire_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61405-61340-saint_hilaire_sur_erre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61405-61340-saint_hilaire_sur_erre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61405-61340-saint_hilaire_sur_erre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61405-61340-saint_hilaire_sur_erre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61406-61270-saint_hilaire_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61406-61270-saint_hilaire_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61406-61270-saint_hilaire_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61406-61270-saint_hilaire_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61407-61430-sainte_honorine_la_chardonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61407-61430-sainte_honorine_la_chardonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61407-61430-sainte_honorine_la_chardonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61407-61430-sainte_honorine_la_chardonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61408-61210-sainte_honorine_la_guillaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61408-61210-sainte_honorine_la_guillaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61408-61210-sainte_honorine_la_guillaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61408-61210-sainte_honorine_la_guillaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61411-61360-saint_jouin_de_blavou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61411-61360-saint_jouin_de_blavou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61411-61360-saint_jouin_de_blavou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61411-61360-saint_jouin_de_blavou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61412-61170-saint_julien_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61412-61170-saint_julien_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61412-61170-saint_julien_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61412-61170-saint_julien_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61413-61160-saint_lambert_sur_dive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61413-61160-saint_lambert_sur_dive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61413-61160-saint_lambert_sur_dive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61413-61160-saint_lambert_sur_dive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61414-61400-saint_langis_les_mortagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61414-61400-saint_langis_les_mortagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61414-61400-saint_langis_les_mortagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61414-61400-saint_langis_les_mortagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61415-61170-saint_leger_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61415-61170-saint_leger_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61415-61170-saint_leger_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61415-61170-saint_leger_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61416-61390-saint_leonard_des_parcs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61416-61390-saint_leonard_des_parcs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61416-61390-saint_leonard_des_parcs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61416-61390-saint_leonard_des_parcs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61418-61400-saint_mard_de_reno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61418-61400-saint_mard_de_reno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61418-61400-saint_mard_de_reno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61418-61400-saint_mard_de_reno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61419-61320-sainte_marguerite_de_carrouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61419-61320-sainte_marguerite_de_carrouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61419-61320-sainte_marguerite_de_carrouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61419-61320-sainte_marguerite_de_carrouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61420-61320-sainte_marie_la_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61420-61320-sainte_marie_la_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61420-61320-sainte_marie_la_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61420-61320-sainte_marie_la_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61421-61350-saint_mars_d_egrenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61421-61350-saint_mars_d_egrenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61421-61350-saint_mars_d_egrenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61421-61350-saint_mars_d_egrenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61422-61270-les_aspres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61422-61270-les_aspres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61422-61270-les_aspres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61422-61270-les_aspres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61423-61300-saint_martin_d_ecublei/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61423-61300-saint_martin_d_ecublei/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61423-61300-saint_martin_d_ecublei/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61423-61300-saint_martin_d_ecublei/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61424-61320-saint_martin_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61424-61320-saint_martin_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61424-61320-saint_martin_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61424-61320-saint_martin_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61425-61380-saint_martin_des_pezerits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61425-61380-saint_martin_des_pezerits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61425-61380-saint_martin_des_pezerits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61425-61380-saint_martin_des_pezerits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61426-61130-saint_martin_du_vieux_belleme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61426-61130-saint_martin_du_vieux_belleme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61426-61130-saint_martin_du_vieux_belleme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61426-61130-saint_martin_du_vieux_belleme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61427-61320-saint_martin_l_aiguillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61427-61320-saint_martin_l_aiguillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61427-61320-saint_martin_l_aiguillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61427-61320-saint_martin_l_aiguillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61429-61190-charencey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61429-61190-charencey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61429-61190-charencey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61429-61190-charencey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61432-61300-saint_michel_tuboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61432-61300-saint_michel_tuboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61432-61300-saint_michel_tuboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61432-61300-saint_michel_tuboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61433-61250-saint_nicolas_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61433-61250-saint_nicolas_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61433-61250-saint_nicolas_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61433-61250-saint_nicolas_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61435-61550-saint_nicolas_de_sommaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61435-61550-saint_nicolas_de_sommaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61435-61550-saint_nicolas_de_sommaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61435-61550-saint_nicolas_de_sommaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61436-61100-sainte_opportune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61436-61100-sainte_opportune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61436-61100-sainte_opportune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61436-61100-sainte_opportune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61438-61560-saint_ouen_de_secherouvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61438-61560-saint_ouen_de_secherouvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61438-61560-saint_ouen_de_secherouvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61438-61560-saint_ouen_de_secherouvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61439-61410-saint_ouen_le_brisoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61439-61410-saint_ouen_le_brisoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61439-61410-saint_ouen_le_brisoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61439-61410-saint_ouen_le_brisoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61440-61300-saint_ouen_sur_iton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61440-61300-saint_ouen_sur_iton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61440-61300-saint_ouen_sur_iton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61440-61300-saint_ouen_sur_iton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61442-61600-saint_patrice_du_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61442-61600-saint_patrice_du_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61442-61600-saint_patrice_du_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61442-61600-saint_patrice_du_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61443-61100-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61443-61100-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61443-61100-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61443-61100-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61444-61430-saint_philbert_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61444-61430-saint_philbert_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61444-61430-saint_philbert_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61444-61430-saint_philbert_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61445-61800-saint_pierre_d_entremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61445-61800-saint_pierre_d_entremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61445-61800-saint_pierre_d_entremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61445-61800-saint_pierre_d_entremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61446-61370-saint_pierre_des_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61446-61370-saint_pierre_des_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61446-61370-saint_pierre_des_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61446-61370-saint_pierre_des_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61447-61790-saint_pierre_du_regard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61447-61790-saint_pierre_du_regard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61447-61790-saint_pierre_du_regard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61447-61790-saint_pierre_du_regard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61448-61340-saint_pierre_la_bruyere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61448-61340-saint_pierre_la_bruyere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61448-61340-saint_pierre_la_bruyere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61448-61340-saint_pierre_la_bruyere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61450-61360-saint_quentin_de_blavou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61450-61360-saint_quentin_de_blavou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61450-61360-saint_quentin_de_blavou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61450-61360-saint_quentin_de_blavou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61451-61800-saint_quentin_les_chardonnets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61451-61800-saint_quentin_les_chardonnets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61451-61800-saint_quentin_les_chardonnets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61451-61800-saint_quentin_les_chardonnets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61452-61350-saint_roch_sur_egrenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61452-61350-saint_roch_sur_egrenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61452-61350-saint_roch_sur_egrenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61452-61350-saint_roch_sur_egrenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61453-61320-saint_sauveur_de_carrouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61453-61320-saint_sauveur_de_carrouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61453-61320-saint_sauveur_de_carrouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61453-61320-saint_sauveur_de_carrouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61454-61170-sainte_scolasse_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61454-61170-sainte_scolasse_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61454-61170-sainte_scolasse_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61454-61170-sainte_scolasse_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61456-61300-saint_sulpice_sur_risle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61456-61300-saint_sulpice_sur_risle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61456-61300-saint_sulpice_sur_risle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61456-61300-saint_sulpice_sur_risle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61457-61300-saint_symphorien_des_bruyeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61457-61300-saint_symphorien_des_bruyeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61457-61300-saint_symphorien_des_bruyeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61457-61300-saint_symphorien_des_bruyeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61459-61220-saires_la_verrerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61459-61220-saires_la_verrerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61459-61220-saires_la_verrerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61459-61220-saires_la_verrerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61460-61470-sap_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61460-61470-sap_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61460-61470-sap_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61460-61470-sap_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61460-61120-sap_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61460-61120-sap_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61460-61120-sap_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61460-61120-sap_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61461-61230-le_sap_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61461-61230-le_sap_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61461-61230-le_sap_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61461-61230-le_sap_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61462-61200-sarceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61462-61200-sarceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61462-61200-sarceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61462-61200-sarceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61463-61600-les_monts_d_andaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61463-61600-les_monts_d_andaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61463-61600-les_monts_d_andaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61463-61600-les_monts_d_andaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61464-61500-sees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61464-61500-sees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61464-61500-sees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61464-61500-sees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61466-61100-la_selle_la_forge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61466-61100-la_selle_la_forge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61466-61100-la_selle_la_forge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61466-61100-la_selle_la_forge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61467-61250-semalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61467-61250-semalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61467-61250-semalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61467-61250-semalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61472-61200-sevigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61472-61200-sevigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61472-61200-sevigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61472-61200-sevigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61473-61150-sevrai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61473-61150-sevrai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61473-61150-sevrai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61473-61150-sevrai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61310-gouffern_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61310-gouffern_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61310-gouffern_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61310-gouffern_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61160-gouffern_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61160-gouffern_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61160-gouffern_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61160-gouffern_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61200-gouffern_en_auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61200-gouffern_en_auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61200-gouffern_en_auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61474-61200-gouffern_en_auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61475-61380-soligny_la_trappe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61475-61380-soligny_la_trappe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61475-61380-soligny_la_trappe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61475-61380-soligny_la_trappe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61476-61360-sure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61476-61360-sure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61476-61360-sure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61476-61360-sure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61479-61150-tanques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61479-61150-tanques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61479-61150-tanques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61479-61150-tanques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61480-61500-tanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61480-61500-tanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61480-61500-tanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61480-61500-tanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61481-61390-tellieres_le_plessis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61481-61390-tellieres_le_plessis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61481-61390-tellieres_le_plessis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61481-61390-tellieres_le_plessis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61482-61410-tesse_froulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61482-61410-tesse_froulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61482-61410-tesse_froulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61482-61410-tesse_froulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61483-61140-bagnoles_de_l_orne_normandie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61483-61140-bagnoles_de_l_orne_normandie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61483-61140-bagnoles_de_l_orne_normandie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61483-61140-bagnoles_de_l_orne_normandie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61483-61600-bagnoles_de_l_orne_normandie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61483-61600-bagnoles_de_l_orne_normandie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61483-61600-bagnoles_de_l_orne_normandie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61483-61600-bagnoles_de_l_orne_normandie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61260-val_au_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61260-val_au_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61260-val_au_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61260-val_au_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61340-val_au_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61340-val_au_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61340-val_au_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61340-val_au_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61130-val_au_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61130-val_au_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61130-val_au_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61484-61130-val_au_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61485-61120-ticheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61485-61120-ticheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61485-61120-ticheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61485-61120-ticheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61486-61800-tinchebray_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61486-61800-tinchebray_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61486-61800-tinchebray_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61486-61800-tinchebray_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61487-61330-torchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61487-61330-torchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61487-61330-torchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61487-61330-torchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61488-61550-touquettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61488-61550-touquettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61488-61550-touquettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61488-61550-touquettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61490-61160-tournai_sur_dive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61490-61160-tournai_sur_dive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61490-61160-tournai_sur_dive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61490-61160-tournai_sur_dive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61491-61190-tourouvre_au_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61491-61190-tourouvre_au_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61491-61190-tourouvre_au_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61491-61190-tourouvre_au_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61492-61390-tremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61492-61390-tremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61492-61390-tremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61492-61390-tremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61493-61230-la_trinite_des_laitiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61493-61230-la_trinite_des_laitiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61493-61230-la_trinite_des_laitiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61493-61230-la_trinite_des_laitiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61494-61160-trun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61494-61160-trun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61494-61160-trun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61494-61160-trun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61497-61250-valframbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61497-61250-valframbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61497-61250-valframbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61497-61250-valframbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61498-61130-vaunoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61498-61130-vaunoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61498-61130-vaunoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61498-61130-vaunoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61499-61170-les_ventes_de_bourse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61499-61170-les_ventes_de_bourse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61499-61170-les_ventes_de_bourse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61499-61170-les_ventes_de_bourse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61500-61190-la_ventrouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61500-61190-la_ventrouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61500-61190-la_ventrouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61500-61190-la_ventrouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61501-61110-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61501-61110-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61501-61110-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61501-61110-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61502-61360-vidai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61502-61360-vidai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61502-61360-vidai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61502-61360-vidai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61503-61150-vieux_pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61503-61150-vieux_pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61503-61150-vieux_pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61503-61150-vieux_pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61505-61160-villedieu_les_bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61505-61160-villedieu_les_bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61505-61160-villedieu_les_bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61505-61160-villedieu_les_bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61507-61400-villiers_sous_mortagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61507-61400-villiers_sous_mortagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61507-61400-villiers_sous_mortagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61507-61400-villiers_sous_mortagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61508-61120-vimoutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61508-61120-vimoutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61508-61120-vimoutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61508-61120-vimoutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61510-61300-vitrai_sous_laigle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61510-61300-vitrai_sous_laigle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61510-61300-vitrai_sous_laigle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61510-61300-vitrai_sous_laigle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61512-61210-les_yveteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61512-61210-les_yveteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61512-61210-les_yveteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt61-orne/commune61512-61210-les_yveteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-62.xml
+++ b/public/sitemaps/sitemap-62.xml
@@ -5,1788 +5,3572 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62001-62153-ablain_saint_nazaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62001-62153-ablain_saint_nazaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62001-62153-ablain_saint_nazaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62001-62153-ablain_saint_nazaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62002-62116-ablainzevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62002-62116-ablainzevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62002-62116-ablainzevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62002-62116-ablainzevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62003-62320-acheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62003-62320-acheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62003-62320-acheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62003-62320-acheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62004-62217-achicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62004-62217-achicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62004-62217-achicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62004-62217-achicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62005-62121-achiet_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62005-62121-achiet_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62005-62121-achiet_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62005-62121-achiet_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62006-62121-achiet_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62006-62121-achiet_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62006-62121-achiet_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62006-62121-achiet_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62007-62144-acq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62007-62144-acq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62007-62144-acq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62007-62144-acq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62008-62380-acquin_westbecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62008-62380-acquin_westbecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62008-62380-acquin_westbecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62008-62380-acquin_westbecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62009-62116-adinfer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62009-62116-adinfer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62009-62116-adinfer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62009-62116-adinfer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62010-62380-affringues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62010-62380-affringues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62010-62380-affringues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62010-62380-affringues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62011-62161-agnez_les_duisans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62011-62161-agnez_les_duisans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62011-62161-agnez_les_duisans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62011-62161-agnez_les_duisans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62012-62690-agnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62012-62690-agnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62012-62690-agnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62012-62690-agnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62013-62217-agny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62013-62217-agny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62013-62217-agny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62013-62217-agny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62014-62120-aire_sur_la_lys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62014-62120-aire_sur_la_lys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62014-62120-aire_sur_la_lys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62014-62120-aire_sur_la_lys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62015-62180-airon_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62015-62180-airon_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62015-62180-airon_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62015-62180-airon_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62016-62180-airon_saint_vaast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62016-62180-airon_saint_vaast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62016-62180-airon_saint_vaast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62016-62180-airon_saint_vaast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62017-62650-aix_en_ergny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62017-62650-aix_en_ergny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62017-62650-aix_en_ergny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62017-62650-aix_en_ergny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62018-62170-aix_en_issart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62018-62170-aix_en_issart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62018-62170-aix_en_issart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62018-62170-aix_en_issart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62019-62160-aix_noulette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62019-62160-aix_noulette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62019-62160-aix_noulette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62019-62160-aix_noulette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62020-62850-alembon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62020-62850-alembon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62020-62850-alembon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62020-62850-alembon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62021-62650-alette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62021-62650-alette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62021-62650-alette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62021-62650-alette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62022-62142-alincthun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62022-62142-alincthun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62022-62142-alincthun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62022-62142-alincthun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62023-62157-allouagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62023-62157-allouagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62023-62157-allouagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62023-62157-allouagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62024-62850-alquines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62024-62850-alquines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62024-62850-alquines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62024-62850-alquines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62025-62164-ambleteuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62025-62164-ambleteuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62025-62164-ambleteuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62025-62164-ambleteuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62026-62310-ambricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62026-62310-ambricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62026-62310-ambricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62026-62310-ambricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62027-62127-ambrines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62027-62127-ambrines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62027-62127-ambrines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62027-62127-ambrines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62028-62190-ames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62028-62190-ames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62028-62190-ames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62028-62190-ames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62029-62260-amettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62029-62260-amettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62029-62260-amettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62029-62260-amettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62030-62760-amplier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62030-62760-amplier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62030-62760-amplier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62030-62760-amplier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62031-62340-andres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62031-62340-andres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62031-62340-andres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62031-62340-andres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62032-62143-angres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62032-62143-angres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62032-62143-angres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62032-62143-angres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62033-62880-annay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62033-62880-annay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62033-62880-annay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62033-62880-annay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62034-62149-annequin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62034-62149-annequin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62034-62149-annequin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62034-62149-annequin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62035-62232-annezin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62035-62232-annezin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62035-62232-annezin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62035-62232-annezin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62036-62134-anvin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62036-62134-anvin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62036-62134-anvin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62036-62134-anvin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62037-62223-anzin_saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62037-62223-anzin_saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62037-62223-anzin_saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62037-62223-anzin_saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62038-62610-ardres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62038-62610-ardres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62038-62610-ardres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62038-62610-ardres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62039-62580-arleux_en_gohelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62039-62580-arleux_en_gohelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62039-62580-arleux_en_gohelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62039-62580-arleux_en_gohelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62040-62510-arques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62040-62510-arques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62040-62510-arques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62040-62510-arques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62041-62000-arras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62041-62000-arras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62041-62000-arras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62041-62000-arras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62042-62223-athies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62042-62223-athies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62042-62223-athies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62042-62223-athies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62043-62730-les_attaques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62043-62730-les_attaques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62043-62730-les_attaques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62043-62730-les_attaques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62044-62170-attin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62044-62170-attin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62044-62170-attin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62044-62170-attin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62045-62690-aubigny_en_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62045-62690-aubigny_en_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62045-62690-aubigny_en_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62045-62690-aubigny_en_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62046-62140-aubin_saint_vaast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62046-62140-aubin_saint_vaast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62046-62140-aubin_saint_vaast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62046-62140-aubin_saint_vaast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62047-62390-aubrometz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62047-62390-aubrometz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62047-62390-aubrometz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62047-62390-aubrometz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62048-62260-auchel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62048-62260-auchel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62048-62260-auchel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62048-62260-auchel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62049-62190-auchy_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62049-62190-auchy_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62049-62190-auchy_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62049-62190-auchy_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62050-62770-auchy_les_hesdin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62050-62770-auchy_les_hesdin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62050-62770-auchy_les_hesdin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62050-62770-auchy_les_hesdin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62051-62138-auchy_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62051-62138-auchy_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62051-62138-auchy_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62051-62138-auchy_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62052-62250-audembert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62052-62250-audembert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62052-62250-audembert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62052-62250-audembert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62053-62560-audincthun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62053-62560-audincthun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62053-62560-audincthun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62053-62560-audincthun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62054-62179-audinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62054-62179-audinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62054-62179-audinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62054-62179-audinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62055-62890-audrehem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62055-62890-audrehem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62055-62890-audrehem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62055-62890-audrehem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62056-62164-audresselles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62056-62164-audresselles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62056-62164-audresselles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62056-62164-audresselles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62057-62370-audruicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62057-62370-audruicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62057-62370-audruicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62057-62370-audruicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62058-62550-aumerval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62058-62550-aumerval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62058-62550-aumerval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62058-62550-aumerval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62059-62610-autingues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62059-62610-autingues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62059-62610-autingues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62059-62610-autingues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62060-62390-auxi_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62060-62390-auxi_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62060-62390-auxi_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62060-62390-auxi_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62061-62127-averdoingt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62061-62127-averdoingt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62061-62127-averdoingt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62061-62127-averdoingt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62062-62650-avesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62062-62650-avesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62062-62650-avesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62062-62650-avesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62063-62810-avesnes_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62063-62810-avesnes_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62063-62810-avesnes_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62063-62810-avesnes_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62064-62450-avesnes_les_bapaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62064-62450-avesnes_les_bapaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62064-62450-avesnes_les_bapaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62064-62450-avesnes_les_bapaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62065-62210-avion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62065-62210-avion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62065-62210-avion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62065-62210-avion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62066-62310-avondance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62066-62310-avondance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62066-62310-avondance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62066-62310-avondance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62067-62560-avroult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62067-62560-avroult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62067-62560-avroult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62067-62560-avroult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62068-62116-ayette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62068-62116-ayette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62068-62116-ayette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62068-62116-ayette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62069-62310-azincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62069-62310-azincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62069-62310-azincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62069-62310-azincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62070-62127-bailleul_aux_cornailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62070-62127-bailleul_aux_cornailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62070-62127-bailleul_aux_cornailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62070-62127-bailleul_aux_cornailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62071-62550-bailleul_les_pernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62071-62550-bailleul_les_pernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62071-62550-bailleul_les_pernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62071-62550-bailleul_les_pernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62072-62123-bailleulmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62072-62123-bailleulmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62072-62123-bailleulmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62072-62123-bailleulmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62073-62580-bailleul_sir_berthoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62073-62580-bailleul_sir_berthoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62073-62580-bailleul_sir_berthoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62073-62580-bailleul_sir_berthoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62074-62123-bailleulval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62074-62123-bailleulval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62074-62123-bailleulval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62074-62123-bailleulval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62075-62360-baincthun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62075-62360-baincthun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62075-62360-baincthun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62075-62360-baincthun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62076-62850-bainghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62076-62850-bainghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62076-62850-bainghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62076-62850-bainghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62077-62150-bajus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62077-62150-bajus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62077-62150-bajus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62077-62150-bajus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62078-62610-balinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62078-62610-balinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62078-62610-balinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62078-62610-balinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62079-62450-bancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62079-62450-bancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62079-62450-bancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62079-62450-bancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62080-62450-bapaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62080-62450-bapaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62080-62450-bapaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62080-62450-bapaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62081-62860-baralle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62081-62860-baralle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62081-62860-baralle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62081-62860-baralle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62082-62124-barastre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62082-62124-barastre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62082-62124-barastre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62082-62124-barastre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62083-62620-barlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62083-62620-barlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62083-62620-barlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62083-62620-barlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62084-62810-barly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62084-62810-barly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62084-62810-barly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62084-62810-barly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62085-62123-basseux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62085-62123-basseux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62085-62123-basseux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62085-62123-basseux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62086-62158-bavincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62086-62158-bavincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62086-62158-bavincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62086-62158-bavincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62087-62910-bayenghem_les_eperlecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62087-62910-bayenghem_les_eperlecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62087-62910-bayenghem_les_eperlecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62087-62910-bayenghem_les_eperlecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62088-62380-bayenghem_les_seninghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62088-62380-bayenghem_les_seninghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62088-62380-bayenghem_les_seninghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62088-62380-bayenghem_les_seninghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62089-62250-bazinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62089-62250-bazinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62089-62250-bazinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62089-62250-bazinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62090-62770-bealencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62090-62770-bealencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62090-62770-bealencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62090-62770-bealencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62091-62810-beaudricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62091-62810-beaudricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62091-62810-beaudricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62091-62810-beaudricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62092-62810-beaufort_blavincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62092-62810-beaufort_blavincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62092-62810-beaufort_blavincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62092-62810-beaufort_blavincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62093-62450-beaulencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62093-62450-beaulencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62093-62450-beaulencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62093-62450-beaulencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62094-62170-beaumerie_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62094-62170-beaumerie_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62094-62170-beaumerie_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62094-62170-beaumerie_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62095-62960-beaumetz_les_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62095-62960-beaumetz_les_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62095-62960-beaumetz_les_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62095-62960-beaumetz_les_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62096-62124-beaumetz_les_cambrai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62096-62124-beaumetz_les_cambrai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62096-62124-beaumetz_les_cambrai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62096-62124-beaumetz_les_cambrai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62097-62123-beaumetz_les_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62097-62123-beaumetz_les_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62097-62123-beaumetz_les_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62097-62123-beaumetz_les_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62099-62217-beaurains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62099-62217-beaurains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62099-62217-beaurains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62099-62217-beaurains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62100-62990-beaurainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62100-62990-beaurainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62100-62990-beaurainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62100-62990-beaurainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62101-62130-beauvois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62101-62130-beauvois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62101-62130-beauvois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62101-62130-beauvois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62102-62240-becourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62102-62240-becourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62102-62240-becourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62102-62240-becourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62103-62121-behagnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62103-62121-behagnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62103-62121-behagnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62103-62121-behagnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62104-62142-bellebrune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62104-62142-bellebrune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62104-62142-bellebrune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62104-62142-bellebrune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62105-62142-belle_et_houllefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62105-62142-belle_et_houllefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62105-62142-belle_et_houllefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62105-62142-belle_et_houllefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62106-62490-bellonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62106-62490-bellonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62106-62490-bellonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62106-62490-bellonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62107-62410-benifontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62107-62410-benifontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62107-62410-benifontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62107-62410-benifontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62108-62600-berck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62108-62600-berck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62108-62600-berck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62108-62600-berck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62109-62134-bergueneuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62109-62134-bergueneuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62109-62134-bergueneuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62109-62134-bergueneuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62111-62810-berlencourt_le_cauroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62111-62810-berlencourt_le_cauroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62111-62810-berlencourt_le_cauroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62111-62810-berlencourt_le_cauroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62112-62123-berles_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62112-62123-berles_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62112-62123-berles_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62112-62123-berles_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62113-62690-berles_monchel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62113-62690-berles_monchel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62113-62690-berles_monchel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62113-62690-berles_monchel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62114-62130-bermicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62114-62130-bermicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62114-62130-bermicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62114-62130-bermicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62115-62123-berneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62115-62123-berneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62115-62123-berneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62115-62123-berneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62116-62170-bernieulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62116-62170-bernieulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62116-62170-bernieulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62116-62170-bernieulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62117-62124-bertincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62117-62124-bertincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62117-62124-bertincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62117-62124-bertincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62118-62690-bethonsart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62118-62690-bethonsart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62118-62690-bethonsart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62118-62690-bethonsart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62119-62400-bethune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62119-62400-bethune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62119-62400-bethune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62119-62400-bethune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62120-62150-beugin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62120-62150-beugin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62120-62150-beugin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62120-62150-beugin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62121-62450-beugnatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62121-62450-beugnatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62121-62450-beugnatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62121-62450-beugnatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62122-62124-beugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62122-62124-beugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62122-62124-beugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62122-62124-beugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62123-62170-beussent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62123-62170-beussent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62123-62170-beussent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62123-62170-beussent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62124-62170-beutin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62124-62170-beutin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62124-62170-beutin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62124-62170-beutin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62125-62250-beuvrequen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62125-62250-beuvrequen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62125-62250-beuvrequen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62125-62250-beuvrequen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62126-62660-beuvry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62126-62660-beuvry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62126-62660-beuvry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62126-62660-beuvry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62127-62650-bezinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62127-62650-bezinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62127-62650-bezinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62127-62650-bezinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62128-62118-biache_saint_vaast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62128-62118-biache_saint_vaast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62128-62118-biache_saint_vaast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62128-62118-biache_saint_vaast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62129-62450-biefvillers_les_bapaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62129-62450-biefvillers_les_bapaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62129-62450-biefvillers_les_bapaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62129-62450-biefvillers_les_bapaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62130-62111-bienvillers_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62130-62111-bienvillers_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62130-62111-bienvillers_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62130-62111-bienvillers_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62131-62121-bihucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62131-62121-bihucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62131-62121-bihucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62131-62121-bihucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62132-62138-billy_berclau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62132-62138-billy_berclau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62132-62138-billy_berclau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62132-62138-billy_berclau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62133-62420-billy_montigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62133-62420-billy_montigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62133-62420-billy_montigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62133-62420-billy_montigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62134-62650-bimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62134-62650-bimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62134-62650-bimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62134-62650-bimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62135-62173-blairville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62135-62173-blairville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62135-62173-blairville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62135-62173-blairville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62137-62270-blangerval_blangermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62137-62270-blangerval_blangermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62137-62270-blangerval_blangermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62137-62270-blangerval_blangermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62138-62770-blangy_sur_ternoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62138-62770-blangy_sur_ternoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62138-62770-blangy_sur_ternoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62138-62770-blangy_sur_ternoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62139-62575-blendecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62139-62575-blendecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62139-62575-blendecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62139-62575-blendecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62140-62380-blequin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62140-62380-blequin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62140-62380-blequin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62140-62380-blequin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62141-62120-blessy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62141-62120-blessy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62141-62120-blessy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62141-62120-blessy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62142-62770-blingel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62142-62770-blingel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62142-62770-blingel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62142-62770-blingel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62143-62390-boffles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62143-62390-boffles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62143-62390-boffles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62143-62390-boffles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62144-62128-boiry_becquerelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62144-62128-boiry_becquerelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62144-62128-boiry_becquerelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62144-62128-boiry_becquerelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62145-62156-boiry_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62145-62156-boiry_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62145-62156-boiry_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62145-62156-boiry_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62146-62175-boiry_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62146-62175-boiry_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62146-62175-boiry_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62146-62175-boiry_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62147-62175-boiry_sainte_rictrude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62147-62175-boiry_sainte_rictrude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62147-62175-boiry_sainte_rictrude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62147-62175-boiry_sainte_rictrude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62148-62320-bois_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62148-62320-bois_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62148-62320-bois_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62148-62320-bois_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62149-62500-boisdinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62149-62500-boisdinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62149-62500-boisdinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62149-62500-boisdinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62150-62170-boisjean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62150-62170-boisjean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62150-62170-boisjean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62150-62170-boisjean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62151-62175-boisleux_au_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62151-62175-boisleux_au_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62151-62175-boisleux_au_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62151-62175-boisleux_au_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62152-62175-boisleux_saint_marc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62152-62175-boisleux_saint_marc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62152-62175-boisleux_saint_marc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62152-62175-boisleux_saint_marc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62153-62960-bomy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62153-62960-bomy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62153-62960-bomy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62153-62960-bomy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62154-62270-bonnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62154-62270-bonnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62154-62270-bonnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62154-62270-bonnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62155-62890-bonningues_les_ardres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62155-62890-bonningues_les_ardres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62155-62890-bonningues_les_ardres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62155-62890-bonningues_les_ardres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62156-62340-bonningues_les_calais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62156-62340-bonningues_les_calais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62156-62340-bonningues_les_calais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62156-62340-bonningues_les_calais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62157-62990-boubers_les_hesmond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62157-62990-boubers_les_hesmond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62157-62990-boubers_les_hesmond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62157-62990-boubers_les_hesmond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62158-62270-boubers_sur_canche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62158-62270-boubers_sur_canche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62158-62270-boubers_sur_canche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62158-62270-boubers_sur_canche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62160-62200-boulogne_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62160-62200-boulogne_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62160-62200-boulogne_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62160-62200-boulogne_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62161-62340-bouquehault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62161-62340-bouquehault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62161-62340-bouquehault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62161-62340-bouquehault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62162-62190-bourecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62162-62190-bourecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62162-62190-bourecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62162-62190-bourecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62163-62270-bouret_sur_canche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62163-62270-bouret_sur_canche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62163-62270-bouret_sur_canche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62163-62270-bouret_sur_canche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62164-62860-bourlon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62164-62860-bourlon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62164-62860-bourlon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62164-62860-bourlon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62165-62240-bournonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62165-62240-bournonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62165-62240-bournonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62165-62240-bournonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62166-62550-bours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62166-62550-bours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62166-62550-bours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62166-62550-bours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62167-62132-boursin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62167-62132-boursin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62167-62132-boursin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62167-62132-boursin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62168-62650-bourthes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62168-62650-bourthes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62168-62650-bourthes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62168-62650-bourthes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62169-62380-bouvelinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62169-62380-bouvelinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62169-62380-bouvelinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62169-62380-bouvelinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62170-62172-bouvigny_boyeffles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62170-62172-bouvigny_boyeffles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62170-62172-bouvigny_boyeffles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62170-62172-bouvigny_boyeffles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62171-62134-boyaval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62171-62134-boyaval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62171-62134-boyaval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62171-62134-boyaval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62172-62128-boyelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62172-62128-boyelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62172-62128-boyelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62172-62128-boyelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62173-62117-brebieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62173-62117-brebieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62173-62117-brebieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62173-62117-brebieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62174-62610-bremes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62174-62610-bremes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62174-62610-bremes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62174-62610-bremes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62175-62140-brevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62175-62140-brevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62175-62140-brevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62175-62140-brevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62176-62170-brexent_enocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62176-62170-brexent_enocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62176-62170-brexent_enocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62176-62170-brexent_enocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62177-62170-brimeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62177-62170-brimeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62177-62170-brimeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62177-62170-brimeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62178-62700-bruay_la_buissiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62178-62700-bruay_la_buissiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62178-62700-bruay_la_buissiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62178-62700-bruay_la_buissiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62179-62240-brunembert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62179-62240-brunembert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62179-62240-brunembert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62179-62240-brunembert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62180-62130-brias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62180-62130-brias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62180-62130-brias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62180-62130-brias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62181-62116-bucquoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62181-62116-bucquoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62181-62116-bucquoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62181-62116-bucquoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62182-62390-buire_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62182-62390-buire_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62182-62390-buire_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62182-62390-buire_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62183-62870-buire_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62183-62870-buire_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62183-62870-buire_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62183-62870-buire_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62184-62860-buissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62184-62860-buissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62184-62860-buissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62184-62860-buissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62185-62128-bullecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62185-62128-bullecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62185-62128-bullecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62185-62128-bullecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62186-62160-bully_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62186-62160-bully_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62186-62160-bully_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62186-62160-bully_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62187-62130-buneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62187-62130-buneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62187-62130-buneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62187-62130-buneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62188-62151-burbure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62188-62151-burbure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62188-62151-burbure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62188-62151-burbure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62189-62124-bus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62189-62124-bus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62189-62124-bus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62189-62124-bus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62190-62350-busnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62190-62350-busnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62190-62350-busnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62190-62350-busnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62191-62132-caffiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62191-62132-caffiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62191-62132-caffiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62191-62132-caffiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62192-62182-cagnicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62192-62182-cagnicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62192-62182-cagnicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62192-62182-cagnicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62193-62100-calais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62193-62100-calais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62193-62100-calais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62193-62100-calais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62194-62470-calonne_ricouart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62194-62470-calonne_ricouart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62194-62470-calonne_ricouart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62194-62470-calonne_ricouart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62195-62350-calonne_sur_la_lys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62195-62350-calonne_sur_la_lys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62195-62350-calonne_sur_la_lys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62195-62350-calonne_sur_la_lys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62196-62170-la_calotterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62196-62170-la_calotterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62196-62170-la_calotterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62196-62170-la_calotterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62197-62470-camblain_chatelain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62197-62470-camblain_chatelain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62197-62470-camblain_chatelain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62197-62470-camblain_chatelain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62198-62690-cambligneul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62198-62690-cambligneul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62198-62690-cambligneul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62198-62690-cambligneul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62199-62690-camblain_l_abbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62199-62690-camblain_l_abbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62199-62690-camblain_l_abbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62199-62690-camblain_l_abbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62200-62149-cambrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62200-62149-cambrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62200-62149-cambrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62200-62149-cambrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62201-62176-camiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62201-62176-camiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62201-62176-camiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62201-62176-camiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62202-62650-campagne_les_boulonnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62202-62650-campagne_les_boulonnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62202-62650-campagne_les_boulonnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62202-62650-campagne_les_boulonnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62203-62340-campagne_les_guines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62203-62340-campagne_les_guines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62203-62340-campagne_les_guines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62203-62340-campagne_les_guines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62204-62870-campagne_les_hesdin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62204-62870-campagne_les_hesdin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62204-62870-campagne_les_hesdin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62204-62870-campagne_les_hesdin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62205-62120-campagne_les_wardrecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62205-62120-campagne_les_wardrecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62205-62120-campagne_les_wardrecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62205-62120-campagne_les_wardrecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62206-62170-campigneulles_les_grandes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62206-62170-campigneulles_les_grandes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62206-62170-campigneulles_les_grandes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62206-62170-campigneulles_les_grandes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62207-62170-campigneulles_les_petites/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62207-62170-campigneulles_les_petites/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62207-62170-campigneulles_les_petites/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62207-62170-campigneulles_les_petites/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62208-62270-canettemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62208-62270-canettemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62208-62270-canettemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62208-62270-canettemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62209-62310-canlers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62209-62310-canlers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62209-62310-canlers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62209-62310-canlers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62211-62690-capelle_fermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62211-62690-capelle_fermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62211-62690-capelle_fermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62211-62690-capelle_fermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62212-62140-capelle_les_hesdin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62212-62140-capelle_les_hesdin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62212-62140-capelle_les_hesdin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62212-62140-capelle_les_hesdin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62213-62144-carency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62213-62144-carency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62213-62144-carency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62213-62144-carency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62214-62830-carly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62214-62830-carly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62214-62830-carly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62214-62830-carly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62215-62220-carvin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62215-62220-carvin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62215-62220-carvin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62215-62220-carvin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62216-62158-la_cauchie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62216-62158-la_cauchie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62216-62158-la_cauchie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62216-62158-la_cauchie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62217-62260-cauchy_a_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62217-62260-cauchy_a_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62217-62260-cauchy_a_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62217-62260-cauchy_a_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62218-62150-caucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62218-62150-caucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62218-62150-caucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62218-62150-caucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62219-62140-caumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62219-62140-caumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62219-62140-caumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62219-62140-caumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62220-62140-cavron_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62220-62140-cavron_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62220-62140-cavron_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62220-62140-cavron_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62221-62127-chelers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62221-62127-chelers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62221-62127-chelers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62221-62127-chelers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62222-62140-cheriennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62222-62140-cheriennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62222-62140-cheriennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62222-62140-cheriennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62223-62128-cherisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62223-62128-cherisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62223-62128-cherisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62223-62128-cherisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62224-62920-chocques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62224-62920-chocques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62224-62920-chocques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62224-62920-chocques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62225-62500-clairmarais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62225-62500-clairmarais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62225-62500-clairmarais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62225-62500-clairmarais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62227-62650-clenleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62227-62650-clenleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62227-62650-clenleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62227-62650-clenleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62228-62890-clerques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62228-62890-clerques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62228-62890-clerques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62228-62890-clerques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62229-62380-clety/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62229-62380-clety/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62229-62380-clety/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62229-62380-clety/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62230-62142-colembert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62230-62142-colembert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62230-62142-colembert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62230-62142-colembert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62231-62180-colline_beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62231-62180-colline_beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62231-62180-colline_beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62231-62180-colline_beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62232-62150-la_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62232-62150-la_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62232-62150-la_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62232-62150-la_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62233-62180-conchil_le_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62233-62180-conchil_le_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62233-62180-conchil_le_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62233-62180-conchil_le_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62234-62270-conchy_sur_canche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62234-62270-conchy_sur_canche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62234-62270-conchy_sur_canche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62234-62270-conchy_sur_canche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62235-62360-condette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62235-62360-condette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62235-62360-condette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62235-62360-condette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62236-62990-contes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62236-62990-contes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62236-62990-contes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62236-62990-contes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62237-62126-conteville_les_boulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62237-62126-conteville_les_boulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62237-62126-conteville_les_boulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62237-62126-conteville_les_boulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62238-62130-conteville_en_ternois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62238-62130-conteville_en_ternois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62238-62130-conteville_en_ternois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62238-62130-conteville_en_ternois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62239-62231-coquelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62239-62231-coquelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62239-62231-coquelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62239-62231-coquelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62240-62112-corbehem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62240-62112-corbehem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62240-62112-corbehem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62240-62112-corbehem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62241-62630-cormont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62241-62630-cormont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62241-62630-cormont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62241-62630-cormont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62242-62760-couin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62242-62760-couin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62242-62760-couin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62242-62760-couin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62243-62158-coullemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62243-62158-coullemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62243-62158-coullemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62243-62158-coullemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62244-62137-coulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62244-62137-coulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62244-62137-coulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62244-62137-coulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62245-62380-coulomby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62245-62380-coulomby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62245-62380-coulomby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62245-62380-coulomby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62246-62310-coupelle_neuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62246-62310-coupelle_neuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62246-62310-coupelle_neuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62246-62310-coupelle_neuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62247-62310-coupelle_vieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62247-62310-coupelle_vieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62247-62310-coupelle_vieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62247-62310-coupelle_vieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62248-62121-courcelles_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62248-62121-courcelles_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62248-62121-courcelles_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62248-62121-courcelles_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62249-62970-courcelles_les_lens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62249-62970-courcelles_les_lens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62249-62970-courcelles_les_lens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62249-62970-courcelles_les_lens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62250-62710-courrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62250-62710-courrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62250-62710-courrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62250-62710-courrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62251-62240-courset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62251-62240-courset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62251-62240-courset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62251-62240-courset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62252-62136-la_couture/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62252-62136-la_couture/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62252-62136-la_couture/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62252-62136-la_couture/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62253-62158-couturelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62253-62158-couturelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62253-62158-couturelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62253-62158-couturelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62254-62560-coyecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62254-62560-coyecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62254-62560-coyecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62254-62560-coyecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62255-62240-cremarest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62255-62240-cremarest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62255-62240-cremarest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62255-62240-cremarest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62256-62310-crepy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62256-62310-crepy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62256-62310-crepy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62256-62310-crepy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62257-62310-crequy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62257-62310-crequy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62257-62310-crequy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62257-62310-crequy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62258-62130-croisette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62258-62130-croisette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62258-62130-croisette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62258-62130-croisette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62259-62128-croisilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62259-62128-croisilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62259-62128-croisilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62259-62128-croisilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62260-62130-croix_en_ternois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62260-62130-croix_en_ternois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62260-62130-croix_en_ternois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62260-62130-croix_en_ternois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62261-62780-cucq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62261-62780-cucq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62261-62780-cucq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62261-62780-cucq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62262-62149-cuinchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62262-62149-cuinchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62262-62149-cuinchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62262-62149-cuinchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62263-62000-dainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62263-62000-dainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62263-62000-dainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62263-62000-dainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62264-62187-dannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62264-62187-dannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62264-62187-dannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62264-62187-dannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62265-62129-delettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62265-62129-delettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62265-62129-delettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62265-62129-delettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62266-62810-denier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62266-62810-denier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62266-62810-denier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62266-62810-denier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62267-62560-dennebroeucq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62267-62560-dennebroeucq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62267-62560-dennebroeucq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62267-62560-dennebroeucq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62268-62240-desvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62268-62240-desvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62268-62240-desvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62268-62240-desvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62269-62460-dieval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62269-62460-dieval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62269-62460-dieval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62269-62460-dieval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62270-62460-divion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62270-62460-divion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62270-62460-divion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62270-62460-divion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62271-62380-dohem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62271-62380-dohem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62271-62380-dohem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62271-62380-dohem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62272-62116-douchy_les_ayette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62272-62116-douchy_les_ayette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62272-62116-douchy_les_ayette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62272-62116-douchy_les_ayette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62273-62830-doudeauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62273-62830-doudeauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62273-62830-doudeauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62273-62830-doudeauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62274-62119-dourges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62274-62119-dourges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62274-62119-dourges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62274-62119-dourges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62275-62870-douriez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62275-62870-douriez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62275-62870-douriez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62275-62870-douriez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62276-62138-douvrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62276-62138-douvrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62276-62138-douvrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62276-62138-douvrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62277-62320-drocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62277-62320-drocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62277-62320-drocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62277-62320-drocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62278-62131-drouvin_le_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62278-62131-drouvin_le_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62278-62131-drouvin_le_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62278-62131-drouvin_le_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62279-62161-duisans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62279-62161-duisans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62279-62161-duisans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62279-62161-duisans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62280-62156-dury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62280-62156-dury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62280-62156-dury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62280-62156-dury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62281-62360-echinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62281-62360-echinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62281-62360-echinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62281-62360-echinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62282-62770-eclimeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62282-62770-eclimeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62282-62770-eclimeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62282-62770-eclimeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62283-62270-ecoivres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62283-62270-ecoivres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62283-62270-ecoivres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62283-62270-ecoivres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62284-62860-ecourt_saint_quentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62284-62860-ecourt_saint_quentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62284-62860-ecourt_saint_quentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62284-62860-ecourt_saint_quentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62285-62128-ecoust_saint_mein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62285-62128-ecoust_saint_mein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62285-62128-ecoust_saint_mein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62285-62128-ecoust_saint_mein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62286-62190-ecquedecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62286-62190-ecquedecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62286-62190-ecquedecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62286-62190-ecquedecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62288-62129-ecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62288-62129-ecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62288-62129-ecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62288-62129-ecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62289-62170-ecuires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62289-62170-ecuires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62289-62170-ecuires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62289-62170-ecuires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62290-62223-ecurie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62290-62223-ecurie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62290-62223-ecurie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62290-62223-ecurie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62291-62300-eleu_dit_leauwette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62291-62300-eleu_dit_leauwette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62291-62300-eleu_dit_leauwette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62291-62300-eleu_dit_leauwette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62292-62380-elnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62292-62380-elnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62292-62380-elnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62292-62380-elnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62293-62990-embry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62293-62990-embry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62293-62990-embry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62293-62990-embry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62295-62145-enquin_lez_guinegatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62295-62145-enquin_lez_guinegatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62295-62145-enquin_lez_guinegatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62295-62145-enquin_lez_guinegatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62296-62650-enquin_sur_baillons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62296-62650-enquin_sur_baillons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62296-62650-enquin_sur_baillons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62296-62650-enquin_sur_baillons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62297-62910-eperlecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62297-62910-eperlecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62297-62910-eperlecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62297-62910-eperlecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62298-62860-epinoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62298-62860-epinoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62298-62860-epinoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62298-62860-epinoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62299-62134-eps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62299-62134-eps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62299-62134-eps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62299-62134-eps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62300-62224-equihen_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62300-62224-equihen_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62300-62224-equihen_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62300-62224-equihen_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62301-62134-equirre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62301-62134-equirre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62301-62134-equirre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62301-62134-equirre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62302-62650-ergny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62302-62650-ergny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62302-62650-ergny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62302-62650-ergny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62303-62134-erin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62303-62134-erin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62303-62134-erin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62303-62134-erin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62304-62960-erny_saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62304-62960-erny_saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62304-62960-erny_saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62304-62960-erny_saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62306-62121-ervillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62306-62121-ervillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62306-62121-ervillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62306-62121-ervillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62307-62179-escalles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62307-62179-escalles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62307-62179-escalles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62307-62179-escalles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62308-62850-escoeuilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62308-62850-escoeuilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62308-62850-escoeuilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62308-62850-escoeuilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62309-62380-esquerdes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62309-62380-esquerdes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62309-62380-esquerdes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62309-62380-esquerdes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62310-62400-essars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62310-62400-essars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62310-62400-essars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62310-62400-essars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62311-62880-estevelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62311-62880-estevelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62311-62880-estevelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62311-62880-estevelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62312-62170-estree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62312-62170-estree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62312-62170-estree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62312-62170-estree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62313-62145-estree_blanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62313-62145-estree_blanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62313-62145-estree_blanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62313-62145-estree_blanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62314-62690-estree_cauchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62314-62690-estree_cauchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62314-62690-estree_cauchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62314-62690-estree_cauchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62315-62170-estreelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62315-62170-estreelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62315-62170-estreelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62315-62170-estreelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62316-62810-estree_wamin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62316-62810-estree_wamin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62316-62810-estree_wamin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62316-62810-estree_wamin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62317-62156-etaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62317-62156-etaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62317-62156-etaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62317-62156-etaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62318-62630-etaples/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62318-62630-etaples/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62318-62630-etaples/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62318-62630-etaples/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62319-62156-eterpigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62319-62156-eterpigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62319-62156-eterpigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62319-62156-eterpigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62320-62161-etrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62320-62161-etrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62320-62161-etrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62320-62161-etrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62321-62141-evin_malmaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62321-62141-evin_malmaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62321-62141-evin_malmaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62321-62141-evin_malmaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62322-62760-famechon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62322-62760-famechon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62322-62760-famechon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62322-62760-famechon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62323-62118-fampoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62323-62118-fampoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62323-62118-fampoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62323-62118-fampoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62324-62580-farbus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62324-62580-farbus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62324-62580-farbus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62324-62580-farbus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62325-62560-fauquembergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62325-62560-fauquembergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62325-62560-fauquembergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62325-62560-fauquembergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62326-62450-favreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62326-62450-favreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62326-62450-favreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62326-62450-favreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62327-62960-febvin_palfart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62327-62960-febvin_palfart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62327-62960-febvin_palfart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62327-62960-febvin_palfart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62328-62260-ferfay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62328-62260-ferfay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62328-62260-ferfay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62328-62260-ferfay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62329-62250-ferques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62329-62250-ferques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62329-62250-ferques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62329-62250-ferques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62330-62149-festubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62330-62149-festubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62330-62149-festubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62330-62149-festubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62331-62223-feuchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62331-62223-feuchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62331-62223-feuchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62331-62223-feuchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62332-62173-ficheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62332-62173-ficheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62332-62173-ficheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62332-62173-ficheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62333-62134-fiefs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62333-62134-fiefs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62333-62134-fiefs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62333-62134-fiefs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62334-62132-fiennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62334-62132-fiennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62334-62132-fiennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62334-62132-fiennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62335-62770-fillievres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62335-62770-fillievres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62335-62770-fillievres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62335-62770-fillievres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62336-62960-flechin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62336-62960-flechin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62336-62960-flechin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62336-62960-flechin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62337-62270-flers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62337-62270-flers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62337-62270-flers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62337-62270-flers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62338-62840-fleurbaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62338-62840-fleurbaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62338-62840-fleurbaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62338-62840-fleurbaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62339-62134-fleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62339-62134-fleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62339-62134-fleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62339-62134-fleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62340-62550-floringhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62340-62550-floringhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62340-62550-floringhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62340-62550-floringhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62341-62111-foncquevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62341-62111-foncquevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62341-62111-foncquevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62341-62111-foncquevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62342-62134-fontaine_les_boulans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62342-62134-fontaine_les_boulans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62342-62134-fontaine_les_boulans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62342-62134-fontaine_les_boulans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62343-62128-fontaine_les_croisilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62343-62128-fontaine_les_croisilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62343-62128-fontaine_les_croisilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62343-62128-fontaine_les_croisilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62344-62550-fontaine_les_hermans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62344-62550-fontaine_les_hermans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62344-62550-fontaine_les_hermans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62344-62550-fontaine_les_hermans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62345-62390-fontaine_l_etalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62345-62390-fontaine_l_etalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62345-62390-fontaine_l_etalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62345-62390-fontaine_l_etalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62346-62270-fortel_en_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62346-62270-fortel_en_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62346-62270-fortel_en_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62346-62270-fortel_en_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62347-62810-fosseux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62347-62810-fosseux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62347-62810-fosseux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62347-62810-fosseux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62348-62130-foufflin_ricametz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62348-62130-foufflin_ricametz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62348-62130-foufflin_ricametz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62348-62130-foufflin_ricametz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62349-62232-fouquereuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62349-62232-fouquereuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62349-62232-fouquereuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62349-62232-fouquereuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62350-62232-fouquieres_les_bethune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62350-62232-fouquieres_les_bethune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62350-62232-fouquieres_les_bethune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62350-62232-fouquieres_les_bethune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62351-62740-fouquieres_les_lens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62351-62740-fouquieres_les_lens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62351-62740-fouquieres_les_lens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62351-62740-fouquieres_les_lens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62352-62130-framecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62352-62130-framecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62352-62130-framecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62352-62130-framecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62353-62450-fremicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62353-62450-fremicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62353-62450-fremicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62353-62450-fremicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62354-62630-frencq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62354-62630-frencq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62354-62630-frencq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62354-62630-frencq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62355-62490-fresnes_les_montauban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62355-62490-fresnes_les_montauban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62355-62490-fresnes_les_montauban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62355-62490-fresnes_les_montauban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62356-62150-fresnicourt_le_dolmen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62356-62150-fresnicourt_le_dolmen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62356-62150-fresnicourt_le_dolmen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62356-62150-fresnicourt_le_dolmen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62357-62770-fresnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62357-62770-fresnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62357-62770-fresnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62357-62770-fresnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62358-62580-fresnoy_en_gohelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62358-62580-fresnoy_en_gohelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62358-62580-fresnoy_en_gohelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62358-62580-fresnoy_en_gohelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62359-62140-fressin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62359-62140-fressin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62359-62140-fressin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62359-62140-fressin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62360-62185-frethun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62360-62185-frethun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62360-62185-frethun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62360-62185-frethun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62361-62270-frevent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62361-62270-frevent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62361-62270-frevent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62361-62270-frevent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62362-62127-frevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62362-62127-frevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62362-62127-frevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62362-62127-frevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62363-62690-frevin_capelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62363-62690-frevin_capelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62363-62690-frevin_capelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62363-62690-frevin_capelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62364-62310-fruges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62364-62310-fruges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62364-62310-fruges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62364-62310-fruges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62365-62770-galametz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62365-62770-galametz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62365-62770-galametz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62365-62770-galametz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62366-62150-gauchin_legal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62366-62150-gauchin_legal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62366-62150-gauchin_legal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62366-62150-gauchin_legal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62367-62130-gauchin_verloingt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62367-62130-gauchin_verloingt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62367-62130-gauchin_verloingt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62367-62130-gauchin_verloingt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62368-62760-gaudiempre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62368-62760-gaudiempre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62368-62760-gaudiempre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62368-62760-gaudiempre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62369-62580-gavrelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62369-62580-gavrelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62369-62580-gavrelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62369-62580-gavrelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62370-62390-gennes_ivergny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62370-62390-gennes_ivergny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62370-62390-gennes_ivergny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62370-62390-gennes_ivergny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62371-62580-givenchy_en_gohelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62371-62580-givenchy_en_gohelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62371-62580-givenchy_en_gohelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62371-62580-givenchy_en_gohelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62372-62810-givenchy_le_noble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62372-62810-givenchy_le_noble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62372-62810-givenchy_le_noble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62372-62810-givenchy_le_noble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62373-62149-givenchy_les_la_bassee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62373-62149-givenchy_les_la_bassee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62373-62149-givenchy_les_la_bassee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62373-62149-givenchy_les_la_bassee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62374-62121-gomiecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62374-62121-gomiecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62374-62121-gomiecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62374-62121-gomiecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62375-62111-gommecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62375-62111-gommecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62375-62111-gommecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62375-62111-gommecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62376-62920-gonnehem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62376-62920-gonnehem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62376-62920-gonnehem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62376-62920-gonnehem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62377-62199-gosnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62377-62199-gosnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62377-62199-gosnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62377-62199-gosnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62378-62123-gouves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62378-62123-gouves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62378-62123-gouves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62378-62123-gouves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62379-62123-gouy_en_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62379-62123-gouy_en_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62379-62123-gouy_en_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62379-62123-gouy_en_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62380-62530-gouy_servins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62380-62530-gouy_servins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62380-62530-gouy_servins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62380-62530-gouy_servins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62381-62127-gouy_en_ternois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62381-62127-gouy_en_ternois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62381-62127-gouy_en_ternois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62381-62127-gouy_en_ternois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62382-62870-gouy_saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62382-62870-gouy_saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62382-62870-gouy_saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62382-62870-gouy_saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62383-62112-gouy_sous_bellonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62383-62112-gouy_sous_bellonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62383-62112-gouy_sous_bellonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62383-62112-gouy_sous_bellonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62384-62147-graincourt_les_havrincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62384-62147-graincourt_les_havrincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62384-62147-graincourt_les_havrincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62384-62147-graincourt_les_havrincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62385-62810-grand_rullecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62385-62810-grand_rullecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62385-62810-grand_rullecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62385-62810-grand_rullecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62386-62160-grenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62386-62160-grenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62386-62160-grenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62386-62160-grenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62387-62450-grevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62387-62450-grevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62387-62450-grevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62387-62450-grevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62388-62140-grigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62388-62140-grigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62388-62140-grigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62388-62140-grigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62389-62760-grincourt_les_pas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62389-62760-grincourt_les_pas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62389-62760-grincourt_les_pas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62389-62760-grincourt_les_pas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62390-62600-groffliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62390-62600-groffliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62390-62600-groffliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62390-62600-groffliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62391-62330-guarbecque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62391-62330-guarbecque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62391-62330-guarbecque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62391-62330-guarbecque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62392-62128-guemappe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62392-62128-guemappe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62392-62128-guemappe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62392-62128-guemappe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62393-62370-guemps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62393-62370-guemps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62393-62370-guemps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62393-62370-guemps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62395-62140-guigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62395-62140-guigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62395-62140-guigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62395-62140-guigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62396-62130-guinecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62396-62130-guinecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62396-62130-guinecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62396-62130-guinecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62397-62340-guines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62397-62340-guines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62397-62340-guines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62397-62340-guines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62398-62140-guisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62398-62140-guisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62398-62140-guisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62398-62140-guisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62399-62123-habarcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62399-62123-habarcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62399-62123-habarcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62399-62123-habarcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62400-62940-haillicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62400-62940-haillicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62400-62940-haillicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62400-62940-haillicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62401-62138-haisnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62401-62138-haisnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62401-62138-haisnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62401-62138-haisnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62402-62830-halinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62402-62830-halinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62402-62830-halinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62402-62830-halinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62403-62570-hallines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62403-62570-hallines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62403-62570-hallines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62403-62570-hallines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62404-62760-halloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62404-62760-halloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62404-62760-halloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62404-62760-halloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62405-62118-hamblain_les_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62405-62118-hamblain_les_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62405-62118-hamblain_les_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62405-62118-hamblain_les_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62406-62121-hamelincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62406-62121-hamelincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62406-62121-hamelincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62406-62121-hamelincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62407-62190-ham_en_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62407-62190-ham_en_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62407-62190-ham_en_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62407-62190-ham_en_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62408-62340-hames_boucres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62408-62340-hames_boucres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62408-62340-hames_boucres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62408-62340-hames_boucres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62409-62111-hannescamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62409-62111-hannescamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62409-62111-hannescamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62409-62111-hannescamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62410-62124-haplincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62410-62124-haplincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62410-62124-haplincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62410-62124-haplincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62411-62390-haravesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62411-62390-haravesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62411-62390-haravesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62411-62390-haravesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62412-62132-hardinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62412-62132-hardinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62412-62132-hardinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62412-62132-hardinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62413-62440-harnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62413-62440-harnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62413-62440-harnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62413-62440-harnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62414-62156-haucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62414-62156-haucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62414-62156-haucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62414-62156-haucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62415-62144-haute_avesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62415-62144-haute_avesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62415-62144-haute_avesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62415-62144-haute_avesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62416-62130-hautecloque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62416-62130-hautecloque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62416-62130-hautecloque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62416-62130-hautecloque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62418-62810-hauteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62418-62810-hauteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62418-62810-hauteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62418-62810-hauteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62419-62850-haut_loquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62419-62850-haut_loquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62419-62850-haut_loquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62419-62850-haut_loquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62421-62147-havrincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62421-62147-havrincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62421-62147-havrincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62421-62147-havrincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62422-62111-hebuterne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62422-62111-hebuterne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62422-62111-hebuterne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62422-62111-hebuterne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62423-62570-helfaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62423-62570-helfaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62423-62570-helfaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62423-62570-helfaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62424-62182-hendecourt_les_cagnicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62424-62182-hendecourt_les_cagnicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62424-62182-hendecourt_les_cagnicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62424-62182-hendecourt_les_cagnicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62425-62175-hendecourt_les_ransart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62425-62175-hendecourt_les_ransart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62425-62175-hendecourt_les_ransart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62425-62175-hendecourt_les_ransart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62426-62128-heninel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62426-62128-heninel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62426-62128-heninel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62426-62128-heninel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62427-62110-henin_beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62427-62110-henin_beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62427-62110-henin_beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62427-62110-henin_beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62428-62128-henin_sur_cojeul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62428-62128-henin_sur_cojeul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62428-62128-henin_sur_cojeul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62428-62128-henin_sur_cojeul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62429-62142-henneveux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62429-62142-henneveux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62429-62142-henneveux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62429-62142-henneveux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62430-62760-henu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62430-62760-henu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62430-62760-henu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62430-62760-henu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62432-62850-herbinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62432-62850-herbinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62432-62850-herbinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62432-62850-herbinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62433-62130-hericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62433-62130-hericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62433-62130-hericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62433-62130-hericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62434-62158-la_herliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62434-62158-la_herliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62434-62158-la_herliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62434-62158-la_herliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62435-62130-herlincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62435-62130-herlincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62435-62130-herlincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62435-62130-herlincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62436-62130-herlin_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62436-62130-herlin_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62436-62130-herlin_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62436-62130-herlin_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62437-62650-herly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62437-62650-herly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62437-62650-herly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62437-62650-herly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62438-62690-hermaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62438-62690-hermaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62438-62690-hermaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62438-62690-hermaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62439-62132-hermelinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62439-62132-hermelinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62439-62132-hermelinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62439-62132-hermelinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62440-62147-hermies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62440-62147-hermies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62440-62147-hermies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62440-62147-hermies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62441-62150-hermin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62441-62150-hermin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62441-62150-hermin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62441-62150-hermin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62442-62130-hernicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62442-62130-hernicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62442-62130-hernicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62442-62130-hernicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62443-62530-hersin_coupigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62443-62530-hersin_coupigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62443-62530-hersin_coupigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62443-62530-hersin_coupigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62444-62179-hervelinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62444-62179-hervelinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62444-62179-hervelinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62444-62179-hervelinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62445-62196-hesdigneul_les_bethune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62445-62196-hesdigneul_les_bethune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62445-62196-hesdigneul_les_bethune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62445-62196-hesdigneul_les_bethune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62446-62360-hesdigneul_les_boulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62446-62360-hesdigneul_les_boulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62446-62360-hesdigneul_les_boulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62446-62360-hesdigneul_les_boulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62447-62140-hesdin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62447-62140-hesdin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62447-62140-hesdin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62447-62140-hesdin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62448-62360-hesdin_l_abbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62448-62360-hesdin_l_abbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62448-62360-hesdin_l_abbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62448-62360-hesdin_l_abbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62449-62990-hesmond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62449-62990-hesmond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62449-62990-hesmond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62449-62990-hesmond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62450-62550-hestrus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62450-62550-hestrus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62450-62550-hestrus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62450-62550-hestrus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62451-62134-heuchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62451-62134-heuchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62451-62134-heuchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62451-62134-heuchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62452-62575-heuringhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62452-62575-heuringhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62452-62575-heuringhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62452-62575-heuringhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62453-62310-hezecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62453-62310-hezecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62453-62310-hezecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62453-62310-hezecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62454-62232-hinges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62454-62232-hinges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62454-62232-hinges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62454-62232-hinges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62455-62850-hocquinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62455-62850-hocquinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62455-62850-hocquinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62455-62850-hocquinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62456-62620-houchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62456-62620-houchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62456-62620-houchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62456-62620-houchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62457-62150-houdain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62457-62150-houdain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62457-62150-houdain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62457-62150-houdain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62458-62910-houlle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62458-62910-houlle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62458-62910-houlle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62458-62910-houlle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62459-62270-houvin_houvigneul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62459-62270-houvin_houvigneul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62459-62270-houvin_houvigneul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62459-62270-houvin_houvigneul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62460-62630-hubersent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62460-62630-hubersent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62460-62630-hubersent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62460-62630-hubersent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62461-62140-huby_saint_leu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62461-62140-huby_saint_leu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62461-62140-huby_saint_leu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62461-62140-huby_saint_leu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62462-62130-huclier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62462-62130-huclier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62462-62130-huclier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62462-62130-huclier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62463-62650-hucqueliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62463-62650-hucqueliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62463-62650-hucqueliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62463-62650-hucqueliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62464-62410-hulluch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62464-62410-hulluch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62464-62410-hulluch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62464-62410-hulluch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62465-62158-humbercamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62465-62158-humbercamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62465-62158-humbercamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62465-62158-humbercamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62466-62650-humbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62466-62650-humbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62466-62650-humbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62466-62650-humbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62467-62130-humeroeuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62467-62130-humeroeuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62467-62130-humeroeuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62467-62130-humeroeuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62468-62130-humieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62468-62130-humieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62468-62130-humieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62468-62130-humieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62469-62860-inchy_en_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62469-62860-inchy_en_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62469-62860-inchy_en_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62469-62860-inchy_en_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62470-62770-incourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62470-62770-incourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62470-62770-incourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62470-62770-incourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62471-62129-bellinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62471-62129-bellinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62471-62129-bellinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62471-62129-bellinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62472-62170-inxent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62472-62170-inxent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62472-62170-inxent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62472-62170-inxent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62473-62330-isbergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62473-62330-isbergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62473-62330-isbergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62473-62330-isbergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62474-62360-isques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62474-62360-isques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62474-62360-isques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62474-62360-isques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62475-62810-ivergny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62475-62810-ivergny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62475-62810-ivergny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62475-62810-ivergny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62476-62490-izel_les_equerchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62476-62490-izel_les_equerchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62476-62490-izel_les_equerchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62476-62490-izel_les_equerchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62477-62690-izel_les_hameau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62477-62690-izel_les_hameau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62477-62690-izel_les_hameau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62477-62690-izel_les_hameau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62478-62850-journy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62478-62850-journy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62478-62850-journy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62478-62850-journy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62479-62122-labeuvriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62479-62122-labeuvriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62479-62122-labeuvriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62479-62122-labeuvriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62480-62113-labourse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62480-62113-labourse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62480-62113-labourse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62480-62113-labourse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62481-62140-labroye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62481-62140-labroye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62481-62140-labroye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62481-62140-labroye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62483-62830-lacres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62483-62830-lacres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62483-62830-lacres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62483-62830-lacres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62484-62159-lagnicourt_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62484-62159-lagnicourt_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62484-62159-lagnicourt_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62484-62159-lagnicourt_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62485-62960-laires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62485-62960-laires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62485-62960-laires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62485-62960-laires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62486-62120-lambres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62486-62120-lambres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62486-62120-lambres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62486-62120-lambres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62487-62250-landrethun_le_nord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62487-62250-landrethun_le_nord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62487-62250-landrethun_le_nord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62487-62250-landrethun_le_nord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62488-62610-landrethun_les_ardres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62488-62610-landrethun_les_ardres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62488-62610-landrethun_les_ardres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62488-62610-landrethun_les_ardres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62489-62122-lapugnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62489-62122-lapugnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62489-62122-lapugnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62489-62122-lapugnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62490-62810-lattre_saint_quentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62490-62810-lattre_saint_quentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62490-62810-lattre_saint_quentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62490-62810-lattre_saint_quentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62491-62840-laventie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62491-62840-laventie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62491-62840-laventie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62491-62840-laventie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62492-62990-lebiez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62492-62990-lebiez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62492-62990-lebiez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62492-62990-lebiez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62493-62124-lebucquiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62493-62124-lebucquiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62493-62124-lebucquiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62493-62124-lebucquiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62494-62124-lechelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62494-62124-lechelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62494-62124-lechelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62494-62124-lechelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62495-62380-ledinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62495-62380-ledinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62495-62380-ledinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62495-62380-ledinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62496-62630-lefaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62496-62630-lefaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62496-62630-lefaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62496-62630-lefaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62497-62790-leforest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62497-62790-leforest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62497-62790-leforest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62497-62790-leforest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62498-62300-lens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62498-62300-lens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62498-62300-lens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62498-62300-lens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62499-62170-lepine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62499-62170-lepine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62499-62170-lepine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62499-62170-lepine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62500-62190-lespesses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62500-62190-lespesses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62500-62190-lespesses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62500-62190-lespesses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62501-62990-lespinoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62501-62990-lespinoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62501-62990-lespinoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62501-62990-lespinoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62502-62136-lestrem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62502-62136-lestrem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62502-62136-lestrem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62502-62136-lestrem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62503-62250-leubringhen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62503-62250-leubringhen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62503-62250-leubringhen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62503-62250-leubringhen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62504-62500-leulinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62504-62500-leulinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62504-62500-leulinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62504-62500-leulinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62505-62250-leulinghen_bernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62505-62250-leulinghen_bernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62505-62250-leulinghen_bernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62505-62250-leulinghen_bernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62506-62850-licques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62506-62850-licques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62506-62850-licques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62506-62850-licques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62507-62810-liencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62507-62810-liencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62507-62810-liencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62507-62810-liencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62508-62190-lieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62508-62190-lieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62508-62190-lieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62508-62190-lieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62509-62145-liettres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62509-62145-liettres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62509-62145-liettres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62509-62145-liettres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62510-62800-lievin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62510-62800-lievin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62510-62800-lievin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62510-62800-lievin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62511-62810-lignereuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62511-62810-lignereuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62511-62810-lignereuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62511-62810-lignereuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62512-62960-ligny_les_aire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62512-62960-ligny_les_aire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62512-62960-ligny_les_aire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62512-62960-ligny_les_aire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62513-62270-ligny_sur_canche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62513-62270-ligny_sur_canche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62513-62270-ligny_sur_canche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62513-62270-ligny_sur_canche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62514-62127-ligny_saint_flochel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62514-62127-ligny_saint_flochel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62514-62127-ligny_saint_flochel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62514-62127-ligny_saint_flochel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62515-62450-ligny_thilloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62515-62450-ligny_thilloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62515-62450-ligny_thilloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62515-62450-ligny_thilloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62516-62190-lillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62516-62190-lillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62516-62190-lillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62516-62190-lillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62517-62120-linghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62517-62120-linghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62517-62120-linghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62517-62120-linghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62518-62270-linzeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62518-62270-linzeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62518-62270-linzeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62518-62270-linzeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62519-62134-lisbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62519-62134-lisbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62519-62134-lisbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62519-62134-lisbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62520-62400-locon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62520-62400-locon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62520-62400-locon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62520-62400-locon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62521-62140-la_loge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62521-62140-la_loge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62521-62140-la_loge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62521-62140-la_loge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62522-62990-loison_sur_crequoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62522-62990-loison_sur_crequoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62522-62990-loison_sur_crequoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62522-62990-loison_sur_crequoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62523-62218-loison_sous_lens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62523-62218-loison_sous_lens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62523-62218-loison_sous_lens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62523-62218-loison_sous_lens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62524-62240-longfosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62524-62240-longfosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62524-62240-longfosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62524-62240-longfosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62525-62219-longuenesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62525-62219-longuenesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62525-62219-longuenesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62525-62219-longuenesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62526-62142-longueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62526-62142-longueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62526-62142-longueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62526-62142-longueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62527-62630-longvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62527-62630-longvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62527-62630-longvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62527-62630-longvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62528-62750-loos_en_gohelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62528-62750-loos_en_gohelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62528-62750-loos_en_gohelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62528-62750-loos_en_gohelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62529-62840-lorgies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62529-62840-lorgies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62529-62840-lorgies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62529-62840-lorgies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62530-62240-lottinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62530-62240-lottinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62530-62240-lottinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62530-62240-lottinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62531-62610-louches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62531-62610-louches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62531-62610-louches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62531-62610-louches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62532-62540-lozinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62532-62540-lozinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62532-62540-lozinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62532-62540-lozinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62533-62310-lugy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62533-62310-lugy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62533-62310-lugy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62533-62310-lugy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62534-62380-lumbres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62534-62380-lumbres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62534-62380-lumbres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62534-62380-lumbres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62535-62170-la_madelaine_sous_montreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62535-62170-la_madelaine_sous_montreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62535-62170-la_madelaine_sous_montreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62535-62170-la_madelaine_sous_montreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62536-62127-magnicourt_en_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62536-62127-magnicourt_en_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62536-62127-magnicourt_en_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62536-62127-magnicourt_en_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62537-62270-magnicourt_sur_canche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62537-62270-magnicourt_sur_canche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62537-62270-magnicourt_sur_canche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62537-62270-magnicourt_sur_canche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62538-62870-maintenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62538-62870-maintenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62538-62870-maintenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62538-62870-maintenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62539-62130-maisnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62539-62130-maisnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62539-62130-maisnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62539-62130-maisnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62540-62620-maisnil_les_ruitz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62540-62620-maisnil_les_ruitz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62540-62620-maisnil_les_ruitz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62540-62620-maisnil_les_ruitz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62541-62310-maisoncelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62541-62310-maisoncelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62541-62310-maisoncelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62541-62310-maisoncelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62542-62127-maizieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62542-62127-maizieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62542-62127-maizieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62542-62127-maizieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62543-62120-mametz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62543-62120-mametz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62543-62120-mametz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62543-62120-mametz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62544-62810-manin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62544-62810-manin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62544-62810-manin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62544-62810-manin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62545-62650-maninghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62545-62650-maninghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62545-62650-maninghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62545-62650-maninghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62546-62250-maninghen_henne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62546-62250-maninghen_henne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62546-62250-maninghen_henne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62546-62250-maninghen_henne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62547-62170-marant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62547-62170-marant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62547-62170-marant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62547-62170-marant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62548-62730-marck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62548-62730-marck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62548-62730-marck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62548-62730-marck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62549-62140-marconne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62549-62140-marconne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62549-62140-marconne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62549-62140-marconne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62550-62140-marconnelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62550-62140-marconnelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62550-62140-marconnelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62550-62140-marconnelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62551-62990-marenla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62551-62990-marenla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62551-62990-marenla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62551-62990-marenla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62552-62990-maresquel_ecquemicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62552-62990-maresquel_ecquemicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62552-62990-maresquel_ecquemicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62552-62990-maresquel_ecquemicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62553-62550-marest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62553-62550-marest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62553-62550-marest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62553-62550-marest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62554-62630-maresville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62554-62630-maresville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62554-62630-maresville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62554-62630-maresville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62555-62540-marles_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62555-62540-marles_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62555-62540-marles_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62555-62540-marles_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62556-62170-marles_sur_canche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62556-62170-marles_sur_canche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62556-62170-marles_sur_canche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62556-62170-marles_sur_canche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62557-62161-maroeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62557-62161-maroeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62557-62161-maroeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62557-62161-maroeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62558-62127-marquay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62558-62127-marquay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62558-62127-marquay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62558-62127-marquay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62559-62860-marquion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62559-62860-marquion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62559-62860-marquion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62559-62860-marquion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62560-62250-marquise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62560-62250-marquise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62560-62250-marquise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62560-62250-marquise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62561-62450-martinpuich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62561-62450-martinpuich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62561-62450-martinpuich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62561-62450-martinpuich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62562-62310-matringhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62562-62310-matringhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62562-62310-matringhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62562-62310-matringhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62563-62670-mazingarbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62563-62670-mazingarbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62563-62670-mazingarbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62563-62670-mazingarbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62564-62120-mazinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62564-62120-mazinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62564-62120-mazinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62564-62120-mazinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62565-62310-mencas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62565-62310-mencas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62565-62310-mencas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62565-62310-mencas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62566-62240-menneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62566-62240-menneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62566-62240-menneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62566-62240-menneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62567-62890-mentque_nortbecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62567-62890-mentque_nortbecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62567-62890-mentque_nortbecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62567-62890-mentque_nortbecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62568-62217-mercatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62568-62217-mercatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62568-62217-mercatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62568-62217-mercatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62569-62560-merck_saint_lievin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62569-62560-merck_saint_lievin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62569-62560-merck_saint_lievin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62569-62560-merck_saint_lievin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62570-62680-mericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62570-62680-mericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62570-62680-mericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62570-62680-mericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62571-62155-merlimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62571-62155-merlimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62571-62155-merlimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62571-62155-merlimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62572-62124-metz_en_couture/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62572-62124-metz_en_couture/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62572-62124-metz_en_couture/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62572-62124-metz_en_couture/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62573-62410-meurchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62573-62410-meurchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62573-62410-meurchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62573-62410-meurchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62574-62690-mingoval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62574-62690-mingoval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62574-62690-mingoval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62574-62690-mingoval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62576-62270-moncheaux_les_frevent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62576-62270-moncheaux_les_frevent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62576-62270-moncheaux_les_frevent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62576-62270-moncheaux_les_frevent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62577-62270-monchel_sur_canche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62577-62270-monchel_sur_canche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62577-62270-monchel_sur_canche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62577-62270-monchel_sur_canche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62578-62123-monchiet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62578-62123-monchiet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62578-62123-monchiet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62578-62123-monchiet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62579-62111-monchy_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62579-62111-monchy_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62579-62111-monchy_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62579-62111-monchy_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62580-62127-monchy_breton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62580-62127-monchy_breton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62580-62127-monchy_breton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62580-62127-monchy_breton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62581-62134-monchy_cayeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62581-62134-monchy_cayeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62581-62134-monchy_cayeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62581-62134-monchy_cayeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62582-62118-monchy_le_preux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62582-62118-monchy_le_preux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62582-62118-monchy_le_preux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62582-62118-monchy_le_preux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62583-62760-mondicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62583-62760-mondicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62583-62760-mondicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62583-62760-mondicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62584-62350-mont_bernanchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62584-62350-mont_bernanchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62584-62350-mont_bernanchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62584-62350-mont_bernanchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62585-62170-montcavrel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62585-62170-montcavrel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62585-62170-montcavrel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62585-62170-montcavrel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62586-62123-montenescourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62586-62123-montenescourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62586-62123-montenescourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62586-62123-montenescourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62587-62640-montigny_en_gohelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62587-62640-montigny_en_gohelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62587-62640-montigny_en_gohelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62587-62640-montigny_en_gohelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62588-62170-montreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62588-62170-montreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62588-62170-montreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62588-62170-montreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62589-62144-mont_saint_eloi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62589-62144-mont_saint_eloi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62589-62144-mont_saint_eloi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62589-62144-mont_saint_eloi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62590-62130-monts_en_ternois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62590-62130-monts_en_ternois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62590-62130-monts_en_ternois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62590-62130-monts_en_ternois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62591-62124-morchies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62591-62124-morchies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62591-62124-morchies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62591-62124-morchies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62592-62910-moringhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62592-62910-moringhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62592-62910-moringhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62592-62910-moringhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62593-62450-morval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62593-62450-morval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62593-62450-morval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62593-62450-morval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62594-62159-mory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62594-62159-mory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62594-62159-mory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62594-62159-mory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62595-62910-moulle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62595-62910-moulle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62595-62910-moulle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62595-62910-moulle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62596-62140-mouriez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62596-62140-mouriez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62596-62140-mouriez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62596-62140-mouriez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62597-62121-moyenneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62597-62121-moyenneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62597-62121-moyenneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62597-62121-moyenneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62598-62890-muncq_nieurlet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62598-62890-muncq_nieurlet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62598-62890-muncq_nieurlet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62598-62890-muncq_nieurlet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62599-62142-nabringhen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62599-62142-nabringhen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62599-62142-nabringhen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62599-62142-nabringhen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62600-62550-nedon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62600-62550-nedon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62600-62550-nedon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62600-62550-nedon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62601-62550-nedonchel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62601-62550-nedonchel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62601-62550-nedonchel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62601-62550-nedonchel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62602-62180-nempont_saint_firmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62602-62180-nempont_saint_firmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62602-62180-nempont_saint_firmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62602-62180-nempont_saint_firmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62603-62152-nesles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62603-62152-nesles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62603-62152-nesles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62603-62152-nesles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62604-62152-neufchatel_hardelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62604-62152-neufchatel_hardelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62604-62152-neufchatel_hardelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62604-62152-neufchatel_hardelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62605-62770-neulette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62605-62770-neulette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62605-62770-neulette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62605-62770-neulette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62606-62840-neuve_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62606-62840-neuve_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62606-62840-neuve_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62606-62840-neuve_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62607-62130-neuville_au_cornet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62607-62130-neuville_au_cornet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62607-62130-neuville_au_cornet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62607-62130-neuville_au_cornet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62608-62124-neuville_bourjonval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62608-62124-neuville_bourjonval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62608-62124-neuville_bourjonval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62608-62124-neuville_bourjonval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62609-62580-neuville_saint_vaast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62609-62580-neuville_saint_vaast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62609-62580-neuville_saint_vaast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62609-62580-neuville_saint_vaast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62610-62170-neuville_sous_montreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62610-62170-neuville_sous_montreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62610-62170-neuville_sous_montreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62610-62170-neuville_sous_montreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62611-62217-neuville_vitasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62611-62217-neuville_vitasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62611-62217-neuville_vitasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62611-62217-neuville_vitasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62612-62580-neuvireuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62612-62580-neuvireuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62612-62580-neuvireuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62612-62580-neuvireuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62613-62380-nielles_les_blequin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62613-62380-nielles_les_blequin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62613-62380-nielles_les_blequin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62613-62380-nielles_les_blequin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62614-62610-nielles_les_ardres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62614-62610-nielles_les_ardres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62614-62610-nielles_les_ardres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62614-62610-nielles_les_ardres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62615-62185-nielles_les_calais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62615-62185-nielles_les_calais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62615-62185-nielles_les_calais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62615-62185-nielles_les_calais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62616-62390-noeux_les_auxi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62616-62390-noeux_les_auxi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62616-62390-noeux_les_auxi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62616-62390-noeux_les_auxi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62617-62290-noeux_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62617-62290-noeux_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62617-62290-noeux_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62617-62290-noeux_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62618-62890-nordausques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62618-62890-nordausques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62618-62890-nordausques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62618-62890-nordausques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62619-62128-noreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62619-62128-noreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62619-62128-noreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62619-62128-noreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62620-62120-norrent_fontes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62620-62120-norrent_fontes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62620-62120-norrent_fontes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62620-62120-norrent_fontes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62621-62370-nortkerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62621-62370-nortkerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62621-62370-nortkerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62621-62370-nortkerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62622-62890-nort_leulinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62622-62890-nort_leulinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62622-62890-nort_leulinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62622-62890-nort_leulinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62623-62370-nouvelle_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62623-62370-nouvelle_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62623-62370-nouvelle_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62623-62370-nouvelle_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62624-62950-noyelles_godault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62624-62950-noyelles_godault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62624-62950-noyelles_godault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62624-62950-noyelles_godault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62625-62770-noyelles_les_humieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62625-62770-noyelles_les_humieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62625-62770-noyelles_les_humieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62625-62770-noyelles_les_humieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62626-62980-noyelles_les_vermelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62626-62980-noyelles_les_vermelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62626-62980-noyelles_les_vermelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62626-62980-noyelles_les_vermelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62627-62490-noyelles_sous_bellonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62627-62490-noyelles_sous_bellonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62627-62490-noyelles_sous_bellonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62627-62490-noyelles_sous_bellonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62628-62221-noyelles_sous_lens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62628-62221-noyelles_sous_lens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62628-62221-noyelles_sous_lens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62628-62221-noyelles_sous_lens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62629-62123-noyellette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62629-62123-noyellette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62629-62123-noyellette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62629-62123-noyellette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62630-62810-noyelle_vion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62630-62810-noyelle_vion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62630-62810-noyelle_vion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62630-62810-noyelle_vion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62631-62270-nuncq_hautecote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62631-62270-nuncq_hautecote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62631-62270-nuncq_hautecote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62631-62270-nuncq_hautecote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62632-62920-oblinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62632-62920-oblinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62632-62920-oblinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62632-62920-oblinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62633-62130-oeuf_en_ternois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62633-62130-oeuf_en_ternois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62633-62130-oeuf_en_ternois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62633-62130-oeuf_en_ternois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62634-62370-offekerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62634-62370-offekerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62634-62370-offekerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62634-62370-offekerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62635-62990-offin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62635-62990-offin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62635-62990-offin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62635-62990-offin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62636-62250-offrethun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62636-62250-offrethun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62636-62250-offrethun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62636-62250-offrethun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62637-62590-oignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62637-62590-oignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62637-62590-oignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62637-62590-oignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62638-62860-oisy_le_verger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62638-62860-oisy_le_verger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62638-62860-oisy_le_verger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62638-62860-oisy_le_verger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62639-62580-oppy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62639-62580-oppy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62639-62580-oppy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62639-62580-oppy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62640-62760-orville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62640-62760-orville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62640-62760-orville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62640-62760-orville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62641-62130-ostreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62641-62130-ostreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62641-62130-ostreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62641-62130-ostreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62642-62460-ourton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62642-62460-ourton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62642-62460-ourton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62642-62460-ourton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62643-62230-outreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62643-62230-outreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62643-62230-outreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62643-62230-outreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62644-62380-ouve_wirquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62644-62380-ouve_wirquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62644-62380-ouve_wirquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62644-62380-ouve_wirquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62645-62215-oye_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62645-62215-oye_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62645-62215-oye_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62645-62215-oye_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62646-62860-palluel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62646-62860-palluel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62646-62860-palluel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62646-62860-palluel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62647-62770-le_parcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62647-62770-le_parcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62647-62770-le_parcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62647-62770-le_parcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62648-62650-parenty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62648-62650-parenty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62648-62650-parenty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62648-62650-parenty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62649-62760-pas_en_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62649-62760-pas_en_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62649-62760-pas_en_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62649-62760-pas_en_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62650-62118-pelves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62650-62118-pelves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62650-62118-pelves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62650-62118-pelves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62651-62127-penin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62651-62127-penin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62651-62127-penin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62651-62127-penin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62652-62550-pernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62652-62550-pernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62652-62550-pernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62652-62550-pernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62653-62126-pernes_les_boulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62653-62126-pernes_les_boulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62653-62126-pernes_les_boulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62653-62126-pernes_les_boulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62654-62231-peuplingues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62654-62231-peuplingues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62654-62231-peuplingues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62654-62231-peuplingues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62655-62130-pierremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62655-62130-pierremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62655-62130-pierremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62655-62130-pierremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62656-62570-pihem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62656-62570-pihem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62656-62570-pihem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62656-62570-pihem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62657-62340-pihen_les_guines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62657-62340-pihen_les_guines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62657-62340-pihen_les_guines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62657-62340-pihen_les_guines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62658-62126-pittefaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62658-62126-pittefaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62658-62126-pittefaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62658-62126-pittefaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62659-62310-planques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62659-62310-planques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62659-62310-planques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62659-62310-planques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62660-62118-plouvain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62660-62118-plouvain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62660-62118-plouvain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62660-62118-plouvain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62661-62140-bouin_plumoison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62661-62140-bouin_plumoison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62661-62140-bouin_plumoison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62661-62140-bouin_plumoison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62662-62370-polincove/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62662-62370-polincove/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62662-62370-polincove/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62662-62370-polincove/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62663-62760-pommera/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62663-62760-pommera/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62663-62760-pommera/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62663-62760-pommera/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62664-62111-pommier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62664-62111-pommier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62664-62111-pommier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62664-62111-pommier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62665-62390-le_ponchel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62665-62390-le_ponchel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62665-62390-le_ponchel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62665-62390-le_ponchel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62666-62880-pont_a_vendin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62666-62880-pont_a_vendin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62666-62880-pont_a_vendin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62666-62880-pont_a_vendin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62667-62480-le_portel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62667-62480-le_portel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62667-62480-le_portel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62667-62480-le_portel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62668-62134-predefin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62668-62134-predefin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62668-62134-predefin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62668-62134-predefin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62669-62550-pressy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62669-62550-pressy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62669-62550-pressy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62669-62550-pressy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62670-62650-preures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62670-62650-preures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62670-62650-preures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62670-62650-preures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62671-62860-pronville_en_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62671-62860-pronville_en_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62671-62860-pronville_en_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62671-62860-pronville_en_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62672-62116-puisieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62672-62116-puisieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62672-62116-puisieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62672-62116-puisieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62673-62860-queant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62673-62860-queant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62673-62860-queant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62673-62860-queant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62674-62500-quelmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62674-62500-quelmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62674-62500-quelmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62674-62500-quelmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62675-62380-quercamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62675-62380-quercamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62675-62380-quercamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62675-62380-quercamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62676-62120-quernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62676-62120-quernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62676-62120-quernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62676-62120-quernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62677-62140-le_quesnoy_en_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62677-62140-le_quesnoy_en_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62677-62140-le_quesnoy_en_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62677-62140-le_quesnoy_en_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62678-62240-quesques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62678-62240-quesques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62678-62240-quesques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62678-62240-quesques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62679-62830-questrecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62679-62830-questrecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62679-62830-questrecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62679-62830-questrecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62680-62490-quiery_la_motte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62680-62490-quiery_la_motte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62680-62490-quiery_la_motte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62680-62490-quiery_la_motte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62681-62120-quiestede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62681-62120-quiestede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62681-62120-quiestede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62681-62120-quiestede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62682-62650-quilen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62682-62650-quilen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62682-62650-quilen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62682-62650-quilen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62683-62390-quoeux_haut_mainil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62683-62390-quoeux_haut_mainil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62683-62390-quoeux_haut_mainil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62683-62390-quoeux_haut_mainil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62684-62120-racquinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62684-62120-racquinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62684-62120-racquinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62684-62120-racquinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62685-62310-radinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62685-62310-radinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62685-62310-radinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62685-62310-radinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62686-62130-ramecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62686-62130-ramecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62686-62130-ramecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62686-62130-ramecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62688-62180-rang_du_fliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62688-62180-rang_du_fliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62688-62180-rang_du_fliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62688-62180-rang_du_fliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62689-62173-ransart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62689-62173-ransart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62689-62173-ransart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62689-62173-ransart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62690-62140-raye_sur_authie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62690-62140-raye_sur_authie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62690-62140-raye_sur_authie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62690-62140-raye_sur_authie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62691-62120-saint_augustin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62691-62120-saint_augustin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62691-62120-saint_augustin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62691-62120-saint_augustin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62691-62129-saint_augustin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62691-62129-saint_augustin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62691-62129-saint_augustin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62691-62129-saint_augustin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62692-62850-rebergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62692-62850-rebergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62692-62850-rebergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62692-62850-rebergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62693-62150-rebreuve_ranchicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62693-62150-rebreuve_ranchicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62693-62150-rebreuve_ranchicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62693-62150-rebreuve_ranchicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62694-62270-rebreuve_sur_canche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62694-62270-rebreuve_sur_canche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62694-62270-rebreuve_sur_canche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62694-62270-rebreuve_sur_canche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62695-62270-rebreuviette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62695-62270-rebreuviette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62695-62270-rebreuviette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62695-62270-rebreuviette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62696-62560-reclinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62696-62560-reclinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62696-62560-reclinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62696-62560-reclinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62697-62860-recourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62697-62860-recourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62697-62860-recourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62697-62860-recourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62698-62170-recques_sur_course/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62698-62170-recques_sur_course/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62698-62170-recques_sur_course/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62698-62170-recques_sur_course/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62699-62890-recques_sur_hem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62699-62890-recques_sur_hem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62699-62890-recques_sur_hem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62699-62890-recques_sur_hem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62700-62140-regnauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62700-62140-regnauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62700-62140-regnauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62700-62140-regnauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62701-62120-rely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62701-62120-rely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62701-62120-rely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62701-62120-rely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62702-62380-remilly_wirquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62702-62380-remilly_wirquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62702-62380-remilly_wirquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62702-62380-remilly_wirquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62703-62156-remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62703-62156-remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62703-62156-remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62703-62156-remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62704-62560-renty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62704-62560-renty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62704-62560-renty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62704-62560-renty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62705-62720-rety/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62705-62720-rety/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62705-62720-rety/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62705-62720-rety/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62706-62136-richebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62706-62136-richebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62706-62136-richebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62706-62136-richebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62708-62450-riencourt_les_bapaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62708-62450-riencourt_les_bapaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62708-62450-riencourt_les_bapaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62708-62450-riencourt_les_bapaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62709-62182-riencourt_les_cagnicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62709-62182-riencourt_les_cagnicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62709-62182-riencourt_les_cagnicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62709-62182-riencourt_les_cagnicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62710-62990-rimboval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62710-62990-rimboval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62710-62990-rimboval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62710-62990-rimboval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62711-62720-rinxent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62711-62720-rinxent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62711-62720-rinxent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62711-62720-rinxent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62712-62173-riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62712-62173-riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62712-62173-riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62712-62173-riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62713-62350-robecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62713-62350-robecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62713-62350-robecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62713-62350-robecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62714-62223-roclincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62714-62223-roclincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62714-62223-roclincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62714-62223-roclincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62715-62450-rocquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62715-62450-rocquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62715-62450-rocquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62715-62450-rocquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62716-62610-rodelinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62716-62610-rodelinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62716-62610-rodelinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62716-62610-rodelinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62717-62130-roellecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62717-62130-roellecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62717-62130-roellecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62717-62130-roellecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62718-62118-roeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62718-62118-roeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62718-62118-roeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62718-62118-roeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62719-62770-rollancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62719-62770-rollancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62719-62770-rollancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62719-62770-rollancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62720-62120-rombly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62720-62120-rombly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62720-62120-rombly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62720-62120-rombly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62721-62120-roquetoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62721-62120-roquetoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62721-62120-roquetoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62721-62120-roquetoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62722-62390-rougefay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62722-62390-rougefay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62722-62390-rougefay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62722-62390-rougefay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62723-62870-roussent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62723-62870-roussent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62723-62870-roussent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62723-62870-roussent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62724-62320-rouvroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62724-62320-rouvroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62724-62320-rouvroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62724-62320-rouvroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62725-62990-royon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62725-62990-royon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62725-62990-royon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62725-62990-royon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62726-62310-ruisseauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62726-62310-ruisseauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62726-62310-ruisseauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62726-62310-ruisseauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62727-62620-ruitz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62727-62620-ruitz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62727-62620-ruitz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62727-62620-ruitz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62728-62860-rumaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62728-62860-rumaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62728-62860-rumaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62728-62860-rumaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62729-62650-rumilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62729-62650-rumilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62729-62650-rumilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62729-62650-rumilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62730-62370-ruminghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62730-62370-ruminghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62730-62370-ruminghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62730-62370-ruminghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62731-62124-ruyaulcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62731-62124-ruyaulcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62731-62124-ruyaulcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62731-62124-ruyaulcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62732-62550-sachin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62732-62550-sachin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62732-62550-sachin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62732-62550-sachin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62733-62111-sailly_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62733-62111-sailly_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62733-62111-sailly_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62733-62111-sailly_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62734-62490-sailly_en_ostrevent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62734-62490-sailly_en_ostrevent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62734-62490-sailly_en_ostrevent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62734-62490-sailly_en_ostrevent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62735-62113-sailly_labourse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62735-62113-sailly_labourse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62735-62113-sailly_labourse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62735-62113-sailly_labourse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62736-62840-sailly_sur_la_lys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62736-62840-sailly_sur_la_lys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62736-62840-sailly_sur_la_lys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62736-62840-sailly_sur_la_lys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62737-62114-sains_en_gohelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62737-62114-sains_en_gohelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62737-62114-sains_en_gohelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62737-62114-sains_en_gohelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62738-62310-sains_les_fressin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62738-62310-sains_les_fressin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62738-62310-sains_les_fressin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62738-62310-sains_les_fressin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62739-62860-sains_les_marquion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62739-62860-sains_les_marquion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62739-62860-sains_les_marquion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62739-62860-sains_les_marquion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62740-62550-sains_les_pernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62740-62550-sains_les_pernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62740-62550-sains_les_pernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62740-62550-sains_les_pernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62741-62760-saint_amand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62741-62760-saint_amand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62741-62760-saint_amand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62741-62760-saint_amand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62742-62170-saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62742-62170-saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62742-62170-saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62742-62170-saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62743-62140-sainte_austreberthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62743-62140-sainte_austreberthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62743-62140-sainte_austreberthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62743-62140-sainte_austreberthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62744-62223-sainte_catherine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62744-62223-sainte_catherine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62744-62223-sainte_catherine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62744-62223-sainte_catherine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62745-62990-saint_denoeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62745-62990-saint_denoeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62745-62990-saint_denoeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62745-62990-saint_denoeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62746-62360-saint_etienne_au_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62746-62360-saint_etienne_au_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62746-62360-saint_etienne_au_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62746-62360-saint_etienne_au_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62747-62350-saint_floris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62747-62350-saint_floris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62747-62350-saint_floris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62747-62350-saint_floris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62748-62370-saint_folquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62748-62370-saint_folquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62748-62370-saint_folquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62748-62370-saint_folquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62749-62770-saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62749-62770-saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62749-62770-saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62749-62770-saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62750-62120-saint_hilaire_cottes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62750-62120-saint_hilaire_cottes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62750-62120-saint_hilaire_cottes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62750-62120-saint_hilaire_cottes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62751-62250-saint_inglevert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62751-62250-saint_inglevert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62751-62250-saint_inglevert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62751-62250-saint_inglevert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62752-62170-saint_josse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62752-62170-saint_josse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62752-62170-saint_josse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62752-62170-saint_josse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62753-62223-saint_laurent_blangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62753-62223-saint_laurent_blangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62753-62223-saint_laurent_blangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62753-62223-saint_laurent_blangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62754-62128-saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62754-62128-saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62754-62128-saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62754-62128-saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62755-62360-saint_leonard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62755-62360-saint_leonard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62755-62360-saint_leonard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62755-62360-saint_leonard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62756-62370-sainte_marie_kerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62756-62370-sainte_marie_kerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62756-62370-sainte_marie_kerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62756-62370-sainte_marie_kerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62757-62500-saint_martin_lez_tatinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62757-62500-saint_martin_lez_tatinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62757-62500-saint_martin_lez_tatinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62757-62500-saint_martin_lez_tatinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62758-62280-saint_martin_boulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62758-62280-saint_martin_boulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62758-62280-saint_martin_boulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62758-62280-saint_martin_boulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62759-62240-saint_martin_choquel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62759-62240-saint_martin_choquel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62759-62240-saint_martin_choquel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62759-62240-saint_martin_choquel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62760-62560-saint_martin_d_hardinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62760-62560-saint_martin_d_hardinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62760-62560-saint_martin_d_hardinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62760-62560-saint_martin_d_hardinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62761-62128-saint_martin_sur_cojeul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62761-62128-saint_martin_sur_cojeul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62761-62128-saint_martin_sur_cojeul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62761-62128-saint_martin_sur_cojeul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62762-62650-saint_michel_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62762-62650-saint_michel_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62762-62650-saint_michel_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62762-62650-saint_michel_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62763-62130-saint_michel_sur_ternoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62763-62130-saint_michel_sur_ternoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62763-62130-saint_michel_sur_ternoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62763-62130-saint_michel_sur_ternoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62764-62223-saint_nicolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62764-62223-saint_nicolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62764-62223-saint_nicolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62764-62223-saint_nicolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62765-62500-saint_omer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62765-62500-saint_omer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62765-62500-saint_omer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62765-62500-saint_omer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62766-62162-saint_omer_capelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62766-62162-saint_omer_capelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62766-62162-saint_omer_capelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62766-62162-saint_omer_capelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62767-62130-saint_pol_sur_ternoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62767-62130-saint_pol_sur_ternoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62767-62130-saint_pol_sur_ternoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62767-62130-saint_pol_sur_ternoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62768-62870-saint_remy_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62768-62870-saint_remy_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62768-62870-saint_remy_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62768-62870-saint_remy_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62769-62185-saint_tricat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62769-62185-saint_tricat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62769-62185-saint_tricat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62769-62185-saint_tricat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62770-62350-saint_venant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62770-62350-saint_venant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62770-62350-saint_venant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62770-62350-saint_venant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62771-62430-sallaumines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62771-62430-sallaumines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62771-62430-sallaumines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62771-62430-sallaumines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62772-62500-salperwick/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62772-62500-salperwick/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62772-62500-salperwick/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62772-62500-salperwick/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62773-62830-samer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62773-62830-samer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62773-62830-samer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62773-62830-samer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62774-62231-sangatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62774-62231-sangatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62774-62231-sangatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62774-62231-sangatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62775-62850-sanghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62775-62850-sanghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62775-62850-sanghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62775-62850-sanghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62776-62121-sapignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62776-62121-sapignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62776-62121-sapignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62776-62121-sapignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62777-62450-le_sars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62777-62450-le_sars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62777-62450-le_sars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62777-62450-le_sars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62778-62810-sars_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62778-62810-sars_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62778-62810-sars_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62778-62810-sars_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62779-62760-sarton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62779-62760-sarton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62779-62760-sarton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62779-62760-sarton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62780-62860-sauchy_cauchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62780-62860-sauchy_cauchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62780-62860-sauchy_cauchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62780-62860-sauchy_cauchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62781-62860-sauchy_lestree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62781-62860-sauchy_lestree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62781-62860-sauchy_lestree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62781-62860-sauchy_lestree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62782-62860-saudemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62782-62860-saudemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62782-62860-saudemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62782-62860-saudemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62783-62870-saulchoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62783-62870-saulchoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62783-62870-saulchoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62783-62870-saulchoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62784-62158-saulty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62784-62158-saulty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62784-62158-saulty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62784-62158-saulty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62785-62690-savy_berlette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62785-62690-savy_berlette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62785-62690-savy_berlette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62785-62690-savy_berlette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62786-62240-selles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62786-62240-selles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62786-62240-selles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62786-62240-selles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62787-62170-sempy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62787-62170-sempy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62787-62170-sempy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62787-62170-sempy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62788-62380-seninghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62788-62380-seninghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62788-62380-seninghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62788-62380-seninghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62789-62240-senlecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62789-62240-senlecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62789-62240-senlecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62789-62240-senlecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62790-62310-senlis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62790-62310-senlis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62790-62310-senlis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62790-62310-senlis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62791-62270-sericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62791-62270-sericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62791-62270-sericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62791-62270-sericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62792-62910-serques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62792-62910-serques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62792-62910-serques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62792-62910-serques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62793-62530-servins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62793-62530-servins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62793-62530-servins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62793-62530-servins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62794-62380-setques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62794-62380-setques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62794-62380-setques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62794-62380-setques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62795-62270-sibiville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62795-62270-sibiville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62795-62270-sibiville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62795-62270-sibiville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62796-62123-simencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62796-62123-simencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62796-62123-simencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62796-62123-simencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62797-62130-siracourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62797-62130-siracourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62797-62130-siracourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62797-62130-siracourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62798-62810-sombrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62798-62810-sombrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62798-62810-sombrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62798-62810-sombrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62799-62170-sorrus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62799-62170-sorrus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62799-62170-sorrus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62799-62170-sorrus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62800-62111-souastre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62800-62111-souastre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62800-62111-souastre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62800-62111-souastre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62801-62153-souchez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62801-62153-souchez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62801-62153-souchez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62801-62153-souchez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62802-62810-le_souich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62802-62810-le_souich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62802-62810-le_souich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62802-62810-le_souich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62803-62850-surques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62803-62850-surques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62803-62850-surques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62803-62850-surques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62804-62810-sus_saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62804-62810-sus_saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62804-62810-sus_saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62804-62810-sus_saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62805-62550-tangry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62805-62550-tangry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62805-62550-tangry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62805-62550-tangry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62806-62179-tardinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62806-62179-tardinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62806-62179-tardinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62806-62179-tardinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62808-62134-teneur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62808-62134-teneur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62808-62134-teneur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62808-62134-teneur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62809-62127-ternas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62809-62127-ternas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62809-62127-ternas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62809-62127-ternas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62810-62580-thelus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62810-62580-thelus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62810-62580-thelus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62810-62580-thelus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62811-62129-therouanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62811-62129-therouanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62811-62129-therouanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62811-62129-therouanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62812-62560-thiembronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62812-62560-thiembronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62812-62560-thiembronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62812-62560-thiembronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62813-62130-la_thieuloye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62813-62130-la_thieuloye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62813-62130-la_thieuloye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62813-62130-la_thieuloye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62814-62760-thievres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62814-62760-thievres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62814-62760-thievres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62814-62760-thievres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62815-62180-tigny_noyelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62815-62180-tigny_noyelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62815-62180-tigny_noyelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62815-62180-tigny_noyelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62816-62690-tilloy_les_hermaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62816-62690-tilloy_les_hermaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62816-62690-tilloy_les_hermaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62816-62690-tilloy_les_hermaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62817-62217-tilloy_les_mofflaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62817-62217-tilloy_les_mofflaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62817-62217-tilloy_les_mofflaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62817-62217-tilloy_les_mofflaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62818-62134-tilly_capelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62818-62134-tilly_capelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62818-62134-tilly_capelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62818-62134-tilly_capelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62819-62500-tilques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62819-62500-tilques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62819-62500-tilques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62819-62500-tilques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62820-62127-tincques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62820-62127-tincques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62820-62127-tincques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62820-62127-tincques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62821-62830-tingry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62821-62830-tingry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62821-62830-tingry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62821-62830-tingry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62822-62390-tollent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62822-62390-tollent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62822-62390-tollent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62822-62390-tollent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62823-62310-torcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62823-62310-torcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62823-62310-torcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62823-62310-torcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62824-62140-tortefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62824-62140-tortefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62824-62140-tortefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62824-62140-tortefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62825-62490-tortequesne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62825-62490-tortequesne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62825-62490-tortequesne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62825-62490-tortequesne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62826-62520-le_touquet_paris_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62826-62520-le_touquet_paris_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62826-62520-le_touquet_paris_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62826-62520-le_touquet_paris_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62827-62890-tournehem_sur_la_hem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62827-62890-tournehem_sur_la_hem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62827-62890-tournehem_sur_la_hem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62827-62890-tournehem_sur_la_hem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62828-62310-tramecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62828-62310-tramecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62828-62310-tramecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62828-62310-tramecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62829-62450-le_transloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62829-62450-le_transloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62829-62450-le_transloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62829-62450-le_transloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62830-62147-trescault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62830-62147-trescault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62830-62147-trescault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62830-62147-trescault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62831-62130-troisvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62831-62130-troisvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62831-62130-troisvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62831-62130-troisvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62832-62630-tubersent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62832-62630-tubersent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62832-62630-tubersent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62832-62630-tubersent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62833-62270-vacquerie_le_boucq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62833-62270-vacquerie_le_boucq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62833-62270-vacquerie_le_boucq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62833-62270-vacquerie_le_boucq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62834-62140-vacqueriette_erquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62834-62140-vacqueriette_erquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62834-62140-vacqueriette_erquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62834-62140-vacqueriette_erquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62835-62550-valhuon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62835-62550-valhuon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62835-62550-valhuon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62835-62550-valhuon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62836-62131-vaudricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62836-62131-vaudricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62836-62131-vaudricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62836-62131-vaudricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62837-62380-vaudringhem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62837-62380-vaudringhem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62837-62380-vaudringhem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62837-62380-vaudringhem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62838-62390-vaulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62838-62390-vaulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62838-62390-vaulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62838-62390-vaulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62839-62159-vaulx_vraucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62839-62159-vaulx_vraucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62839-62159-vaulx_vraucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62839-62159-vaulx_vraucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62840-62124-velu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62840-62124-velu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62840-62124-velu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62840-62124-velu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62841-62232-vendin_les_bethune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62841-62232-vendin_les_bethune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62841-62232-vendin_les_bethune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62841-62232-vendin_les_bethune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62842-62880-vendin_le_vieil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62842-62880-vendin_le_vieil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62842-62880-vendin_le_vieil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62842-62880-vendin_le_vieil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62843-62310-verchin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62843-62310-verchin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62843-62310-verchin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62843-62310-verchin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62844-62560-verchocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62844-62560-verchocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62844-62560-verchocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62844-62560-verchocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62845-62830-verlincthun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62845-62830-verlincthun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62845-62830-verlincthun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62845-62830-verlincthun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62846-62980-vermelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62846-62980-vermelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62846-62980-vermelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62846-62980-vermelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62847-62113-verquigneul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62847-62113-verquigneul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62847-62113-verquigneul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62847-62113-verquigneul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62848-62131-verquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62848-62131-verquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62848-62131-verquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62848-62131-verquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62849-62180-verton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62849-62180-verton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62849-62180-verton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62849-62180-verton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62850-62770-vieil_hesdin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62850-62770-vieil_hesdin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62850-62770-vieil_hesdin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62850-62770-vieil_hesdin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62851-62136-vieille_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62851-62136-vieille_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62851-62136-vieille_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62851-62136-vieille_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62852-62162-vieille_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62852-62162-vieille_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62852-62162-vieille_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62852-62162-vieille_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62853-62240-vieil_moutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62853-62240-vieil_moutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62853-62240-vieil_moutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62853-62240-vieil_moutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62854-62144-villers_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62854-62144-villers_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62854-62144-villers_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62854-62144-villers_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62855-62450-villers_au_flos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62855-62450-villers_au_flos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62855-62450-villers_au_flos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62855-62450-villers_au_flos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62856-62690-villers_brulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62856-62690-villers_brulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62856-62690-villers_brulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62856-62690-villers_brulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62857-62690-villers_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62857-62690-villers_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62857-62690-villers_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62857-62690-villers_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62858-62182-villers_les_cagnicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62858-62182-villers_les_cagnicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62858-62182-villers_les_cagnicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62858-62182-villers_les_cagnicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62859-62390-villers_l_hopital/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62859-62390-villers_l_hopital/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62859-62390-villers_l_hopital/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62859-62390-villers_l_hopital/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62860-62127-villers_sir_simon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62860-62127-villers_sir_simon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62860-62127-villers_sir_simon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62860-62127-villers_sir_simon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62861-62580-vimy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62861-62580-vimy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62861-62580-vimy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62861-62580-vimy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62862-62310-vincly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62862-62310-vincly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62862-62310-vincly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62862-62310-vincly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62863-62138-violaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62863-62138-violaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62863-62138-violaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62863-62138-violaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62864-62156-vis_en_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62864-62156-vis_en_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62864-62156-vis_en_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62864-62156-vis_en_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62865-62490-vitry_en_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62865-62490-vitry_en_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62865-62490-vitry_en_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62865-62490-vitry_en_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62866-62180-waben/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62866-62180-waben/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62866-62180-waben/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62866-62180-waben/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62867-62250-wacquinghen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62867-62250-wacquinghen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62867-62250-wacquinghen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62867-62250-wacquinghen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62868-62770-wail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62868-62770-wail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62868-62770-wail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62868-62770-wail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62869-62217-wailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62869-62217-wailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62869-62217-wailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62869-62217-wailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62870-62170-wailly_beaucamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62870-62170-wailly_beaucamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62870-62170-wailly_beaucamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62870-62170-wailly_beaucamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62871-62140-wambercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62871-62140-wambercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62871-62140-wambercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62871-62140-wambercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62872-62770-wamin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62872-62770-wamin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62872-62770-wamin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62872-62770-wamin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62873-62128-wancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62873-62128-wancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62873-62128-wancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62873-62128-wancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62874-62123-wanquetin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62874-62123-wanquetin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62874-62123-wanquetin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62874-62123-wanquetin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62875-62120-wardrecques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62875-62120-wardrecques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62875-62120-wardrecques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62875-62120-wardrecques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62876-62450-warlencourt_eaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62876-62450-warlencourt_eaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62876-62450-warlencourt_eaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62876-62450-warlencourt_eaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62877-62760-warlincourt_les_pas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62877-62760-warlincourt_les_pas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62877-62760-warlincourt_les_pas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62877-62760-warlincourt_les_pas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62878-62123-warlus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62878-62123-warlus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62878-62123-warlus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62878-62123-warlus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62879-62810-warluzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62879-62810-warluzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62879-62810-warluzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62879-62810-warluzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62880-62142-le_wast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62880-62142-le_wast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62880-62142-le_wast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62880-62142-le_wast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62881-62390-beauvoir_wavans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62881-62390-beauvoir_wavans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62881-62390-beauvoir_wavans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62881-62390-beauvoir_wavans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62882-62380-wavrans_sur_l_aa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62882-62380-wavrans_sur_l_aa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62882-62380-wavrans_sur_l_aa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62882-62380-wavrans_sur_l_aa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62883-62130-wavrans_sur_ternoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62883-62130-wavrans_sur_ternoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62883-62130-wavrans_sur_ternoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62883-62130-wavrans_sur_ternoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62885-62960-westrehem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62885-62960-westrehem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62885-62960-westrehem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62885-62960-westrehem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62886-62650-wicquinghem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62886-62650-wicquinghem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62886-62650-wicquinghem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62886-62650-wicquinghem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62887-62630-widehem/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62887-62630-widehem/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62887-62630-widehem/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62887-62630-widehem/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62888-62830-wierre_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62888-62830-wierre_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62888-62830-wierre_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62888-62830-wierre_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62889-62720-wierre_effroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62889-62720-wierre_effroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62889-62720-wierre_effroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62889-62720-wierre_effroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62890-62770-willeman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62890-62770-willeman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62890-62770-willeman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62890-62770-willeman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62891-62390-willencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62891-62390-willencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62891-62390-willencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62891-62390-willencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62892-62580-willerval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62892-62580-willerval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62892-62580-willerval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62892-62580-willerval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62893-62930-wimereux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62893-62930-wimereux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62893-62930-wimereux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62893-62930-wimereux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62894-62126-wimille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62894-62126-wimille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62894-62126-wimille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62894-62126-wimille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62895-62410-wingles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62895-62410-wingles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62895-62410-wingles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62895-62410-wingles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62896-62240-wirwignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62896-62240-wirwignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62896-62240-wirwignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62896-62240-wirwignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62897-62380-wismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62897-62380-wismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62897-62380-wismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62897-62380-wismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62898-62219-wisques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62898-62219-wisques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62898-62219-wisques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62898-62219-wisques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62899-62179-wissant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62899-62179-wissant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62899-62179-wissant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62899-62179-wissant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62900-62120-witternesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62900-62120-witternesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62900-62120-witternesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62900-62120-witternesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62901-62120-wittes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62901-62120-wittes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62901-62120-wittes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62901-62120-wittes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62902-62570-wizernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62902-62570-wizernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62902-62570-wizernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62902-62570-wizernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62903-62650-zoteux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62903-62650-zoteux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62903-62650-zoteux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62903-62650-zoteux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62904-62890-zouafques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62904-62890-zouafques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62904-62890-zouafques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62904-62890-zouafques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62905-62500-zudausques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62905-62500-zudausques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62905-62500-zudausques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62905-62500-zudausques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62906-62370-zutkerque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62906-62370-zutkerque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62906-62370-zutkerque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62906-62370-zutkerque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62907-62820-libercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62907-62820-libercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62907-62820-libercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62907-62820-libercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62908-62360-la_capelle_les_boulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62908-62360-la_capelle_les_boulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62908-62360-la_capelle_les_boulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62908-62360-la_capelle_les_boulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62909-62124-ytres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62909-62124-ytres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62909-62124-ytres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt62-pas_de_calais/commune62909-62124-ytres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-63.xml
+++ b/public/sitemaps/sitemap-63.xml
@@ -5,938 +5,1872 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63001-63260-aigueperse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63001-63260-aigueperse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63001-63260-aigueperse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63001-63260-aigueperse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63002-63980-aix_la_fayette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63002-63980-aix_la_fayette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63002-63980-aix_la_fayette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63002-63980-aix_la_fayette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63003-63600-ambert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63003-63600-ambert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63003-63600-ambert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63003-63600-ambert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63004-63770-les_ancizes_comps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63004-63770-les_ancizes_comps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63004-63770-les_ancizes_comps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63004-63770-les_ancizes_comps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63005-63340-antoingt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63005-63340-antoingt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63005-63340-antoingt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63005-63340-antoingt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63006-63420-anzat_le_luguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63006-63420-anzat_le_luguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63006-63420-anzat_le_luguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63006-63420-anzat_le_luguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63007-63420-apchat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63007-63420-apchat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63007-63420-apchat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63007-63420-apchat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63008-63250-arconsat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63008-63250-arconsat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63008-63250-arconsat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63008-63250-arconsat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63009-63420-ardes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63009-63420-ardes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63009-63420-ardes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63009-63420-ardes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63010-63220-arlanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63010-63220-arlanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63010-63220-arlanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63010-63220-arlanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63011-63700-ars_les_favets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63011-63700-ars_les_favets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63011-63700-ars_les_favets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63011-63700-ars_les_favets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63012-63460-artonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63012-63460-artonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63012-63460-artonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63012-63460-artonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63013-63260-aubiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63013-63260-aubiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63013-63260-aubiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63013-63260-aubiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63014-63170-aubiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63014-63170-aubiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63014-63170-aubiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63014-63170-aubiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63015-63120-aubusson_d_auvergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63015-63120-aubusson_d_auvergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63015-63120-aubusson_d_auvergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63015-63120-aubusson_d_auvergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63016-63930-augerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63016-63930-augerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63016-63930-augerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63016-63930-augerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63017-63340-augnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63017-63340-augnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63017-63340-augnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63017-63340-augnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63019-63510-aulnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63019-63510-aulnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63019-63510-aulnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63019-63510-aulnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63020-63210-aurieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63020-63210-aurieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63020-63210-aurieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63020-63210-aurieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63021-63114-authezat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63021-63114-authezat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63021-63114-authezat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63021-63114-authezat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63022-63570-auzat_la_combelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63022-63570-auzat_la_combelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63022-63570-auzat_la_combelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63022-63570-auzat_la_combelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63023-63590-auzelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63023-63590-auzelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63023-63590-auzelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63023-63590-auzelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63024-63690-aveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63024-63690-aveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63024-63690-aveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63024-63690-aveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63025-63390-ayat_sur_sioule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63025-63390-ayat_sur_sioule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63025-63390-ayat_sur_sioule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63025-63390-ayat_sur_sioule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63026-63970-aydat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63026-63970-aydat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63026-63970-aydat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63026-63970-aydat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63027-63600-baffie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63027-63600-baffie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63027-63600-baffie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63027-63600-baffie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63028-63810-bagnols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63028-63810-bagnols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63028-63810-bagnols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63028-63810-bagnols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63029-63570-bansat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63029-63570-bansat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63029-63570-bansat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63029-63570-bansat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63030-63310-bas_et_lezat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63030-63310-bas_et_lezat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63030-63310-bas_et_lezat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63030-63310-bas_et_lezat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63031-63570-beaulieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63031-63570-beaulieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63031-63570-beaulieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63031-63570-beaulieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63032-63110-beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63032-63110-beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63032-63110-beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63032-63110-beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63033-63310-beaumont_les_randan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63033-63310-beaumont_les_randan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63033-63310-beaumont_les_randan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63033-63310-beaumont_les_randan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63034-63116-beauregard_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63034-63116-beauregard_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63034-63116-beauregard_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63034-63116-beauregard_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63035-63460-beauregard_vendon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63035-63460-beauregard_vendon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63035-63460-beauregard_vendon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63035-63460-beauregard_vendon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63036-63500-bergonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63036-63500-bergonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63036-63500-bergonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63036-63500-bergonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63037-63480-bertignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63037-63480-bertignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63037-63480-bertignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63037-63480-bertignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63038-63610-besse_et_saint_anastaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63038-63610-besse_et_saint_anastaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63038-63610-besse_et_saint_anastaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63038-63610-besse_et_saint_anastaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63039-63220-beurieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63039-63220-beurieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63039-63220-beurieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63039-63220-beurieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63040-63160-billom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63040-63160-billom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63040-63160-billom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63040-63160-billom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63041-63640-biollet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63041-63640-biollet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63041-63640-biollet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63041-63640-biollet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63042-63112-blanzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63042-63112-blanzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63042-63112-blanzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63042-63112-blanzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63043-63440-blot_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63043-63440-blot_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63043-63440-blot_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63043-63440-blot_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63044-63160-bongheat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63044-63160-bongheat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63044-63160-bongheat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63044-63160-bongheat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63045-63190-bort_l_etang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63045-63190-bort_l_etang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63045-63190-bort_l_etang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63045-63190-bort_l_etang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63046-63340-boudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63046-63340-boudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63046-63340-boudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63046-63340-boudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63047-63150-la_bourboule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63047-63150-la_bourboule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63047-63150-la_bourboule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63047-63150-la_bourboule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63048-63760-bourg_lastic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63048-63760-bourg_lastic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63048-63760-bourg_lastic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63048-63760-bourg_lastic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63049-63910-bouzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63049-63910-bouzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63049-63910-bouzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63049-63910-bouzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63050-63570-brassac_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63050-63570-brassac_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63050-63570-brassac_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63050-63570-brassac_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63051-63500-brenat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63051-63500-brenat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63051-63500-brenat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63051-63500-brenat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63052-63340-le_breuil_sur_couze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63052-63340-le_breuil_sur_couze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63052-63340-le_breuil_sur_couze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63052-63340-le_breuil_sur_couze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63053-63820-briffons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63053-63820-briffons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63053-63820-briffons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63053-63820-briffons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63054-63500-le_broc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63054-63500-le_broc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63054-63500-le_broc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63054-63500-le_broc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63055-63230-bromont_lamothe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63055-63230-bromont_lamothe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63055-63230-bromont_lamothe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63055-63230-bromont_lamothe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63056-63490-brousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63056-63490-brousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63056-63490-brousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63056-63490-brousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63057-63880-le_brugeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63057-63880-le_brugeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63057-63880-le_brugeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63057-63880-le_brugeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63058-63350-bulhon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63058-63350-bulhon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63058-63350-bulhon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63058-63350-bulhon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63059-63270-busseol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63059-63270-busseol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63059-63270-busseol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63059-63270-busseol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63060-63330-bussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63060-63330-bussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63060-63330-bussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63060-63330-bussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63061-63260-bussieres_et_pruns/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63061-63260-bussieres_et_pruns/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63061-63260-bussieres_et_pruns/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63061-63260-bussieres_et_pruns/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63062-63700-buxieres_sous_montaigut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63062-63700-buxieres_sous_montaigut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63062-63700-buxieres_sous_montaigut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63062-63700-buxieres_sous_montaigut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63063-63118-cebazat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63063-63118-cebazat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63063-63118-cebazat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63063-63118-cebazat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63064-63620-la_celle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63064-63620-la_celle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63064-63620-la_celle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63064-63620-la_celle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63065-63520-ceilloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63065-63520-ceilloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63065-63520-ceilloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63065-63520-ceilloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63066-63250-celles_sur_durolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63066-63250-celles_sur_durolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63066-63250-celles_sur_durolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63066-63250-celles_sur_durolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63067-63330-la_cellette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63067-63330-la_cellette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63067-63330-la_cellette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63067-63330-la_cellette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63069-63670-le_cendre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63069-63670-le_cendre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63069-63670-le_cendre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63069-63670-le_cendre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63070-63122-ceyrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63070-63122-ceyrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63070-63122-ceyrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63070-63122-ceyrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63071-63210-ceyssat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63071-63210-ceyssat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63071-63210-ceyssat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63071-63210-ceyssat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63072-63250-chabreloche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63072-63250-chabreloche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63072-63250-chabreloche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63072-63250-chabreloche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63073-63320-chadeleuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63073-63320-chadeleuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63073-63320-chadeleuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63073-63320-chadeleuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63074-63340-chalus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63074-63340-chalus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63074-63340-chalus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63074-63340-chalus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63075-63400-chamalieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63075-63400-chamalieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63075-63400-chamalieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63075-63400-chamalieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63076-63980-chambon_sur_dolore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63076-63980-chambon_sur_dolore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63076-63980-chambon_sur_dolore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63076-63980-chambon_sur_dolore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63077-63790-chambon_sur_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63077-63790-chambon_sur_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63077-63790-chambon_sur_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63077-63790-chambon_sur_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63079-63580-champagnat_le_jeune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63079-63580-champagnat_le_jeune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63079-63580-champagnat_le_jeune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63079-63580-champagnat_le_jeune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63080-63320-champeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63080-63320-champeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63080-63320-champeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63080-63320-champeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63081-63600-champetieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63081-63600-champetieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63081-63600-champetieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63081-63600-champetieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63082-63440-champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63082-63440-champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63082-63440-champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63082-63440-champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63083-63530-chanat_la_mouteyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63083-63530-chanat_la_mouteyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63083-63530-chanat_la_mouteyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63083-63530-chanat_la_mouteyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63084-63450-chanonat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63084-63450-chanonat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63084-63450-chanonat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63084-63450-chanonat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63085-63230-chapdes_beaufort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63085-63230-chapdes_beaufort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63085-63230-chapdes_beaufort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63085-63230-chapdes_beaufort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63086-63590-la_chapelle_agnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63086-63590-la_chapelle_agnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63086-63590-la_chapelle_agnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63086-63590-la_chapelle_agnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63087-63420-la_chapelle_marcousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63087-63420-la_chapelle_marcousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63087-63420-la_chapelle_marcousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63087-63420-la_chapelle_marcousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63088-63580-la_chapelle_sur_usson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63088-63580-la_chapelle_sur_usson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63088-63580-la_chapelle_sur_usson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63088-63580-la_chapelle_sur_usson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63089-63720-chappes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63089-63720-chappes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63089-63720-chappes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63089-63720-chappes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63090-63260-chaptuzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63090-63260-chaptuzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63090-63260-chaptuzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63090-63260-chaptuzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63091-63340-charbonnier_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63091-63340-charbonnier_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63091-63340-charbonnier_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63091-63340-charbonnier_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63092-63410-charbonnieres_les_varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63092-63410-charbonnieres_les_varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63092-63410-charbonnieres_les_varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63092-63410-charbonnieres_les_varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63093-63410-charbonnieres_les_vieilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63093-63410-charbonnieres_les_vieilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63093-63410-charbonnieres_les_vieilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63093-63410-charbonnieres_les_vieilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63094-63640-charensat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63094-63640-charensat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63094-63640-charensat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63094-63640-charensat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63095-63290-charnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63095-63290-charnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63095-63290-charnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63095-63290-charnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63096-63160-chas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63096-63160-chas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63096-63160-chas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63096-63160-chas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63097-63320-chassagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63097-63320-chassagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63097-63320-chassagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63097-63320-chassagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63098-63680-chastreix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63098-63680-chastreix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63098-63680-chastreix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63098-63680-chastreix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63099-63119-chateaugay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63099-63119-chateaugay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63099-63119-chateaugay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63099-63119-chateaugay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63100-63390-chateauneuf_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63100-63390-chateauneuf_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63100-63390-chateauneuf_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63100-63390-chateauneuf_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63101-63330-chateau_sur_cher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63101-63330-chateau_sur_cher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63101-63330-chateau_sur_cher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63101-63330-chateau_sur_cher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63102-63290-chateldon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63102-63290-chateldon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63102-63290-chateldon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63102-63290-chateldon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63103-63140-chatel_guyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63103-63140-chatel_guyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63103-63140-chatel_guyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63103-63140-chatel_guyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63104-63660-la_chaulme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63104-63660-la_chaulme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63104-63660-la_chaulme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63104-63660-la_chaulme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63105-63220-chaumont_le_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63105-63220-chaumont_le_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63105-63220-chaumont_le_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63105-63220-chaumont_le_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63106-63117-chauriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63106-63117-chauriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63106-63117-chauriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63106-63117-chauriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63107-63720-chavaroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63107-63720-chavaroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63107-63720-chavaroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63107-63720-chavaroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63108-63200-le_cheix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63108-63200-le_cheix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63108-63200-le_cheix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63108-63200-le_cheix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63109-63320-chidrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63109-63320-chidrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63109-63320-chidrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63109-63320-chidrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63110-63740-cisternes_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63110-63740-cisternes_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63110-63740-cisternes_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63110-63740-cisternes_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63111-63320-clemensat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63111-63320-clemensat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63111-63320-clemensat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63111-63320-clemensat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63112-63720-clerlande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63112-63720-clerlande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63112-63720-clerlande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63112-63720-clerlande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63113-63100-clermont_ferrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63113-63100-clermont_ferrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63113-63100-clermont_ferrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63113-63100-clermont_ferrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63113-63000-clermont_ferrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63113-63000-clermont_ferrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63113-63000-clermont_ferrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63113-63000-clermont_ferrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63114-63340-collanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63114-63340-collanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63114-63340-collanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63114-63340-collanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63115-63380-combrailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63115-63380-combrailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63115-63380-combrailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63115-63380-combrailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63116-63460-combronde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63116-63460-combronde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63116-63460-combronde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63116-63460-combronde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63117-63610-compains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63117-63610-compains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63117-63610-compains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63117-63610-compains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63118-63380-condat_en_combraille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63118-63380-condat_en_combraille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63118-63380-condat_en_combraille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63118-63380-condat_en_combraille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63119-63490-condat_les_montboissier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63119-63490-condat_les_montboissier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63119-63490-condat_les_montboissier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63119-63490-condat_les_montboissier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63120-63730-corent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63120-63730-corent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63120-63730-corent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63120-63730-corent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63121-63114-coudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63121-63114-coudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63121-63114-coudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63121-63114-coudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63122-63320-courgoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63122-63320-courgoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63122-63320-courgoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63122-63320-courgoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63123-63450-cournols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63123-63450-cournols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63123-63450-cournols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63123-63450-cournols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63124-63800-cournon_d_auvergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63124-63800-cournon_d_auvergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63124-63800-cournon_d_auvergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63124-63800-cournon_d_auvergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63125-63120-courpiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63125-63120-courpiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63125-63120-courpiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63125-63120-courpiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63126-63450-le_crest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63126-63450-le_crest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63126-63450-le_crest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63126-63450-le_crest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63128-63350-crevant_laveine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63128-63350-crevant_laveine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63128-63350-crevant_laveine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63128-63350-crevant_laveine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63129-63810-cros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63129-63810-cros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63129-63810-cros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63129-63810-cros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63130-63700-la_crouzille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63130-63700-la_crouzille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63130-63700-la_crouzille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63130-63700-la_crouzille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63131-63350-culhat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63131-63350-culhat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63131-63350-culhat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63131-63350-culhat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63132-63590-cunlhat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63132-63590-cunlhat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63132-63590-cunlhat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63132-63590-cunlhat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63134-63340-dauzat_sur_vodable/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63134-63340-dauzat_sur_vodable/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63134-63340-dauzat_sur_vodable/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63134-63340-dauzat_sur_vodable/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63135-63200-davayat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63135-63200-davayat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63135-63200-davayat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63135-63200-davayat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63136-63520-domaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63136-63520-domaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63136-63520-domaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63136-63520-domaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63137-63220-doranges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63137-63220-doranges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63137-63220-doranges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63137-63220-doranges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63138-63300-dorat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63138-63300-dorat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63138-63300-dorat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63138-63300-dorat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63139-63220-dore_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63139-63220-dore_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63139-63220-dore_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63139-63220-dore_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63140-63700-durmignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63140-63700-durmignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63140-63700-durmignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63140-63700-durmignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63141-63830-durtol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63141-63830-durtol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63141-63830-durtol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63141-63830-durtol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63142-63980-echandelys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63142-63980-echandelys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63142-63980-echandelys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63142-63980-echandelys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63143-63260-effiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63143-63260-effiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63143-63260-effiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63143-63260-effiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63144-63850-egliseneuve_d_entraigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63144-63850-egliseneuve_d_entraigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63144-63850-egliseneuve_d_entraigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63144-63850-egliseneuve_d_entraigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63145-63490-egliseneuve_des_liards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63145-63490-egliseneuve_des_liards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63145-63490-egliseneuve_des_liards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63145-63490-egliseneuve_des_liards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63146-63160-egliseneuve_pres_billom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63146-63160-egliseneuve_pres_billom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63146-63160-egliseneuve_pres_billom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63146-63160-egliseneuve_pres_billom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63147-63840-eglisolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63147-63840-eglisolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63147-63840-eglisolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63147-63840-eglisolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63148-63720-ennezat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63148-63720-ennezat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63148-63720-ennezat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63148-63720-ennezat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63149-63720-entraigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63149-63720-entraigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63149-63720-entraigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63149-63720-entraigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63150-63530-enval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63150-63530-enval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63150-63530-enval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63150-63530-enval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63151-63300-escoutoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63151-63300-escoutoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63151-63300-escoutoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63151-63300-escoutoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63152-63390-espinasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63152-63390-espinasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63152-63390-espinasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63152-63390-espinasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63153-63850-espinchal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63153-63850-espinchal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63153-63850-espinchal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63153-63850-espinchal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63154-63160-espirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63154-63160-espirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63154-63160-espirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63154-63160-espirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63155-63520-estandeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63155-63520-estandeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63155-63520-estandeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63155-63520-estandeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63156-63570-esteil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63156-63570-esteil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63156-63570-esteil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63156-63570-esteil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63157-63160-fayet_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63157-63160-fayet_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63157-63160-fayet_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63157-63160-fayet_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63158-63630-fayet_ronaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63158-63630-fayet_ronaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63158-63630-fayet_ronaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63158-63630-fayet_ronaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63159-63620-fernoel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63159-63620-fernoel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63159-63620-fernoel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63159-63620-fernoel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63160-63500-aulhat_flat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63160-63500-aulhat_flat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63160-63500-aulhat_flat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63160-63500-aulhat_flat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63161-63600-la_forie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63161-63600-la_forie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63161-63600-la_forie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63161-63600-la_forie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63162-63980-fournols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63162-63980-fournols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63162-63980-fournols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63162-63980-fournols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63163-63740-gelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63163-63740-gelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63163-63740-gelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63163-63740-gelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63164-63360-gerzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63164-63360-gerzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63164-63360-gerzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63164-63360-gerzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63165-63620-giat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63165-63620-giat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63165-63620-giat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63165-63620-giat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63166-63340-gignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63166-63340-gignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63166-63340-gignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63166-63340-gignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63167-63200-gimeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63167-63200-gimeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63167-63200-gimeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63167-63200-gimeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63168-63160-glaine_montaigut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63168-63160-glaine_montaigut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63168-63160-glaine_montaigut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63168-63160-glaine_montaigut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63169-63850-la_godivelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63169-63850-la_godivelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63169-63850-la_godivelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63169-63850-la_godivelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63170-63230-la_goutelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63170-63230-la_goutelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63170-63230-la_goutelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63170-63230-la_goutelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63171-63390-gouttieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63171-63390-gouttieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63171-63390-gouttieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63171-63390-gouttieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63172-63320-grandeyrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63172-63320-grandeyrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63172-63320-grandeyrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63172-63320-grandeyrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63173-63600-grandrif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63173-63600-grandrif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63173-63600-grandrif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63173-63600-grandrif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63174-63890-grandval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63174-63890-grandval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63174-63890-grandval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63174-63890-grandval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63175-63470-herment/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63175-63470-herment/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63175-63470-herment/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63175-63470-herment/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63176-63210-heume_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63176-63210-heume_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63176-63210-heume_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63176-63210-heume_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63177-63270-isserteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63177-63270-isserteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63177-63270-isserteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63177-63270-isserteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63178-63500-issoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63178-63500-issoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63178-63500-issoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63178-63500-issoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63179-63990-job/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63179-63990-job/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63179-63990-job/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63179-63990-job/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63180-63350-joze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63180-63350-joze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63180-63350-joze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63180-63350-joze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63181-63460-jozerand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63181-63460-jozerand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63181-63460-jozerand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63181-63460-jozerand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63182-63570-jumeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63182-63570-jumeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63182-63570-jumeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63182-63570-jumeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63183-63690-labessette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63183-63690-labessette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63183-63690-labessette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63183-63690-labessette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63184-63290-lachaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63184-63290-lachaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63184-63290-lachaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63184-63290-lachaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63185-63570-lamontgie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63185-63570-lamontgie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63185-63570-lamontgie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63185-63570-lamontgie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63186-63380-landogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63186-63380-landogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63186-63380-landogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63186-63380-landogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63187-63700-lapeyrouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63187-63700-lapeyrouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63187-63700-lapeyrouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63187-63700-lapeyrouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63188-63270-laps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63188-63270-laps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63188-63270-laps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63188-63270-laps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63189-63820-laqueuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63189-63820-laqueuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63189-63820-laqueuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63189-63820-laqueuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63190-63690-larodde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63190-63690-larodde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63190-63690-larodde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63190-63690-larodde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63191-63760-lastic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63191-63760-lastic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63191-63760-lastic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63191-63760-lastic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63192-63680-la_tour_d_auvergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63192-63680-la_tour_d_auvergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63192-63680-la_tour_d_auvergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63192-63680-la_tour_d_auvergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63193-63370-lempdes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63193-63370-lempdes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63193-63370-lempdes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63193-63370-lempdes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63194-63190-lempty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63194-63190-lempty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63194-63190-lempty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63194-63190-lempty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63195-63190-lezoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63195-63190-lezoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63195-63190-lezoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63195-63190-lezoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63196-63290-limons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63196-63290-limons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63196-63290-limons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63196-63290-limons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63197-63440-lisseuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63197-63440-lisseuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63197-63440-lisseuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63197-63440-lisseuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63198-63410-loubeyrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63198-63410-loubeyrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63198-63410-loubeyrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63198-63410-loubeyrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63199-63320-ludesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63199-63320-ludesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63199-63320-ludesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63199-63320-ludesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63200-63360-lussat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63200-63360-lussat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63200-63360-lussat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63200-63360-lussat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63201-63350-luzillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63201-63350-luzillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63201-63350-luzillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63201-63350-luzillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63202-63340-madriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63202-63340-madriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63202-63340-madriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63202-63340-madriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63203-63200-malauzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63203-63200-malauzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63203-63200-malauzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63203-63200-malauzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63204-63510-malintrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63204-63510-malintrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63204-63510-malintrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63204-63510-malintrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63205-63270-manglieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63205-63270-manglieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63205-63270-manglieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63205-63270-manglieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63206-63410-manzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63206-63410-manzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63206-63410-manzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63206-63410-manzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63207-63480-marat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63207-63480-marat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63207-63480-marat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63207-63480-marat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63208-63440-marcillat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63208-63440-marcillat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63208-63440-marcillat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63208-63440-marcillat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63209-63340-mareugheol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63209-63340-mareugheol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63209-63340-mareugheol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63209-63340-mareugheol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63210-63350-maringues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63210-63350-maringues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63210-63350-maringues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63210-63350-maringues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63211-63940-marsac_en_livradois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63211-63940-marsac_en_livradois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63211-63940-marsac_en_livradois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63211-63940-marsac_en_livradois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63212-63200-marsat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63212-63200-marsat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63212-63200-marsat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63212-63200-marsat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63213-63430-les_martres_d_artiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63213-63430-les_martres_d_artiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63213-63430-les_martres_d_artiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63213-63430-les_martres_d_artiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63214-63730-les_martres_de_veyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63214-63730-les_martres_de_veyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63214-63730-les_martres_de_veyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63214-63730-les_martres_de_veyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63215-63720-martres_sur_morge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63215-63720-martres_sur_morge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63215-63720-martres_sur_morge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63215-63720-martres_sur_morge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63216-63160-mauzun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63216-63160-mauzun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63216-63160-mauzun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63216-63160-mauzun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63218-63220-mayres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63218-63220-mayres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63218-63220-mayres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63218-63220-mayres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63219-63230-mazaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63219-63230-mazaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63219-63230-mazaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63219-63230-mazaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63220-63420-mazoires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63220-63420-mazoires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63220-63420-mazoires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63220-63420-mazoires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63221-63220-medeyrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63221-63220-medeyrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63221-63220-medeyrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63221-63220-medeyrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63222-63320-meilhaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63222-63320-meilhaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63222-63320-meilhaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63222-63320-meilhaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63223-63560-menat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63223-63560-menat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63223-63560-menat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63223-63560-menat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63224-63200-menetrol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63224-63200-menetrol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63224-63200-menetrol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63224-63200-menetrol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63225-63750-messeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63225-63750-messeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63225-63750-messeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63225-63750-messeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63226-63115-mur_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63226-63115-mur_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63226-63115-mur_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63226-63115-mur_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63226-63111-mur_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63226-63111-mur_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63226-63111-mur_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63226-63111-mur_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63227-63730-mirefleurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63227-63730-mirefleurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63227-63730-mirefleurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63227-63730-mirefleurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63228-63380-miremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63228-63380-miremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63228-63380-miremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63228-63380-miremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63229-63190-moissat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63229-63190-moissat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63229-63190-moissat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63229-63190-moissat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63230-63890-le_monestier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63230-63890-le_monestier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63230-63890-le_monestier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63230-63890-le_monestier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63231-63650-la_monnerie_le_montel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63231-63650-la_monnerie_le_montel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63231-63650-la_monnerie_le_montel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63231-63650-la_monnerie_le_montel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63232-63310-mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63232-63310-mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63232-63310-mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63232-63310-mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63233-63700-montaigut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63233-63700-montaigut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63233-63700-montaigut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63233-63700-montaigut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63234-63320-montaigut_le_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63234-63320-montaigut_le_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63234-63320-montaigut_le_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63234-63320-montaigut_le_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63235-63460-montcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63235-63460-montcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63235-63460-montcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63235-63460-montcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63236-63240-mont_dore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63236-63240-mont_dore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63236-63240-mont_dore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63236-63240-mont_dore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63237-63380-montel_de_gelat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63237-63380-montel_de_gelat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63237-63380-montel_de_gelat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63237-63380-montel_de_gelat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63238-63230-montfermy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63238-63230-montfermy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63238-63230-montfermy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63238-63230-montfermy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63239-63160-montmorin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63239-63160-montmorin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63239-63160-montmorin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63239-63160-montmorin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63240-63260-montpensier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63240-63260-montpensier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63240-63260-montpensier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63240-63260-montpensier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63241-63114-montpeyroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63241-63114-montpeyroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63241-63114-montpeyroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63241-63114-montpeyroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63242-63340-moriat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63242-63340-moriat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63242-63340-moriat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63242-63340-moriat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63243-63700-moureuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63243-63700-moureuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63243-63700-moureuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63243-63700-moureuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63244-63200-chambaron_sur_morge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63244-63200-chambaron_sur_morge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63244-63200-chambaron_sur_morge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63244-63200-chambaron_sur_morge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63245-63200-mozac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63245-63200-mozac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63245-63200-mozac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63245-63200-mozac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63246-63150-murat_le_quaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63246-63150-murat_le_quaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63246-63150-murat_le_quaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63246-63150-murat_le_quaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63247-63790-murol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63247-63790-murol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63247-63790-murol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63247-63790-murol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63248-63210-nebouzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63248-63210-nebouzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63248-63210-nebouzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63248-63210-nebouzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63249-63120-neronde_sur_dore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63249-63120-neronde_sur_dore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63249-63120-neronde_sur_dore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63249-63120-neronde_sur_dore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63250-63320-neschers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63250-63320-neschers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63250-63320-neschers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63250-63320-neschers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63251-63560-neuf_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63251-63560-neuf_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63251-63560-neuf_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63251-63560-neuf_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63252-63160-neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63252-63160-neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63252-63160-neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63252-63160-neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63253-63290-noalhat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63253-63290-noalhat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63253-63290-noalhat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63253-63290-noalhat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63254-63830-nohanent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63254-63830-nohanent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63254-63830-nohanent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63254-63830-nohanent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63255-63340-nonette_orsonnette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63255-63340-nonette_orsonnette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63255-63340-nonette_orsonnette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63255-63340-nonette_orsonnette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63256-63220-novacelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63256-63220-novacelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63256-63220-novacelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63256-63220-novacelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63257-63210-olby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63257-63210-olby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63257-63210-olby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63257-63210-olby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63258-63880-olliergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63258-63880-olliergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63258-63880-olliergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63258-63880-olliergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63259-63450-olloix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63259-63450-olloix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63259-63450-olloix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63259-63450-olloix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63260-63880-olmet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63260-63880-olmet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63260-63880-olmet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63260-63880-olmet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63261-63500-orbeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63261-63500-orbeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63261-63500-orbeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63261-63500-orbeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63262-63670-orcet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63262-63670-orcet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63262-63670-orcet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63262-63670-orcet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63263-63870-orcines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63263-63870-orcines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63263-63870-orcines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63263-63870-orcines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63264-63210-orcival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63264-63210-orcival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63264-63210-orcival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63264-63210-orcival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63265-63190-orleat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63265-63190-orleat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63265-63190-orleat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63265-63190-orleat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63267-63550-palladuc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63267-63550-palladuc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63267-63550-palladuc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63267-63550-palladuc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63268-63500-pardines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63268-63500-pardines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63268-63500-pardines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63268-63500-pardines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63269-63270-parent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63269-63270-parent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63269-63270-parent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63269-63270-parent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63270-63500-parentignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63270-63500-parentignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63270-63500-parentignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63270-63500-parentignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63271-63290-paslieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63271-63290-paslieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63271-63290-paslieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63271-63290-paslieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63272-63170-perignat_les_sarlieve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63272-63170-perignat_les_sarlieve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63272-63170-perignat_les_sarlieve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63272-63170-perignat_les_sarlieve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63273-63800-perignat_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63273-63800-perignat_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63273-63800-perignat_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63273-63800-perignat_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63274-63210-perpezat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63274-63210-perpezat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63274-63210-perpezat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63274-63210-perpezat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63275-63500-perrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63275-63500-perrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63275-63500-perrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63275-63500-perrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63276-63920-peschadoires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63276-63920-peschadoires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63276-63920-peschadoires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63276-63920-peschadoires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63277-63580-peslieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63277-63580-peslieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63277-63580-peslieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63277-63580-peslieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63278-63200-pessat_villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63278-63200-pessat_villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63278-63200-pessat_villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63278-63200-pessat_villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63279-63113-picherande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63279-63113-picherande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63279-63113-picherande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63279-63113-picherande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63280-63270-pignols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63280-63270-pignols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63280-63270-pignols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63280-63270-pignols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63281-63330-pionsat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63281-63330-pionsat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63281-63330-pionsat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63281-63330-pionsat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63282-63730-plauzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63282-63730-plauzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63282-63730-plauzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63282-63730-plauzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63283-63380-pontaumur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63283-63380-pontaumur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63283-63380-pontaumur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63283-63380-pontaumur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63284-63430-pont_du_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63284-63430-pont_du_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63284-63430-pont_du_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63284-63430-pont_du_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63285-63230-pontgibaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63285-63230-pontgibaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63285-63230-pontgibaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63285-63230-pontgibaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63286-63440-pouzol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63286-63440-pouzol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63286-63440-pouzol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63286-63440-pouzol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63287-63500-les_pradeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63287-63500-les_pradeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63287-63500-les_pradeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63287-63500-les_pradeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63288-63200-prompsat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63288-63200-prompsat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63288-63200-prompsat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63288-63200-prompsat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63289-63470-prondines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63289-63470-prondines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63289-63470-prondines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63289-63470-prondines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63290-63230-pulverieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63290-63230-pulverieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63290-63230-pulverieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63290-63230-pulverieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63291-63290-puy_guillaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63291-63290-puy_guillaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63291-63290-puy_guillaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63291-63290-puy_guillaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63292-63470-puy_saint_gulmier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63292-63470-puy_saint_gulmier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63292-63470-puy_saint_gulmier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63292-63470-puy_saint_gulmier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63293-63330-le_quartier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63293-63330-le_quartier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63293-63330-le_quartier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63293-63330-le_quartier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63294-63780-queuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63294-63780-queuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63294-63780-queuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63294-63780-queuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63295-63310-randan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63295-63310-randan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63295-63310-randan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63295-63310-randan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63296-63190-ravel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63296-63190-ravel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63296-63190-ravel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63296-63190-ravel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63297-63160-reignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63297-63160-reignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63297-63160-reignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63297-63160-reignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63298-63930-la_renaudie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63298-63930-la_renaudie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63298-63930-la_renaudie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63298-63930-la_renaudie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63299-63420-rentieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63299-63420-rentieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63299-63420-rentieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63299-63420-rentieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63300-63200-riom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63300-63200-riom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63300-63200-riom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63300-63200-riom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63301-63290-ris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63301-63290-ris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63301-63290-ris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63301-63290-ris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63302-63670-la_roche_blanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63302-63670-la_roche_blanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63302-63670-la_roche_blanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63302-63670-la_roche_blanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63303-63420-roche_charles_la_mayrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63303-63420-roche_charles_la_mayrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63303-63420-roche_charles_la_mayrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63303-63420-roche_charles_la_mayrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63304-63330-roche_d_agoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63304-63330-roche_d_agoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63304-63330-roche_d_agoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63304-63330-roche_d_agoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63305-63210-rochefort_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63305-63210-rochefort_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63305-63210-rochefort_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63305-63210-rochefort_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63306-63800-la_roche_noire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63306-63800-la_roche_noire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63306-63800-la_roche_noire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63306-63800-la_roche_noire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63307-63540-romagnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63307-63540-romagnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63307-63540-romagnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63307-63540-romagnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63308-63130-royat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63308-63130-royat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63308-63130-royat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63308-63130-royat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63309-63840-saillant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63309-63840-saillant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63309-63840-saillant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63309-63840-saillant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63310-63120-sainte_agathe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63310-63120-sainte_agathe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63310-63120-sainte_agathe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63310-63120-sainte_agathe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63311-63260-saint_agoulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63311-63260-saint_agoulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63311-63260-saint_agoulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63311-63260-saint_agoulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63312-63220-saint_alyre_d_arlanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63312-63220-saint_alyre_d_arlanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63312-63220-saint_alyre_d_arlanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63312-63220-saint_alyre_d_arlanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63313-63420-saint_alyre_es_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63313-63420-saint_alyre_es_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63313-63420-saint_alyre_es_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63313-63420-saint_alyre_es_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63314-63890-saint_amant_roche_savine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63314-63890-saint_amant_roche_savine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63314-63890-saint_amant_roche_savine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63314-63890-saint_amant_roche_savine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63315-63450-saint_amant_tallende/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63315-63450-saint_amant_tallende/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63315-63450-saint_amant_tallende/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63315-63450-saint_amant_tallende/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63317-63310-saint_andre_le_coq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63317-63310-saint_andre_le_coq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63317-63310-saint_andre_le_coq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63317-63310-saint_andre_le_coq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63318-63410-saint_angel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63318-63410-saint_angel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63318-63410-saint_angel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63318-63410-saint_angel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63319-63660-saint_antheme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63319-63660-saint_antheme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63319-63660-saint_antheme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63319-63660-saint_antheme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63320-63380-saint_avit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63320-63380-saint_avit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63320-63380-saint_avit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63320-63380-saint_avit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63321-63500-saint_babel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63321-63500-saint_babel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63321-63500-saint_babel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63321-63500-saint_babel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63322-63360-saint_beauzire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63322-63360-saint_beauzire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63322-63360-saint_beauzire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63322-63360-saint_beauzire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63323-63630-saint_bonnet_le_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63323-63630-saint_bonnet_le_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63323-63630-saint_bonnet_le_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63323-63630-saint_bonnet_le_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63324-63630-saint_bonnet_le_chastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63324-63630-saint_bonnet_le_chastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63324-63630-saint_bonnet_le_chastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63324-63630-saint_bonnet_le_chastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63325-63800-saint_bonnet_les_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63325-63800-saint_bonnet_les_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63325-63800-saint_bonnet_les_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63325-63800-saint_bonnet_les_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63326-63210-saint_bonnet_pres_orcival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63326-63210-saint_bonnet_pres_orcival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63326-63210-saint_bonnet_pres_orcival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63326-63210-saint_bonnet_pres_orcival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63327-63200-saint_bonnet_pres_riom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63327-63200-saint_bonnet_pres_riom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63327-63200-saint_bonnet_pres_riom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63327-63200-saint_bonnet_pres_riom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63328-63580-sainte_catherine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63328-63580-sainte_catherine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63328-63580-sainte_catherine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63328-63580-sainte_catherine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63329-63390-sainte_christine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63329-63390-sainte_christine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63329-63390-sainte_christine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63329-63390-sainte_christine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63330-63320-saint_cirgues_sur_couze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63330-63320-saint_cirgues_sur_couze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63330-63320-saint_cirgues_sur_couze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63330-63320-saint_cirgues_sur_couze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63331-63660-saint_clement_de_valorgue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63331-63660-saint_clement_de_valorgue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63331-63660-saint_clement_de_valorgue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63331-63660-saint_clement_de_valorgue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63332-63310-saint_clement_de_regnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63332-63310-saint_clement_de_regnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63332-63310-saint_clement_de_regnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63332-63310-saint_clement_de_regnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63333-63310-saint_denis_combarnazat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63333-63310-saint_denis_combarnazat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63333-63310-saint_denis_combarnazat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63333-63310-saint_denis_combarnazat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63334-63520-saint_dier_d_auvergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63334-63520-saint_dier_d_auvergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63334-63520-saint_dier_d_auvergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63334-63520-saint_dier_d_auvergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63335-63320-saint_diery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63335-63320-saint_diery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63335-63320-saint_diery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63335-63320-saint_diery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63336-63680-saint_donat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63336-63680-saint_donat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63336-63680-saint_donat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63336-63680-saint_donat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63337-63890-saint_eloy_la_glaciere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63337-63890-saint_eloy_la_glaciere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63337-63890-saint_eloy_la_glaciere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63337-63890-saint_eloy_la_glaciere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63338-63700-saint_eloy_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63338-63700-saint_eloy_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63338-63700-saint_eloy_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63338-63700-saint_eloy_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63339-63380-saint_etienne_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63339-63380-saint_etienne_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63339-63380-saint_etienne_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63339-63380-saint_etienne_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63340-63580-saint_etienne_sur_usson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63340-63580-saint_etienne_sur_usson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63340-63580-saint_etienne_sur_usson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63340-63580-saint_etienne_sur_usson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63341-63600-saint_ferreol_des_cotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63341-63600-saint_ferreol_des_cotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63341-63600-saint_ferreol_des_cotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63341-63600-saint_ferreol_des_cotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63342-63320-saint_floret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63342-63320-saint_floret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63342-63320-saint_floret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63342-63320-saint_floret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63343-63520-saint_flour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63343-63520-saint_flour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63343-63520-saint_flour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63343-63520-saint_flour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63344-63440-saint_gal_sur_sioule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63344-63440-saint_gal_sur_sioule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63344-63440-saint_gal_sur_sioule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63344-63440-saint_gal_sur_sioule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63345-63122-saint_genes_champanelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63345-63122-saint_genes_champanelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63345-63122-saint_genes_champanelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63345-63122-saint_genes_champanelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63346-63850-saint_genes_champespe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63346-63850-saint_genes_champespe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63346-63850-saint_genes_champespe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63346-63850-saint_genes_champespe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63347-63260-saint_genes_du_retz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63347-63260-saint_genes_du_retz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63347-63260-saint_genes_du_retz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63347-63260-saint_genes_du_retz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63348-63580-saint_genes_la_tourette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63348-63580-saint_genes_la_tourette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63348-63580-saint_genes_la_tourette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63348-63580-saint_genes_la_tourette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63349-63780-saint_georges_de_mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63349-63780-saint_georges_de_mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63349-63780-saint_georges_de_mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63349-63780-saint_georges_de_mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63350-63800-saint_georges_sur_allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63350-63800-saint_georges_sur_allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63350-63800-saint_georges_sur_allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63350-63800-saint_georges_sur_allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63351-63470-saint_germain_pres_herment/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63351-63470-saint_germain_pres_herment/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63351-63470-saint_germain_pres_herment/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63351-63470-saint_germain_pres_herment/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63352-63340-saint_germain_lembron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63352-63340-saint_germain_lembron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63352-63340-saint_germain_lembron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63352-63340-saint_germain_lembron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63353-63630-saint_germain_l_herm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63353-63630-saint_germain_l_herm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63353-63630-saint_germain_l_herm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63353-63630-saint_germain_l_herm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63354-63390-saint_gervais_d_auvergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63354-63390-saint_gervais_d_auvergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63354-63390-saint_gervais_d_auvergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63354-63390-saint_gervais_d_auvergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63355-63880-saint_gervais_sous_meymont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63355-63880-saint_gervais_sous_meymont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63355-63880-saint_gervais_sous_meymont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63355-63880-saint_gervais_sous_meymont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63356-63340-saint_gervazy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63356-63340-saint_gervazy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63356-63340-saint_gervazy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63356-63340-saint_gervazy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63357-63340-saint_herent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63357-63340-saint_herent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63357-63340-saint_herent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63357-63340-saint_herent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63358-63440-saint_hilaire_la_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63358-63440-saint_hilaire_la_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63358-63440-saint_hilaire_la_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63358-63440-saint_hilaire_la_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63359-63380-saint_hilaire_les_monges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63359-63380-saint_hilaire_les_monges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63359-63380-saint_hilaire_les_monges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63359-63380-saint_hilaire_les_monges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63360-63330-saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63360-63330-saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63360-63330-saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63360-63330-saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63362-63720-saint_ignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63362-63720-saint_ignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63362-63720-saint_ignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63362-63720-saint_ignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63363-63230-saint_jacques_d_ambur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63363-63230-saint_jacques_d_ambur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63363-63230-saint_jacques_d_ambur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63363-63230-saint_jacques_d_ambur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63364-63190-saint_jean_d_heurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63364-63190-saint_jean_d_heurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63364-63190-saint_jean_d_heurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63364-63190-saint_jean_d_heurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63365-63520-saint_jean_des_ollieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63365-63520-saint_jean_des_ollieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63365-63520-saint_jean_des_ollieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63365-63520-saint_jean_des_ollieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63366-63490-saint_jean_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63366-63490-saint_jean_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63366-63490-saint_jean_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63366-63490-saint_jean_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63367-63570-saint_jean_saint_gervais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63367-63570-saint_jean_saint_gervais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63367-63570-saint_jean_saint_gervais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63367-63570-saint_jean_saint_gervais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63368-63160-saint_julien_de_coppel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63368-63160-saint_julien_de_coppel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63368-63160-saint_julien_de_coppel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63368-63160-saint_julien_de_coppel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63369-63390-saint_julien_la_geneste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63369-63390-saint_julien_la_geneste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63369-63390-saint_julien_la_geneste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63369-63390-saint_julien_la_geneste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63370-63820-saint_julien_puy_laveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63370-63820-saint_julien_puy_laveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63370-63820-saint_julien_puy_laveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63370-63820-saint_julien_puy_laveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63371-63600-saint_just/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63371-63600-saint_just/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63371-63600-saint_just/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63371-63600-saint_just/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63372-63350-saint_laure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63372-63350-saint_laure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63372-63350-saint_laure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63372-63350-saint_laure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63373-63330-saint_maigner/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63373-63330-saint_maigner/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63373-63330-saint_maigner/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63373-63330-saint_maigner/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63374-63600-saint_martin_des_olmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63374-63600-saint_martin_des_olmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63374-63600-saint_martin_des_olmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63374-63600-saint_martin_des_olmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63375-63570-saint_martin_des_plains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63375-63570-saint_martin_des_plains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63375-63570-saint_martin_des_plains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63375-63570-saint_martin_des_plains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63376-63580-saint_martin_d_ollieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63376-63580-saint_martin_d_ollieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63376-63580-saint_martin_d_ollieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63376-63580-saint_martin_d_ollieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63377-63330-saint_maurice_pres_pionsat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63377-63330-saint_maurice_pres_pionsat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63377-63330-saint_maurice_pres_pionsat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63377-63330-saint_maurice_pres_pionsat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63378-63270-saint_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63378-63270-saint_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63378-63270-saint_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63378-63270-saint_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63379-63460-saint_myon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63379-63460-saint_myon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63379-63460-saint_myon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63379-63460-saint_myon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63380-63710-saint_nectaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63380-63710-saint_nectaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63380-63710-saint_nectaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63380-63710-saint_nectaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63381-63230-saint_ours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63381-63230-saint_ours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63381-63230-saint_ours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63381-63230-saint_ours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63382-63440-saint_pardoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63382-63440-saint_pardoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63382-63440-saint_pardoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63382-63440-saint_pardoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63383-63610-saint_pierre_colamine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63383-63610-saint_pierre_colamine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63383-63610-saint_pierre_colamine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63383-63610-saint_pierre_colamine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63384-63480-saint_pierre_la_bourlhonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63384-63480-saint_pierre_la_bourlhonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63384-63480-saint_pierre_la_bourlhonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63384-63480-saint_pierre_la_bourlhonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63385-63230-saint_pierre_le_chastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63385-63230-saint_pierre_le_chastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63385-63230-saint_pierre_le_chastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63385-63230-saint_pierre_le_chastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63386-63210-saint_pierre_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63386-63210-saint_pierre_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63386-63210-saint_pierre_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63386-63210-saint_pierre_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63387-63310-saint_priest_bramefant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63387-63310-saint_priest_bramefant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63387-63310-saint_priest_bramefant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63387-63310-saint_priest_bramefant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63388-63640-saint_priest_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63388-63640-saint_priest_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63388-63640-saint_priest_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63388-63640-saint_priest_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63389-63490-saint_quentin_sur_sauxillanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63389-63490-saint_quentin_sur_sauxillanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63389-63490-saint_quentin_sur_sauxillanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63389-63490-saint_quentin_sur_sauxillanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63390-63440-saint_quintin_sur_sioule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63390-63440-saint_quintin_sur_sioule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63390-63440-saint_quintin_sur_sioule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63390-63440-saint_quintin_sur_sioule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63391-63440-saint_remy_de_blot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63391-63440-saint_remy_de_blot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63391-63440-saint_remy_de_blot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63391-63440-saint_remy_de_blot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63392-63500-saint_remy_de_chargnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63392-63500-saint_remy_de_chargnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63392-63500-saint_remy_de_chargnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63392-63500-saint_remy_de_chargnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63393-63550-saint_remy_sur_durolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63393-63550-saint_remy_sur_durolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63393-63550-saint_remy_sur_durolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63393-63550-saint_remy_sur_durolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63394-63660-saint_romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63394-63660-saint_romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63394-63660-saint_romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63394-63660-saint_romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63395-63450-saint_sandoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63395-63450-saint_sandoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63395-63450-saint_sandoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63395-63450-saint_sandoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63396-63450-saint_saturnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63396-63450-saint_saturnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63396-63450-saint_saturnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63396-63450-saint_saturnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63397-63950-saint_sauves_d_auvergne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63397-63950-saint_sauves_d_auvergne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63397-63950-saint_sauves_d_auvergne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63397-63950-saint_sauves_d_auvergne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63398-63220-saint_sauveur_la_sagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63398-63220-saint_sauveur_la_sagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63398-63220-saint_sauveur_la_sagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63398-63220-saint_sauveur_la_sagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63399-63760-saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63399-63760-saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63399-63760-saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63399-63760-saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63400-63310-saint_sylvestre_pragoulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63400-63310-saint_sylvestre_pragoulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63400-63310-saint_sylvestre_pragoulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63400-63310-saint_sylvestre_pragoulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63401-63790-saint_victor_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63401-63790-saint_victor_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63401-63790-saint_victor_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63401-63790-saint_victor_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63402-63550-saint_victor_montvianeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63402-63550-saint_victor_montvianeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63402-63550-saint_victor_montvianeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63402-63550-saint_victor_montvianeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63403-63320-saint_vincent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63403-63320-saint_vincent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63403-63320-saint_vincent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63403-63320-saint_vincent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63404-63500-saint_yvoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63404-63500-saint_yvoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63404-63500-saint_yvoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63404-63500-saint_yvoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63405-63270-salledes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63405-63270-salledes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63405-63270-salledes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63405-63270-salledes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63406-63260-sardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63406-63260-sardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63406-63260-sardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63406-63260-sardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63407-63970-saulzet_le_froid/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63407-63970-saulzet_le_froid/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63407-63970-saulzet_le_froid/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63407-63970-saulzet_le_froid/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63408-63390-sauret_besserve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63408-63390-sauret_besserve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63408-63390-sauret_besserve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63408-63390-sauret_besserve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63409-63320-saurier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63409-63320-saurier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63409-63320-saurier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63409-63320-saurier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63410-63470-sauvagnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63410-63470-sauvagnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63410-63470-sauvagnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63410-63470-sauvagnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63411-63500-sauvagnat_sainte_marthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63411-63500-sauvagnat_sainte_marthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63411-63500-sauvagnat_sainte_marthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63411-63500-sauvagnat_sainte_marthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63412-63840-sauvessanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63412-63840-sauvessanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63412-63840-sauvessanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63412-63840-sauvessanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63413-63730-la_sauvetat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63413-63730-la_sauvetat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63413-63730-la_sauvetat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63413-63730-la_sauvetat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63414-63120-sauviat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63414-63120-sauviat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63414-63120-sauviat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63414-63120-sauviat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63415-63490-sauxillanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63415-63490-sauxillanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63415-63490-sauxillanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63415-63490-sauxillanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63416-63750-savennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63416-63750-savennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63416-63750-savennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63416-63750-savennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63417-63530-sayat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63417-63530-sayat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63417-63530-sayat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63417-63530-sayat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63418-63120-sermentizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63418-63120-sermentizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63418-63120-sermentizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63418-63120-sermentizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63419-63560-servant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63419-63560-servant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63419-63560-servant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63419-63560-servant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63420-63190-seychalles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63420-63190-seychalles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63420-63190-seychalles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63420-63190-seychalles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63421-63690-singles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63421-63690-singles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63421-63690-singles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63421-63690-singles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63422-63500-solignat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63422-63500-solignat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63422-63500-solignat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63422-63500-solignat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63423-63490-sugeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63423-63490-sugeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63423-63490-sugeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63423-63490-sugeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63424-63720-surat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63424-63720-surat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63424-63720-surat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63424-63720-surat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63425-63450-tallende/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63425-63450-tallende/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63425-63450-tallende/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63425-63450-tallende/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63426-63690-tauves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63426-63690-tauves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63426-63690-tauves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63426-63690-tauves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63427-63460-teilhede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63427-63460-teilhede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63427-63460-teilhede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63427-63460-teilhede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63428-63560-teilhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63428-63560-teilhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63428-63560-teilhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63428-63560-teilhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63429-63340-ternant_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63429-63340-ternant_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63429-63340-ternant_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63429-63340-ternant_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63430-63300-thiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63430-63300-thiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63430-63300-thiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63430-63300-thiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63431-63600-thiolieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63431-63600-thiolieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63431-63600-thiolieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63431-63600-thiolieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63432-63260-thuret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63432-63260-thuret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63432-63260-thuret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63432-63260-thuret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63433-63470-tortebesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63433-63470-tortebesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63433-63470-tortebesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63433-63470-tortebesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63434-63590-tours_sur_meymont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63434-63590-tours_sur_meymont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63434-63590-tours_sur_meymont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63434-63590-tours_sur_meymont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63435-63320-tourzel_ronzieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63435-63320-tourzel_ronzieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63435-63320-tourzel_ronzieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63435-63320-tourzel_ronzieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63436-63380-tralaigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63436-63380-tralaigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63436-63380-tralaigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63436-63380-tralaigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63437-63810-tremouille_saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63437-63810-tremouille_saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63437-63810-tremouille_saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63437-63810-tremouille_saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63438-63520-trezioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63438-63520-trezioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63438-63520-trezioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63438-63520-trezioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63439-63490-usson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63439-63490-usson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63439-63490-usson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63439-63490-usson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63440-63610-valbeleix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63440-63610-valbeleix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63440-63610-valbeleix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63440-63610-valbeleix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63441-63600-valcivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63441-63600-valcivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63441-63600-valcivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63441-63600-valcivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63442-63580-valz_sous_chateauneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63442-63580-valz_sous_chateauneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63442-63580-valz_sous_chateauneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63442-63580-valz_sous_chateauneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63443-63720-varennes_sur_morge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63443-63720-varennes_sur_morge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63443-63720-varennes_sur_morge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63443-63720-varennes_sur_morge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63444-63500-varennes_sur_usson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63444-63500-varennes_sur_usson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63444-63500-varennes_sur_usson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63444-63500-varennes_sur_usson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63445-63910-vassel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63445-63910-vassel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63445-63910-vassel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63445-63910-vassel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63446-63260-vensat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63446-63260-vensat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63446-63260-vensat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63446-63260-vensat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63447-63330-vergheas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63447-63330-vergheas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63447-63330-vergheas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63447-63330-vergheas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63448-63580-le_vernet_chameane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63448-63580-le_vernet_chameane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63448-63580-le_vernet_chameane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63448-63580-le_vernet_chameane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63449-63710-le_vernet_sainte_marguerite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63449-63710-le_vernet_sainte_marguerite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63449-63710-le_vernet_sainte_marguerite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63449-63710-le_vernet_sainte_marguerite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63450-63470-verneugheol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63450-63470-verneugheol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63450-63470-verneugheol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63450-63470-verneugheol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63451-63210-vernines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63451-63210-vernines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63451-63210-vernines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63451-63210-vernines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63452-63320-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63452-63320-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63452-63320-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63452-63320-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63453-63910-vertaizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63453-63910-vertaizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63453-63910-vertaizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63453-63910-vertaizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63454-63480-vertolaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63454-63480-vertolaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63454-63480-vertolaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63454-63480-vertolaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63455-63960-veyre_monton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63455-63960-veyre_monton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63455-63960-veyre_monton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63455-63960-veyre_monton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63456-63340-vichel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63456-63340-vichel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63456-63340-vichel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63456-63340-vichel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63457-63270-vic_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63457-63270-vic_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63457-63270-vic_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63457-63270-vic_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63458-63340-villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63458-63340-villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63458-63340-villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63458-63340-villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63459-63310-villeneuve_les_cerfs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63459-63310-villeneuve_les_cerfs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63459-63310-villeneuve_les_cerfs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63459-63310-villeneuve_les_cerfs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63460-63380-villosanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63460-63380-villosanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63460-63380-villosanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63460-63380-villosanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63461-63350-vinzelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63461-63350-vinzelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63461-63350-vinzelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63461-63350-vinzelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63462-63330-virlet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63462-63330-virlet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63462-63330-virlet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63462-63330-virlet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63463-63250-viscomtat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63463-63250-viscomtat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63463-63250-viscomtat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63463-63250-viscomtat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63464-63410-vitrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63464-63410-vitrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63464-63410-vitrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63464-63410-vitrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63465-63840-viverols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63465-63840-viverols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63465-63840-viverols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63465-63840-viverols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63466-63500-vodable/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63466-63500-vodable/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63466-63500-vodable/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63466-63500-vodable/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63467-63620-voingt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63467-63620-voingt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63467-63620-voingt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63467-63620-voingt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63468-63120-vollore_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63468-63120-vollore_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63468-63120-vollore_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63468-63120-vollore_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63469-63120-vollore_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63469-63120-vollore_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63469-63120-vollore_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63469-63120-vollore_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63470-63530-volvic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63470-63530-volvic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63470-63530-volvic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63470-63530-volvic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63471-63700-youx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63471-63700-youx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63471-63700-youx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63471-63700-youx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63472-63270-yronde_et_buron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63472-63270-yronde_et_buron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63472-63270-yronde_et_buron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63472-63270-yronde_et_buron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63473-63200-yssac_la_tourette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63473-63200-yssac_la_tourette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63473-63200-yssac_la_tourette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt63-puy_de_dome/commune63473-63200-yssac_la_tourette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-64.xml
+++ b/public/sitemaps/sitemap-64.xml
@@ -5,1100 +5,2196 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64001-64460-aast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64001-64460-aast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64001-64460-aast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64001-64460-aast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64002-64160-abere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64002-64160-abere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64002-64160-abere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64002-64160-abere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64003-64150-abidos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64003-64150-abidos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64003-64150-abidos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64003-64150-abidos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64004-64390-abitain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64004-64390-abitain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64004-64390-abitain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64004-64390-abitain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64005-64360-abos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64005-64360-abos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64005-64360-abos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64005-64360-abos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64006-64490-accous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64006-64490-accous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64006-64490-accous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64006-64490-accous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64007-64400-agnos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64007-64400-agnos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64007-64400-agnos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64007-64400-agnos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64008-64220-ahaxe_alciette_bascassan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64008-64220-ahaxe_alciette_bascassan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64008-64220-ahaxe_alciette_bascassan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64008-64220-ahaxe_alciette_bascassan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64009-64210-ahetze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64009-64210-ahetze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64009-64210-ahetze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64009-64210-ahetze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64010-64120-aicirits_camou_suhast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64010-64120-aicirits_camou_suhast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64010-64120-aicirits_camou_suhast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64010-64120-aicirits_camou_suhast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64011-64220-aincille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64011-64220-aincille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64011-64220-aincille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64011-64220-aincille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64012-64130-ainharp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64012-64130-ainharp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64012-64130-ainharp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64012-64130-ainharp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64013-64220-ainhice_mongelos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64013-64220-ainhice_mongelos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64013-64220-ainhice_mongelos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64013-64220-ainhice_mongelos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64014-64250-ainhoa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64014-64250-ainhoa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64014-64250-ainhoa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64014-64250-ainhoa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64015-64470-alcay_alcabehety_sunharette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64015-64470-alcay_alcabehety_sunharette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64015-64470-alcay_alcabehety_sunharette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64015-64470-alcay_alcabehety_sunharette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64016-64430-aldudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64016-64430-aldudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64016-64430-aldudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64016-64430-aldudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64017-64470-alos_sibas_abense/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64017-64470-alos_sibas_abense/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64017-64470-alos_sibas_abense/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64017-64470-alos_sibas_abense/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64018-64120-amendeuix_oneix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64018-64120-amendeuix_oneix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64018-64120-amendeuix_oneix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64018-64120-amendeuix_oneix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64019-64120-amorots_succos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64019-64120-amorots_succos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64019-64120-amorots_succos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64019-64120-amorots_succos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64021-64420-andoins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64021-64420-andoins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64021-64420-andoins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64021-64420-andoins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64022-64390-andrein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64022-64390-andrein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64022-64390-andrein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64022-64390-andrein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64023-64510-angais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64023-64510-angais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64023-64510-angais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64023-64510-angais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64024-64600-anglet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64024-64600-anglet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64024-64600-anglet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64024-64600-anglet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64025-64190-angous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64025-64190-angous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64025-64190-angous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64025-64190-angous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64026-64220-anhaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64026-64220-anhaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64026-64220-anhaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64026-64220-anhaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64027-64160-anos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64027-64160-anos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64027-64160-anos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64027-64160-anos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64028-64350-anoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64028-64350-anoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64028-64350-anoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64028-64350-anoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64029-64570-aramits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64029-64570-aramits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64029-64570-aramits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64029-64570-aramits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64031-64270-arancou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64031-64270-arancou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64031-64270-arancou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64031-64270-arancou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64032-64190-araujuzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64032-64190-araujuzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64032-64190-araujuzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64032-64190-araujuzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64033-64190-araux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64033-64190-araux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64033-64190-araux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64033-64190-araux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64034-64120-arberats_sillegue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64034-64120-arberats_sillegue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64034-64120-arberats_sillegue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64034-64120-arberats_sillegue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64035-64210-arbonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64035-64210-arbonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64035-64210-arbonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64035-64210-arbonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64036-64120-arbouet_sussaute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64036-64120-arbouet_sussaute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64036-64120-arbouet_sussaute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64036-64120-arbouet_sussaute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64037-64230-arbus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64037-64230-arbus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64037-64230-arbus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64037-64230-arbus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64038-64200-arcangues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64038-64200-arcangues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64038-64200-arcangues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64038-64200-arcangues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64039-64400-aren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64039-64400-aren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64039-64400-aren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64039-64400-aren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64040-64570-arette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64040-64570-arette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64040-64570-arette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64040-64570-arette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64041-64320-aressy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64041-64320-aressy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64041-64320-aressy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64041-64320-aressy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64042-64300-argagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64042-64300-argagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64042-64300-argagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64042-64300-argagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64043-64450-argelos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64043-64450-argelos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64043-64450-argelos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64043-64450-argelos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64044-64410-arget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64044-64410-arget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64044-64410-arget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64044-64410-arget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64045-64120-arhansus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64045-64120-arhansus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64045-64120-arhansus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64045-64120-arhansus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64046-64640-armendarits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64046-64640-armendarits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64046-64640-armendarits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64046-64640-armendarits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64047-64220-arneguy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64047-64220-arneguy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64047-64220-arneguy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64047-64220-arneguy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64048-64370-arnos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64048-64370-arnos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64048-64370-arnos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64048-64370-arnos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64049-64120-aroue_ithorots_olhaiby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64049-64120-aroue_ithorots_olhaiby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64049-64120-aroue_ithorots_olhaiby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64049-64120-aroue_ithorots_olhaiby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64050-64130-arrast_larrebieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64050-64130-arrast_larrebieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64050-64130-arrast_larrebieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64050-64130-arrast_larrebieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64051-64120-arraute_charritte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64051-64120-arraute_charritte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64051-64120-arraute_charritte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64051-64120-arraute_charritte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64052-64350-arricau_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64052-64350-arricau_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64052-64350-arricau_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64052-64350-arricau_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64053-64420-arrien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64053-64420-arrien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64053-64420-arrien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64053-64420-arrien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64054-64800-arros_de_nay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64054-64800-arros_de_nay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64054-64800-arros_de_nay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64054-64800-arros_de_nay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64056-64350-arroses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64056-64350-arroses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64056-64350-arroses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64056-64350-arroses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64057-64370-arthez_de_bearn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64057-64370-arthez_de_bearn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64057-64370-arthez_de_bearn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64057-64370-arthez_de_bearn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64058-64800-arthez_d_asson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64058-64800-arthez_d_asson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64058-64800-arthez_d_asson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64058-64800-arthez_d_asson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64059-64420-artigueloutan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64059-64420-artigueloutan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64059-64420-artigueloutan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64059-64420-artigueloutan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64060-64230-artiguelouve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64060-64230-artiguelouve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64060-64230-artiguelouve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64060-64230-artiguelouve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64061-64170-artix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64061-64170-artix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64061-64170-artix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64061-64170-artix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64062-64260-arudy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64062-64260-arudy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64062-64260-arudy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64062-64260-arudy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64063-64410-arzacq_arraziguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64063-64410-arzacq_arraziguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64063-64410-arzacq_arraziguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64063-64410-arzacq_arraziguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64064-64660-asasp_arros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64064-64660-asasp_arros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64064-64660-asasp_arros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64064-64660-asasp_arros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64065-64310-ascain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64065-64310-ascain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64065-64310-ascain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64065-64310-ascain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64066-64220-ascarat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64066-64220-ascarat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64066-64220-ascarat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64066-64220-ascarat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64067-64510-assat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64067-64510-assat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64067-64510-assat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64067-64510-assat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64068-64800-asson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64068-64800-asson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64068-64800-asson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64068-64800-asson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64069-64260-aste_beon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64069-64260-aste_beon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64069-64260-aste_beon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64069-64260-aste_beon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64070-64450-astis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64070-64450-astis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64070-64450-astis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64070-64450-astis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64071-64390-athos_aspis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64071-64390-athos_aspis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64071-64390-athos_aspis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64071-64390-athos_aspis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64072-64290-aubertin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64072-64290-aubertin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64072-64290-aubertin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64072-64290-aubertin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64073-64230-aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64073-64230-aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64073-64230-aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64073-64230-aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64074-64330-aubous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64074-64330-aubous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64074-64330-aubous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64074-64330-aubous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64075-64190-audaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64075-64190-audaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64075-64190-audaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64075-64190-audaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64077-64450-auga/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64077-64450-auga/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64077-64450-auga/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64077-64450-auga/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64078-64450-auriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64078-64450-auriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64078-64450-auriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64078-64450-auriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64079-64350-aurions_idernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64079-64350-aurions_idernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64079-64350-aurions_idernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64079-64350-aurions_idernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64080-64230-aussevielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64080-64230-aussevielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64080-64230-aussevielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64080-64230-aussevielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64081-64130-aussurucq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64081-64130-aussurucq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64081-64130-aussurucq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64081-64130-aussurucq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64082-64270-auterrive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64082-64270-auterrive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64082-64270-auterrive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64082-64270-auterrive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64083-64390-autevielle_saint_martin_bideren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64083-64390-autevielle_saint_martin_bideren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64083-64390-autevielle_saint_martin_bideren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64083-64390-autevielle_saint_martin_bideren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64084-64330-aydie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64084-64330-aydie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64084-64330-aydie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64084-64330-aydie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64085-64490-aydius/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64085-64490-aydius/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64085-64490-aydius/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64085-64490-aydius/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64086-64240-ayherre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64086-64240-ayherre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64086-64240-ayherre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64086-64240-ayherre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64087-64300-baigts_de_bearn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64087-64300-baigts_de_bearn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64087-64300-baigts_de_bearn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64087-64300-baigts_de_bearn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64088-64300-balansun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64088-64300-balansun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64088-64300-balansun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64088-64300-balansun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64089-64460-baleix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64089-64460-baleix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64089-64460-baleix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64089-64460-baleix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64090-64330-baliracq_maumusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64090-64330-baliracq_maumusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64090-64330-baliracq_maumusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64090-64330-baliracq_maumusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64091-64510-baliros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64091-64510-baliros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64091-64510-baliros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64091-64510-baliros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64092-64430-banca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64092-64430-banca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64092-64430-banca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64092-64430-banca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64093-64130-barcus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64093-64130-barcus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64093-64130-barcus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64093-64130-barcus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64094-64520-bardos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64094-64520-bardos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64094-64520-bardos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64094-64520-bardos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64095-64160-barinque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64095-64160-barinque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64095-64160-barinque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64095-64160-barinque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64096-64390-barraute_camu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64096-64390-barraute_camu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64096-64390-barraute_camu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64096-64390-barraute_camu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64097-64530-barzun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64097-64530-barzun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64097-64530-barzun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64097-64530-barzun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64098-64350-bassillon_vauze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64098-64350-bassillon_vauze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64098-64350-bassillon_vauze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64098-64350-bassillon_vauze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64099-64190-bastanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64099-64190-bastanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64099-64190-bastanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64099-64190-bastanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64100-64200-bassussarry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64100-64200-bassussarry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64100-64200-bassussarry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64100-64200-bassussarry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64101-64800-baudreix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64101-64800-baudreix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64101-64800-baudreix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64101-64800-baudreix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64102-64100-bayonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64102-64100-bayonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64102-64100-bayonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64102-64100-bayonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64103-64460-bedeille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64103-64460-bedeille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64103-64460-bedeille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64103-64460-bedeille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64104-64490-bedous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64104-64490-bedous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64104-64490-bedous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64104-64490-bedous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64105-64120-beguios/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64105-64120-beguios/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64105-64120-beguios/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64105-64120-beguios/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64106-64120-behasque_lapiste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64106-64120-behasque_lapiste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64106-64120-behasque_lapiste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64106-64120-behasque_lapiste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64107-64220-behorleguy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64107-64220-behorleguy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64107-64220-behorleguy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64107-64220-behorleguy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64108-64270-bellocq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64108-64270-bellocq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64108-64270-bellocq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64108-64270-bellocq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64109-64800-benejacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64109-64800-benejacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64109-64800-benejacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64109-64800-benejacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64110-64440-beost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64110-64440-beost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64110-64440-beost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64110-64440-beost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64111-64460-bentayou_seree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64111-64460-bentayou_seree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64111-64460-bentayou_seree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64111-64460-bentayou_seree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64112-64300-berenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64112-64300-berenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64112-64300-berenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64112-64300-berenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64113-64270-bergouey_viellenave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64113-64270-bergouey_viellenave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64113-64270-bergouey_viellenave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64113-64270-bergouey_viellenave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64114-64160-bernadets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64114-64160-bernadets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64114-64160-bernadets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64114-64160-bernadets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64115-64130-berrogain_laruns/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64115-64130-berrogain_laruns/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64115-64130-berrogain_laruns/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64115-64130-berrogain_laruns/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64116-64260-bescat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64116-64260-bescat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64116-64260-bescat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64116-64260-bescat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64117-64150-besingrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64117-64150-besingrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64117-64150-besingrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64117-64150-besingrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64118-64350-betracq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64118-64350-betracq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64118-64350-betracq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64118-64350-betracq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64119-64800-beuste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64119-64800-beuste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64119-64800-beuste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64119-64800-beuste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64120-64120-beyrie_sur_joyeuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64120-64120-beyrie_sur_joyeuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64120-64120-beyrie_sur_joyeuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64120-64120-beyrie_sur_joyeuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64121-64230-beyrie_en_bearn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64121-64230-beyrie_en_bearn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64121-64230-beyrie_en_bearn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64121-64230-beyrie_en_bearn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64122-64200-biarritz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64122-64200-biarritz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64122-64200-biarritz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64122-64200-biarritz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64123-64520-bidache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64123-64520-bidache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64123-64520-bidache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64123-64520-bidache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64124-64780-bidarray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64124-64780-bidarray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64124-64780-bidarray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64124-64780-bidarray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64125-64210-bidart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64125-64210-bidart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64125-64210-bidart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64125-64210-bidart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64126-64400-bidos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64126-64400-bidos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64126-64400-bidos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64126-64400-bidos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64127-64260-bielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64127-64260-bielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64127-64260-bielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64127-64260-bielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64128-64260-bilheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64128-64260-bilheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64128-64260-bilheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64128-64260-bilheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64129-64140-billere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64129-64140-billere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64129-64140-billere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64129-64140-billere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64130-64700-biriatou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64130-64700-biriatou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64130-64700-biriatou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64130-64700-biriatou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64131-64300-biron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64131-64300-biron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64131-64300-biron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64131-64300-biron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64132-64320-bizanos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64132-64320-bizanos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64132-64320-bizanos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64132-64320-bizanos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64133-64510-boeil_bezing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64133-64510-boeil_bezing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64133-64510-boeil_bezing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64133-64510-boeil_bezing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64134-64240-bonloc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64134-64240-bonloc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64134-64240-bonloc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64134-64240-bonloc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64135-64300-bonnut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64135-64300-bonnut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64135-64300-bonnut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64135-64300-bonnut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64136-64490-borce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64136-64490-borce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64136-64490-borce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64136-64490-borce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64137-64800-borderes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64137-64800-borderes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64137-64800-borderes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64137-64800-borderes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64138-64510-bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64138-64510-bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64138-64510-bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64138-64510-bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64139-64290-bosdarros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64139-64290-bosdarros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64139-64290-bosdarros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64139-64290-bosdarros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64140-64340-boucau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64140-64340-boucau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64140-64340-boucau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64140-64340-boucau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64141-64330-boueilh_boueilho_lasque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64141-64330-boueilh_boueilho_lasque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64141-64330-boueilh_boueilho_lasque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64141-64330-boueilh_boueilho_lasque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64142-64230-bougarber/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64142-64230-bougarber/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64142-64230-bougarber/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64142-64230-bougarber/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64143-64410-bouillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64143-64410-bouillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64143-64410-bouillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64143-64410-bouillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64144-64370-boumourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64144-64370-boumourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64144-64370-boumourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64144-64370-boumourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64145-64800-bourdettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64145-64800-bourdettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64145-64800-bourdettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64145-64800-bourdettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64146-64450-bournos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64146-64450-bournos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64146-64450-bournos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64146-64450-bournos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64147-64240-briscous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64147-64240-briscous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64147-64240-briscous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64147-64240-briscous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64148-64800-bruges_capbis_mifaget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64148-64800-bruges_capbis_mifaget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64148-64800-bruges_capbis_mifaget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64148-64800-bruges_capbis_mifaget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64149-64190-bugnein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64149-64190-bugnein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64149-64190-bugnein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64149-64190-bugnein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64150-64120-bunus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64150-64120-bunus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64150-64120-bunus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64150-64120-bunus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64151-64390-burgaronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64151-64390-burgaronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64151-64390-burgaronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64151-64390-burgaronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64152-64160-buros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64152-64160-buros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64152-64160-buros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64152-64160-buros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64153-64330-burosse_mendousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64153-64330-burosse_mendousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64153-64330-burosse_mendousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64153-64330-burosse_mendousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64154-64220-bussunarits_sarrasquette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64154-64220-bussunarits_sarrasquette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64154-64220-bussunarits_sarrasquette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64154-64220-bussunarits_sarrasquette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64155-64220-bustince_iriberry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64155-64220-bustince_iriberry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64155-64220-bustince_iriberry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64155-64220-bustince_iriberry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64156-64680-buziet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64156-64680-buziet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64156-64680-buziet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64156-64680-buziet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64157-64260-buzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64157-64260-buzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64157-64260-buzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64157-64260-buzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64158-64410-cabidos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64158-64410-cabidos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64158-64410-cabidos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64158-64410-cabidos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64159-64330-cadillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64159-64330-cadillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64159-64330-cadillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64159-64330-cadillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64160-64250-cambo_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64160-64250-cambo_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64160-64250-cambo_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64160-64250-cambo_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64161-64520-came/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64161-64520-came/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64161-64520-came/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64161-64520-came/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64162-64470-camou_cihigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64162-64470-camou_cihigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64162-64470-camou_cihigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64162-64470-camou_cihigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64165-64360-cardesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64165-64360-cardesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64165-64360-cardesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64165-64360-cardesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64166-64220-caro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64166-64220-caro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64166-64220-caro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64166-64220-caro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64167-64160-carrere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64167-64160-carrere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64167-64160-carrere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64167-64160-carrere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64168-64270-carresse_cassaber/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64168-64270-carresse_cassaber/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64168-64270-carresse_cassaber/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64168-64270-carresse_cassaber/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64170-64270-castagnede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64170-64270-castagnede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64170-64270-castagnede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64170-64270-castagnede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64171-64170-casteide_cami/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64171-64170-casteide_cami/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64171-64170-casteide_cami/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64171-64170-casteide_cami/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64172-64370-casteide_candau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64172-64370-casteide_candau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64172-64370-casteide_candau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64172-64370-casteide_candau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64173-64460-casteide_doat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64173-64460-casteide_doat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64173-64460-casteide_doat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64173-64460-casteide_doat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64174-64460-castera_loubix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64174-64460-castera_loubix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64174-64460-castera_loubix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64174-64460-castera_loubix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64175-64260-castet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64175-64260-castet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64175-64260-castet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64175-64260-castet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64176-64190-castetbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64176-64190-castetbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64176-64190-castetbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64176-64190-castetbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64177-64300-castetis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64177-64300-castetis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64177-64300-castetis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64177-64300-castetis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64178-64190-castetnau_camblong/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64178-64190-castetnau_camblong/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64178-64190-castetnau_camblong/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64178-64190-castetnau_camblong/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64179-64300-castetner/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64179-64300-castetner/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64179-64300-castetner/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64179-64300-castetner/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64180-64330-castetpugon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64180-64330-castetpugon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64180-64330-castetpugon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64180-64330-castetpugon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64181-64370-castillon_(canton_d_arthez_de_bearn)/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64181-64370-castillon_(canton_d_arthez_de_bearn)/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64181-64370-castillon_(canton_d_arthez_de_bearn)/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64181-64370-castillon_(canton_d_arthez_de_bearn)/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64182-64350-castillon_(canton_de_lembeye)/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64182-64350-castillon_(canton_de_lembeye)/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64182-64350-castillon_(canton_de_lembeye)/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64182-64350-castillon_(canton_de_lembeye)/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64183-64230-caubios_loos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64183-64230-caubios_loos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64183-64230-caubios_loos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64183-64230-caubios_loos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64184-64170-cescau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64184-64170-cescau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64184-64170-cescau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64184-64170-cescau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64185-64490-cette_eygun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64185-64490-cette_eygun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64185-64490-cette_eygun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64185-64490-cette_eygun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64186-64190-charre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64186-64190-charre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64186-64190-charre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64186-64190-charre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64187-64130-charritte_de_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64187-64130-charritte_de_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64187-64130-charritte_de_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64187-64130-charritte_de_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64188-64130-cheraute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64188-64130-cheraute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64188-64130-cheraute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64188-64130-cheraute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64189-64500-ciboure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64189-64500-ciboure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64189-64500-ciboure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64189-64500-ciboure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64190-64330-claracq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64190-64330-claracq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64190-64330-claracq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64190-64330-claracq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64191-64800-coarraze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64191-64800-coarraze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64191-64800-coarraze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64191-64800-coarraze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64192-64330-conchez_de_bearn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64192-64330-conchez_de_bearn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64192-64330-conchez_de_bearn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64192-64330-conchez_de_bearn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64193-64350-corbere_aberes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64193-64350-corbere_aberes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64193-64350-corbere_aberes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64193-64350-corbere_aberes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64194-64160-cosledaa_lube_boast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64194-64160-cosledaa_lube_boast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64194-64160-cosledaa_lube_boast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64194-64160-cosledaa_lube_boast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64195-64410-coublucq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64195-64410-coublucq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64195-64410-coublucq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64195-64410-coublucq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64196-64350-crouseilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64196-64350-crouseilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64196-64350-crouseilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64196-64350-crouseilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64197-64360-cuqueron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64197-64360-cuqueron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64197-64360-cuqueron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64197-64360-cuqueron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64198-64230-denguin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64198-64230-denguin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64198-64230-denguin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64198-64230-denguin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64199-64330-diusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64199-64330-diusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64199-64330-diusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64199-64330-diusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64200-64370-doazon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64200-64370-doazon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64200-64370-doazon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64200-64370-doazon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64201-64190-dognen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64201-64190-dognen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64201-64190-dognen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64201-64190-dognen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64202-64120-domezain_berraute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64202-64120-domezain_berraute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64202-64120-domezain_berraute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64202-64120-domezain_berraute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64203-64450-doumy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64203-64450-doumy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64203-64450-doumy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64203-64450-doumy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64204-64440-eaux_bonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64204-64440-eaux_bonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64204-64440-eaux_bonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64204-64440-eaux_bonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64205-64270-escos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64205-64270-escos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64205-64270-escos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64205-64270-escos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64206-64490-escot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64206-64490-escot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64206-64490-escot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64206-64490-escot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64207-64870-escou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64207-64870-escou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64207-64870-escou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64207-64870-escou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64208-64160-escoubes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64208-64160-escoubes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64208-64160-escoubes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64208-64160-escoubes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64209-64870-escout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64209-64870-escout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64209-64870-escout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64209-64870-escout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64210-64350-escures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64210-64350-escures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64210-64350-escures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64210-64350-escures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64211-64420-eslourenties_daban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64211-64420-eslourenties_daban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64211-64420-eslourenties_daban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64211-64420-eslourenties_daban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64212-64160-espechede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64212-64160-espechede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64212-64160-espechede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64212-64160-espechede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64213-64250-espelette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64213-64250-espelette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64213-64250-espelette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64213-64250-espelette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64214-64130-espes_undurein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64214-64130-espes_undurein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64214-64130-espes_undurein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64214-64130-espes_undurein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64215-64390-espiute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64215-64390-espiute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64215-64390-espiute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64215-64390-espiute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64216-64420-espoey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64216-64420-espoey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64216-64420-espoey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64216-64420-espoey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64217-64400-esquiule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64217-64400-esquiule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64217-64400-esquiule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64217-64400-esquiule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64218-64220-esterencuby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64218-64220-esterencuby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64218-64220-esterencuby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64218-64220-esterencuby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64219-64290-estialescq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64219-64290-estialescq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64219-64290-estialescq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64219-64290-estialescq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64220-64400-estos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64220-64400-estos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64220-64400-estos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64220-64400-estos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64221-64120-etcharry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64221-64120-etcharry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64221-64120-etcharry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64221-64120-etcharry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64222-64470-etchebar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64222-64470-etchebar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64222-64470-etchebar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64222-64470-etchebar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64223-64490-etsaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64223-64490-etsaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64223-64490-etsaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64223-64490-etsaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64224-64400-eysus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64224-64400-eysus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64224-64400-eysus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64224-64400-eysus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64225-64570-ance_feas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64225-64570-ance_feas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64225-64570-ance_feas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64225-64570-ance_feas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64226-64410-fichous_riumayou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64226-64410-fichous_riumayou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64226-64410-fichous_riumayou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64226-64410-fichous_riumayou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64227-64160-gabaston/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64227-64160-gabaston/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64227-64160-gabaston/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64227-64160-gabaston/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64228-64120-gabat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64228-64120-gabat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64228-64120-gabat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64228-64120-gabat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64229-64220-gamarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64229-64220-gamarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64229-64220-gamarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64229-64220-gamarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64230-64290-gan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64230-64290-gan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64230-64290-gan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64230-64290-gan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64231-64130-garindein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64231-64130-garindein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64231-64130-garindein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64231-64130-garindein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64232-64450-garlede_mondebat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64232-64450-garlede_mondebat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64232-64450-garlede_mondebat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64232-64450-garlede_mondebat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64233-64330-garlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64233-64330-garlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64233-64330-garlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64233-64330-garlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64234-64410-garos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64234-64410-garos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64234-64410-garos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64234-64410-garos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64235-64120-garris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64235-64120-garris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64235-64120-garris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64235-64120-garris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64236-64350-gayon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64236-64350-gayon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64236-64350-gayon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64236-64350-gayon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64237-64110-gelos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64237-64110-gelos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64237-64110-gelos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64237-64110-gelos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64238-64530-ger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64238-64530-ger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64238-64530-ger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64238-64530-ger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64239-64160-gerderest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64239-64160-gerderest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64239-64160-gerderest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64239-64160-gerderest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64240-64260-gere_belesten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64240-64260-gere_belesten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64240-64260-gere_belesten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64240-64260-gere_belesten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64241-64400-geronce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64241-64400-geronce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64241-64400-geronce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64241-64400-geronce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64242-64190-gestas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64242-64190-gestas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64242-64190-gestas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64242-64190-gestas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64243-64370-geus_d_arzacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64243-64370-geus_d_arzacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64243-64370-geus_d_arzacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64243-64370-geus_d_arzacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64244-64400-geus_d_oloron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64244-64400-geus_d_oloron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64244-64400-geus_d_oloron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64244-64400-geus_d_oloron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64245-64400-goes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64245-64400-goes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64245-64400-goes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64245-64400-goes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64246-64420-gomer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64246-64420-gomer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64246-64420-gomer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64246-64420-gomer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64247-64130-gotein_libarrenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64247-64130-gotein_libarrenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64247-64130-gotein_libarrenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64247-64130-gotein_libarrenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64249-64210-guethary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64249-64210-guethary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64249-64210-guethary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64249-64210-guethary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64250-64520-guiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64250-64520-guiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64250-64520-guiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64250-64520-guiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64251-64390-guinarthe_parenties/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64251-64390-guinarthe_parenties/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64251-64390-guinarthe_parenties/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64251-64390-guinarthe_parenties/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64252-64400-gurmencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64252-64400-gurmencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64252-64400-gurmencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64252-64400-gurmencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64253-64190-gurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64253-64190-gurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64253-64190-gurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64253-64190-gurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64254-64370-hagetaubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64254-64370-hagetaubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64254-64370-hagetaubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64254-64370-hagetaubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64255-64480-halsou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64255-64480-halsou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64255-64480-halsou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64255-64480-halsou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64256-64240-hasparren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64256-64240-hasparren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64256-64240-hasparren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64256-64240-hasparren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64257-64800-haut_de_bosdarros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64257-64800-haut_de_bosdarros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64257-64800-haut_de_bosdarros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64257-64800-haut_de_bosdarros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64258-64470-haux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64258-64470-haux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64258-64470-haux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64258-64470-haux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64259-64640-helette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64259-64640-helette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64259-64640-helette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64259-64640-helette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64260-64700-hendaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64260-64700-hendaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64260-64700-hendaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64260-64700-hendaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64261-64680-herrere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64261-64680-herrere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64261-64680-herrere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64261-64680-herrere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64262-64160-higueres_souye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64262-64160-higueres_souye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64262-64160-higueres_souye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64262-64160-higueres_souye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64263-64270-l_hopital_d_orion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64263-64270-l_hopital_d_orion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64263-64270-l_hopital_d_orion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64263-64270-l_hopital_d_orion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64264-64130-l_hopital_saint_blaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64264-64130-l_hopital_saint_blaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64264-64130-l_hopital_saint_blaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64264-64130-l_hopital_saint_blaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64265-64120-hosta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64265-64120-hosta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64265-64120-hosta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64265-64120-hosta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64266-64420-hours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64266-64420-hours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64266-64420-hours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64266-64420-hours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64267-64120-ibarrolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64267-64120-ibarrolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64267-64120-ibarrolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64267-64120-ibarrolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64268-64130-idaux_mendy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64268-64130-idaux_mendy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64268-64130-idaux_mendy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64268-64130-idaux_mendy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64269-64320-idron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64269-64320-idron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64269-64320-idron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64269-64320-idron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64270-64800-igon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64270-64800-igon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64270-64800-igon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64270-64800-igon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64271-64640-iholdy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64271-64640-iholdy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64271-64640-iholdy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64271-64640-iholdy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64272-64120-ilharre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64272-64120-ilharre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64272-64120-ilharre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64272-64120-ilharre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64273-64780-irissarry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64273-64780-irissarry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64273-64780-irissarry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64273-64780-irissarry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64274-64220-irouleguy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64274-64220-irouleguy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64274-64220-irouleguy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64274-64220-irouleguy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64275-64220-ispoure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64275-64220-ispoure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64275-64220-ispoure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64275-64220-ispoure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64276-64570-issor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64276-64570-issor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64276-64570-issor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64276-64570-issor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64277-64240-isturits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64277-64240-isturits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64277-64240-isturits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64277-64240-isturits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64279-64250-itxassou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64279-64250-itxassou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64279-64250-itxassou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64279-64250-itxassou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64280-64260-izeste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64280-64260-izeste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64280-64260-izeste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64280-64260-izeste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64281-64190-jasses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64281-64190-jasses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64281-64190-jasses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64281-64190-jasses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64282-64480-jatxou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64282-64480-jatxou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64282-64480-jatxou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64282-64480-jatxou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64283-64220-jaxu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64283-64220-jaxu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64283-64220-jaxu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64283-64220-jaxu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64284-64110-jurancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64284-64110-jurancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64284-64110-jurancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64284-64110-jurancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64285-64120-juxue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64285-64120-juxue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64285-64120-juxue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64285-64120-juxue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64286-64300-laa_mondrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64286-64300-laa_mondrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64286-64300-laa_mondrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64286-64300-laa_mondrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64287-64390-laas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64287-64390-laas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64287-64390-laas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64287-64390-laas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64288-64170-labastide_cezeracq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64288-64170-labastide_cezeracq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64288-64170-labastide_cezeracq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64288-64170-labastide_cezeracq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64289-64240-la_bastide_clairence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64289-64240-la_bastide_clairence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64289-64240-la_bastide_clairence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64289-64240-la_bastide_clairence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64290-64170-labastide_monrejeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64290-64170-labastide_monrejeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64290-64170-labastide_monrejeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64290-64170-labastide_monrejeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64291-64270-labastide_villefranche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64291-64270-labastide_villefranche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64291-64270-labastide_villefranche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64291-64270-labastide_villefranche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64292-64530-labatmale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64292-64530-labatmale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64292-64530-labatmale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64292-64530-labatmale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64293-64460-labatut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64293-64460-labatut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64293-64460-labatut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64293-64460-labatut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64294-64120-labets_biscay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64294-64120-labets_biscay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64294-64120-labets_biscay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64294-64120-labets_biscay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64295-64300-labeyrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64295-64300-labeyrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64295-64300-labeyrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64295-64300-labeyrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64296-64300-lacadee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64296-64300-lacadee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64296-64300-lacadee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64296-64300-lacadee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64297-64220-lacarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64297-64220-lacarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64297-64220-lacarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64297-64220-lacarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64298-64470-lacarry_arhan_charritte_de_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64298-64470-lacarry_arhan_charritte_de_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64298-64470-lacarry_arhan_charritte_de_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64298-64470-lacarry_arhan_charritte_de_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64299-64360-lacommande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64299-64360-lacommande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64299-64360-lacommande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64299-64360-lacommande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64300-64170-lacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64300-64170-lacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64300-64170-lacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64300-64170-lacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64301-64150-lagor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64301-64150-lagor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64301-64150-lagor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64301-64150-lagor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64302-64800-lagos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64302-64800-lagos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64302-64800-lagos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64302-64800-lagos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64303-64470-laguinge_restoue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64303-64470-laguinge_restoue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64303-64470-laguinge_restoue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64303-64470-laguinge_restoue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64304-64990-lahonce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64304-64990-lahonce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64304-64990-lahonce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64304-64990-lahonce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64305-64270-lahontan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64305-64270-lahontan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64305-64270-lahontan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64305-64270-lahontan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64306-64150-lahourcade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64306-64150-lahourcade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64306-64150-lahourcade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64306-64150-lahourcade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64307-64350-lalongue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64307-64350-lalongue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64307-64350-lalongue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64307-64350-lalongue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64308-64450-lalonquette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64308-64450-lalonquette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64308-64450-lalonquette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64308-64450-lalonquette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64309-64460-lamayou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64309-64460-lamayou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64309-64460-lamayou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64309-64460-lamayou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64310-64570-lanne_en_baretous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64310-64570-lanne_en_baretous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64310-64570-lanne_en_baretous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64310-64570-lanne_en_baretous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64311-64350-lannecaube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64311-64350-lannecaube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64311-64350-lannecaube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64311-64350-lannecaube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64312-64300-lanneplaa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64312-64300-lanneplaa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64312-64300-lanneplaa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64312-64300-lanneplaa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64313-64640-lantabat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64313-64640-lantabat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64313-64640-lantabat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64313-64640-lantabat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64314-64120-larceveau_arros_cibits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64314-64120-larceveau_arros_cibits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64314-64120-larceveau_arros_cibits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64314-64120-larceveau_arros_cibits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64315-64110-laroin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64315-64110-laroin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64315-64110-laroin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64315-64110-laroin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64316-64560-larrau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64316-64560-larrau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64316-64560-larrau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64316-64560-larrau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64317-64480-larressore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64317-64480-larressore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64317-64480-larressore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64317-64480-larressore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64318-64410-larreule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64318-64410-larreule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64318-64410-larreule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64318-64410-larreule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64319-64120-larribar_sorhapuru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64319-64120-larribar_sorhapuru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64319-64120-larribar_sorhapuru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64319-64120-larribar_sorhapuru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64320-64440-laruns/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64320-64440-laruns/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64320-64440-laruns/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64320-64440-laruns/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64321-64450-lasclaveries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64321-64450-lasclaveries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64321-64450-lasclaveries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64321-64450-lasclaveries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64322-64220-lasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64322-64220-lasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64322-64220-lasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64322-64220-lasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64323-64350-lasserre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64323-64350-lasserre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64323-64350-lasserre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64323-64350-lasserre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64324-64290-lasseube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64324-64290-lasseube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64324-64290-lasseube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64324-64290-lasseube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64325-64290-lasseubetat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64325-64290-lasseubetat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64325-64290-lasseubetat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64325-64290-lasseubetat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64326-64190-lay_lamidou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64326-64190-lay_lamidou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64326-64190-lay_lamidou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64326-64190-lay_lamidou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64327-64220-lecumberry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64327-64220-lecumberry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64327-64220-lecumberry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64327-64220-lecumberry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64328-64400-ledeuix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64328-64400-ledeuix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64328-64400-ledeuix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64328-64400-ledeuix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64329-64320-lee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64329-64320-lee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64329-64320-lee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64329-64320-lee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64330-64490-lees_athas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64330-64490-lees_athas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64330-64490-lees_athas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64330-64490-lees_athas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64331-64350-lembeye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64331-64350-lembeye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64331-64350-lembeye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64331-64350-lembeye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64332-64450-leme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64332-64450-leme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64332-64450-leme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64332-64450-leme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64334-64270-leren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64334-64270-leren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64334-64270-leren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64334-64270-leren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64335-64230-lescar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64335-64230-lescar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64335-64230-lescar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64335-64230-lescar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64336-64490-lescun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64336-64490-lescun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64336-64490-lescun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64336-64490-lescun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64337-64350-lespielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64337-64350-lespielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64337-64350-lespielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64337-64350-lespielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64338-64160-lespourcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64338-64160-lespourcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64338-64160-lespourcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64338-64160-lespourcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64339-64800-lestelle_betharram/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64339-64800-lestelle_betharram/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64339-64800-lestelle_betharram/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64339-64800-lestelle_betharram/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64340-64470-lichans_sunhar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64340-64470-lichans_sunhar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64340-64470-lichans_sunhar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64340-64470-lichans_sunhar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64341-64130-lichos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64341-64130-lichos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64341-64130-lichos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64341-64130-lichos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64342-64560-licq_atherey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64342-64560-licq_atherey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64342-64560-licq_atherey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64342-64560-licq_atherey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64343-64420-limendous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64343-64420-limendous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64343-64420-limendous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64343-64420-limendous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64344-64530-livron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64344-64530-livron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64344-64530-livron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64344-64530-livron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64345-64120-lohitzun_oyhercq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64345-64120-lohitzun_oyhercq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64345-64120-lohitzun_oyhercq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64345-64120-lohitzun_oyhercq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64346-64160-lombia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64346-64160-lombia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64346-64160-lombia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64346-64160-lombia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64347-64410-loncon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64347-64410-loncon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64347-64410-loncon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64347-64410-loncon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64348-64140-lons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64348-64140-lons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64348-64140-lons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64348-64140-lons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64349-64300-loubieng/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64349-64300-loubieng/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64349-64300-loubieng/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64349-64300-loubieng/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64350-64250-louhossoa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64350-64250-louhossoa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64350-64250-louhossoa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64350-64250-louhossoa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64351-64570-lourdios_ichere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64351-64570-lourdios_ichere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64351-64570-lourdios_ichere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64351-64570-lourdios_ichere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64352-64420-lourenties/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64352-64420-lourenties/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64352-64420-lourenties/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64352-64420-lourenties/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64353-64260-louvie_juzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64353-64260-louvie_juzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64353-64260-louvie_juzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64353-64260-louvie_juzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64354-64440-louvie_soubiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64354-64440-louvie_soubiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64354-64440-louvie_soubiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64354-64440-louvie_soubiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64355-64410-louvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64355-64410-louvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64355-64410-louvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64355-64410-louvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64356-64350-luc_armau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64356-64350-luc_armau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64356-64350-luc_armau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64356-64350-luc_armau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64357-64350-lucarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64357-64350-lucarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64357-64350-lucarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64357-64350-lucarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64358-64420-lucgarier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64358-64420-lucgarier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64358-64420-lucgarier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64358-64420-lucgarier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64359-64360-lucq_de_bearn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64359-64360-lucq_de_bearn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64359-64360-lucq_de_bearn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64359-64360-lucq_de_bearn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64360-64660-lurbe_saint_christau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64360-64660-lurbe_saint_christau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64360-64660-lurbe_saint_christau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64360-64660-lurbe_saint_christau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64361-64160-lussagnet_lusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64361-64160-lussagnet_lusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64361-64160-lussagnet_lusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64361-64160-lussagnet_lusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64362-64120-luxe_sumberraute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64362-64120-luxe_sumberraute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64362-64120-luxe_sumberraute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64362-64120-luxe_sumberraute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64363-64260-lys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64363-64260-lys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64363-64260-lys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64363-64260-lys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64364-64240-macaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64364-64240-macaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64364-64240-macaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64364-64240-macaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64365-64410-malaussanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64365-64410-malaussanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64365-64410-malaussanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64365-64410-malaussanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64366-64330-mascaraas_haron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64366-64330-mascaraas_haron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64366-64330-mascaraas_haron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64366-64330-mascaraas_haron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64367-64300-maslacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64367-64300-maslacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64367-64300-maslacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64367-64300-maslacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64368-64120-masparraute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64368-64120-masparraute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64368-64120-masparraute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64368-64120-masparraute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64369-64350-maspie_lalonquere_juillacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64369-64350-maspie_lalonquere_juillacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64369-64350-maspie_lalonquere_juillacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64369-64350-maspie_lalonquere_juillacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64370-64160-maucor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64370-64160-maucor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64370-64160-maucor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64370-64160-maucor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64371-64130-mauleon_licharre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64371-64130-mauleon_licharre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64371-64130-mauleon_licharre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64371-64130-mauleon_licharre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64372-64460-maure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64372-64460-maure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64372-64460-maure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64372-64460-maure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64373-64110-mazeres_lezons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64373-64110-mazeres_lezons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64373-64110-mazeres_lezons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64373-64110-mazeres_lezons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64374-64230-mazerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64374-64230-mazerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64374-64230-mazerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64374-64230-mazerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64375-64120-meharin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64375-64120-meharin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64375-64120-meharin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64375-64120-meharin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64376-64510-meillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64376-64510-meillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64376-64510-meillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64376-64510-meillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64377-64240-mendionde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64377-64240-mendionde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64377-64240-mendionde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64377-64240-mendionde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64378-64130-menditte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64378-64130-menditte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64378-64130-menditte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64378-64130-menditte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64379-64220-mendive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64379-64220-mendive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64379-64220-mendive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64379-64220-mendive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64380-64410-meracq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64380-64410-meracq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64380-64410-meracq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64380-64410-meracq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64381-64190-meritein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64381-64190-meritein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64381-64190-meritein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64381-64190-meritein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64382-64370-mesplede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64382-64370-mesplede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64382-64370-mesplede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64382-64370-mesplede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64383-64410-mialos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64383-64410-mialos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64383-64410-mialos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64383-64410-mialos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64385-64450-miossens_lanusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64385-64450-miossens_lanusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64385-64450-miossens_lanusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64385-64450-miossens_lanusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64386-64800-mirepeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64386-64800-mirepeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64386-64800-mirepeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64386-64800-mirepeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64387-64230-momas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64387-64230-momas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64387-64230-momas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64387-64230-momas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64388-64350-momy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64388-64350-momy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64388-64350-momy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64388-64350-momy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64389-64160-monassut_audiracq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64389-64160-monassut_audiracq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64389-64160-monassut_audiracq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64389-64160-monassut_audiracq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64390-64350-moncaup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64390-64350-moncaup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64390-64350-moncaup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64390-64350-moncaup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64391-64130-moncayolle_larrory_mendibieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64391-64130-moncayolle_larrory_mendibieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64391-64130-moncayolle_larrory_mendibieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64391-64130-moncayolle_larrory_mendibieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64392-64330-moncla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64392-64330-moncla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64392-64330-moncla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64392-64330-moncla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64393-64360-monein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64393-64360-monein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64393-64360-monein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64393-64360-monein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64394-64350-monpezat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64394-64350-monpezat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64394-64350-monpezat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64394-64350-monpezat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64395-64460-monsegur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64395-64460-monsegur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64395-64460-monsegur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64395-64460-monsegur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64396-64300-mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64396-64300-mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64396-64300-mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64396-64300-mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64397-64410-montagut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64397-64410-montagut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64397-64410-montagut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64397-64410-montagut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64398-64460-montaner/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64398-64460-montaner/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64398-64460-montaner/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64398-64460-montaner/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64399-64121-montardon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64399-64121-montardon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64399-64121-montardon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64399-64121-montardon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64400-64800-montaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64400-64800-montaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64400-64800-montaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64400-64800-montaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64401-64330-mont_disse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64401-64330-mont_disse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64401-64330-mont_disse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64401-64330-mont_disse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64403-64190-montfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64403-64190-montfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64403-64190-montfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64403-64190-montfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64404-64470-montory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64404-64470-montory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64404-64470-montory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64404-64470-montory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64405-64160-morlaas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64405-64160-morlaas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64405-64160-morlaas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64405-64160-morlaas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64406-64370-morlanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64406-64370-morlanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64406-64370-morlanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64406-64370-morlanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64407-64990-mouguerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64407-64990-mouguerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64407-64990-mouguerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64407-64990-mouguerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64408-64330-mouhous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64408-64330-mouhous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64408-64330-mouhous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64408-64330-mouhous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64409-64400-moumour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64409-64400-moumour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64409-64400-moumour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64409-64400-moumour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64410-64150-mourenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64410-64150-mourenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64410-64150-mourenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64410-64150-mourenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64411-64130-musculdy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64411-64130-musculdy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64411-64130-musculdy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64411-64130-musculdy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64412-64190-nabas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64412-64190-nabas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64412-64190-nabas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64412-64190-nabas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64413-64510-narcastet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64413-64510-narcastet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64413-64510-narcastet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64413-64510-narcastet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64414-64190-narp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64414-64190-narp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64414-64190-narp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64414-64190-narp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64415-64450-navailles_angos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64415-64450-navailles_angos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64415-64450-navailles_angos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64415-64450-navailles_angos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64416-64190-navarrenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64416-64190-navarrenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64416-64190-navarrenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64416-64190-navarrenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64417-64800-nay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64417-64800-nay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64417-64800-nay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64417-64800-nay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64418-64150-nogueres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64418-64150-nogueres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64418-64150-nogueres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64418-64150-nogueres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64419-64420-nousty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64419-64420-nousty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64419-64420-nousty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64419-64420-nousty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64420-64190-ogenne_camptort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64420-64190-ogenne_camptort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64420-64190-ogenne_camptort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64420-64190-ogenne_camptort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64421-64680-ogeu_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64421-64680-ogeu_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64421-64680-ogeu_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64421-64680-ogeu_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64422-64400-oloron_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64422-64400-oloron_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64422-64400-oloron_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64422-64400-oloron_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64423-64390-oraas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64423-64390-oraas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64423-64390-oraas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64423-64390-oraas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64424-64130-ordiarp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64424-64130-ordiarp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64424-64130-ordiarp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64424-64130-ordiarp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64425-64120-oregue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64425-64120-oregue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64425-64120-oregue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64425-64120-oregue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64426-64400-orin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64426-64400-orin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64426-64400-orin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64426-64400-orin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64427-64390-orion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64427-64390-orion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64427-64390-orion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64427-64390-orion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64428-64390-orriule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64428-64390-orriule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64428-64390-orriule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64428-64390-orriule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64429-64120-orsanco/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64429-64120-orsanco/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64429-64120-orsanco/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64429-64120-orsanco/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64430-64300-orthez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64430-64300-orthez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64430-64300-orthez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64430-64300-orthez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64431-64150-os_marsillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64431-64150-os_marsillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64431-64150-os_marsillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64431-64150-os_marsillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64432-64470-ossas_suhare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64432-64470-ossas_suhare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64432-64470-ossas_suhare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64432-64470-ossas_suhare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64433-64490-osse_en_aspe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64433-64490-osse_en_aspe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64433-64490-osse_en_aspe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64433-64490-osse_en_aspe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64434-64190-ossenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64434-64190-ossenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64434-64190-ossenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64434-64190-ossenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64435-64390-osserain_rivareyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64435-64390-osserain_rivareyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64435-64390-osserain_rivareyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64435-64390-osserain_rivareyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64436-64780-osses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64436-64780-osses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64436-64780-osses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64436-64780-osses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64437-64120-ostabat_asme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64437-64120-ostabat_asme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64437-64120-ostabat_asme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64437-64120-ostabat_asme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64438-64160-ouillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64438-64160-ouillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64438-64160-ouillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64438-64160-ouillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64439-64320-ousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64439-64320-ousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64439-64320-ousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64439-64320-ousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64440-64300-ozenx_montestrucq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64440-64300-ozenx_montestrucq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64440-64300-ozenx_montestrucq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64440-64300-ozenx_montestrucq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64441-64120-pagolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64441-64120-pagolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64441-64120-pagolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64441-64120-pagolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64442-64360-parbayse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64442-64360-parbayse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64442-64360-parbayse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64442-64360-parbayse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64443-64150-pardies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64443-64150-pardies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64443-64150-pardies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64443-64150-pardies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64444-64800-pardies_pietat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64444-64800-pardies_pietat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64444-64800-pardies_pietat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64444-64800-pardies_pietat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64445-64000-pau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64445-64000-pau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64445-64000-pau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64445-64000-pau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64445-64023-pau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64445-64023-pau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64445-64023-pau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64445-64023-pau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64446-64350-peyrelongue_abos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64446-64350-peyrelongue_abos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64446-64350-peyrelongue_abos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64446-64350-peyrelongue_abos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64447-64410-piets_plasence_moustrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64447-64410-piets_plasence_moustrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64447-64410-piets_plasence_moustrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64447-64410-piets_plasence_moustrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64448-64230-poey_de_lescar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64448-64230-poey_de_lescar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64448-64230-poey_de_lescar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64448-64230-poey_de_lescar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64449-64400-poey_d_oloron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64449-64400-poey_d_oloron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64449-64400-poey_d_oloron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64449-64400-poey_d_oloron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64450-64370-pomps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64450-64370-pomps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64450-64370-pomps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64450-64370-pomps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64451-64460-ponson_debat_pouts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64451-64460-ponson_debat_pouts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64451-64460-ponson_debat_pouts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64451-64460-ponson_debat_pouts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64452-64460-ponson_dessus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64452-64460-ponson_dessus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64452-64460-ponson_dessus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64452-64460-ponson_dessus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64453-64530-pontacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64453-64530-pontacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64453-64530-pontacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64453-64530-pontacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64454-64460-pontiacq_viellepinte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64454-64460-pontiacq_viellepinte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64454-64460-pontiacq_viellepinte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64454-64460-pontiacq_viellepinte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64455-64330-portet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64455-64330-portet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64455-64330-portet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64455-64330-portet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64456-64410-pouliacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64456-64410-pouliacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64456-64410-pouliacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64456-64410-pouliacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64457-64410-poursiugues_boucoue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64457-64410-poursiugues_boucoue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64457-64410-poursiugues_boucoue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64457-64410-poursiugues_boucoue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64458-64190-prechacq_josbaig/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64458-64190-prechacq_josbaig/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64458-64190-prechacq_josbaig/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64458-64190-prechacq_josbaig/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64459-64190-prechacq_navarrenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64459-64190-prechacq_navarrenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64459-64190-prechacq_navarrenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64459-64190-prechacq_navarrenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64460-64400-precilhon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64460-64400-precilhon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64460-64400-precilhon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64460-64400-precilhon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64461-64270-puyoo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64461-64270-puyoo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64461-64270-puyoo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64461-64270-puyoo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64462-64270-ramous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64462-64270-ramous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64462-64270-ramous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64462-64270-ramous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64463-64260-rebenacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64463-64260-rebenacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64463-64260-rebenacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64463-64260-rebenacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64464-64330-ribarrouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64464-64330-ribarrouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64464-64330-ribarrouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64464-64330-ribarrouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64465-64160-riupeyrous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64465-64160-riupeyrous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64465-64160-riupeyrous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64465-64160-riupeyrous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64466-64190-rivehaute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64466-64190-rivehaute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64466-64190-rivehaute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64466-64190-rivehaute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64467-64110-rontignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64467-64110-rontignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64467-64110-rontignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64467-64110-rontignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64468-64130-roquiague/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64468-64130-roquiague/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64468-64130-roquiague/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64468-64130-roquiague/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64469-64800-saint_abit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64469-64800-saint_abit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64469-64800-saint_abit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64469-64800-saint_abit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64470-64160-saint_armou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64470-64160-saint_armou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64470-64160-saint_armou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64470-64160-saint_armou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64471-64300-saint_boes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64471-64300-saint_boes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64471-64300-saint_boes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64471-64300-saint_boes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64472-64160-saint_castin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64472-64160-saint_castin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64472-64160-saint_castin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64472-64160-saint_castin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64473-64260-sainte_colome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64473-64260-sainte_colome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64473-64260-sainte_colome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64473-64260-sainte_colome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64474-64270-saint_dos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64474-64270-saint_dos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64474-64270-saint_dos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64474-64270-saint_dos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64475-64560-sainte_engrace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64475-64560-sainte_engrace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64475-64560-sainte_engrace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64475-64560-sainte_engrace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64476-64640-saint_esteben/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64476-64640-saint_esteben/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64476-64640-saint_esteben/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64476-64640-saint_esteben/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64477-64430-saint_etienne_de_baigorry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64477-64430-saint_etienne_de_baigorry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64477-64430-saint_etienne_de_baigorry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64477-64430-saint_etienne_de_baigorry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64478-64110-saint_faust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64478-64110-saint_faust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64478-64110-saint_faust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64478-64110-saint_faust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64479-64300-saint_girons_en_bearn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64479-64300-saint_girons_en_bearn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64479-64300-saint_girons_en_bearn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64479-64300-saint_girons_en_bearn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64480-64390-saint_gladie_arrive_munein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64480-64390-saint_gladie_arrive_munein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64480-64390-saint_gladie_arrive_munein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64480-64390-saint_gladie_arrive_munein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64481-64400-saint_goin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64481-64400-saint_goin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64481-64400-saint_goin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64481-64400-saint_goin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64482-64160-saint_jammes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64482-64160-saint_jammes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64482-64160-saint_jammes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64482-64160-saint_jammes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64483-64500-saint_jean_de_luz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64483-64500-saint_jean_de_luz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64483-64500-saint_jean_de_luz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64483-64500-saint_jean_de_luz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64484-64220-saint_jean_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64484-64220-saint_jean_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64484-64220-saint_jean_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64484-64220-saint_jean_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64485-64220-saint_jean_pied_de_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64485-64220-saint_jean_pied_de_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64485-64220-saint_jean_pied_de_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64485-64220-saint_jean_pied_de_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64486-64330-saint_jean_poudge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64486-64330-saint_jean_poudge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64486-64330-saint_jean_poudge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64486-64330-saint_jean_poudge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64487-64120-saint_just_ibarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64487-64120-saint_just_ibarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64487-64120-saint_just_ibarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64487-64120-saint_just_ibarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64488-64160-saint_laurent_bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64488-64160-saint_laurent_bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64488-64160-saint_laurent_bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64488-64160-saint_laurent_bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64489-64640-saint_martin_d_arberoue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64489-64640-saint_martin_d_arberoue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64489-64640-saint_martin_d_arberoue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64489-64640-saint_martin_d_arberoue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64490-64780-saint_martin_d_arrossa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64490-64780-saint_martin_d_arrossa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64490-64780-saint_martin_d_arrossa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64490-64780-saint_martin_d_arrossa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64491-64370-saint_medard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64491-64370-saint_medard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64491-64370-saint_medard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64491-64370-saint_medard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64492-64220-saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64492-64220-saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64492-64220-saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64492-64220-saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64493-64120-saint_palais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64493-64120-saint_palais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64493-64120-saint_palais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64493-64120-saint_palais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64494-64270-saint_pe_de_leren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64494-64270-saint_pe_de_leren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64494-64270-saint_pe_de_leren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64494-64270-saint_pe_de_leren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64495-64310-saint_pee_sur_nivelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64495-64310-saint_pee_sur_nivelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64495-64310-saint_pee_sur_nivelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64495-64310-saint_pee_sur_nivelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64496-64990-saint_pierre_d_irube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64496-64990-saint_pierre_d_irube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64496-64990-saint_pierre_d_irube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64496-64990-saint_pierre_d_irube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64498-64800-saint_vincent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64498-64800-saint_vincent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64498-64800-saint_vincent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64498-64800-saint_vincent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64499-64270-salies_de_bearn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64499-64270-salies_de_bearn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64499-64270-salies_de_bearn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64499-64270-salies_de_bearn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64500-64300-salles_mongiscard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64500-64300-salles_mongiscard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64500-64300-salles_mongiscard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64500-64300-salles_mongiscard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64501-64300-sallespisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64501-64300-sallespisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64501-64300-sallespisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64501-64300-sallespisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64502-64520-sames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64502-64520-sames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64502-64520-sames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64502-64520-sames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64503-64350-samsons_lion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64503-64350-samsons_lion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64503-64350-samsons_lion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64503-64350-samsons_lion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64504-64310-sare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64504-64310-sare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64504-64310-sare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64504-64310-sare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64505-64300-sarpourenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64505-64300-sarpourenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64505-64300-sarpourenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64505-64300-sarpourenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64506-64490-sarrance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64506-64490-sarrance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64506-64490-sarrance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64506-64490-sarrance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64507-64420-saubole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64507-64420-saubole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64507-64420-saubole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64507-64420-saubole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64508-64400-saucede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64508-64400-saucede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64508-64400-saucede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64508-64400-saucede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64509-64470-sauguis_saint_etienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64509-64470-sauguis_saint_etienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64509-64470-sauguis_saint_etienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64509-64470-sauguis_saint_etienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64510-64300-sault_de_navailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64510-64300-sault_de_navailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64510-64300-sault_de_navailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64510-64300-sault_de_navailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64511-64230-sauvagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64511-64230-sauvagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64511-64230-sauvagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64511-64230-sauvagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64512-64150-sauvelade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64512-64150-sauvelade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64512-64150-sauvelade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64512-64150-sauvelade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64513-64390-sauveterre_de_bearn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64513-64390-sauveterre_de_bearn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64513-64390-sauveterre_de_bearn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64513-64390-sauveterre_de_bearn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64514-64410-seby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64514-64410-seby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64514-64410-seby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64514-64410-seby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64515-64160-sedze_maubecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64515-64160-sedze_maubecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64515-64160-sedze_maubecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64515-64160-sedze_maubecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64516-64160-sedzere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64516-64160-sedzere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64516-64160-sedzere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64516-64160-sedzere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64517-64350-semeacq_blachon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64517-64350-semeacq_blachon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64517-64350-semeacq_blachon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64517-64350-semeacq_blachon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64518-64320-sendets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64518-64320-sendets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64518-64320-sendets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64518-64320-sendets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64519-64121-serres_castet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64519-64121-serres_castet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64519-64121-serres_castet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64519-64121-serres_castet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64520-64160-serres_morlaas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64520-64160-serres_morlaas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64520-64160-serres_morlaas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64520-64160-serres_morlaas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64521-64170-serres_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64521-64170-serres_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64521-64170-serres_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64521-64170-serres_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64522-64260-sevignacq_meyracq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64522-64260-sevignacq_meyracq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64522-64260-sevignacq_meyracq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64522-64260-sevignacq_meyracq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64523-64160-sevignacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64523-64160-sevignacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64523-64160-sevignacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64523-64160-sevignacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64524-64350-simacourbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64524-64350-simacourbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64524-64350-simacourbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64524-64350-simacourbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64525-64230-siros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64525-64230-siros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64525-64230-siros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64525-64230-siros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64526-64420-soumoulou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64526-64420-soumoulou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64526-64420-soumoulou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64526-64420-soumoulou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64527-64250-souraide/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64527-64250-souraide/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64527-64250-souraide/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64527-64250-souraide/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64528-64780-suhescun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64528-64780-suhescun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64528-64780-suhescun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64528-64780-suhescun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64529-64190-sus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64529-64190-sus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64529-64190-sus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64529-64190-sus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64530-64190-susmiou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64530-64190-susmiou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64530-64190-susmiou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64530-64190-susmiou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64531-64190-tabaille_usquain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64531-64190-tabaille_usquain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64531-64190-tabaille_usquain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64531-64190-tabaille_usquain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64532-64330-tadousse_ussau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64532-64330-tadousse_ussau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64532-64330-tadousse_ussau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64532-64330-tadousse_ussau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64533-64470-tardets_sorholus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64533-64470-tardets_sorholus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64533-64470-tardets_sorholus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64533-64470-tardets_sorholus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64534-64330-taron_sadirac_viellenave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64534-64330-taron_sadirac_viellenave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64534-64330-taron_sadirac_viellenave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64534-64330-taron_sadirac_viellenave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64535-64360-tarsacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64535-64360-tarsacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64535-64360-tarsacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64535-64360-tarsacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64536-64450-theze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64536-64450-theze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64536-64450-theze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64536-64450-theze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64537-64470-trois_villes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64537-64470-trois_villes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64537-64470-trois_villes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64537-64470-trois_villes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64538-64220-uhart_cize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64538-64220-uhart_cize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64538-64220-uhart_cize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64538-64220-uhart_cize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64539-64120-uhart_mixe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64539-64120-uhart_mixe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64539-64120-uhart_mixe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64539-64120-uhart_mixe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64540-64990-urcuit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64540-64990-urcuit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64540-64990-urcuit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64540-64990-urcuit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64541-64370-urdes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64541-64370-urdes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64541-64370-urdes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64541-64370-urdes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64542-64490-urdos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64542-64490-urdos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64542-64490-urdos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64542-64490-urdos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64543-64430-urepel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64543-64430-urepel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64543-64430-urepel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64543-64430-urepel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64544-64160-urost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64544-64160-urost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64544-64160-urost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64544-64160-urost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64545-64122-urrugne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64545-64122-urrugne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64545-64122-urrugne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64545-64122-urrugne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64546-64240-urt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64546-64240-urt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64546-64240-urt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64546-64240-urt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64547-64480-ustaritz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64547-64480-ustaritz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64547-64480-ustaritz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64547-64480-ustaritz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64548-64370-uzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64548-64370-uzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64548-64370-uzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64548-64370-uzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64549-64230-uzein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64549-64230-uzein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64549-64230-uzein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64549-64230-uzein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64550-64110-uzos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64550-64110-uzos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64550-64110-uzos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64550-64110-uzos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64551-64400-verdets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64551-64400-verdets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64551-64400-verdets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64551-64400-verdets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64552-64330-vialer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64552-64330-vialer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64552-64330-vialer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64552-64330-vialer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64554-64170-viellenave_d_arthez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64554-64170-viellenave_d_arthez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64554-64170-viellenave_d_arthez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64554-64170-viellenave_d_arthez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64555-64190-viellenave_de_navarrenx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64555-64190-viellenave_de_navarrenx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64555-64190-viellenave_de_navarrenx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64555-64190-viellenave_de_navarrenx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64556-64150-viellesegure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64556-64150-viellesegure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64556-64150-viellesegure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64556-64150-viellesegure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64557-64410-vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64557-64410-vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64557-64410-vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64557-64410-vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64558-64990-villefranque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64558-64990-villefranque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64558-64990-villefranque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64558-64990-villefranque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64559-64130-viodos_abense_de_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64559-64130-viodos_abense_de_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64559-64130-viodos_abense_de_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64559-64130-viodos_abense_de_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64560-64450-viven/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64560-64450-viven/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64560-64450-viven/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt64-pyrenees_atlantiques/commune64560-64450-viven/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-65.xml
+++ b/public/sitemaps/sitemap-65.xml
@@ -5,946 +5,1888 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65001-65260-adast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65001-65260-adast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65001-65260-adast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65001-65260-adast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65002-65100-ade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65002-65100-ade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65002-65100-ade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65002-65100-ade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65003-65240-adervielle_pouchergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65003-65240-adervielle_pouchergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65003-65240-adervielle_pouchergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65003-65240-adervielle_pouchergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65004-65400-agos_vidalos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65004-65400-agos_vidalos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65004-65400-agos_vidalos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65004-65400-agos_vidalos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65005-65360-allier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65005-65360-allier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65005-65360-allier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65005-65360-allier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65006-65440-ancizan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65006-65440-ancizan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65006-65440-ancizan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65006-65440-ancizan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65007-65390-andrest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65007-65390-andrest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65007-65390-andrest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65007-65390-andrest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65009-65150-aneres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65009-65150-aneres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65009-65150-aneres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65009-65150-aneres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65010-65690-angos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65010-65690-angos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65010-65690-angos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65010-65690-angos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65011-65100-les_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65011-65100-les_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65011-65100-les_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65011-65100-les_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65012-65370-anla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65012-65370-anla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65012-65370-anla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65012-65370-anla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65013-65140-ansost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65013-65140-ansost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65013-65140-ansost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65013-65140-ansost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65014-65370-antichan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65014-65370-antichan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65014-65370-antichan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65014-65370-antichan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65015-65220-antin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65015-65220-antin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65015-65220-antin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65015-65220-antin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65016-65200-antist/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65016-65200-antist/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65016-65200-antist/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65016-65200-antist/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65017-65170-aragnouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65017-65170-aragnouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65017-65170-aragnouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65017-65170-aragnouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65018-65560-arbeost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65018-65560-arbeost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65018-65560-arbeost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65018-65560-arbeost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65019-65360-arcizac_adour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65019-65360-arcizac_adour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65019-65360-arcizac_adour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65019-65360-arcizac_adour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65020-65100-arcizac_ez_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65020-65100-arcizac_ez_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65020-65100-arcizac_ez_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65020-65100-arcizac_ez_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65021-65400-arcizans_avant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65021-65400-arcizans_avant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65021-65400-arcizans_avant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65021-65400-arcizans_avant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65022-65400-arcizans_dessus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65022-65400-arcizans_dessus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65022-65400-arcizans_dessus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65022-65400-arcizans_dessus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65023-65240-ardengost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65023-65240-ardengost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65023-65240-ardengost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65023-65240-ardengost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65024-65200-argeles_bagneres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65024-65200-argeles_bagneres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65024-65200-argeles_bagneres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65024-65200-argeles_bagneres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65025-65400-argeles_gazost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65025-65400-argeles_gazost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65025-65400-argeles_gazost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65025-65400-argeles_gazost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65026-65230-aries_espenan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65026-65230-aries_espenan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65026-65230-aries_espenan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65026-65230-aries_espenan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65028-65670-arne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65028-65670-arne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65028-65670-arne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65028-65670-arne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65029-65400-arras_en_lavedan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65029-65400-arras_en_lavedan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65029-65400-arras_en_lavedan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65029-65400-arras_en_lavedan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65031-65240-arreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65031-65240-arreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65031-65240-arreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65031-65240-arreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65032-65400-arrens_marsous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65032-65400-arrens_marsous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65032-65400-arrens_marsous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65032-65400-arrens_marsous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65033-65100-arrodets_ez_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65033-65100-arrodets_ez_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65033-65100-arrodets_ez_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65033-65100-arrodets_ez_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65034-65130-arrodets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65034-65130-arrodets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65034-65130-arrodets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65034-65130-arrodets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65035-65500-artagnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65035-65500-artagnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65035-65500-artagnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65035-65500-artagnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65036-65400-artalens_souin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65036-65400-artalens_souin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65036-65400-artalens_souin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65036-65400-artalens_souin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65037-65130-artiguemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65037-65130-artiguemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65037-65130-artiguemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65037-65130-artiguemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65038-65100-artigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65038-65100-artigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65038-65100-artigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65038-65100-artigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65039-65240-aspin_aure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65039-65240-aspin_aure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65039-65240-aspin_aure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65039-65240-aspin_aure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65040-65100-aspin_en_lavedan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65040-65100-aspin_en_lavedan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65040-65100-aspin_en_lavedan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65040-65100-aspin_en_lavedan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65041-65130-asque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65041-65130-asque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65041-65130-asque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65041-65130-asque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65042-65200-aste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65042-65200-aste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65042-65200-aste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65042-65200-aste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65043-65200-astugue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65043-65200-astugue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65043-65200-astugue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65043-65200-astugue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65044-65350-aubarede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65044-65350-aubarede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65044-65350-aubarede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65044-65350-aubarede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65045-65400-aucun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65045-65400-aucun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65045-65400-aucun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65045-65400-aucun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65046-65240-aulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65046-65240-aulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65046-65240-aulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65046-65240-aulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65047-65800-aureilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65047-65800-aureilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65047-65800-aureilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65047-65800-aureilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65048-65390-aurensan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65048-65390-aurensan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65048-65390-aurensan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65048-65390-aurensan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65049-65700-auriebat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65049-65700-auriebat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65049-65700-auriebat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65049-65700-auriebat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65050-65240-avajan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65050-65240-avajan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65050-65240-avajan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65050-65240-avajan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65051-65660-aventignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65051-65660-aventignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65051-65660-aventignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65051-65660-aventignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65052-65380-averan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65052-65380-averan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65052-65380-averan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65052-65380-averan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65053-65370-aveux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65053-65370-aveux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65053-65370-aveux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65053-65370-aveux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65054-65130-avezac_prat_lahitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65054-65130-avezac_prat_lahitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65054-65130-avezac_prat_lahitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65054-65130-avezac_prat_lahitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65055-65400-ayros_arbouix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65055-65400-ayros_arbouix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65055-65400-ayros_arbouix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65055-65400-ayros_arbouix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65056-65400-ayzac_ost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65056-65400-ayzac_ost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65056-65400-ayzac_ost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65056-65400-ayzac_ost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65057-65380-azereix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65057-65380-azereix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65057-65380-azereix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65057-65380-azereix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65058-65170-azet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65058-65170-azet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65058-65170-azet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65058-65170-azet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65059-65200-bagneres_de_bigorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65059-65200-bagneres_de_bigorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65059-65200-bagneres_de_bigorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65059-65200-bagneres_de_bigorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65060-65200-banios/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65060-65200-banios/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65060-65200-banios/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65060-65200-banios/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65061-65140-barbachen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65061-65140-barbachen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65061-65140-barbachen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65061-65140-barbachen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65062-65690-barbazan_debat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65062-65690-barbazan_debat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65062-65690-barbazan_debat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65062-65690-barbazan_debat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65063-65360-barbazan_dessus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65063-65360-barbazan_dessus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65063-65360-barbazan_dessus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65063-65360-barbazan_dessus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65064-65240-bareilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65064-65240-bareilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65064-65240-bareilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65064-65240-bareilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65065-65100-barlest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65065-65100-barlest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65065-65100-barlest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65065-65100-barlest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65066-65240-barrancoueu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65066-65240-barrancoueu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65066-65240-barrancoueu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65066-65240-barrancoueu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65067-65380-barry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65067-65380-barry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65067-65380-barry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65067-65380-barry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65068-65230-barthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65068-65230-barthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65068-65230-barthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65068-65230-barthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65069-65250-la_barthe_de_neste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65069-65250-la_barthe_de_neste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65069-65250-la_barthe_de_neste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65069-65250-la_barthe_de_neste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65070-65100-bartres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65070-65100-bartres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65070-65100-bartres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65070-65100-bartres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65071-65130-batsere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65071-65130-batsere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65071-65130-batsere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65071-65130-batsere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65072-65460-bazet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65072-65460-bazet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65072-65460-bazet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65072-65460-bazet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65073-65140-bazillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65073-65140-bazillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65073-65140-bazillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65073-65140-bazillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65074-65670-bazordan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65074-65670-bazordan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65074-65670-bazordan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65074-65670-bazordan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65075-65170-bazus_aure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65075-65170-bazus_aure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65075-65170-bazus_aure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65075-65170-bazus_aure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65076-65250-bazus_neste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65076-65250-bazus_neste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65076-65250-bazus_neste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65076-65250-bazus_neste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65077-65400-beaucens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65077-65400-beaucens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65077-65400-beaucens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65077-65400-beaucens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65078-65710-beaudean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65078-65710-beaudean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65078-65710-beaudean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65078-65710-beaudean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65079-65190-begole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65079-65190-begole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65079-65190-begole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65079-65190-begole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65080-65380-benac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65080-65380-benac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65080-65380-benac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65080-65380-benac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65081-65130-benque_molere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65081-65130-benque_molere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65081-65130-benque_molere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65081-65130-benque_molere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65082-65100-berberust_lias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65082-65100-berberust_lias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65082-65100-berberust_lias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65082-65100-berberust_lias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65083-65360-bernac_debat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65083-65360-bernac_debat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65083-65360-bernac_debat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65083-65360-bernac_debat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65084-65360-bernac_dessus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65084-65360-bernac_dessus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65084-65360-bernac_dessus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65084-65360-bernac_dessus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65085-65220-bernadets_debat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65085-65220-bernadets_debat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65085-65220-bernadets_debat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65085-65220-bernadets_debat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65086-65190-bernadets_dessus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65086-65190-bernadets_dessus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65086-65190-bernadets_dessus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65086-65190-bernadets_dessus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65087-65370-bertren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65087-65370-bertren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65087-65370-bertren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65087-65370-bertren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65088-65230-betbeze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65088-65230-betbeze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65088-65230-betbeze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65088-65230-betbeze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65089-65120-betpouey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65089-65120-betpouey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65089-65120-betpouey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65089-65120-betpouey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65090-65230-betpouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65090-65230-betpouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65090-65230-betpouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65090-65230-betpouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65091-65130-bettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65091-65130-bettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65091-65130-bettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65091-65130-bettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65092-65410-beyrede_jumet_camous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65092-65410-beyrede_jumet_camous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65092-65410-beyrede_jumet_camous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65092-65410-beyrede_jumet_camous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65093-65150-bize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65093-65150-bize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65093-65150-bize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65093-65150-bize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65094-65150-bizous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65094-65150-bizous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65094-65150-bizous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65094-65150-bizous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65095-65220-bonnefont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65095-65220-bonnefont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65095-65220-bonnefont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65095-65220-bonnefont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65096-65130-bonnemazon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65096-65130-bonnemazon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65096-65130-bonnemazon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65096-65130-bonnemazon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65097-65330-bonrepos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65097-65330-bonrepos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65097-65330-bonrepos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65097-65330-bonrepos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65098-65400-boo_silhen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65098-65400-boo_silhen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65098-65400-boo_silhen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65098-65400-boo_silhen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65099-65590-borderes_louron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65099-65590-borderes_louron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65099-65590-borderes_louron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65099-65590-borderes_louron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65100-65320-borderes_sur_l_echez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65100-65320-borderes_sur_l_echez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65100-65320-borderes_sur_l_echez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65100-65320-borderes_sur_l_echez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65101-65190-bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65101-65190-bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65101-65190-bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65101-65190-bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65102-65140-bouilh_devant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65102-65140-bouilh_devant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65102-65140-bouilh_devant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65102-65140-bouilh_devant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65103-65350-bouilh_pereuilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65103-65350-bouilh_pereuilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65103-65350-bouilh_pereuilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65103-65350-bouilh_pereuilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65104-65350-boulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65104-65350-boulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65104-65350-boulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65104-65350-boulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65105-65130-bourg_de_bigorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65105-65130-bourg_de_bigorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65105-65130-bourg_de_bigorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65105-65130-bourg_de_bigorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65106-65170-bourisp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65106-65170-bourisp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65106-65170-bourisp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65106-65170-bourisp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65107-65100-bourreac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65107-65100-bourreac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65107-65100-bourreac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65107-65100-bourreac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65108-65460-bours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65108-65460-bours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65108-65460-bours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65108-65460-bours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65109-65370-bramevaque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65109-65370-bramevaque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65109-65370-bramevaque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65109-65370-bramevaque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65110-65220-bugard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65110-65220-bugard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65110-65220-bugard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65110-65220-bugard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65111-65130-bulan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65111-65130-bulan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65111-65130-bulan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65111-65130-bulan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65112-65400-bun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65112-65400-bun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65112-65400-bun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65112-65400-bun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65113-65190-burg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65113-65190-burg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65113-65190-burg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65113-65190-burg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65114-65140-buzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65114-65140-buzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65114-65140-buzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65114-65140-buzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65115-65350-cabanac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65115-65350-cabanac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65115-65350-cabanac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65115-65350-cabanac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65116-65240-cadeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65116-65240-cadeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65116-65240-cadeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65116-65240-cadeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65117-65170-cadeilhan_trachere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65117-65170-cadeilhan_trachere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65117-65170-cadeilhan_trachere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65117-65170-cadeilhan_trachere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65118-65190-caharet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65118-65190-caharet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65118-65190-caharet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65118-65190-caharet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65119-65500-caixon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65119-65500-caixon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65119-65500-caixon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65119-65500-caixon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65120-65190-calavante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65120-65190-calavante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65120-65190-calavante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65120-65190-calavante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65121-65500-camales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65121-65500-camales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65121-65500-camales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65121-65500-camales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65123-65710-campan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65123-65710-campan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65123-65710-campan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65123-65710-campan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65124-65170-camparan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65124-65170-camparan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65124-65170-camparan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65124-65170-camparan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65125-65300-campistrous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65125-65300-campistrous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65125-65300-campistrous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65125-65300-campistrous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65126-65230-campuzan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65126-65230-campuzan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65126-65230-campuzan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65126-65230-campuzan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65127-65130-capvern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65127-65130-capvern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65127-65130-capvern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65127-65130-capvern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65128-65330-castelbajac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65128-65330-castelbajac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65128-65330-castelbajac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65128-65330-castelbajac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65129-65230-castelnau_magnoac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65129-65230-castelnau_magnoac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65129-65230-castelnau_magnoac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65129-65230-castelnau_magnoac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65130-65700-castelnau_riviere_basse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65130-65700-castelnau_riviere_basse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65130-65700-castelnau_riviere_basse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65130-65700-castelnau_riviere_basse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65131-65350-castelvieilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65131-65350-castelvieilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65131-65350-castelvieilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65131-65350-castelvieilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65132-65190-castera_lanusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65132-65190-castera_lanusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65132-65190-castera_lanusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65132-65190-castera_lanusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65133-65350-castera_lou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65133-65350-castera_lou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65133-65350-castera_lou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65133-65350-castera_lou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65134-65230-casterets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65134-65230-casterets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65134-65230-casterets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65134-65230-casterets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65135-65130-castillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65135-65130-castillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65135-65130-castillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65135-65130-castillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65136-65230-caubous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65136-65230-caubous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65136-65230-caubous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65136-65230-caubous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65137-65700-caussade_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65137-65700-caussade_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65137-65700-caussade_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65137-65700-caussade_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65138-65110-cauterets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65138-65110-cauterets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65138-65110-cauterets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65138-65110-cauterets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65139-65370-cazarilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65139-65370-cazarilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65139-65370-cazarilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65139-65370-cazarilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65140-65590-cazaux_debat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65140-65590-cazaux_debat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65140-65590-cazaux_debat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65140-65590-cazaux_debat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65141-65240-cazaux_frechet_aneran_camors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65141-65240-cazaux_frechet_aneran_camors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65141-65240-cazaux_frechet_aneran_camors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65141-65240-cazaux_frechet_aneran_camors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65142-65350-chelle_debat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65142-65350-chelle_debat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65142-65350-chelle_debat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65142-65350-chelle_debat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65143-65130-chelle_spou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65143-65130-chelle_spou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65143-65130-chelle_spou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65143-65130-chelle_spou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65144-65100-cheust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65144-65100-cheust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65144-65100-cheust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65144-65100-cheust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65145-65120-cheze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65145-65120-cheze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65145-65120-cheze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65145-65120-cheze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65146-65800-chis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65146-65800-chis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65146-65800-chis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65146-65800-chis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65147-65200-cieutat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65147-65200-cieutat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65147-65200-cieutat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65147-65200-cieutat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65148-65230-cizos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65148-65230-cizos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65148-65230-cizos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65148-65230-cizos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65149-65190-clarac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65149-65190-clarac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65149-65190-clarac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65149-65190-clarac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65150-65300-clarens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65150-65300-clarens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65150-65300-clarens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65150-65300-clarens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65151-65350-collongues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65151-65350-collongues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65151-65350-collongues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65151-65350-collongues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65153-65350-coussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65153-65350-coussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65153-65350-coussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65153-65350-coussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65154-65370-crechets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65154-65370-crechets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65154-65370-crechets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65154-65370-crechets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65155-65230-deveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65155-65230-deveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65155-65230-deveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65155-65230-deveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65156-65350-dours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65156-65350-dours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65156-65350-dours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65156-65350-dours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65157-65170-ens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65157-65170-ens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65157-65170-ens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65157-65170-ens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65158-65370-esbareich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65158-65370-esbareich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65158-65370-esbareich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65158-65370-esbareich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65159-65250-escala/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65159-65250-escala/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65159-65250-escala/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65159-65250-escala/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65160-65500-escaunets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65160-65500-escaunets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65160-65500-escaunets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65160-65500-escaunets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65161-65140-escondeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65161-65140-escondeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65161-65140-escondeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65161-65140-escondeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65162-65130-esconnets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65162-65130-esconnets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65162-65130-esconnets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65162-65130-esconnets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65163-65130-escots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65163-65130-escots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65163-65130-escots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65163-65130-escots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65164-65100-escoubes_pouts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65164-65100-escoubes_pouts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65164-65100-escoubes_pouts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65164-65100-escoubes_pouts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65165-65130-esparros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65165-65130-esparros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65165-65130-esparros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65165-65130-esparros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65166-65130-espeche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65166-65130-espeche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65166-65130-espeche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65166-65130-espeche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65167-65130-espieilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65167-65130-espieilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65167-65130-espieilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65167-65130-espieilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65168-65120-esquieze_sere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65168-65120-esquieze_sere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65168-65120-esquieze_sere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65168-65120-esquieze_sere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65169-65400-estaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65169-65400-estaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65169-65400-estaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65169-65400-estaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65170-65220-estampures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65170-65220-estampures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65170-65220-estampures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65170-65220-estampures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65171-65240-estarvielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65171-65240-estarvielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65171-65240-estarvielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65171-65240-estarvielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65172-65170-estensan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65172-65170-estensan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65172-65170-estensan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65172-65170-estensan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65173-65120-esterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65173-65120-esterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65173-65120-esterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65173-65120-esterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65174-65700-estirac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65174-65700-estirac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65174-65700-estirac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65174-65700-estirac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65175-65370-ferrere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65175-65370-ferrere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65175-65370-ferrere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65175-65370-ferrere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65176-65560-ferrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65176-65560-ferrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65176-65560-ferrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65176-65560-ferrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65177-65220-fontrailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65177-65220-fontrailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65177-65220-fontrailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65177-65220-fontrailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65178-65220-frechede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65178-65220-frechede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65178-65220-frechede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65178-65220-frechede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65179-65130-frechendets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65179-65130-frechendets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65179-65130-frechendets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65179-65130-frechendets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65180-65240-frechet_aure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65180-65240-frechet_aure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65180-65240-frechet_aure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65180-65240-frechet_aure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65181-65190-frechou_frechet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65181-65190-frechou_frechet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65181-65190-frechou_frechet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65181-65190-frechou_frechet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65182-65400-gaillagos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65182-65400-gaillagos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65182-65400-gaillagos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65182-65400-gaillagos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65183-65330-galan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65183-65330-galan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65183-65330-galan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65183-65330-galan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65184-65330-galez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65184-65330-galez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65184-65330-galez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65184-65330-galez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65185-65320-garderes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65185-65320-garderes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65185-65320-garderes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65185-65320-garderes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65186-65370-gaudent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65186-65370-gaudent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65186-65370-gaudent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65186-65370-gaudent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65187-65670-gaussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65187-65670-gaussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65187-65670-gaussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65187-65670-gaussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65189-65320-gayan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65189-65320-gayan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65189-65320-gayan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65189-65320-gayan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65190-65250-gazave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65190-65250-gazave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65190-65250-gazave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65190-65250-gazave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65191-65100-gazost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65191-65100-gazost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65191-65100-gazost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65191-65100-gazost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65192-65120-gavarnie_gedre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65192-65120-gavarnie_gedre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65192-65120-gavarnie_gedre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65192-65120-gavarnie_gedre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65193-65370-gembrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65193-65370-gembrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65193-65370-gembrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65193-65370-gembrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65194-65150-generest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65194-65150-generest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65194-65150-generest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65194-65150-generest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65195-65240-genos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65195-65240-genos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65195-65240-genos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65195-65240-genos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65196-65140-gensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65196-65140-gensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65196-65140-gensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65196-65140-gensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65197-65100-ger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65197-65100-ger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65197-65100-ger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65197-65100-ger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65198-65200-gerde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65198-65200-gerde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65198-65200-gerde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65198-65200-gerde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65199-65240-germ/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65199-65240-germ/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65199-65240-germ/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65199-65240-germ/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65200-65200-germs_sur_l_oussouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65200-65200-germs_sur_l_oussouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65200-65200-germs_sur_l_oussouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65200-65200-germs_sur_l_oussouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65201-65100-geu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65201-65100-geu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65201-65100-geu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65201-65100-geu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65202-65400-gez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65202-65400-gez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65202-65400-gez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65202-65400-gez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65203-65100-gez_ez_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65203-65100-gez_ez_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65203-65100-gez_ez_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65203-65100-gez_ez_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65204-65350-gonez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65204-65350-gonez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65204-65350-gonez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65204-65350-gonez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65205-65240-gouaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65205-65240-gouaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65205-65240-gouaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65205-65240-gouaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65206-65190-goudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65206-65190-goudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65206-65190-goudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65206-65190-goudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65207-65130-gourgue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65207-65130-gourgue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65207-65130-gourgue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65207-65130-gourgue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65208-65170-grailhen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65208-65170-grailhen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65208-65170-grailhen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65208-65170-grailhen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65209-65240-grezian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65209-65240-grezian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65209-65240-grezian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65209-65240-grezian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65210-65120-grust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65210-65120-grust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65210-65120-grust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65210-65120-grust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65211-65170-guchan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65211-65170-guchan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65211-65170-guchan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65211-65170-guchan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65212-65240-guchen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65212-65240-guchen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65212-65240-guchen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65212-65240-guchen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65213-65230-guizerix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65213-65230-guizerix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65213-65230-guizerix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65213-65230-guizerix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65214-65230-hachan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65214-65230-hachan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65214-65230-hachan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65214-65230-hachan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65215-65700-hagedet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65215-65700-hagedet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65215-65700-hagedet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65215-65700-hagedet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65216-65200-hauban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65216-65200-hauban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65216-65200-hauban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65216-65200-hauban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65217-65150-hautaget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65217-65150-hautaget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65217-65150-hautaget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65217-65150-hautaget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65218-65250-heches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65218-65250-heches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65218-65250-heches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65218-65250-heches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65219-65700-heres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65219-65700-heres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65219-65700-heres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65219-65700-heres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65220-65380-hibarette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65220-65380-hibarette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65220-65380-hibarette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65220-65380-hibarette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65221-65200-hiis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65221-65200-hiis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65221-65200-hiis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65221-65200-hiis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65222-65190-hitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65222-65190-hitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65222-65190-hitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65222-65190-hitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65223-65310-horgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65223-65310-horgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65223-65310-horgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65223-65310-horgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65224-65330-houeydets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65224-65330-houeydets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65224-65330-houeydets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65224-65330-houeydets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65225-65350-hourc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65225-65350-hourc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65225-65350-hourc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65225-65350-hourc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65226-65420-ibos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65226-65420-ibos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65226-65420-ibos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65226-65420-ibos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65228-65410-ilhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65228-65410-ilhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65228-65410-ilhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65228-65410-ilhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65229-65370-ilheu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65229-65370-ilheu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65229-65370-ilheu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65229-65370-ilheu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65230-65370-izaourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65230-65370-izaourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65230-65370-izaourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65230-65370-izaourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65231-65250-izaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65231-65250-izaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65231-65250-izaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65231-65250-izaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65232-65350-jacque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65232-65350-jacque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65232-65350-jacque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65232-65350-jacque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65233-65100-jarret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65233-65100-jarret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65233-65100-jarret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65233-65100-jarret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65234-65240-jezeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65234-65240-jezeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65234-65240-jezeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65234-65240-jezeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65235-65290-juillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65235-65290-juillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65235-65290-juillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65235-65290-juillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65236-65100-julos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65236-65100-julos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65236-65100-julos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65236-65100-julos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65237-65100-juncalas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65237-65100-juncalas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65237-65100-juncalas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65237-65100-juncalas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65238-65200-labassere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65238-65200-labassere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65238-65200-labassere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65238-65200-labassere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65239-65130-labastide/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65239-65130-labastide/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65239-65130-labastide/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65239-65130-labastide/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65240-65700-labatut_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65240-65700-labatut_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65240-65700-labatut_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65240-65700-labatut_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65241-65130-laborde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65241-65130-laborde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65241-65130-laborde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65241-65130-laborde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65242-65140-lacassagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65242-65140-lacassagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65242-65140-lacassagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65242-65140-lacassagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65243-65700-lafitole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65243-65700-lafitole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65243-65700-lafitole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65243-65700-lafitole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65244-65320-lagarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65244-65320-lagarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65244-65320-lagarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65244-65320-lagarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65245-65300-lagrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65245-65300-lagrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65245-65300-lagrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65245-65300-lagrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65247-65100-arrayou_lahitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65247-65100-arrayou_lahitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65247-65100-arrayou_lahitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65247-65100-arrayou_lahitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65248-65700-lahitte_toupiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65248-65700-lahitte_toupiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65248-65700-lahitte_toupiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65248-65700-lahitte_toupiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65249-65230-lalanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65249-65230-lalanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65249-65230-lalanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65249-65230-lalanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65250-65220-lalanne_trie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65250-65220-lalanne_trie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65250-65220-lalanne_trie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65250-65220-lalanne_trie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65251-65310-laloubere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65251-65310-laloubere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65251-65310-laloubere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65251-65310-laloubere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65252-65380-lamarque_pontacq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65252-65380-lamarque_pontacq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65252-65380-lamarque_pontacq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65252-65380-lamarque_pontacq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65253-65220-lamarque_rustaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65253-65220-lamarque_rustaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65253-65220-lamarque_rustaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65253-65220-lamarque_rustaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65254-65140-lameac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65254-65140-lameac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65254-65140-lameac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65254-65140-lameac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65255-65240-lancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65255-65240-lancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65255-65240-lancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65255-65240-lancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65256-65190-lanespede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65256-65190-lanespede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65256-65190-lanespede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65256-65190-lanespede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65257-65380-lanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65257-65380-lanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65257-65380-lanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65257-65380-lanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65258-65300-lannemezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65258-65300-lannemezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65258-65300-lannemezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65258-65300-lannemezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65259-65350-lansac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65259-65350-lansac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65259-65350-lansac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65259-65350-lansac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65260-65220-lapeyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65260-65220-lapeyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65260-65220-lapeyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65260-65220-lapeyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65261-65670-laran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65261-65670-laran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65261-65670-laran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65261-65670-laran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65262-65700-larreule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65262-65700-larreule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65262-65700-larreule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65262-65700-larreule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65263-65230-larroque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65263-65230-larroque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65263-65230-larroque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65263-65230-larroque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65264-65700-lascazeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65264-65700-lascazeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65264-65700-lascazeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65264-65700-lascazeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65265-65350-laslades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65265-65350-laslades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65265-65350-laslades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65265-65350-laslades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65266-65670-lassales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65266-65670-lassales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65266-65670-lassales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65266-65670-lassales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65267-65400-lau_balagnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65267-65400-lau_balagnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65267-65400-lau_balagnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65267-65400-lau_balagnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65268-65380-layrisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65268-65380-layrisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65268-65380-layrisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65268-65380-layrisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65269-65140-lescurry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65269-65140-lescurry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65269-65140-lescurry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65269-65140-lescurry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65270-65190-lespouey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65270-65190-lespouey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65270-65190-lespouey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65270-65190-lespouey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65271-65100-lezignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65271-65100-lezignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65271-65100-lezignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65271-65100-lezignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65272-65190-lhez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65272-65190-lhez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65272-65190-lhez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65272-65190-lhez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65273-65140-liac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65273-65140-liac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65273-65140-liac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65273-65140-liac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65274-65330-libaros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65274-65330-libaros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65274-65330-libaros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65274-65330-libaros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65275-65200-lies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65275-65200-lies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65275-65200-lies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65275-65200-lies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65276-65350-lizos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65276-65350-lizos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65276-65350-lizos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65276-65350-lizos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65277-65150-lombres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65277-65150-lombres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65277-65150-lombres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65277-65150-lombres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65278-65130-lomne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65278-65130-lomne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65278-65130-lomne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65278-65130-lomne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65279-65250-lortet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65279-65250-lortet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65279-65250-lortet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65279-65250-lortet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65280-65100-loubajac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65280-65100-loubajac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65280-65100-loubajac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65280-65100-loubajac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65281-65200-loucrup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65281-65200-loucrup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65281-65200-loucrup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65281-65200-loucrup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65282-65510-loudenvielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65282-65510-loudenvielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65282-65510-loudenvielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65282-65510-loudenvielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65282-65240-loudenvielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65282-65240-loudenvielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65282-65240-loudenvielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65282-65240-loudenvielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65283-65240-loudervielle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65283-65240-loudervielle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65283-65240-loudervielle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65283-65240-loudervielle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65284-65290-louey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65284-65290-louey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65284-65290-louey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65284-65290-louey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65285-65350-louit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65285-65350-louit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65285-65350-louit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65285-65350-louit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65286-65100-lourdes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65286-65100-lourdes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65286-65100-lourdes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65286-65100-lourdes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65287-65370-loures_barousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65287-65370-loures_barousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65287-65370-loures_barousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65287-65370-loures_barousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65288-65220-lubret_saint_luc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65288-65220-lubret_saint_luc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65288-65220-lubret_saint_luc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65288-65220-lubret_saint_luc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65289-65220-luby_betmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65289-65220-luby_betmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65289-65220-luby_betmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65289-65220-luby_betmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65290-65190-luc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65290-65190-luc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65290-65190-luc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65290-65190-luc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65291-65100-lugagnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65291-65100-lugagnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65291-65100-lugagnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65291-65100-lugagnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65292-65320-luquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65292-65320-luquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65292-65320-luquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65292-65320-luquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65293-65220-lustar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65293-65220-lustar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65293-65220-lustar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65293-65220-lustar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65294-65300-lutilhous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65294-65300-lutilhous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65294-65300-lutilhous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65294-65300-lutilhous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65295-65120-luz_saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65295-65120-luz_saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65295-65120-luz_saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65295-65120-luz_saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65296-65700-madiran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65296-65700-madiran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65296-65700-madiran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65296-65700-madiran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65297-65140-mansan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65297-65140-mansan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65297-65140-mansan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65297-65140-mansan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65298-65350-marquerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65298-65350-marquerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65298-65350-marquerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65298-65350-marquerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65299-65500-marsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65299-65500-marsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65299-65500-marsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65299-65500-marsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65300-65200-marsas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65300-65200-marsas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65300-65200-marsas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65300-65200-marsas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65301-65350-marseillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65301-65350-marseillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65301-65350-marseillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65301-65350-marseillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65303-65190-mascaras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65303-65190-mascaras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65303-65190-mascaras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65303-65190-mascaras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65304-65700-maubourguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65304-65700-maubourguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65304-65700-maubourguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65304-65700-maubourguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65305-65370-mauleon_barousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65305-65370-mauleon_barousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65305-65370-mauleon_barousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65305-65370-mauleon_barousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65306-65130-mauvezin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65306-65130-mauvezin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65306-65130-mauvezin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65306-65130-mauvezin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65307-65150-mazeres_de_neste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65307-65150-mazeres_de_neste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65307-65150-mazeres_de_neste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65307-65150-mazeres_de_neste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65308-65220-mazerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65308-65220-mazerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65308-65220-mazerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65308-65220-mazerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65309-65250-mazouau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65309-65250-mazouau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65309-65250-mazouau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65309-65250-mazouau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65310-65200-merilheu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65310-65200-merilheu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65310-65200-merilheu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65310-65200-merilheu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65311-65140-mingot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65311-65140-mingot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65311-65140-mingot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65311-65140-mingot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65313-65360-momeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65313-65360-momeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65313-65360-momeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65313-65360-momeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65314-65140-monfaucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65314-65140-monfaucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65314-65140-monfaucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65314-65140-monfaucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65315-65670-monleon_magnoac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65315-65670-monleon_magnoac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65315-65670-monleon_magnoac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65315-65670-monleon_magnoac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65316-65670-monlong/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65316-65670-monlong/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65316-65670-monlong/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65316-65670-monlong/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65317-65240-mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65317-65240-mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65317-65240-mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65317-65240-mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65318-65330-montastruc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65318-65330-montastruc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65318-65330-montastruc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65318-65330-montastruc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65319-65150-montegut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65319-65150-montegut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65319-65150-montegut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65319-65150-montegut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65320-65200-montgaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65320-65200-montgaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65320-65200-montgaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65320-65200-montgaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65321-65690-montignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65321-65690-montignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65321-65690-montignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65321-65690-montignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65322-65250-montousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65322-65250-montousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65322-65250-montousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65322-65250-montousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65323-65150-montserie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65323-65150-montserie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65323-65150-montserie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65323-65150-montserie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65324-65190-mouledous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65324-65190-mouledous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65324-65190-mouledous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65324-65190-mouledous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65325-65140-moumoulous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65325-65140-moumoulous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65325-65140-moumoulous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65325-65140-moumoulous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65326-65350-mun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65326-65350-mun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65326-65350-mun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65326-65350-mun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65327-65150-nestier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65327-65150-nestier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65327-65150-nestier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65327-65150-nestier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65328-65200-neuilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65328-65200-neuilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65328-65200-neuilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65328-65200-neuilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65329-65150-nistos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65329-65150-nistos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65329-65150-nistos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65329-65150-nistos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65330-65500-nouilhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65330-65500-nouilhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65330-65500-nouilhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65330-65500-nouilhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65331-65310-odos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65331-65310-odos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65331-65310-odos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65331-65310-odos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65332-65350-oleac_debat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65332-65350-oleac_debat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65332-65350-oleac_debat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65332-65350-oleac_debat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65333-65190-oleac_dessus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65333-65190-oleac_dessus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65333-65190-oleac_dessus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65333-65190-oleac_dessus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65334-65100-omex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65334-65100-omex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65334-65100-omex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65334-65100-omex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65335-65200-ordizan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65335-65200-ordizan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65335-65200-ordizan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65335-65200-ordizan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65336-65230-organ/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65336-65230-organ/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65336-65230-organ/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65336-65230-organ/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65337-65190-orieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65337-65190-orieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65337-65190-orieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65337-65190-orieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65338-65200-orignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65338-65200-orignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65338-65200-orignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65338-65200-orignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65339-65380-orincles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65339-65380-orincles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65339-65380-orincles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65339-65380-orincles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65340-65800-orleix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65340-65800-orleix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65340-65800-orleix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65340-65800-orleix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65341-65320-oroix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65341-65320-oroix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65341-65320-oroix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65341-65320-oroix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65342-65350-osmets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65342-65350-osmets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65342-65350-osmets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65342-65350-osmets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65343-65100-ossen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65343-65100-ossen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65343-65100-ossen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65343-65100-ossen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65344-65380-ossun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65344-65380-ossun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65344-65380-ossun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65344-65380-ossun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65345-65100-ossun_ez_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65345-65100-ossun_ez_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65345-65100-ossun_ez_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65345-65100-ossun_ez_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65346-65190-oueilloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65346-65190-oueilloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65346-65190-oueilloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65346-65190-oueilloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65347-65370-ourde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65347-65370-ourde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65347-65370-ourde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65347-65370-ourde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65348-65100-ourdis_cotdoussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65348-65100-ourdis_cotdoussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65348-65100-ourdis_cotdoussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65348-65100-ourdis_cotdoussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65349-65100-ourdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65349-65100-ourdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65349-65100-ourdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65349-65100-ourdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65350-65490-oursbelille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65350-65490-oursbelille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65350-65490-oursbelille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65350-65490-oursbelille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65351-65100-ouste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65351-65100-ouste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65351-65100-ouste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65351-65100-ouste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65352-65400-ouzous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65352-65400-ouzous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65352-65400-ouzous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65352-65400-ouzous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65353-65190-ozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65353-65190-ozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65353-65190-ozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65353-65190-ozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65354-65240-pailhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65354-65240-pailhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65354-65240-pailhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65354-65240-pailhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65355-65100-pareac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65355-65100-pareac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65355-65100-pareac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65355-65100-pareac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65356-65130-pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65356-65130-pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65356-65130-pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65356-65130-pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65357-65190-peyraube/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65357-65190-peyraube/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65357-65190-peyraube/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65357-65190-peyraube/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65358-65230-peyret_saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65358-65230-peyret_saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65358-65230-peyret_saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65358-65230-peyret_saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65359-65350-peyriguere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65359-65350-peyriguere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65359-65350-peyriguere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65359-65350-peyriguere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65360-65270-peyrouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65360-65270-peyrouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65360-65270-peyrouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65360-65270-peyrouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65361-65140-peyrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65361-65140-peyrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65361-65140-peyrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65361-65140-peyrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65362-65260-pierrefitte_nestalas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65362-65260-pierrefitte_nestalas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65362-65260-pierrefitte_nestalas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65362-65260-pierrefitte_nestalas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65363-65300-pinas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65363-65300-pinas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65363-65300-pinas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65363-65300-pinas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65364-65320-pintac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65364-65320-pintac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65364-65320-pintac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65364-65320-pintac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65366-65100-poueyferre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65366-65100-poueyferre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65366-65100-poueyferre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65366-65100-poueyferre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65367-65190-poumarous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65367-65190-poumarous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65367-65190-poumarous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65367-65190-poumarous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65368-65230-pouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65368-65230-pouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65368-65230-pouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65368-65230-pouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65369-65350-pouyastruc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65369-65350-pouyastruc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65369-65350-pouyastruc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65369-65350-pouyastruc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65370-65200-pouzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65370-65200-pouzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65370-65200-pouzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65370-65200-pouzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65371-65400-prechac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65371-65400-prechac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65371-65400-prechac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65371-65400-prechac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65372-65500-pujo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65372-65500-pujo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65372-65500-pujo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65372-65500-pujo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65373-65230-puntous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65373-65230-puntous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65373-65230-puntous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65373-65230-puntous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65374-65220-puydarrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65374-65220-puydarrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65374-65220-puydarrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65374-65220-puydarrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65375-65140-rabastens_de_bigorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65375-65140-rabastens_de_bigorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65375-65140-rabastens_de_bigorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65375-65140-rabastens_de_bigorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65376-65330-recurt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65376-65330-recurt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65376-65330-recurt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65376-65330-recurt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65377-65300-rejaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65377-65300-rejaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65377-65300-rejaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65377-65300-rejaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65378-65190-ricaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65378-65190-ricaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65378-65190-ricaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65378-65190-ricaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65379-65590-ris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65379-65590-ris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65379-65590-ris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65379-65590-ris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65380-65350-sabalos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65380-65350-sabalos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65380-65350-sabalos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65380-65350-sabalos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65381-65330-sabarros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65381-65330-sabarros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65381-65330-sabarros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65381-65330-sabarros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65382-65370-sacoue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65382-65370-sacoue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65382-65370-sacoue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65382-65370-sacoue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65383-65220-sadournin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65383-65220-sadournin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65383-65220-sadournin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65383-65220-sadournin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65384-65170-sailhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65384-65170-sailhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65384-65170-sailhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65384-65170-sailhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65385-65250-saint_arroman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65385-65250-saint_arroman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65385-65250-saint_arroman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65385-65250-saint_arroman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65386-65100-saint_creac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65386-65100-saint_creac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65386-65100-saint_creac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65386-65100-saint_creac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65387-65700-saint_lanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65387-65700-saint_lanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65387-65700-saint_lanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65387-65700-saint_lanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65388-65170-saint_lary_soulan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65388-65170-saint_lary_soulan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65388-65170-saint_lary_soulan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65388-65170-saint_lary_soulan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65389-65150-saint_laurent_de_neste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65389-65150-saint_laurent_de_neste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65389-65150-saint_laurent_de_neste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65389-65150-saint_laurent_de_neste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65390-65500-saint_lezer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65390-65500-saint_lezer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65390-65500-saint_lezer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65390-65500-saint_lezer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65391-65370-sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65391-65370-sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65391-65370-sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65391-65370-sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65392-65360-saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65392-65360-saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65392-65360-saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65392-65360-saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65393-65400-saint_pastous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65393-65400-saint_pastous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65393-65400-saint_pastous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65393-65400-saint_pastous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65394-65150-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65394-65150-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65394-65150-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65394-65150-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65395-65270-saint_pe_de_bigorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65395-65270-saint_pe_de_bigorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65395-65270-saint_pe_de_bigorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65395-65270-saint_pe_de_bigorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65396-65400-saint_savin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65396-65400-saint_savin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65396-65400-saint_savin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65396-65400-saint_savin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65397-65140-saint_sever_de_rustan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65397-65140-saint_sever_de_rustan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65397-65140-saint_sever_de_rustan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65397-65140-saint_sever_de_rustan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65398-65370-salechan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65398-65370-salechan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65398-65370-salechan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65398-65370-salechan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65399-65120-saligos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65399-65120-saligos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65399-65120-saligos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65399-65120-saligos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65400-65400-salles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65400-65400-salles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65400-65400-salles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65400-65400-salles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65401-65360-salles_adour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65401-65360-salles_adour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65401-65360-salles_adour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65401-65360-salles_adour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65402-65370-samuran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65402-65370-samuran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65402-65370-samuran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65402-65370-samuran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65403-65500-sanous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65403-65500-sanous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65403-65500-sanous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65403-65500-sanous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65404-65230-sariac_magnoac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65404-65230-sariac_magnoac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65404-65230-sariac_magnoac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65404-65230-sariac_magnoac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65405-65130-sarlabous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65405-65130-sarlabous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65405-65130-sarlabous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65405-65130-sarlabous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65406-65390-sarniguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65406-65390-sarniguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65406-65390-sarniguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65406-65390-sarniguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65407-65370-sarp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65407-65370-sarp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65407-65370-sarp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65407-65370-sarp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65408-65410-sarrancolin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65408-65410-sarrancolin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65408-65410-sarrancolin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65408-65410-sarrancolin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65409-65140-sarriac_bigorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65409-65140-sarriac_bigorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65409-65140-sarriac_bigorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65409-65140-sarriac_bigorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65410-65600-sarrouilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65410-65600-sarrouilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65410-65600-sarrouilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65410-65600-sarrouilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65411-65120-sassis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65411-65120-sassis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65411-65120-sassis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65411-65120-sassis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65412-65700-sauveterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65412-65700-sauveterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65412-65700-sauveterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65412-65700-sauveterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65413-65120-sazos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65413-65120-sazos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65413-65120-sazos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65413-65120-sazos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65414-65140-segalas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65414-65140-segalas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65414-65140-segalas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65414-65140-segalas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65415-65100-segus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65415-65100-segus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65415-65100-segus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65415-65100-segus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65416-65150-seich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65416-65150-seich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65416-65150-seich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65416-65150-seich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65417-65600-semeac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65417-65600-semeac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65417-65600-semeac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65417-65600-semeac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65418-65140-senac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65418-65140-senac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65418-65140-senac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65418-65140-senac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65419-65330-sentous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65419-65330-sentous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65419-65330-sentous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65419-65330-sentous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65420-65400-sere_en_lavedan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65420-65400-sere_en_lavedan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65420-65400-sere_en_lavedan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65420-65400-sere_en_lavedan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65421-65100-sere_lanso/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65421-65100-sere_lanso/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65421-65100-sere_lanso/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65421-65100-sere_lanso/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65422-65320-seron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65422-65320-seron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65422-65320-seron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65422-65320-seron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65423-65220-sere_rustaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65423-65220-sere_rustaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65423-65220-sere_rustaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65423-65220-sere_rustaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65424-65120-sers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65424-65120-sers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65424-65120-sers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65424-65120-sers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65425-65500-siarrouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65425-65500-siarrouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65425-65500-siarrouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65425-65500-siarrouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65426-65190-sinzos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65426-65190-sinzos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65426-65190-sinzos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65426-65190-sinzos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65427-65370-siradan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65427-65370-siradan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65427-65370-siradan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65427-65370-siradan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65428-65400-sireix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65428-65400-sireix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65428-65400-sireix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65428-65400-sireix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65429-65700-sombrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65429-65700-sombrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65429-65700-sombrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65429-65700-sombrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65430-65350-soreac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65430-65350-soreac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65430-65350-soreac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65430-65350-soreac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65431-65370-sost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65431-65370-sost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65431-65370-sost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65431-65370-sost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65432-65700-soublecause/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65432-65700-soublecause/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65432-65700-soublecause/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65432-65700-soublecause/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65433-65430-soues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65433-65430-soues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65433-65430-soues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65433-65430-soues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65435-65260-soulom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65435-65260-soulom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65435-65260-soulom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65435-65260-soulom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65436-65350-souyeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65436-65350-souyeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65436-65350-souyeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65436-65350-souyeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65437-65300-tajan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65437-65300-tajan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65437-65300-tajan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65437-65300-tajan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65438-65500-talazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65438-65500-talazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65438-65500-talazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65438-65500-talazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65439-65320-tarasteix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65439-65320-tarasteix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65439-65320-tarasteix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65439-65320-tarasteix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65440-65000-tarbes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65440-65000-tarbes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65440-65000-tarbes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65440-65000-tarbes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65441-65370-thebe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65441-65370-thebe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65441-65370-thebe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65441-65370-thebe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65442-65230-thermes_magnoac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65442-65230-thermes_magnoac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65442-65230-thermes_magnoac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65442-65230-thermes_magnoac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65443-65350-thuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65443-65350-thuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65443-65350-thuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65443-65350-thuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65444-65150-tibiran_jaunac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65444-65150-tibiran_jaunac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65444-65150-tibiran_jaunac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65444-65150-tibiran_jaunac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65445-65130-tilhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65445-65130-tilhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65445-65130-tilhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65445-65130-tilhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65446-65140-tostat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65446-65140-tostat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65446-65140-tostat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65446-65140-tostat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65447-65190-tournay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65447-65190-tournay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65447-65190-tournay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65447-65190-tournay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65448-65220-tournous_darre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65448-65220-tournous_darre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65448-65220-tournous_darre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65448-65220-tournous_darre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65449-65330-tournous_devant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65449-65330-tournous_devant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65449-65330-tournous_devant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65449-65330-tournous_devant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65450-65170-tramezaigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65450-65170-tramezaigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65450-65170-tramezaigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65450-65170-tramezaigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65451-65200-trebons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65451-65200-trebons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65451-65200-trebons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65451-65200-trebons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65452-65220-trie_sur_baise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65452-65220-trie_sur_baise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65452-65220-trie_sur_baise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65452-65220-trie_sur_baise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65453-65370-troubat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65453-65370-troubat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65453-65370-troubat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65453-65370-troubat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65454-65140-trouley_labarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65454-65140-trouley_labarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65454-65140-trouley_labarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65454-65140-trouley_labarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65455-65150-tuzaguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65455-65150-tuzaguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65455-65150-tuzaguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65455-65150-tuzaguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65456-65300-uglas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65456-65300-uglas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65456-65300-uglas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65456-65300-uglas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65457-65140-ugnouas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65457-65140-ugnouas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65457-65140-ugnouas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65457-65140-ugnouas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65458-65400-uz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65458-65400-uz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65458-65400-uz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65458-65400-uz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65459-65200-uzer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65459-65200-uzer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65459-65200-uzer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65459-65200-uzer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65460-65500-vic_en_bigorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65460-65500-vic_en_bigorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65460-65500-vic_en_bigorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65460-65500-vic_en_bigorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65461-65220-vidou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65461-65220-vidou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65461-65220-vidou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65461-65220-vidou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65462-65700-vidouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65462-65700-vidouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65462-65700-vidouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65462-65700-vidouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65463-65120-viella/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65463-65120-viella/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65463-65120-viella/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65463-65120-viella/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65464-65360-vielle_adour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65464-65360-vielle_adour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65464-65360-vielle_adour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65464-65360-vielle_adour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65465-65170-vielle_aure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65465-65170-vielle_aure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65465-65170-vielle_aure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65465-65170-vielle_aure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65466-65240-vielle_louron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65466-65240-vielle_louron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65466-65240-vielle_louron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65466-65240-vielle_louron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65467-65400-vier_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65467-65400-vier_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65467-65400-vier_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65467-65400-vier_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65468-65230-vieuzos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65468-65230-vieuzos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65468-65230-vieuzos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65468-65230-vieuzos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65469-65120-viey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65469-65120-viey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65469-65120-viey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65469-65120-viey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65470-65100-viger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65470-65100-viger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65470-65100-viger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65470-65100-viger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65471-65170-vignec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65471-65170-vignec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65471-65170-vignec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65471-65170-vignec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65472-65700-villefranque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65472-65700-villefranque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65472-65700-villefranque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65472-65700-villefranque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65473-65260-villelongue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65473-65260-villelongue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65473-65260-villelongue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65473-65260-villelongue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65474-65220-villembits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65474-65220-villembits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65474-65220-villembits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65474-65220-villembits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65475-65230-villemur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65475-65230-villemur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65475-65230-villemur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65475-65230-villemur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65476-65500-villenave_pres_bearn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65476-65500-villenave_pres_bearn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65476-65500-villenave_pres_bearn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65476-65500-villenave_pres_bearn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65477-65500-villenave_pres_marsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65477-65500-villenave_pres_marsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65477-65500-villenave_pres_marsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65477-65500-villenave_pres_marsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65478-65120-viscos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65478-65120-viscos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65478-65120-viscos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65478-65120-viscos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65479-65200-visker/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65479-65200-visker/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65479-65200-visker/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65479-65200-visker/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65481-65120-bareges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65481-65120-bareges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65481-65120-bareges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65481-65120-bareges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65482-65150-cantaous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65482-65150-cantaous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65482-65150-cantaous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt65-hautes_pyrenees/commune65482-65150-cantaous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-66.xml
+++ b/public/sitemaps/sitemap-66.xml
@@ -5,460 +5,916 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66001-66480-l_albere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66001-66480-l_albere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66001-66480-l_albere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66001-66480-l_albere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66002-66200-alenya/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66002-66200-alenya/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66002-66200-alenya/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66002-66200-alenya/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66003-66110-amelie_les_bains_palalda/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66003-66110-amelie_les_bains_palalda/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66003-66110-amelie_les_bains_palalda/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66003-66110-amelie_les_bains_palalda/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66004-66210-les_angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66004-66210-les_angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66004-66210-les_angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66004-66210-les_angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66005-66760-angoustrine_villeneuve_des_escaldes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66005-66760-angoustrine_villeneuve_des_escaldes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66005-66760-angoustrine_villeneuve_des_escaldes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66005-66760-angoustrine_villeneuve_des_escaldes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66006-66220-ansignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66006-66220-ansignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66006-66220-ansignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66006-66220-ansignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66007-66320-arboussols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66007-66320-arboussols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66007-66320-arboussols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66007-66320-arboussols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66008-66700-argeles_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66008-66700-argeles_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66008-66700-argeles_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66008-66700-argeles_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66009-66150-arles_sur_tech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66009-66150-arles_sur_tech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66009-66150-arles_sur_tech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66009-66150-arles_sur_tech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66010-66360-ayguatebia_talau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66010-66360-ayguatebia_talau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66010-66360-ayguatebia_talau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66010-66360-ayguatebia_talau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66011-66670-bages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66011-66670-bages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66011-66670-bages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66011-66670-bages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66012-66540-baho/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66012-66540-baho/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66012-66540-baho/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66012-66540-baho/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66013-66320-baillestavy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66013-66320-baillestavy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66013-66320-baillestavy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66013-66320-baillestavy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66014-66390-baixas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66014-66390-baixas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66014-66390-baixas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66014-66390-baixas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66015-66300-banyuls_dels_aspres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66015-66300-banyuls_dels_aspres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66015-66300-banyuls_dels_aspres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66015-66300-banyuls_dels_aspres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66016-66650-banyuls_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66016-66650-banyuls_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66016-66650-banyuls_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66016-66650-banyuls_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66017-66420-le_barcares/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66017-66420-le_barcares/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66017-66420-le_barcares/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66017-66420-le_barcares/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66018-66110-la_bastide/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66018-66110-la_bastide/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66018-66110-la_bastide/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66018-66110-la_bastide/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66019-66720-belesta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66019-66720-belesta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66019-66720-belesta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66019-66720-belesta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66020-66210-bolquere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66020-66210-bolquere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66020-66210-bolquere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66020-66210-bolquere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66021-66430-bompas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66021-66430-bompas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66021-66430-bompas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66021-66430-bompas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66022-66130-boule_d_amont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66022-66130-boule_d_amont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66022-66130-boule_d_amont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66022-66130-boule_d_amont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66023-66130-bouleternere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66023-66130-bouleternere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66023-66130-bouleternere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66023-66130-bouleternere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66024-66160-le_boulou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66024-66160-le_boulou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66024-66160-le_boulou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66024-66160-le_boulou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66025-66760-bourg_madame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66025-66760-bourg_madame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66025-66760-bourg_madame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66025-66760-bourg_madame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66026-66620-brouilla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66026-66620-brouilla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66026-66620-brouilla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66026-66620-brouilla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66027-66210-la_cabanasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66027-66210-la_cabanasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66027-66210-la_cabanasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66027-66210-la_cabanasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66028-66330-cabestany/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66028-66330-cabestany/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66028-66330-cabestany/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66028-66330-cabestany/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66029-66300-caixas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66029-66300-caixas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66029-66300-caixas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66029-66300-caixas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66030-66600-calce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66030-66600-calce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66030-66600-calce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66030-66600-calce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66032-66400-calmeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66032-66400-calmeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66032-66400-calmeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66032-66400-calmeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66033-66300-camelas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66033-66300-camelas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66033-66300-camelas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66033-66300-camelas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66034-66500-campome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66034-66500-campome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66034-66500-campome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66034-66500-campome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66035-66730-campoussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66035-66730-campoussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66035-66730-campoussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66035-66730-campoussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66036-66360-canaveilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66036-66360-canaveilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66036-66360-canaveilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66036-66360-canaveilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66037-66140-canet_en_roussillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66037-66140-canet_en_roussillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66037-66140-canet_en_roussillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66037-66140-canet_en_roussillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66038-66680-canohes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66038-66680-canohes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66038-66680-canohes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66038-66680-canohes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66039-66720-caramany/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66039-66720-caramany/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66039-66720-caramany/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66039-66720-caramany/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66040-66130-casefabre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66040-66130-casefabre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66040-66130-casefabre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66040-66130-casefabre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66041-66600-cases_de_pene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66041-66600-cases_de_pene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66041-66600-cases_de_pene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66041-66600-cases_de_pene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66042-66720-cassagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66042-66720-cassagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66042-66720-cassagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66042-66720-cassagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66043-66820-casteil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66043-66820-casteil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66043-66820-casteil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66043-66820-casteil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66044-66300-castelnou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66044-66300-castelnou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66044-66300-castelnou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66044-66300-castelnou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66045-66500-catllar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66045-66500-catllar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66045-66500-catllar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66045-66500-catllar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66046-66220-caudies_de_fenouilledes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66046-66220-caudies_de_fenouilledes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66046-66220-caudies_de_fenouilledes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66046-66220-caudies_de_fenouilledes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66047-66360-caudies_de_conflent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66047-66360-caudies_de_conflent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66047-66360-caudies_de_conflent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66047-66360-caudies_de_conflent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66048-66290-cerbere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66048-66290-cerbere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66048-66290-cerbere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66048-66290-cerbere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66049-66400-ceret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66049-66400-ceret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66049-66400-ceret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66049-66400-ceret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66050-66530-claira/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66050-66530-claira/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66050-66530-claira/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66050-66530-claira/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66051-66500-clara_villerach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66051-66500-clara_villerach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66051-66500-clara_villerach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66051-66500-clara_villerach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66052-66500-codalet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66052-66500-codalet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66052-66500-codalet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66052-66500-codalet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66053-66190-collioure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66053-66190-collioure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66053-66190-collioure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66053-66190-collioure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66054-66500-conat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66054-66500-conat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66054-66500-conat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66054-66500-conat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66055-66130-corbere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66055-66130-corbere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66055-66130-corbere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66055-66130-corbere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66056-66130-corbere_les_cabanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66056-66130-corbere_les_cabanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66056-66130-corbere_les_cabanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66056-66130-corbere_les_cabanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66057-66820-corneilla_de_conflent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66057-66820-corneilla_de_conflent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66057-66820-corneilla_de_conflent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66057-66820-corneilla_de_conflent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66058-66550-corneilla_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66058-66550-corneilla_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66058-66550-corneilla_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66058-66550-corneilla_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66059-66200-corneilla_del_vercol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66059-66200-corneilla_del_vercol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66059-66200-corneilla_del_vercol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66059-66200-corneilla_del_vercol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66060-66150-corsavy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66060-66150-corsavy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66060-66150-corsavy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66060-66150-corsavy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66061-66260-coustouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66061-66260-coustouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66061-66260-coustouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66061-66260-coustouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66062-66760-dorres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66062-66760-dorres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66062-66760-dorres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66062-66760-dorres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66063-66480-les_cluses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66063-66480-les_cluses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66063-66480-les_cluses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66063-66480-les_cluses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66064-66120-egat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66064-66120-egat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66064-66120-egat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66064-66120-egat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66065-66200-elne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66065-66200-elne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66065-66200-elne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66065-66200-elne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66066-66760-enveitg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66066-66760-enveitg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66066-66760-enveitg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66066-66760-enveitg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66067-66800-err/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66067-66800-err/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66067-66800-err/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66067-66800-err/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66068-66360-escaro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66068-66360-escaro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66068-66360-escaro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66068-66360-escaro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66069-66600-espira_de_l_agly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66069-66600-espira_de_l_agly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66069-66600-espira_de_l_agly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66069-66600-espira_de_l_agly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66070-66320-espira_de_conflent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66070-66320-espira_de_conflent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66070-66320-espira_de_conflent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66070-66320-espira_de_conflent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66071-66310-estagel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66071-66310-estagel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66071-66310-estagel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66071-66310-estagel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66072-66800-estavar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66072-66800-estavar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66072-66800-estavar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66072-66800-estavar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66073-66320-estoher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66073-66320-estoher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66073-66320-estoher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66073-66320-estoher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66074-66500-eus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66074-66500-eus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66074-66500-eus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66074-66500-eus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66075-66800-eyne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66075-66800-eyne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66075-66800-eyne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66075-66800-eyne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66076-66730-felluns/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66076-66730-felluns/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66076-66730-felluns/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66076-66730-felluns/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66077-66220-fenouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66077-66220-fenouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66077-66220-fenouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66077-66220-fenouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66078-66820-fillols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66078-66820-fillols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66078-66820-fillols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66078-66820-fillols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66079-66320-finestret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66079-66320-finestret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66079-66320-finestret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66079-66320-finestret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66080-66360-fontpedrouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66080-66360-fontpedrouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66080-66360-fontpedrouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66080-66360-fontpedrouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66081-66210-fontrabiouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66081-66210-fontrabiouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66081-66210-fontrabiouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66081-66210-fontrabiouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66082-66210-formigueres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66082-66210-formigueres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66082-66210-formigueres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66082-66210-formigueres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66083-66220-fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66083-66220-fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66083-66220-fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66083-66220-fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66084-66300-fourques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66084-66300-fourques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66084-66300-fourques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66084-66300-fourques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66085-66820-fuilla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66085-66820-fuilla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66085-66820-fuilla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66085-66820-fuilla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66086-66320-glorianes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66086-66320-glorianes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66086-66320-glorianes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66086-66320-glorianes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66088-66130-ille_sur_tet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66088-66130-ille_sur_tet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66088-66130-ille_sur_tet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66088-66130-ille_sur_tet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66089-66320-joch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66089-66320-joch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66089-66320-joch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66089-66320-joch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66090-66360-jujols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66090-66360-jujols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66090-66360-jujols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66090-66360-jujols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66091-66230-lamanere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66091-66230-lamanere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66091-66230-lamanere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66091-66230-lamanere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66092-66720-lansac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66092-66720-lansac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66092-66720-lansac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66092-66720-lansac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66093-66740-laroque_des_alberes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66093-66740-laroque_des_alberes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66093-66740-laroque_des_alberes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66093-66740-laroque_des_alberes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66094-66200-latour_bas_elne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66094-66200-latour_bas_elne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66094-66200-latour_bas_elne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66094-66200-latour_bas_elne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66095-66760-latour_de_carol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66095-66760-latour_de_carol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66095-66760-latour_de_carol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66095-66760-latour_de_carol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66096-66720-latour_de_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66096-66720-latour_de_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66096-66720-latour_de_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66096-66720-latour_de_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66097-66220-lesquerde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66097-66220-lesquerde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66097-66220-lesquerde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66097-66220-lesquerde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66098-66210-la_llagonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66098-66210-la_llagonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66098-66210-la_llagonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66098-66210-la_llagonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66099-66300-llauro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66099-66300-llauro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66099-66300-llauro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66099-66300-llauro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66100-66800-llo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66100-66800-llo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66100-66800-llo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66100-66800-llo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66101-66300-llupia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66101-66300-llupia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66101-66300-llupia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66101-66300-llupia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66102-66360-mantet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66102-66360-mantet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66102-66360-mantet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66102-66360-mantet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66103-66320-marquixanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66103-66320-marquixanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66103-66320-marquixanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66103-66320-marquixanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66104-66500-los_masos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66104-66500-los_masos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66104-66500-los_masos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66104-66500-los_masos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66105-66210-matemale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66105-66210-matemale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66105-66210-matemale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66105-66210-matemale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66106-66480-maureillas_las_illas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66106-66480-maureillas_las_illas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66106-66480-maureillas_las_illas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66106-66480-maureillas_las_illas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66107-66460-maury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66107-66460-maury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66107-66460-maury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66107-66460-maury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66108-66170-millas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66108-66170-millas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66108-66170-millas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66108-66170-millas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66109-66500-molitg_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66109-66500-molitg_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66109-66500-molitg_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66109-66500-molitg_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66111-66130-montalba_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66111-66130-montalba_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66111-66130-montalba_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66111-66130-montalba_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66112-66300-montauriol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66112-66300-montauriol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66112-66300-montauriol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66112-66300-montauriol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66113-66110-montbolo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66113-66110-montbolo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66113-66110-montbolo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66113-66110-montbolo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66114-66200-montescot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66114-66200-montescot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66114-66200-montescot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66114-66200-montescot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66115-66740-montesquieu_des_alberes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66115-66740-montesquieu_des_alberes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66115-66740-montesquieu_des_alberes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66115-66740-montesquieu_des_alberes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66116-66150-montferrer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66116-66150-montferrer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66116-66150-montferrer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66116-66150-montferrer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66117-66210-mont_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66117-66210-mont_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66117-66210-mont_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66117-66210-mont_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66118-66720-montner/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66118-66720-montner/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66118-66720-montner/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66118-66720-montner/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66119-66500-mosset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66119-66500-mosset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66119-66500-mosset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66119-66500-mosset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66120-66340-nahuja/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66120-66340-nahuja/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66120-66340-nahuja/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66120-66340-nahuja/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66121-66170-nefiach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66121-66170-nefiach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66121-66170-nefiach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66121-66170-nefiach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66122-66500-nohedes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66122-66500-nohedes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66122-66500-nohedes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66122-66500-nohedes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66123-66360-nyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66123-66360-nyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66123-66360-nyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66123-66360-nyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66124-66120-font_romeu_odeillo_via/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66124-66120-font_romeu_odeillo_via/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66124-66120-font_romeu_odeillo_via/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66124-66120-font_romeu_odeillo_via/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66125-66360-olette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66125-66360-olette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66125-66360-olette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66125-66360-olette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66126-66400-oms/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66126-66400-oms/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66126-66400-oms/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66126-66400-oms/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66127-66600-opoul_perillos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66127-66600-opoul_perillos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66127-66600-opoul_perillos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66127-66600-opoul_perillos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66128-66360-oreilla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66128-66360-oreilla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66128-66360-oreilla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66128-66360-oreilla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66129-66560-ortaffa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66129-66560-ortaffa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66129-66560-ortaffa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66129-66560-ortaffa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66130-66340-osseja/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66130-66340-osseja/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66130-66340-osseja/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66130-66340-osseja/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66132-66340-palau_de_cerdagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66132-66340-palau_de_cerdagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66132-66340-palau_de_cerdagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66132-66340-palau_de_cerdagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66133-66690-palau_del_vidre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66133-66690-palau_del_vidre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66133-66690-palau_del_vidre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66133-66690-palau_del_vidre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66134-66300-passa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66134-66300-passa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66134-66300-passa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66134-66300-passa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66136-66000-perpignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66136-66000-perpignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66136-66000-perpignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66136-66000-perpignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66136-66100-perpignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66136-66100-perpignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66136-66100-perpignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66136-66100-perpignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66137-66480-le_perthus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66137-66480-le_perthus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66137-66480-le_perthus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66137-66480-le_perthus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66138-66600-peyrestortes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66138-66600-peyrestortes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66138-66600-peyrestortes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66138-66600-peyrestortes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66139-66730-pezilla_de_conflent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66139-66730-pezilla_de_conflent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66139-66730-pezilla_de_conflent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66139-66730-pezilla_de_conflent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66140-66370-pezilla_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66140-66370-pezilla_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66140-66370-pezilla_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66140-66370-pezilla_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66141-66380-pia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66141-66380-pia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66141-66380-pia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66141-66380-pia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66142-66210-planes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66142-66210-planes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66142-66210-planes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66142-66210-planes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66143-66720-planezes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66143-66720-planezes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66143-66720-planezes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66143-66720-planezes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66144-66450-pollestres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66144-66450-pollestres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66144-66450-pollestres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66144-66450-pollestres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66145-66300-ponteilla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66145-66300-ponteilla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66145-66300-ponteilla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66145-66300-ponteilla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66146-66760-porta/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66146-66760-porta/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66146-66760-porta/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66146-66760-porta/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66147-66760-porte_puymorens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66147-66760-porte_puymorens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66147-66760-porte_puymorens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66147-66760-porte_puymorens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66148-66660-port_vendres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66148-66660-port_vendres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66148-66660-port_vendres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66148-66660-port_vendres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66149-66500-prades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66149-66500-prades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66149-66500-prades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66149-66500-prades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66150-66230-prats_de_mollo_la_preste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66150-66230-prats_de_mollo_la_preste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66150-66230-prats_de_mollo_la_preste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66150-66230-prats_de_mollo_la_preste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66151-66730-prats_de_sournia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66151-66730-prats_de_sournia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66151-66730-prats_de_sournia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66151-66730-prats_de_sournia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66152-66220-prugnanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66152-66220-prugnanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66152-66220-prugnanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66152-66220-prugnanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66153-66130-prunet_et_belpuig/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66153-66130-prunet_et_belpuig/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66153-66130-prunet_et_belpuig/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66153-66130-prunet_et_belpuig/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66154-66210-puyvalador/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66154-66210-puyvalador/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66154-66210-puyvalador/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66154-66210-puyvalador/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66155-66360-py/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66155-66360-py/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66155-66360-py/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66155-66360-py/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66156-66730-rabouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66156-66730-rabouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66156-66730-rabouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66156-66730-rabouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66157-66360-railleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66157-66360-railleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66157-66360-railleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66157-66360-railleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66158-66720-rasigueres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66158-66720-rasigueres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66158-66720-rasigueres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66158-66720-rasigueres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66159-66210-real/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66159-66210-real/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66159-66210-real/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66159-66210-real/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66160-66400-reynes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66160-66400-reynes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66160-66400-reynes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66160-66400-reynes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66161-66500-ria_sirach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66161-66500-ria_sirach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66161-66500-ria_sirach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66161-66500-ria_sirach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66162-66320-rigarda/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66162-66320-rigarda/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66162-66320-rigarda/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66162-66320-rigarda/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66164-66600-rivesaltes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66164-66600-rivesaltes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66164-66600-rivesaltes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66164-66600-rivesaltes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66165-66320-rodes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66165-66320-rodes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66165-66320-rodes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66165-66320-rodes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66166-66360-sahorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66166-66360-sahorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66166-66360-sahorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66166-66360-sahorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66167-66800-saillagouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66167-66800-saillagouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66167-66800-saillagouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66167-66800-saillagouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66168-66690-saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66168-66690-saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66168-66690-saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66168-66690-saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66169-66220-saint_arnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66169-66220-saint_arnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66169-66220-saint_arnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66169-66220-saint_arnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66170-66300-sainte_colombe_de_la_commanderie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66170-66300-sainte_colombe_de_la_commanderie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66170-66300-sainte_colombe_de_la_commanderie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66170-66300-sainte_colombe_de_la_commanderie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66171-66750-saint_cyprien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66171-66750-saint_cyprien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66171-66750-saint_cyprien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66171-66750-saint_cyprien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66172-66240-saint_esteve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66172-66240-saint_esteve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66172-66240-saint_esteve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66172-66240-saint_esteve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66173-66170-saint_feliu_d_amont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66173-66170-saint_feliu_d_amont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66173-66170-saint_feliu_d_amont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66173-66170-saint_feliu_d_amont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66174-66170-saint_feliu_d_avall/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66174-66170-saint_feliu_d_avall/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66174-66170-saint_feliu_d_avall/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66174-66170-saint_feliu_d_avall/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66175-66740-saint_genis_des_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66175-66740-saint_genis_des_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66175-66740-saint_genis_des_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66175-66740-saint_genis_des_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66176-66510-saint_hippolyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66176-66510-saint_hippolyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66176-66510-saint_hippolyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66176-66510-saint_hippolyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66177-66300-saint_jean_lasseille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66177-66300-saint_jean_lasseille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66177-66300-saint_jean_lasseille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66177-66300-saint_jean_lasseille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66178-66490-saint_jean_pla_de_corts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66178-66490-saint_jean_pla_de_corts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66178-66490-saint_jean_pla_de_corts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66178-66490-saint_jean_pla_de_corts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66179-66260-saint_laurent_de_cerdans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66179-66260-saint_laurent_de_cerdans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66179-66260-saint_laurent_de_cerdans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66179-66260-saint_laurent_de_cerdans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66180-66250-saint_laurent_de_la_salanque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66180-66250-saint_laurent_de_la_salanque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66180-66250-saint_laurent_de_la_salanque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66180-66250-saint_laurent_de_la_salanque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66181-66800-sainte_leocadie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66181-66800-sainte_leocadie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66181-66800-sainte_leocadie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66181-66800-sainte_leocadie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66182-66470-sainte_marie_la_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66182-66470-sainte_marie_la_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66182-66470-sainte_marie_la_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66182-66470-sainte_marie_la_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66183-66110-saint_marsal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66183-66110-saint_marsal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66183-66110-saint_marsal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66183-66110-saint_marsal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66184-66220-saint_martin_de_fenouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66184-66220-saint_martin_de_fenouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66184-66220-saint_martin_de_fenouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66184-66220-saint_martin_de_fenouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66185-66130-saint_michel_de_llotes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66185-66130-saint_michel_de_llotes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66185-66130-saint_michel_de_llotes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66185-66130-saint_michel_de_llotes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66186-66570-saint_nazaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66186-66570-saint_nazaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66186-66570-saint_nazaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66186-66570-saint_nazaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66187-66220-saint_paul_de_fenouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66187-66220-saint_paul_de_fenouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66187-66220-saint_paul_de_fenouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66187-66220-saint_paul_de_fenouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66188-66210-saint_pierre_dels_forcats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66188-66210-saint_pierre_dels_forcats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66188-66210-saint_pierre_dels_forcats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66188-66210-saint_pierre_dels_forcats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66189-66280-saleilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66189-66280-saleilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66189-66280-saleilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66189-66280-saleilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66190-66600-salses_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66190-66600-salses_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66190-66600-salses_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66190-66600-salses_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66191-66360-sansa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66191-66360-sansa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66191-66360-sansa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66191-66360-sansa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66192-66210-sauto/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66192-66210-sauto/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66192-66210-sauto/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66192-66210-sauto/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66193-66360-serdinya/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66193-66360-serdinya/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66193-66360-serdinya/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66193-66360-serdinya/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66194-66230-serralongue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66194-66230-serralongue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66194-66230-serralongue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66194-66230-serralongue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66195-66270-le_soler/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66195-66270-le_soler/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66195-66270-le_soler/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66195-66270-le_soler/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66196-66690-sorede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66196-66690-sorede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66196-66690-sorede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66196-66690-sorede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66197-66360-souanyas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66197-66360-souanyas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66197-66360-souanyas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66197-66360-souanyas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66198-66730-sournia/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66198-66730-sournia/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66198-66730-sournia/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66198-66730-sournia/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66199-66400-taillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66199-66400-taillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66199-66400-taillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66199-66400-taillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66201-66320-tarerach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66201-66320-tarerach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66201-66320-tarerach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66201-66320-tarerach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66202-66120-targassonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66202-66120-targassonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66202-66120-targassonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66202-66120-targassonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66203-66110-taulis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66203-66110-taulis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66203-66110-taulis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66203-66110-taulis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66204-66500-taurinya/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66204-66500-taurinya/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66204-66500-taurinya/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66204-66500-taurinya/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66205-66720-tautavel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66205-66720-tautavel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66205-66720-tautavel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66205-66720-tautavel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66206-66230-le_tech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66206-66230-le_tech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66206-66230-le_tech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66206-66230-le_tech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66207-66300-terrats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66207-66300-terrats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66207-66300-terrats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66207-66300-terrats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66208-66200-theza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66208-66200-theza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66208-66200-theza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66208-66200-theza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66209-66360-thues_entre_valls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66209-66360-thues_entre_valls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66209-66360-thues_entre_valls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66209-66360-thues_entre_valls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66210-66300-thuir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66210-66300-thuir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66210-66300-thuir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66210-66300-thuir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66211-66300-torderes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66211-66300-torderes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66211-66300-torderes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66211-66300-torderes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66212-66440-torreilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66212-66440-torreilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66212-66440-torreilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66212-66440-torreilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66213-66350-toulouges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66213-66350-toulouges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66213-66350-toulouges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66213-66350-toulouges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66214-66300-tresserre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66214-66300-tresserre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66214-66300-tresserre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66214-66300-tresserre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66215-66130-trevillach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66215-66130-trevillach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66215-66130-trevillach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66215-66130-trevillach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66216-66220-trilla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66216-66220-trilla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66216-66220-trilla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66216-66220-trilla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66217-66300-trouillas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66217-66300-trouillas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66217-66300-trouillas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66217-66300-trouillas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66218-66760-ur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66218-66760-ur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66218-66760-ur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66218-66760-ur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66219-66500-urbanya/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66219-66500-urbanya/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66219-66500-urbanya/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66219-66500-urbanya/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66220-66340-valcebollere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66220-66340-valcebollere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66220-66340-valcebollere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66220-66340-valcebollere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66221-66320-valmanya/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66221-66320-valmanya/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66221-66320-valmanya/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66221-66320-valmanya/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66222-66820-vernet_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66222-66820-vernet_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66222-66820-vernet_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66222-66820-vernet_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66223-66500-villefranche_de_conflent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66223-66500-villefranche_de_conflent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66223-66500-villefranche_de_conflent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66223-66500-villefranche_de_conflent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66224-66410-villelongue_de_la_salanque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66224-66410-villelongue_de_la_salanque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66224-66410-villelongue_de_la_salanque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66224-66410-villelongue_de_la_salanque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66225-66740-villelongue_dels_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66225-66740-villelongue_dels_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66225-66740-villelongue_dels_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66225-66740-villelongue_dels_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66226-66300-villemolaque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66226-66300-villemolaque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66226-66300-villemolaque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66226-66300-villemolaque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66227-66180-villeneuve_de_la_raho/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66227-66180-villeneuve_de_la_raho/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66227-66180-villeneuve_de_la_raho/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66227-66180-villeneuve_de_la_raho/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66228-66610-villeneuve_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66228-66610-villeneuve_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66228-66610-villeneuve_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66228-66610-villeneuve_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66230-66320-vinca/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66230-66320-vinca/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66230-66320-vinca/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66230-66320-vinca/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66231-66600-vingrau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66231-66600-vingrau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66231-66600-vingrau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66231-66600-vingrau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66232-66220-vira/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66232-66220-vira/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66232-66220-vira/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66232-66220-vira/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66233-66490-vives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66233-66490-vives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66233-66490-vives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66233-66490-vives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66234-66730-le_vivier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66234-66730-le_vivier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66234-66730-le_vivier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt66-pyrenees_orientales/commune66234-66730-le_vivier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-67.xml
+++ b/public/sitemaps/sitemap-67.xml
@@ -5,1068 +5,2132 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67001-67204-achenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67001-67204-achenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67001-67204-achenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67001-67204-achenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67002-67320-adamswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67002-67320-adamswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67002-67320-adamswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67002-67320-adamswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67003-67220-albe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67003-67220-albe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67003-67220-albe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67003-67220-albe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67004-67310-sommerau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67004-67310-sommerau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67004-67310-sommerau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67004-67310-sommerau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67004-67440-sommerau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67004-67440-sommerau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67004-67440-sommerau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67004-67440-sommerau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67005-67270-alteckendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67005-67270-alteckendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67005-67270-alteckendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67005-67270-alteckendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67006-67490-altenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67006-67490-altenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67006-67490-altenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67006-67490-altenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67008-67120-altorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67008-67120-altorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67008-67120-altorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67008-67120-altorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67009-67260-altwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67009-67260-altwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67009-67260-altwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67009-67260-altwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67010-67140-andlau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67010-67140-andlau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67010-67140-andlau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67010-67140-andlau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67011-67390-artolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67011-67390-artolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67011-67390-artolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67011-67390-artolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67012-67250-aschbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67012-67250-aschbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67012-67250-aschbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67012-67250-aschbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67013-67320-asswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67013-67320-asswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67013-67320-asswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67013-67320-asswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67016-67120-avolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67016-67120-avolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67016-67120-avolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67016-67120-avolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67017-67320-baerendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67017-67320-baerendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67017-67320-baerendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67017-67320-baerendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67018-67310-balbronn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67018-67310-balbronn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67018-67310-balbronn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67018-67310-balbronn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67019-67600-baldenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67019-67600-baldenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67019-67600-baldenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67019-67600-baldenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67020-67130-barembach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67020-67130-barembach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67020-67130-barembach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67020-67130-barembach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67021-67140-barr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67021-67140-barr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67021-67140-barr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67021-67140-barr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67022-67220-bassemberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67022-67220-bassemberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67022-67220-bassemberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67022-67220-bassemberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67023-67500-batzendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67023-67500-batzendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67023-67500-batzendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67023-67500-batzendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67025-67930-beinheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67025-67930-beinheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67025-67930-beinheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67025-67930-beinheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67026-67130-bellefosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67026-67130-bellefosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67026-67130-bellefosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67026-67130-bellefosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67027-67130-belmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67027-67130-belmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67027-67130-belmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67027-67130-belmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67028-67230-benfeld/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67028-67230-benfeld/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67028-67230-benfeld/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67028-67230-benfeld/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67029-67320-berg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67029-67320-berg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67029-67320-berg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67029-67320-berg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67030-67310-bergbieten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67030-67310-bergbieten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67030-67310-bergbieten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67030-67310-bergbieten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67031-67210-bernardswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67031-67210-bernardswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67031-67210-bernardswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67031-67210-bernardswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67032-67140-bernardville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67032-67140-bernardville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67032-67140-bernardville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67032-67140-bernardville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67033-67170-bernolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67033-67170-bernolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67033-67170-bernolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67033-67170-bernolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67034-67370-berstett/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67034-67370-berstett/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67034-67370-berstett/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67034-67370-berstett/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67035-67170-berstheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67035-67170-berstheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67035-67170-berstheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67035-67170-berstheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67036-67320-bettwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67036-67320-bettwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67036-67320-bettwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67036-67320-bettwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67037-67360-biblisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67037-67360-biblisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67037-67360-biblisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67037-67360-biblisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67038-67720-bietlenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67038-67720-bietlenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67038-67720-bietlenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67038-67720-bietlenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67039-67170-bilwisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67039-67170-bilwisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67039-67170-bilwisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67039-67170-bilwisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67040-67600-bindernheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67040-67600-bindernheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67040-67600-bindernheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67040-67600-bindernheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67043-67800-bischheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67043-67800-bischheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67043-67800-bischheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67043-67800-bischheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67044-67340-bischholtz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67044-67340-bischholtz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67044-67340-bischholtz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67044-67340-bischholtz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67045-67870-bischoffsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67045-67870-bischoffsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67045-67870-bischoffsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67045-67870-bischoffsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67046-67240-bischwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67046-67240-bischwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67046-67240-bischwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67046-67240-bischwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67047-67260-bissert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67047-67260-bissert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67047-67260-bissert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67047-67260-bissert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67048-67350-bitschhoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67048-67350-bitschhoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67048-67350-bitschhoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67048-67350-bitschhoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67049-67113-blaesheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67049-67113-blaesheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67049-67113-blaesheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67049-67113-blaesheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67050-67130-blancherupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67050-67130-blancherupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67050-67130-blancherupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67050-67130-blancherupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67051-67650-blienschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67051-67650-blienschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67051-67650-blienschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67051-67650-blienschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67052-67530-boersch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67052-67530-boersch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67052-67530-boersch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67052-67530-boersch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67053-67390-boesenbiesen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67053-67390-boesenbiesen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67053-67390-boesenbiesen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67053-67390-boesenbiesen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67054-67150-bolsenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67054-67150-bolsenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67054-67150-bolsenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67054-67150-bolsenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67055-67860-boofzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67055-67860-boofzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67055-67860-boofzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67055-67860-boofzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67056-67390-bootzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67056-67390-bootzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67056-67390-bootzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67056-67390-bootzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67057-67330-bosselshausen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67057-67330-bosselshausen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67057-67330-bosselshausen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67057-67330-bosselshausen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67058-67270-bossendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67058-67270-bossendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67058-67270-bossendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67058-67270-bossendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67059-67420-bourg_bruche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67059-67420-bourg_bruche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67059-67420-bourg_bruche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67059-67420-bourg_bruche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67060-67140-bourgheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67060-67140-bourgheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67060-67140-bourgheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67060-67140-bourgheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67061-67330-bouxwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67061-67330-bouxwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67061-67330-bouxwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67061-67330-bouxwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67062-67220-breitenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67062-67220-breitenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67062-67220-breitenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67062-67220-breitenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67063-67220-breitenbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67063-67220-breitenbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67063-67220-breitenbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67063-67220-breitenbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67065-67112-breuschwickersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67065-67112-breuschwickersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67065-67112-breuschwickersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67065-67112-breuschwickersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67066-67570-la_broque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67066-67570-la_broque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67066-67570-la_broque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67066-67570-la_broque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67066-67130-la_broque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67066-67130-la_broque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67066-67130-la_broque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67066-67130-la_broque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67067-67170-brumath/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67067-67170-brumath/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67067-67170-brumath/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67067-67170-brumath/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67068-67350-buswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67068-67350-buswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67068-67350-buswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67068-67350-buswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67069-67470-buhl/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67069-67470-buhl/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67069-67470-buhl/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67069-67470-buhl/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67070-67260-burbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67070-67260-burbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67070-67260-burbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67070-67260-burbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67071-67320-bust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67071-67320-bust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67071-67320-bust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67071-67320-bust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67072-67430-butten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67072-67430-butten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67072-67430-butten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67072-67430-butten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67073-67730-chatenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67073-67730-chatenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67073-67730-chatenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67073-67730-chatenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67074-67160-cleebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67074-67160-cleebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67074-67160-cleebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67074-67160-cleebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67075-67510-climbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67075-67510-climbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67075-67510-climbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67075-67510-climbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67076-67420-colroy_la_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67076-67420-colroy_la_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67076-67420-colroy_la_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67076-67420-colroy_la_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67077-67310-cosswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67077-67310-cosswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67077-67310-cosswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67077-67310-cosswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67078-67310-crastatt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67078-67310-crastatt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67078-67310-crastatt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67078-67310-crastatt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67079-67470-croettwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67079-67470-croettwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67079-67470-croettwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67079-67470-croettwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67080-67120-dachstein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67080-67120-dachstein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67080-67120-dachstein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67080-67120-dachstein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67081-67310-dahlenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67081-67310-dahlenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67081-67310-dahlenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67081-67310-dahlenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67082-67770-dalhunden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67082-67770-dalhunden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67082-67770-dalhunden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67082-67770-dalhunden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67083-67110-dambach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67083-67110-dambach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67083-67110-dambach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67083-67110-dambach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67084-67650-dambach_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67084-67650-dambach_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67084-67650-dambach_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67084-67650-dambach_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67085-67310-dangolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67085-67310-dangolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67085-67310-dangolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67085-67310-dangolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67086-67150-daubensand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67086-67150-daubensand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67086-67150-daubensand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67086-67150-daubensand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67087-67350-dauendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67087-67350-dauendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67087-67350-dauendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67087-67350-dauendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-67430-dehlingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-67430-dehlingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-67430-dehlingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-67430-dehlingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-57410-dehlingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-57410-dehlingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-57410-dehlingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-57410-dehlingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-57412-dehlingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-57412-dehlingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-57412-dehlingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67088-57412-dehlingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67089-67490-dettwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67089-67490-dettwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67089-67490-dettwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67089-67490-dettwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67090-67230-diebolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67090-67230-diebolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67090-67230-diebolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67090-67230-diebolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67091-67260-diedendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67091-67260-diedendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67091-67260-diedendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67091-67260-diedendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67092-67220-dieffenbach_au_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67092-67220-dieffenbach_au_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67092-67220-dieffenbach_au_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67092-67220-dieffenbach_au_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67093-67360-dieffenbach_les_woerth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67093-67360-dieffenbach_les_woerth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67093-67360-dieffenbach_les_woerth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67093-67360-dieffenbach_les_woerth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67094-67650-dieffenthal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67094-67650-dieffenthal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67094-67650-dieffenthal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67094-67650-dieffenthal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67095-67430-diemeringen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67095-67430-diemeringen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67095-67430-diemeringen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67095-67430-diemeringen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67096-67440-dimbsthal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67096-67440-dimbsthal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67096-67440-dimbsthal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67096-67440-dimbsthal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67097-67370-dingsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67097-67370-dingsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67097-67370-dingsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67097-67370-dingsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67098-67190-dinsheim_sur_bruche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67098-67190-dinsheim_sur_bruche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67098-67190-dinsheim_sur_bruche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67098-67190-dinsheim_sur_bruche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67099-67430-domfessel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67099-67430-domfessel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67099-67430-domfessel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67099-67430-domfessel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67100-67170-donnenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67100-67170-donnenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67100-67170-donnenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67100-67170-donnenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67101-67120-dorlisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67101-67120-dorlisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67101-67120-dorlisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67101-67120-dorlisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67102-67117-dossenheim_kochersberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67102-67117-dossenheim_kochersberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67102-67117-dossenheim_kochersberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67102-67117-dossenheim_kochersberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67103-67330-dossenheim_sur_zinsel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67103-67330-dossenheim_sur_zinsel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67103-67330-dossenheim_sur_zinsel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67103-67330-dossenheim_sur_zinsel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67104-67160-drachenbronn_birlenbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67104-67160-drachenbronn_birlenbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67104-67160-drachenbronn_birlenbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67104-67160-drachenbronn_birlenbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67105-67320-drulingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67105-67320-drulingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67105-67320-drulingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67105-67320-drulingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67106-67410-drusenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67106-67410-drusenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67106-67410-drusenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67106-67410-drusenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67107-67270-duntzenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67107-67270-duntzenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67107-67270-duntzenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67107-67270-duntzenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67108-67120-duppigheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67108-67120-duppigheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67108-67120-duppigheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67108-67120-duppigheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67109-67270-durningen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67109-67270-durningen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67109-67270-durningen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67109-67270-durningen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67110-67360-durrenbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67110-67360-durrenbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67110-67360-durrenbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67110-67360-durrenbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67111-67320-durstel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67111-67320-durstel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67111-67320-durstel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67111-67320-durstel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67112-67120-duttlenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67112-67120-duttlenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67112-67120-duttlenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67112-67120-duttlenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67113-67470-eberbach_seltz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67113-67470-eberbach_seltz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67113-67470-eberbach_seltz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67113-67470-eberbach_seltz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67115-67600-ebersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67115-67600-ebersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67115-67600-ebersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67115-67600-ebersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67116-67600-ebersmunster/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67116-67600-ebersmunster/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67116-67600-ebersmunster/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67116-67600-ebersmunster/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67117-67700-eckartswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67117-67700-eckartswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67117-67700-eckartswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67117-67700-eckartswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67118-67201-eckbolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67118-67201-eckbolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67118-67201-eckbolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67118-67201-eckbolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67119-67550-eckwersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67119-67550-eckwersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67119-67550-eckwersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67119-67550-eckwersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67120-67140-eichhoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67120-67140-eichhoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67120-67140-eichhoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67120-67140-eichhoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67121-67390-elsenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67121-67390-elsenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67121-67390-elsenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67121-67390-elsenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67122-67710-wangenbourg_engenthal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67122-67710-wangenbourg_engenthal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67122-67710-wangenbourg_engenthal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67122-67710-wangenbourg_engenthal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67123-67350-engwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67123-67350-engwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67123-67350-engwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67123-67350-engwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67124-67960-entzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67124-67960-entzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67124-67960-entzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67124-67960-entzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67125-67680-epfig/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67125-67680-epfig/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67125-67680-epfig/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67125-67680-epfig/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67126-67290-erckartswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67126-67290-erckartswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67126-67290-erckartswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67126-67290-erckartswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67127-67120-ergersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67127-67120-ergersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67127-67120-ergersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67127-67120-ergersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67128-67120-ernolsheim_bruche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67128-67120-ernolsheim_bruche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67128-67120-ernolsheim_bruche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67128-67120-ernolsheim_bruche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67129-67330-ernolsheim_les_saverne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67129-67330-ernolsheim_les_saverne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67129-67330-ernolsheim_les_saverne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67129-67330-ernolsheim_les_saverne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67130-67150-erstein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67130-67150-erstein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67130-67150-erstein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67130-67150-erstein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67131-67114-eschau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67131-67114-eschau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67131-67114-eschau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67131-67114-eschau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67132-67360-eschbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67132-67360-eschbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67132-67360-eschbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67132-67360-eschbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67133-67320-eschbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67133-67320-eschbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67133-67320-eschbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67133-67320-eschbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67134-67320-eschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67134-67320-eschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67134-67320-eschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67134-67320-eschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67135-67350-ettendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67135-67350-ettendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67135-67350-ettendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67135-67350-ettendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67136-67320-eywiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67136-67320-eywiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67136-67320-eywiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67136-67320-eywiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67137-67640-fegersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67137-67640-fegersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67137-67640-fegersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67137-67640-fegersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67138-67117-fessenheim_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67138-67117-fessenheim_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67138-67117-fessenheim_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67138-67117-fessenheim_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67139-67310-flexbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67139-67310-flexbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67139-67310-flexbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67139-67310-flexbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67140-67480-forstfeld/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67140-67480-forstfeld/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67140-67480-forstfeld/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67140-67480-forstfeld/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67141-67580-forstheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67141-67580-forstheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67141-67580-forstheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67141-67580-forstheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67142-67480-fort_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67142-67480-fort_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67142-67480-fort_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67142-67480-fort_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67143-67220-fouchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67143-67220-fouchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67143-67220-fouchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67143-67220-fouchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67144-67130-fouday/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67144-67130-fouday/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67144-67130-fouday/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67144-67130-fouday/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67145-67490-friedolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67145-67490-friedolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67145-67490-friedolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67145-67490-friedolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67146-67860-friesenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67146-67860-friesenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67146-67860-friesenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67146-67860-friesenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67147-67360-froeschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67147-67360-froeschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67147-67360-froeschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67147-67360-froeschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67148-67290-frohmuhl/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67148-67290-frohmuhl/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67148-67290-frohmuhl/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67148-67290-frohmuhl/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67149-67700-furchhausen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67149-67700-furchhausen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67149-67700-furchhausen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67149-67700-furchhausen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67150-67117-furdenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67150-67117-furdenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67150-67117-furdenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67150-67117-furdenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67151-67760-gambsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67151-67760-gambsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67151-67760-gambsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67151-67760-gambsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67152-67118-geispolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67152-67118-geispolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67152-67118-geispolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67152-67118-geispolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67153-67270-geiswiller_zoebersdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67153-67270-geiswiller_zoebersdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67153-67270-geiswiller_zoebersdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67153-67270-geiswiller_zoebersdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67154-67150-gerstheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67154-67150-gerstheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67154-67150-gerstheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67154-67150-gerstheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67155-67140-gertwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67155-67140-gertwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67155-67140-gertwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67155-67140-gertwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67156-67170-geudertheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67156-67170-geudertheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67156-67170-geudertheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67156-67170-geudertheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67159-67320-goerlingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67159-67320-goerlingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67159-67320-goerlingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67159-67320-goerlingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67160-67360-goersdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67160-67360-goersdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67160-67360-goersdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67160-67360-goersdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67161-67700-gottenhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67161-67700-gottenhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67161-67700-gottenhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67161-67700-gottenhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67162-67490-gottesheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67162-67490-gottesheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67162-67490-gottesheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67162-67490-gottesheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67163-67270-gougenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67163-67270-gougenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67163-67270-gougenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67163-67270-gougenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67164-67210-goxwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67164-67210-goxwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67164-67210-goxwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67164-67210-goxwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67165-67130-grandfontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67165-67130-grandfontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67165-67130-grandfontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67165-67130-grandfontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67166-67350-grassendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67166-67350-grassendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67166-67350-grassendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67166-67350-grassendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67167-67190-grendelbruch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67167-67190-grendelbruch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67167-67190-grendelbruch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67167-67190-grendelbruch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67168-67190-gresswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67168-67190-gresswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67168-67190-gresswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67168-67190-gresswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67169-67500-gries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67169-67500-gries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67169-67500-gries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67169-67500-gries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67169-67240-gries/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67169-67240-gries/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67169-67240-gries/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67169-67240-gries/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67172-67870-griesheim_pres_molsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67172-67870-griesheim_pres_molsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67172-67870-griesheim_pres_molsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67172-67870-griesheim_pres_molsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67173-67370-griesheim_sur_souffel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67173-67370-griesheim_sur_souffel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67173-67370-griesheim_sur_souffel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67173-67370-griesheim_sur_souffel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67174-67110-gumbrechtshoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67174-67110-gumbrechtshoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67174-67110-gumbrechtshoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67174-67110-gumbrechtshoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67176-67110-gundershoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67176-67110-gundershoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67176-67110-gundershoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67176-67110-gundershoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67177-67360-gunstett/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67177-67360-gunstett/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67177-67360-gunstett/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67177-67360-gunstett/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67178-67320-gungwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67178-67320-gungwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67178-67320-gungwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67178-67320-gungwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67179-67700-haegen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67179-67700-haegen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67179-67700-haegen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67179-67700-haegen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67500-haguenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67500-haguenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67500-haguenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67500-haguenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67580-haguenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67580-haguenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67580-haguenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67580-haguenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67240-haguenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67240-haguenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67240-haguenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67240-haguenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67620-haguenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67620-haguenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67620-haguenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67620-haguenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67360-haguenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67360-haguenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67360-haguenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67360-haguenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67660-haguenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67660-haguenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67660-haguenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67660-haguenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67350-haguenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67350-haguenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67350-haguenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67350-haguenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67250-haguenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67250-haguenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67250-haguenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67250-haguenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67590-haguenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67590-haguenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67590-haguenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67180-67590-haguenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67181-67117-handschuheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67181-67117-handschuheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67181-67117-handschuheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67181-67117-handschuheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67182-67980-hangenbieten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67182-67980-hangenbieten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67182-67980-hangenbieten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67182-67980-hangenbieten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67183-67260-harskirchen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67183-67260-harskirchen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67183-67260-harskirchen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67183-67260-harskirchen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67184-67690-hatten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67184-67690-hatten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67184-67690-hatten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67184-67690-hatten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67185-67330-hattmatt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67185-67330-hattmatt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67185-67330-hattmatt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67185-67330-hattmatt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67186-67360-hegeney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67186-67360-hegeney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67186-67360-hegeney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67186-67360-hegeney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67187-67390-heidolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67187-67390-heidolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67187-67390-heidolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67187-67390-heidolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67188-67190-heiligenberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67188-67190-heiligenberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67188-67190-heiligenberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67188-67190-heiligenberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67189-67140-heiligenstein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67189-67140-heiligenstein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67189-67140-heiligenstein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67189-67140-heiligenstein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67190-67440-hengwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67190-67440-hengwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67190-67440-hengwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67190-67440-hengwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67191-67260-herbitzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67191-67260-herbitzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67191-67260-herbitzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67191-67260-herbitzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67192-67230-herbsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67192-67230-herbsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67192-67230-herbsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67192-67230-herbsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67194-67850-herrlisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67194-67850-herrlisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67194-67850-herrlisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67194-67850-herrlisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67195-67390-hessenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67195-67390-hessenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67195-67390-hessenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67195-67390-hessenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67196-67600-hilsenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67196-67600-hilsenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67196-67600-hilsenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67196-67600-hilsenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67197-67150-hindisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67197-67150-hindisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67197-67150-hindisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67197-67150-hindisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67198-67290-hinsbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67198-67290-hinsbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67198-67290-hinsbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67198-67290-hinsbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67199-67260-hinsingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67199-67260-hinsingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67199-67260-hinsingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67199-67260-hinsingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67200-67150-hipsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67200-67150-hipsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67200-67150-hipsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67200-67150-hipsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67201-67320-hirschland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67201-67320-hirschland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67201-67320-hirschland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67201-67320-hirschland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67202-67270-hochfelden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67202-67270-hochfelden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67202-67270-hochfelden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67202-67270-hochfelden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67203-67170-hochstett/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67203-67170-hochstett/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67203-67170-hochstett/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67203-67170-hochstett/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67204-67800-hoenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67204-67800-hoenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67204-67800-hoenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67204-67800-hoenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67205-67720-hoerdt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67205-67720-hoerdt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67205-67720-hoerdt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67205-67720-hoerdt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67206-67250-hoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67206-67250-hoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67206-67250-hoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67206-67250-hoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67208-67310-hohengoeft/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67208-67310-hohengoeft/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67208-67310-hohengoeft/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67208-67310-hohengoeft/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67209-67270-hohfrankenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67209-67270-hohfrankenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67209-67270-hohfrankenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67209-67270-hohfrankenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67210-67140-le_hohwald/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67210-67140-le_hohwald/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67210-67140-le_hohwald/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67210-67140-le_hohwald/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67212-67810-holtzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67212-67810-holtzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67212-67810-holtzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67212-67810-holtzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67213-67250-hunspach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67213-67250-hunspach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67213-67250-hunspach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67213-67250-hunspach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67214-67117-hurtigheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67214-67117-hurtigheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67214-67117-hurtigheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67214-67117-hurtigheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67215-67270-huttendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67215-67270-huttendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67215-67270-huttendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67215-67270-huttendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67216-67230-huttenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67216-67230-huttenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67216-67230-huttenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67216-67230-huttenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67217-67640-ichtratzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67217-67640-ichtratzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67217-67640-ichtratzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67217-67640-ichtratzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67218-67400-illkirch_graffenstaden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67218-67400-illkirch_graffenstaden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67218-67400-illkirch_graffenstaden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67218-67400-illkirch_graffenstaden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67220-67270-ingenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67220-67270-ingenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67220-67270-ingenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67220-67270-ingenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67221-67250-ingolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67221-67250-ingolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67221-67250-ingolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67221-67250-ingolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67222-67340-ingwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67222-67340-ingwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67222-67340-ingwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67222-67340-ingwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67223-67880-innenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67223-67880-innenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67223-67880-innenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67223-67880-innenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67225-67330-issenhausen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67225-67330-issenhausen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67225-67330-issenhausen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67225-67330-issenhausen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67226-67117-ittenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67226-67117-ittenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67226-67117-ittenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67226-67117-ittenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67227-67140-itterswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67227-67140-itterswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67227-67140-itterswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67227-67140-itterswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67228-67370-neugartheim_ittlenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67228-67370-neugartheim_ittlenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67228-67370-neugartheim_ittlenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67228-67370-neugartheim_ittlenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67229-67440-jetterswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67229-67440-jetterswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67229-67440-jetterswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67229-67440-jetterswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67230-67240-kaltenhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67230-67240-kaltenhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67230-67240-kaltenhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67230-67240-kaltenhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67231-67480-kauffenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67231-67480-kauffenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67231-67480-kauffenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67231-67480-kauffenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67232-67250-keffenach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67232-67250-keffenach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67232-67250-keffenach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67232-67250-keffenach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67233-67230-kertzfeld/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67233-67230-kertzfeld/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67233-67230-kertzfeld/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67233-67230-kertzfeld/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67234-67260-keskastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67234-67260-keskastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67234-67260-keskastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67234-67260-keskastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67235-67930-kesseldorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67235-67930-kesseldorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67235-67930-kesseldorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67235-67930-kesseldorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67236-67270-kienheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67236-67270-kienheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67236-67270-kienheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67236-67270-kienheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67237-67840-kilstett/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67237-67840-kilstett/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67237-67840-kilstett/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67237-67840-kilstett/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67238-67350-kindwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67238-67350-kindwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67238-67350-kindwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67238-67350-kindwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67239-67600-kintzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67239-67600-kintzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67239-67600-kintzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67239-67600-kintzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67240-67520-kirchheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67240-67520-kirchheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67240-67520-kirchheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67240-67520-kirchheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67241-67320-kirrberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67241-67320-kirrberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67241-67320-kirrberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67241-67320-kirrberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67242-67330-kirrwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67242-67330-kirrwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67242-67330-kirrwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67242-67330-kirrwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67244-67440-kleingoeft/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67244-67440-kleingoeft/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67244-67440-kleingoeft/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67244-67440-kleingoeft/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67245-67310-knoersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67245-67310-knoersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67245-67310-knoersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67245-67310-knoersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67246-67230-kogenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67246-67230-kogenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67246-67230-kogenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67246-67230-kogenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67247-67120-kolbsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67247-67120-kolbsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67247-67120-kolbsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67247-67120-kolbsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67248-67880-krautergersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67248-67880-krautergersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67248-67880-krautergersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67248-67880-krautergersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67249-67170-krautwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67249-67170-krautwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67249-67170-krautwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67249-67170-krautwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67250-67170-kriegsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67250-67170-kriegsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67250-67170-kriegsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67250-67170-kriegsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67252-67240-kurtzenhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67252-67240-kurtzenhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67252-67240-kurtzenhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67252-67240-kurtzenhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67253-67520-kuttolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67253-67520-kuttolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67253-67520-kuttolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67253-67520-kuttolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67254-67250-kutzenhausen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67254-67250-kutzenhausen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67254-67250-kutzenhausen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67254-67250-kutzenhausen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67255-67220-lalaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67255-67220-lalaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67255-67220-lalaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67255-67220-lalaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67256-67450-lampertheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67256-67450-lampertheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67256-67450-lampertheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67256-67450-lampertheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67257-67250-lampertsloch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67257-67250-lampertsloch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67257-67250-lampertsloch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67257-67250-lampertsloch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67258-67700-landersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67258-67700-landersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67258-67700-landersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67258-67700-landersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67259-67360-langensoultzbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67259-67360-langensoultzbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67259-67360-langensoultzbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67259-67360-langensoultzbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67260-67580-laubach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67260-67580-laubach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67260-67580-laubach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67260-67580-laubach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67261-67630-lauterbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67261-67630-lauterbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67261-67630-lauterbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67261-67630-lauterbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67263-67510-lembach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67263-67510-lembach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67263-67510-lembach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67263-67510-lembach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67264-67480-leutenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67264-67480-leutenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67264-67480-leutenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67264-67480-leutenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67265-67340-lichtenberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67265-67340-lichtenberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67265-67340-lichtenberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67265-67340-lichtenberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67266-67150-limersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67266-67150-limersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67266-67150-limersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67266-67150-limersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67267-67380-lingolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67267-67380-lingolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67267-67380-lingolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67267-67380-lingolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67268-67640-lipsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67268-67640-lipsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67268-67640-lipsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67268-67640-lipsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67269-67490-littenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67269-67490-littenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67269-67490-littenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67269-67490-littenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67270-67270-lixhausen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67270-67270-lixhausen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67270-67270-lixhausen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67270-67270-lixhausen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67271-67250-lobsann/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67271-67250-lobsann/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67271-67250-lobsann/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67271-67250-lobsann/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67272-67440-lochwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67272-67440-lochwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67272-67440-lochwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67272-67440-lochwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67273-67290-lohr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67273-67290-lohr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67273-67290-lohr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67273-67290-lohr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67274-67430-lorentzen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67274-67430-lorentzen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67274-67430-lorentzen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67274-67430-lorentzen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67275-67490-lupstein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67275-67490-lupstein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67275-67490-lupstein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67275-67490-lupstein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67276-67130-lutzelhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67276-67130-lutzelhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67276-67130-lutzelhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67276-67130-lutzelhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67277-67390-mackenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67277-67390-mackenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67277-67390-mackenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67277-67390-mackenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67278-67430-mackwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67278-67430-mackwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67278-67430-mackwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67278-67430-mackwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67279-67700-maennolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67279-67700-maennolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67279-67700-maennolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67279-67700-maennolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67280-67220-maisonsgoutte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67280-67220-maisonsgoutte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67280-67220-maisonsgoutte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67280-67220-maisonsgoutte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67281-67390-marckolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67281-67390-marckolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67281-67390-marckolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67281-67390-marckolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67282-67520-marlenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67282-67520-marlenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67282-67520-marlenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67282-67520-marlenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67283-67440-marmoutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67283-67440-marmoutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67283-67440-marmoutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67283-67440-marmoutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67285-67150-matzenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67285-67150-matzenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67285-67150-matzenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67285-67150-matzenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67286-67210-meistratzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67286-67210-meistratzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67286-67210-meistratzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67286-67210-meistratzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67287-67270-melsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67287-67270-melsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67287-67270-melsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67287-67270-melsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67288-67250-memmelshoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67288-67250-memmelshoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67288-67250-memmelshoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67288-67250-memmelshoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67289-67340-menchhoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67289-67340-menchhoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67289-67340-menchhoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67289-67340-menchhoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67290-67250-merkwiller_pechelbronn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67290-67250-merkwiller_pechelbronn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67290-67250-merkwiller_pechelbronn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67290-67250-merkwiller_pechelbronn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67291-67580-mertzwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67291-67580-mertzwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67291-67580-mertzwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67291-67580-mertzwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67292-67580-mietesheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67292-67580-mietesheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67292-67580-mietesheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67292-67580-mietesheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67293-67270-minversheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67293-67270-minversheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67293-67270-minversheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67293-67270-minversheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67295-67140-mittelbergheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67295-67140-mittelbergheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67295-67140-mittelbergheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67295-67140-mittelbergheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67296-67206-mittelhausbergen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67296-67206-mittelhausbergen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67296-67206-mittelhausbergen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67296-67206-mittelhausbergen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67298-67170-mittelschaeffolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67298-67170-mittelschaeffolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67298-67170-mittelschaeffolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67298-67170-mittelschaeffolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67299-67190-mollkirch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67299-67190-mollkirch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67299-67190-mollkirch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67299-67190-mollkirch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67300-67120-molsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67300-67120-molsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67300-67120-molsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67300-67120-molsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67301-67670-mommenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67301-67670-mommenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67301-67670-mommenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67301-67670-mommenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67302-67700-monswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67302-67700-monswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67302-67700-monswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67302-67700-monswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67303-67360-morsbronn_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67303-67360-morsbronn_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67303-67360-morsbronn_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67303-67360-morsbronn_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67304-67350-morschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67304-67350-morschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67304-67350-morschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67304-67350-morschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67305-67470-mothern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67305-67470-mothern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67305-67470-mothern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67305-67470-mothern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67306-67130-muhlbach_sur_bruche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67306-67130-muhlbach_sur_bruche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67306-67130-muhlbach_sur_bruche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67306-67130-muhlbach_sur_bruche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67307-67350-mulhausen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67307-67350-mulhausen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67307-67350-mulhausen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67307-67350-mulhausen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67308-67470-munchhausen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67308-67470-munchhausen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67308-67470-munchhausen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67308-67470-munchhausen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67309-67450-mundolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67309-67450-mundolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67309-67450-mundolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67309-67450-mundolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67310-67600-mussig/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67310-67600-mussig/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67310-67600-mussig/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67310-67600-mussig/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67311-67600-muttersholtz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67311-67600-muttersholtz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67311-67600-muttersholtz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67311-67600-muttersholtz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67312-67270-mutzenhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67312-67270-mutzenhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67312-67270-mutzenhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67312-67270-mutzenhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67313-67190-mutzig/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67313-67190-mutzig/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67313-67190-mutzig/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67313-67190-mutzig/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67314-67130-natzwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67314-67130-natzwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67314-67130-natzwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67314-67130-natzwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67315-67630-neewiller_pres_lauterbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67315-67630-neewiller_pres_lauterbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67315-67630-neewiller_pres_lauterbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67315-67630-neewiller_pres_lauterbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67317-67220-neubois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67317-67220-neubois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67317-67220-neubois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67317-67220-neubois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67319-67480-neuhaeusel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67319-67480-neuhaeusel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67319-67480-neuhaeusel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67319-67480-neuhaeusel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67320-67220-neuve_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67320-67220-neuve_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67320-67220-neuve_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67320-67220-neuve_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67321-67130-neuviller_la_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67321-67130-neuviller_la_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67321-67130-neuviller_la_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67321-67130-neuviller_la_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67322-67330-neuwiller_les_saverne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67322-67330-neuwiller_les_saverne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67322-67330-neuwiller_les_saverne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67322-67330-neuwiller_les_saverne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67324-67110-niederbronn_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67324-67110-niederbronn_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67324-67110-niederbronn_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67324-67110-niederbronn_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67325-67280-niederhaslach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67325-67280-niederhaslach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67325-67280-niederhaslach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67325-67280-niederhaslach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67326-67207-niederhausbergen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67326-67207-niederhausbergen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67326-67207-niederhausbergen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67326-67207-niederhausbergen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67327-67630-niederlauterbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67327-67630-niederlauterbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67327-67630-niederlauterbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67327-67630-niederlauterbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67328-67350-niedermodern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67328-67350-niedermodern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67328-67350-niedermodern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67328-67350-niedermodern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67329-67210-niedernai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67329-67210-niedernai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67329-67210-niedernai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67329-67210-niedernai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67330-67470-niederroedern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67330-67470-niederroedern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67330-67470-niederroedern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67330-67470-niederroedern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67331-67500-niederschaeffolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67331-67500-niederschaeffolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67331-67500-niederschaeffolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67331-67500-niederschaeffolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67333-67330-niedersoultzbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67333-67330-niedersoultzbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67333-67330-niedersoultzbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67333-67330-niedersoultzbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67334-67510-niedersteinbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67334-67510-niedersteinbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67334-67510-niedersteinbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67334-67510-niedersteinbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67335-67520-nordheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67335-67520-nordheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67335-67520-nordheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67335-67520-nordheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67336-67150-nordhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67336-67150-nordhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67336-67150-nordhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67336-67150-nordhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67337-67680-nothalten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67337-67680-nothalten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67337-67680-nothalten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67337-67680-nothalten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67338-67230-obenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67338-67230-obenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67338-67230-obenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67338-67230-obenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67339-67660-betschdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67339-67660-betschdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67339-67660-betschdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67339-67660-betschdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67340-67110-oberbronn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67340-67110-oberbronn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67340-67110-oberbronn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67340-67110-oberbronn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67341-67360-oberdorf_spachbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67341-67360-oberdorf_spachbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67341-67360-oberdorf_spachbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67341-67360-oberdorf_spachbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67342-67280-oberhaslach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67342-67280-oberhaslach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67342-67280-oberhaslach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67342-67280-oberhaslach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67343-67205-oberhausbergen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67343-67205-oberhausbergen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67343-67205-oberhausbergen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67343-67205-oberhausbergen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67344-67160-oberhoffen_les_wissembourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67344-67160-oberhoffen_les_wissembourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67344-67160-oberhoffen_les_wissembourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67344-67160-oberhoffen_les_wissembourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67345-67240-oberhoffen_sur_moder/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67345-67240-oberhoffen_sur_moder/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67345-67240-oberhoffen_sur_moder/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67345-67240-oberhoffen_sur_moder/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67346-67160-oberlauterbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67346-67160-oberlauterbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67346-67160-oberlauterbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67346-67160-oberlauterbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67347-67330-obermodern_zutzendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67347-67330-obermodern_zutzendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67347-67330-obermodern_zutzendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67347-67330-obermodern_zutzendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67348-67210-obernai/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67348-67210-obernai/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67348-67210-obernai/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67348-67210-obernai/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67349-67250-oberroedern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67349-67250-oberroedern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67349-67250-oberroedern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67349-67250-oberroedern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67350-67203-oberschaeffolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67350-67203-oberschaeffolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67350-67203-oberschaeffolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67350-67203-oberschaeffolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67351-67160-seebach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67351-67160-seebach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67351-67160-seebach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67351-67160-seebach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67352-67330-obersoultzbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67352-67330-obersoultzbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67352-67330-obersoultzbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67352-67330-obersoultzbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67353-67510-obersteinbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67353-67510-obersteinbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67353-67510-obersteinbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67353-67510-obersteinbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67354-67520-odratzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67354-67520-odratzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67354-67520-odratzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67354-67520-odratzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67355-67970-oermingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67355-67970-oermingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67355-67970-oermingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67355-67970-oermingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67356-67850-offendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67356-67850-offendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67356-67850-offendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67356-67850-offendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67358-67340-offwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67358-67340-offwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67358-67340-offwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67358-67340-offwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67359-67590-ohlungen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67359-67590-ohlungen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67359-67590-ohlungen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67359-67590-ohlungen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67360-67390-ohnenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67360-67390-ohnenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67360-67390-ohnenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67360-67390-ohnenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67361-67170-olwisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67361-67170-olwisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67361-67170-olwisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67361-67170-olwisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67362-67600-orschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67362-67600-orschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67362-67600-orschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67362-67600-orschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67363-67990-osthoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67363-67990-osthoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67363-67990-osthoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67363-67990-osthoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67364-67150-osthouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67364-67150-osthouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67364-67150-osthouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67364-67150-osthouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67365-67540-ostwald/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67365-67540-ostwald/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67365-67540-ostwald/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67365-67540-ostwald/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67366-67700-ottersthal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67366-67700-ottersthal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67366-67700-ottersthal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67366-67700-ottersthal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67367-67700-otterswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67367-67700-otterswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67367-67700-otterswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67367-67700-otterswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67368-67530-ottrott/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67368-67530-ottrott/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67368-67530-ottrott/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67368-67530-ottrott/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67369-67320-ottwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67369-67320-ottwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67369-67320-ottwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67369-67320-ottwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67370-67290-petersbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67370-67290-petersbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67370-67290-petersbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67370-67290-petersbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67371-67290-la_petite_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67371-67290-la_petite_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67371-67290-la_petite_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67371-67290-la_petite_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67372-67350-val_de_moder/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67372-67350-val_de_moder/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67372-67350-val_de_moder/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67372-67350-val_de_moder/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67373-67320-pfalzweyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67373-67320-pfalzweyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67373-67320-pfalzweyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67373-67320-pfalzweyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67375-67370-pfulgriesheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67375-67370-pfulgriesheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67375-67370-pfulgriesheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67375-67370-pfulgriesheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67377-67420-plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67377-67420-plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67377-67420-plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67377-67420-plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67377-67130-plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67377-67130-plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67377-67130-plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67377-67130-plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67378-67115-plobsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67378-67115-plobsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67378-67115-plobsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67378-67115-plobsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67379-67250-preuschdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67379-67250-preuschdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67379-67250-preuschdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67379-67250-preuschdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67380-67490-printzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67380-67490-printzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67380-67490-printzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67380-67490-printzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67381-67290-puberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67381-67290-puberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67381-67290-puberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67381-67290-puberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67382-67117-quatzenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67382-67117-quatzenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67382-67117-quatzenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67382-67117-quatzenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67383-67310-rangen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67383-67310-rangen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67383-67310-rangen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67383-67310-rangen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67384-67420-ranrupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67384-67420-ranrupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67384-67420-ranrupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67384-67420-ranrupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67385-67430-ratzwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67385-67430-ratzwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67385-67430-ratzwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67385-67430-ratzwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67386-67320-rauwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67386-67320-rauwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67386-67320-rauwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67386-67320-rauwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67387-67140-reichsfeld/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67387-67140-reichsfeld/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67387-67140-reichsfeld/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67387-67140-reichsfeld/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67388-67110-reichshoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67388-67110-reichshoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67388-67110-reichshoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67388-67110-reichshoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67389-67116-reichstett/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67389-67116-reichstett/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67389-67116-reichstett/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67389-67116-reichstett/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67391-67440-reinhardsmunster/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67391-67440-reinhardsmunster/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67391-67440-reinhardsmunster/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67391-67440-reinhardsmunster/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67392-67340-reipertswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67392-67340-reipertswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67392-67340-reipertswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67392-67340-reipertswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67394-67250-retschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67394-67250-retschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67394-67250-retschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67394-67250-retschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67395-67440-reutenbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67395-67440-reutenbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67395-67440-reutenbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67395-67440-reutenbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67396-67320-rexingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67396-67320-rexingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67396-67320-rexingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67396-67320-rexingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67397-67860-rhinau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67397-67860-rhinau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67397-67860-rhinau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67397-67860-rhinau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67398-67390-richtolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67398-67390-richtolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67398-67390-richtolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67398-67390-richtolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67400-67160-riedseltz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67400-67160-riedseltz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67400-67160-riedseltz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67400-67160-riedseltz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67401-67260-rimsdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67401-67260-rimsdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67401-67260-rimsdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67401-67260-rimsdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67403-67350-ringendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67403-67350-ringendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67403-67350-ringendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67403-67350-ringendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67404-67690-rittershoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67404-67690-rittershoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67404-67690-rittershoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67404-67690-rittershoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67405-67480-roeschwoog/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67405-67480-roeschwoog/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67405-67480-roeschwoog/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67405-67480-roeschwoog/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67406-67270-rohr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67406-67270-rohr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67406-67270-rohr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67406-67270-rohr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67407-67410-rohrwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67407-67410-rohrwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67407-67410-rohrwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67407-67410-rohrwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67408-67310-romanswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67408-67310-romanswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67408-67310-romanswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67408-67310-romanswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67409-67480-roppenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67409-67480-roppenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67409-67480-roppenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67409-67480-roppenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67410-67560-rosenwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67410-67560-rosenwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67410-67560-rosenwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67410-67560-rosenwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67411-67560-rosheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67411-67560-rosheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67411-67560-rosheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67411-67560-rosheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67412-67230-rossfeld/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67412-67230-rossfeld/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67412-67230-rossfeld/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67412-67230-rossfeld/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67413-67290-rosteig/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67413-67290-rosteig/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67413-67290-rosteig/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67413-67290-rosteig/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67414-67570-rothau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67414-67570-rothau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67414-67570-rothau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67414-67570-rothau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67415-67340-rothbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67415-67340-rothbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67415-67340-rothbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67415-67340-rothbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67416-67160-rott/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67416-67160-rott/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67416-67160-rott/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67416-67160-rott/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67417-67170-rottelsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67417-67170-rottelsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67417-67170-rottelsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67417-67170-rottelsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67418-67480-rountzenheim_auenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67418-67480-rountzenheim_auenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67418-67480-rountzenheim_auenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67418-67480-rountzenheim_auenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67420-67130-russ/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67420-67130-russ/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67420-67130-russ/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67420-67130-russ/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67421-67420-saales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67421-67420-saales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67421-67420-saales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67421-67420-saales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67422-67390-saasenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67422-67390-saasenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67422-67390-saasenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67422-67390-saasenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67423-67270-saessolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67423-67270-saessolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67423-67270-saessolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67423-67270-saessolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67424-67420-saint_blaise_la_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67424-67420-saint_blaise_la_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67424-67420-saint_blaise_la_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67424-67420-saint_blaise_la_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67425-67700-saint_jean_saverne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67425-67700-saint_jean_saverne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67425-67700-saint_jean_saverne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67425-67700-saint_jean_saverne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67426-67220-saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67426-67220-saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67426-67220-saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67426-67220-saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67427-67220-saint_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67427-67220-saint_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67427-67220-saint_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67427-67220-saint_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67428-67530-saint_nabor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67428-67530-saint_nabor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67428-67530-saint_nabor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67428-67530-saint_nabor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67429-67140-saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67429-67140-saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67429-67140-saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67429-67140-saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67430-67220-saint_pierre_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67430-67220-saint_pierre_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67430-67220-saint_pierre_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67430-67220-saint_pierre_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67432-67160-salmbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67432-67160-salmbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67432-67160-salmbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67432-67160-salmbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67433-67230-sand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67433-67230-sand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67433-67230-sand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67433-67230-sand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67434-67260-sarre_union/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67434-67260-sarre_union/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67434-67260-sarre_union/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67434-67260-sarre_union/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67435-67260-sarrewerden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67435-67260-sarrewerden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67435-67260-sarrewerden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67435-67260-sarrewerden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67436-67420-saulxures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67436-67420-saulxures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67436-67420-saulxures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67436-67420-saulxures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67437-67700-saverne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67437-67700-saverne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67437-67700-saverne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67437-67700-saverne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67438-67150-schaeffersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67438-67150-schaeffersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67438-67150-schaeffersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67438-67150-schaeffersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67440-67470-schaffhouse_pres_seltz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67440-67470-schaffhouse_pres_seltz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67440-67470-schaffhouse_pres_seltz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67440-67470-schaffhouse_pres_seltz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67441-67350-schalkendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67441-67350-schalkendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67441-67350-schalkendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67441-67350-schalkendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67442-67310-scharrachbergheim_irmstett/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67442-67310-scharrachbergheim_irmstett/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67442-67310-scharrachbergheim_irmstett/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67442-67310-scharrachbergheim_irmstett/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67443-67630-scheibenhard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67443-67630-scheibenhard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67443-67630-scheibenhard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67443-67630-scheibenhard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67444-67270-scherlenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67444-67270-scherlenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67444-67270-scherlenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67444-67270-scherlenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67445-67750-scherwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67445-67750-scherwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67445-67750-scherwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67445-67750-scherwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67446-67340-schillersdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67446-67340-schillersdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67446-67340-schillersdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67446-67340-schillersdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67447-67300-schiltigheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67447-67300-schiltigheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67447-67300-schiltigheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67447-67300-schiltigheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67448-67130-schirmeck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67448-67130-schirmeck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67448-67130-schirmeck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67448-67130-schirmeck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67449-67240-schirrhein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67449-67240-schirrhein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67449-67240-schirrhein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67449-67240-schirrhein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67450-67240-schirrhoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67450-67240-schirrhoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67450-67240-schirrhoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67450-67240-schirrhoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67451-67160-schleithal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67451-67160-schleithal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67451-67160-schleithal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67451-67160-schleithal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67452-67370-schnersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67452-67370-schnersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67452-67370-schnersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67452-67370-schnersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67453-67390-schoenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67453-67390-schoenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67453-67390-schoenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67453-67390-schoenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67454-67320-schoenbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67454-67320-schoenbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67454-67320-schoenbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67454-67320-schoenbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67455-67250-schoenenbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67455-67250-schoenenbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67455-67250-schoenenbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67455-67250-schoenenbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67456-67260-schopperten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67456-67260-schopperten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67456-67260-schopperten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67456-67260-schopperten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67458-67590-schweighouse_sur_moder/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67458-67590-schweighouse_sur_moder/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67458-67590-schweighouse_sur_moder/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67458-67590-schweighouse_sur_moder/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67459-67440-schwenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67459-67440-schwenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67459-67440-schwenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67459-67440-schwenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67460-67270-schwindratzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67460-67270-schwindratzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67460-67270-schwindratzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67460-67270-schwindratzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67461-67390-schwobsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67461-67390-schwobsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67461-67390-schwobsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67461-67390-schwobsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67462-67600-selestat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67462-67600-selestat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67462-67600-selestat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67462-67600-selestat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67463-67470-seltz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67463-67470-seltz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67463-67470-seltz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67463-67470-seltz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67464-67230-sermersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67464-67230-sermersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67464-67230-sermersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67464-67230-sermersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67465-67770-sessenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67465-67770-sessenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67465-67770-sessenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67465-67770-sessenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67466-67160-siegen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67466-67160-siegen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67466-67160-siegen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67466-67160-siegen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67467-67320-siewiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67467-67320-siewiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67467-67320-siewiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67467-67320-siewiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67468-67260-siltzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67468-67260-siltzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67468-67260-siltzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67468-67260-siltzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67470-67130-solbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67470-67130-solbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67470-67130-solbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67470-67130-solbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67471-67460-souffelweyersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67471-67460-souffelweyersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67471-67460-souffelweyersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67471-67460-souffelweyersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67472-67620-soufflenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67472-67620-soufflenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67472-67620-soufflenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67472-67620-soufflenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67473-67120-soultz_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67473-67120-soultz_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67473-67120-soultz_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67473-67120-soultz_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67474-67250-soultz_sous_forets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67474-67250-soultz_sous_forets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67474-67250-soultz_sous_forets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67474-67250-soultz_sous_forets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67475-67340-sparsbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67475-67340-sparsbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67475-67340-sparsbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67475-67340-sparsbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67476-67770-stattmatten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67476-67770-stattmatten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67476-67770-stattmatten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67476-67770-stattmatten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67477-67220-steige/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67477-67220-steige/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67477-67220-steige/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67477-67220-steige/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67478-67790-steinbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67478-67790-steinbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67478-67790-steinbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67478-67790-steinbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67479-67160-steinseltz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67479-67160-steinseltz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67479-67160-steinseltz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67479-67160-steinseltz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67480-67190-still/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67480-67190-still/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67480-67190-still/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67480-67190-still/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67481-67140-stotzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67481-67140-stotzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67481-67140-stotzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67481-67140-stotzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67200-strasbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67200-strasbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67200-strasbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67200-strasbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67000-strasbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67000-strasbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67000-strasbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67000-strasbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67100-strasbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67100-strasbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67100-strasbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67482-67100-strasbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67483-67290-struth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67483-67290-struth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67483-67290-struth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67483-67290-struth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67484-67250-stundwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67484-67250-stundwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67484-67250-stundwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67484-67250-stundwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67485-67370-stutzheim_offenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67485-67370-stutzheim_offenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67485-67370-stutzheim_offenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67485-67370-stutzheim_offenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67486-67920-sundhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67486-67920-sundhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67486-67920-sundhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67486-67920-sundhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67487-67250-surbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67487-67250-surbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67487-67250-surbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67487-67250-surbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67488-67320-thal_drulingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67488-67320-thal_drulingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67488-67320-thal_drulingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67488-67320-thal_drulingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67489-67440-thal_marmoutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67489-67440-thal_marmoutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67489-67440-thal_marmoutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67489-67440-thal_marmoutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67490-67220-thanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67490-67220-thanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67490-67220-thanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67490-67220-thanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67491-67290-tieffenbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67491-67290-tieffenbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67491-67290-tieffenbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67491-67290-tieffenbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67492-67310-traenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67492-67310-traenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67492-67310-traenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67492-67310-traenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67493-67220-triembach_au_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67493-67220-triembach_au_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67493-67220-triembach_au_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67493-67220-triembach_au_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67494-67470-trimbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67494-67470-trimbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67494-67470-trimbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67494-67470-trimbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67495-67370-truchtersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67495-67370-truchtersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67495-67370-truchtersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67495-67370-truchtersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67497-67350-uhlwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67497-67350-uhlwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67497-67350-uhlwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67497-67350-uhlwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67498-67350-uhrwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67498-67350-uhrwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67498-67350-uhrwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67498-67350-uhrwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67499-67220-urbeis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67499-67220-urbeis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67499-67220-urbeis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67499-67220-urbeis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67500-67280-urmatt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67500-67280-urmatt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67500-67280-urmatt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67500-67280-urmatt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67501-67150-uttenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67501-67150-uttenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67501-67150-uttenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67501-67150-uttenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67502-67110-uttenhoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67502-67110-uttenhoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67502-67110-uttenhoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67502-67110-uttenhoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67503-67330-uttwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67503-67330-uttwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67503-67330-uttwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67503-67330-uttwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67504-67210-valff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67504-67210-valff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67504-67210-valff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67504-67210-valff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67505-67730-la_vancelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67505-67730-la_vancelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67505-67730-la_vancelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67505-67730-la_vancelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67506-67550-vendenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67506-67550-vendenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67506-67550-vendenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67506-67550-vendenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67507-67220-ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67507-67220-ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67507-67220-ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67507-67220-ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67508-67430-voellerdingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67508-67430-voellerdingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67508-67430-voellerdingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67508-67430-voellerdingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67509-67290-volksberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67509-67290-volksberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67509-67290-volksberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67509-67290-volksberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67510-67170-wahlenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67510-67170-wahlenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67510-67170-wahlenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67510-67170-wahlenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67511-67360-walbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67511-67360-walbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67511-67360-walbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67511-67360-walbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67513-67130-waldersbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67513-67130-waldersbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67513-67130-waldersbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67513-67130-waldersbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67514-67430-waldhambach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67514-67430-waldhambach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67514-67430-waldhambach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67514-67430-waldhambach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67515-67700-waldolwisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67515-67700-waldolwisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67515-67700-waldolwisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67515-67700-waldolwisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67516-67670-waltenheim_sur_zorn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67516-67670-waltenheim_sur_zorn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67516-67670-waltenheim_sur_zorn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67516-67670-waltenheim_sur_zorn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67517-67520-wangen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67517-67520-wangen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67517-67520-wangen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67517-67520-wangen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67519-67610-la_wantzenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67519-67610-la_wantzenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67519-67610-la_wantzenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67519-67610-la_wantzenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67520-67310-wasselonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67520-67310-wasselonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67520-67310-wasselonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67520-67310-wasselonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67521-67340-weinbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67521-67340-weinbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67521-67340-weinbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67521-67340-weinbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67522-67290-weislingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67522-67290-weislingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67522-67290-weislingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67522-67290-weislingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67523-67500-weitbruch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67523-67500-weitbruch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67523-67500-weitbruch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67523-67500-weitbruch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67524-67340-weiterswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67524-67340-weiterswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67524-67340-weiterswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67524-67340-weiterswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67525-67310-westhoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67525-67310-westhoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67525-67310-westhoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67525-67310-westhoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67526-67230-westhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67526-67230-westhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67526-67230-westhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67526-67230-westhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67527-67440-westhouse_marmoutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67527-67440-westhouse_marmoutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67527-67440-westhouse_marmoutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67527-67440-westhouse_marmoutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67528-67320-weyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67528-67320-weyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67528-67320-weyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67528-67320-weyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67529-67720-weyersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67529-67720-weyersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67529-67720-weyersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67529-67720-weyersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67530-67270-wickersheim_wilshausen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67530-67270-wickersheim_wilshausen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67530-67270-wickersheim_wilshausen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67530-67270-wickersheim_wilshausen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67531-67130-wildersbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67531-67130-wildersbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67531-67130-wildersbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67531-67130-wildersbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67532-67370-willgottheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67532-67370-willgottheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67532-67370-willgottheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67532-67370-willgottheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67534-67270-wilwisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67534-67270-wilwisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67534-67270-wilwisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67534-67270-wilwisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67535-67290-wimmenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67535-67290-wimmenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67535-67290-wimmenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67535-67290-wimmenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67536-67110-windstein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67536-67110-windstein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67536-67110-windstein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67536-67110-windstein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67537-67510-wingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67537-67510-wingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67537-67510-wingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67537-67510-wingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67538-67290-wingen_sur_moder/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67538-67290-wingen_sur_moder/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67538-67290-wingen_sur_moder/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67538-67290-wingen_sur_moder/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67539-67170-wingersheim_les_quatre_bans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67539-67170-wingersheim_les_quatre_bans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67539-67170-wingersheim_les_quatre_bans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67539-67170-wingersheim_les_quatre_bans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67539-67270-wingersheim_les_quatre_bans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67539-67270-wingersheim_les_quatre_bans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67539-67270-wingersheim_les_quatre_bans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67539-67270-wingersheim_les_quatre_bans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67540-67590-wintershouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67540-67590-wintershouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67540-67590-wintershouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67540-67590-wintershouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67541-67470-wintzenbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67541-67470-wintzenbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67541-67470-wintzenbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67541-67470-wintzenbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67542-67370-wintzenheim_kochersberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67542-67370-wintzenheim_kochersberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67542-67370-wintzenheim_kochersberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67542-67370-wintzenheim_kochersberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67543-67130-wisches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67543-67130-wisches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67543-67130-wisches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67543-67130-wisches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67544-67160-wissembourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67544-67160-wissembourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67544-67160-wissembourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67544-67160-wissembourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67545-67230-witternheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67545-67230-witternheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67545-67230-witternheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67545-67230-witternheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67546-67670-wittersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67546-67670-wittersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67546-67670-wittersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67546-67670-wittersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67547-67820-wittisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67547-67820-wittisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67547-67820-wittisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67547-67820-wittisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67548-67370-wiwersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67548-67370-wiwersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67548-67370-wiwersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67548-67370-wiwersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67550-67360-woerth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67550-67360-woerth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67550-67360-woerth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67550-67360-woerth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67551-67202-wolfisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67551-67202-wolfisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67551-67202-wolfisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67551-67202-wolfisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67552-67260-wolfskirchen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67552-67260-wolfskirchen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67552-67260-wolfskirchen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67552-67260-wolfskirchen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67553-67700-wolschheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67553-67700-wolschheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67553-67700-wolschheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67553-67700-wolschheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67554-67120-wolxheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67554-67120-wolxheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67554-67120-wolxheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67554-67120-wolxheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67555-67310-zehnacker/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67555-67310-zehnacker/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67555-67310-zehnacker/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67555-67310-zehnacker/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67556-67310-zeinheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67556-67310-zeinheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67556-67310-zeinheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67556-67310-zeinheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67557-67140-zellwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67557-67140-zellwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67557-67140-zellwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67557-67140-zellwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67558-67110-zinswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67558-67110-zinswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67558-67110-zinswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67558-67110-zinswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67559-67290-zittersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67559-67290-zittersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67559-67290-zittersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt67-bas_rhin/commune67559-67290-zittersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-68.xml
+++ b/public/sitemaps/sitemap-68.xml
@@ -5,756 +5,1508 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68001-68600-algolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68001-68600-algolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68001-68600-algolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68001-68600-algolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68002-68210-altenach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68002-68210-altenach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68002-68210-altenach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68002-68210-altenach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68004-68130-altkirch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68004-68130-altkirch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68004-68130-altkirch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68004-68130-altkirch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68005-68770-ammerschwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68005-68770-ammerschwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68005-68770-ammerschwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68005-68770-ammerschwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68005-68410-ammerschwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68005-68410-ammerschwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68005-68410-ammerschwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68005-68410-ammerschwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68006-68210-bernwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68006-68210-bernwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68006-68210-bernwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68006-68210-bernwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68007-68280-andolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68007-68280-andolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68007-68280-andolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68007-68280-andolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68008-68280-appenwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68008-68280-appenwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68008-68280-appenwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68008-68280-appenwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68009-68320-artzenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68009-68320-artzenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68009-68320-artzenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68009-68320-artzenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68010-68130-aspach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68010-68130-aspach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68010-68130-aspach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68010-68130-aspach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68011-68700-aspach_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68011-68700-aspach_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68011-68700-aspach_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68011-68700-aspach_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68012-68700-aspach_michelbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68012-68700-aspach_michelbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68012-68700-aspach_michelbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68012-68700-aspach_michelbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68013-68220-attenschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68013-68220-attenschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68013-68220-attenschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68013-68220-attenschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68014-68150-aubure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68014-68150-aubure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68014-68150-aubure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68014-68150-aubure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68015-68390-baldersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68015-68390-baldersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68015-68390-baldersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68015-68390-baldersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68016-68740-balgau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68016-68740-balgau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68016-68740-balgau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68016-68740-balgau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68017-68210-ballersdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68017-68210-ballersdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68017-68210-ballersdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68017-68210-ballersdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68018-68210-balschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68018-68210-balschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68018-68210-balschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68018-68210-balschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68019-68320-baltzenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68019-68320-baltzenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68019-68320-baltzenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68019-68320-baltzenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68020-68490-bantzenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68020-68490-bantzenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68020-68490-bantzenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68020-68490-bantzenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68021-68870-bartenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68021-68870-bartenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68021-68870-bartenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68021-68870-bartenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68022-68390-battenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68022-68390-battenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68022-68390-battenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68022-68390-battenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68023-68980-beblenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68023-68980-beblenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68023-68980-beblenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68023-68980-beblenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68024-68210-bellemagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68024-68210-bellemagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68024-68210-bellemagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68024-68210-bellemagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68025-68480-bendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68025-68480-bendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68025-68480-bendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68025-68480-bendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68026-68630-bennwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68026-68630-bennwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68026-68630-bennwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68026-68630-bennwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68026-68126-bennwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68026-68126-bennwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68026-68126-bennwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68026-68126-bennwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68027-68130-berentzwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68027-68130-berentzwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68027-68130-berentzwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68027-68130-berentzwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68028-68750-bergheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68028-68750-bergheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68028-68750-bergheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68028-68750-bergheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68029-68500-bergholtz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68029-68500-bergholtz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68029-68500-bergholtz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68029-68500-bergholtz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68030-68500-bergholtzzell/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68030-68500-bergholtzzell/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68030-68500-bergholtzzell/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68030-68500-bergholtzzell/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68032-68500-berrwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68032-68500-berrwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68032-68500-berrwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68032-68500-berrwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68033-68560-bettendorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68033-68560-bettendorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68033-68560-bettendorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68033-68560-bettendorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68034-68480-bettlach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68034-68480-bettlach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68034-68480-bettlach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68034-68480-bettlach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68035-68480-biederthal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68035-68480-biederthal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68035-68480-biederthal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68035-68480-biederthal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68036-68600-biesheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68036-68600-biesheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68036-68600-biesheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68036-68600-biesheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68037-68127-biltzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68037-68127-biltzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68037-68127-biltzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68037-68127-biltzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68038-68320-bischwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68038-68320-bischwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68038-68320-bischwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68038-68320-bischwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68039-68580-bisel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68039-68580-bisel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68039-68580-bisel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68039-68580-bisel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68040-68620-bitschwiller_les_thann/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68040-68620-bitschwiller_les_thann/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68040-68620-bitschwiller_les_thann/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68040-68620-bitschwiller_les_thann/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68041-68740-blodelsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68041-68740-blodelsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68041-68740-blodelsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68041-68740-blodelsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68042-68730-blotzheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68042-68730-blotzheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68042-68730-blotzheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68042-68730-blotzheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68043-68540-bollwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68043-68540-bollwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68043-68540-bollwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68043-68540-bollwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68044-68650-le_bonhomme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68044-68650-le_bonhomme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68044-68650-le_bonhomme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68044-68650-le_bonhomme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68045-68290-bourbach_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68045-68290-bourbach_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68045-68290-bourbach_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68045-68290-bourbach_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68046-68290-bourbach_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68046-68290-bourbach_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68046-68290-bourbach_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68046-68290-bourbach_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68049-68480-bouxwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68049-68480-bouxwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68049-68480-bouxwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68049-68480-bouxwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68050-68210-brechaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68050-68210-brechaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68050-68210-brechaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68050-68210-brechaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68051-68380-breitenbach_haut_rhin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68051-68380-breitenbach_haut_rhin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68051-68380-breitenbach_haut_rhin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68051-68380-breitenbach_haut_rhin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68052-68780-bretten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68052-68780-bretten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68052-68780-bretten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68052-68780-bretten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68054-68870-brinckheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68054-68870-brinckheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68054-68870-brinckheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68054-68870-brinckheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68055-68440-bruebach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68055-68440-bruebach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68055-68440-bruebach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68055-68440-bruebach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68056-68350-brunstatt_didenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68056-68350-brunstatt_didenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68056-68350-brunstatt_didenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68056-68350-brunstatt_didenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68057-68210-buethwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68057-68210-buethwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68057-68210-buethwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68057-68210-buethwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68058-68530-buhl/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68058-68530-buhl/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68058-68530-buhl/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68058-68530-buhl/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68059-68520-burnhaupt_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68059-68520-burnhaupt_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68059-68520-burnhaupt_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68059-68520-burnhaupt_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68060-68520-burnhaupt_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68060-68520-burnhaupt_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68060-68520-burnhaupt_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68060-68520-burnhaupt_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68061-68220-buschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68061-68220-buschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68061-68220-buschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68061-68220-buschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68062-68130-carspach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68062-68130-carspach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68062-68130-carspach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68062-68130-carspach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68063-68700-cernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68063-68700-cernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68063-68700-cernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68063-68700-cernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68064-68490-chalampe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68064-68490-chalampe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68064-68490-chalampe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68064-68490-chalampe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68065-68210-chavannes_sur_l_etang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68065-68210-chavannes_sur_l_etang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68065-68210-chavannes_sur_l_etang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68065-68210-chavannes_sur_l_etang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68066-68000-colmar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68066-68000-colmar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68066-68000-colmar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68066-68000-colmar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68067-68480-courtavon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68067-68480-courtavon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68067-68480-courtavon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68067-68480-courtavon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68068-68210-dannemarie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68068-68210-dannemarie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68068-68210-dannemarie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68068-68210-dannemarie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68069-68600-dessenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68069-68600-dessenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68069-68600-dessenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68069-68600-dessenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68071-68780-diefmatten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68071-68780-diefmatten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68071-68780-diefmatten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68071-68780-diefmatten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68072-68440-dietwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68072-68440-dietwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68072-68440-dietwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68072-68440-dietwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68073-68290-dolleren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68073-68290-dolleren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68073-68290-dolleren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68073-68290-dolleren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68074-68480-durlinsdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68074-68480-durlinsdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68074-68480-durlinsdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68074-68480-durlinsdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68075-68480-durmenach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68075-68480-durmenach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68075-68480-durmenach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68075-68480-durmenach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68076-68320-durrenentzen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68076-68320-durrenentzen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68076-68320-durrenentzen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68076-68320-durrenentzen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68077-68720-eglingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68077-68720-eglingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68077-68720-eglingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68077-68720-eglingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68078-68420-eguisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68078-68420-eguisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68078-68420-eguisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68078-68420-eguisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68079-68210-elbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68079-68210-elbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68079-68210-elbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68079-68210-elbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68080-68130-emlingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68080-68130-emlingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68080-68130-emlingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68080-68130-emlingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68081-68720-saint_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68081-68720-saint_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68081-68720-saint_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68081-68720-saint_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68082-68190-ensisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68082-68190-ensisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68082-68190-ensisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68082-68190-ensisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68083-68140-eschbach_au_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68083-68140-eschbach_au_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68083-68140-eschbach_au_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68083-68140-eschbach_au_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68084-68440-eschentzwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68084-68440-eschentzwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68084-68440-eschentzwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68084-68440-eschentzwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68085-68210-eteimbes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68085-68210-eteimbes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68085-68210-eteimbes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68085-68210-eteimbes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68086-68210-falkwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68086-68210-falkwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68086-68210-falkwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68086-68210-falkwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68087-68640-feldbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68087-68640-feldbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68087-68640-feldbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68087-68640-feldbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68088-68540-feldkirch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68088-68540-feldkirch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68088-68540-feldkirch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68088-68540-feldkirch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68089-68470-fellering/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68089-68470-fellering/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68089-68470-fellering/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68089-68470-fellering/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68090-68480-ferrette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68090-68480-ferrette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68090-68480-ferrette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68090-68480-ferrette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68091-68740-fessenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68091-68740-fessenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68091-68740-fessenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68091-68740-fessenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68092-68480-fislis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68092-68480-fislis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68092-68480-fislis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68092-68480-fislis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68093-68720-flaxlanden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68093-68720-flaxlanden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68093-68720-flaxlanden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68093-68720-flaxlanden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68094-68220-folgensbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68094-68220-folgensbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68094-68220-folgensbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68094-68220-folgensbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68095-68320-fortschwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68095-68320-fortschwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68095-68320-fortschwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68095-68320-fortschwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68096-68130-franken/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68096-68130-franken/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68096-68130-franken/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68096-68130-franken/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68097-68240-freland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68097-68240-freland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68097-68240-freland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68097-68240-freland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68097-68150-freland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68097-68150-freland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68097-68150-freland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68097-68150-freland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68098-68580-friesen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68098-68580-friesen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68098-68580-friesen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68098-68580-friesen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68099-68720-froeningen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68099-68720-froeningen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68099-68720-froeningen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68099-68720-froeningen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68100-68210-fulleren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68100-68210-fulleren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68100-68210-fulleren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68100-68210-fulleren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68101-68990-galfingue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68101-68990-galfingue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68101-68990-galfingue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68101-68990-galfingue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68102-68690-geishouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68102-68690-geishouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68102-68690-geishouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68102-68690-geishouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68103-68510-geispitzen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68103-68510-geispitzen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68103-68510-geispitzen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68103-68510-geispitzen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68104-68600-geiswasser/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68104-68600-geiswasser/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68104-68600-geiswasser/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68104-68600-geiswasser/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68105-68210-gildwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68105-68210-gildwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68105-68210-gildwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68105-68210-gildwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68106-68760-goldbach_altenbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68106-68760-goldbach_altenbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68106-68760-goldbach_altenbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68106-68760-goldbach_altenbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68107-68210-gommersdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68107-68210-gommersdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68107-68210-gommersdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68107-68210-gommersdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68109-68140-griesbach_au_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68109-68140-griesbach_au_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68109-68140-griesbach_au_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68109-68140-griesbach_au_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68110-68320-grussenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68110-68320-grussenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68110-68320-grussenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68110-68320-grussenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68111-68420-gueberschwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68111-68420-gueberschwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68111-68420-gueberschwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68111-68420-gueberschwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68112-68500-guebwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68112-68500-guebwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68112-68500-guebwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68112-68500-guebwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68113-68970-guemar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68113-68970-guemar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68113-68970-guemar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68113-68970-guemar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68114-68210-guevenatten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68114-68210-guevenatten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68114-68210-guevenatten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68114-68210-guevenatten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68115-68116-guewenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68115-68116-guewenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68115-68116-guewenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68115-68116-guewenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68116-68250-gundolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68116-68250-gundolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68116-68250-gundolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68116-68250-gundolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68117-68140-gunsbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68117-68140-gunsbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68117-68140-gunsbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68117-68140-gunsbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68118-68440-habsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68118-68440-habsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68118-68440-habsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68118-68440-habsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68119-68210-hagenbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68119-68210-hagenbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68119-68210-hagenbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68119-68210-hagenbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68120-68220-hagenthal_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68120-68220-hagenthal_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68120-68220-hagenthal_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68120-68220-hagenthal_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68121-68220-hagenthal_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68121-68220-hagenthal_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68121-68220-hagenthal_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68121-68220-hagenthal_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68122-68500-hartmannswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68122-68500-hartmannswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68122-68500-hartmannswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68122-68500-hartmannswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68123-68420-hattstatt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68123-68420-hattstatt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68123-68420-hattstatt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68123-68420-hattstatt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68124-68130-hausgauen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68124-68130-hausgauen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68124-68130-hausgauen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68124-68130-hausgauen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68125-68210-hecken/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68125-68210-hecken/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68125-68210-hecken/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68125-68210-hecken/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68126-68220-hegenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68126-68220-hegenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68126-68220-hegenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68126-68220-hegenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68127-68720-heidwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68127-68720-heidwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68127-68720-heidwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68127-68720-heidwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68128-68560-heimersdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68128-68560-heimersdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68128-68560-heimersdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68128-68560-heimersdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68129-68990-heimsbrunn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68129-68990-heimsbrunn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68129-68990-heimsbrunn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68129-68990-heimsbrunn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68130-68600-heiteren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68130-68600-heiteren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68130-68600-heiteren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68130-68600-heiteren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68131-68130-heiwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68131-68130-heiwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68131-68130-heiwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68131-68130-heiwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68132-68510-helfrantzkirch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68132-68510-helfrantzkirch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68132-68510-helfrantzkirch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68132-68510-helfrantzkirch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68134-68420-herrlisheim_pres_colmar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68134-68420-herrlisheim_pres_colmar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68134-68420-herrlisheim_pres_colmar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68134-68420-herrlisheim_pres_colmar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68135-68220-hesingue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68135-68220-hesingue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68135-68220-hesingue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68135-68220-hesingue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68136-68600-hettenschlag/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68136-68600-hettenschlag/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68136-68600-hettenschlag/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68136-68600-hettenschlag/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68137-68580-hindlingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68137-68580-hindlingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68137-68580-hindlingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68137-68580-hindlingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68138-68560-hirsingue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68138-68560-hirsingue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68138-68560-hirsingue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68138-68560-hirsingue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68139-68118-hirtzbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68139-68118-hirtzbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68139-68118-hirtzbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68139-68118-hirtzbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68140-68740-hirtzfelden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68140-68740-hirtzfelden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68140-68740-hirtzfelden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68140-68740-hirtzfelden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68141-68720-hochstatt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68141-68720-hochstatt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68141-68720-hochstatt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68141-68720-hochstatt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68142-68140-hohrod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68142-68140-hohrod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68142-68140-hohrod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68142-68140-hohrod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68143-68320-porte_du_ried/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68143-68320-porte_du_ried/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68143-68320-porte_du_ried/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68143-68320-porte_du_ried/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68144-68490-hombourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68144-68490-hombourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68144-68490-hombourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68144-68490-hombourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68145-68180-horbourg_wihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68145-68180-horbourg_wihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68145-68180-horbourg_wihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68145-68180-horbourg_wihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68146-68125-houssen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68146-68125-houssen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68146-68125-houssen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68146-68125-houssen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68147-68150-hunawihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68147-68150-hunawihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68147-68150-hunawihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68147-68150-hunawihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68148-68130-hundsbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68148-68130-hundsbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68148-68130-hundsbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68148-68130-hundsbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68149-68330-huningue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68149-68330-huningue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68149-68330-huningue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68149-68330-huningue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68149-68300-huningue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68149-68300-huningue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68149-68300-huningue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68149-68300-huningue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68150-68420-husseren_les_chateaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68150-68420-husseren_les_chateaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68150-68420-husseren_les_chateaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68150-68420-husseren_les_chateaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68151-68470-husseren_wesserling/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68151-68470-husseren_wesserling/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68151-68470-husseren_wesserling/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68151-68470-husseren_wesserling/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68152-68720-illfurth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68152-68720-illfurth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68152-68720-illfurth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68152-68720-illfurth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68153-68970-illhaeusern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68153-68970-illhaeusern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68153-68970-illhaeusern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68153-68970-illhaeusern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68154-68110-illzach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68154-68110-illzach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68154-68110-illzach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68154-68110-illzach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68155-68040-ingersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68155-68040-ingersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68155-68040-ingersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68155-68040-ingersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68156-68500-issenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68156-68500-issenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68156-68500-issenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68156-68500-issenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68157-68320-jebsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68157-68320-jebsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68157-68320-jebsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68157-68320-jebsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68158-68130-jettingen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68158-68130-jettingen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68158-68130-jettingen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68158-68130-jettingen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68159-68500-jungholtz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68159-68500-jungholtz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68159-68500-jungholtz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68159-68500-jungholtz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68160-68510-kappelen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68160-68510-kappelen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68160-68510-kappelen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68160-68510-kappelen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68161-68230-katzenthal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68161-68230-katzenthal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68161-68230-katzenthal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68161-68230-katzenthal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68162-68240-kaysersberg_vignoble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68162-68240-kaysersberg_vignoble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68162-68240-kaysersberg_vignoble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68162-68240-kaysersberg_vignoble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68163-68680-kembs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68163-68680-kembs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68163-68680-kembs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68163-68680-kembs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68165-68480-kiffis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68165-68480-kiffis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68165-68480-kiffis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68165-68480-kiffis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68166-68260-kingersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68166-68260-kingersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68166-68260-kingersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68166-68260-kingersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68167-68290-kirchberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68167-68290-kirchberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68167-68290-kirchberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68167-68290-kirchberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68168-68220-knoeringue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68168-68220-knoeringue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68168-68220-knoeringue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68168-68220-knoeringue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68169-68480-koestlach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68169-68480-koestlach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68169-68480-koestlach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68169-68480-koestlach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68170-68510-koetzingue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68170-68510-koetzingue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68170-68510-koetzingue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68170-68510-koetzingue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68171-68820-kruth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68171-68820-kruth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68171-68820-kruth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68171-68820-kruth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68172-68320-kunheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68172-68320-kunheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68172-68320-kunheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68172-68320-kunheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68173-68910-labaroche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68173-68910-labaroche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68173-68910-labaroche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68173-68910-labaroche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68174-68440-landser/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68174-68440-landser/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68174-68440-landser/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68174-68440-landser/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68175-68650-lapoutroie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68175-68650-lapoutroie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68175-68650-lapoutroie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68175-68650-lapoutroie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68176-68580-largitzen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68176-68580-largitzen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68176-68580-largitzen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68176-68580-largitzen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68177-68610-lautenbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68177-68610-lautenbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68177-68610-lautenbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68177-68610-lautenbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68178-68610-lautenbachzell/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68178-68610-lautenbachzell/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68178-68610-lautenbachzell/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68178-68610-lautenbachzell/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68179-68290-lauw/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68179-68290-lauw/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68179-68290-lauw/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68179-68290-lauw/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68180-68800-leimbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68180-68800-leimbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68180-68800-leimbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68180-68800-leimbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68181-68480-levoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68181-68480-levoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68181-68480-levoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68181-68480-levoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68182-68220-leymen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68182-68220-leymen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68182-68220-leymen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68182-68220-leymen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68183-68220-liebenswiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68183-68220-liebenswiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68183-68220-liebenswiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68183-68220-liebenswiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68184-68480-liebsdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68184-68480-liebsdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68184-68480-liebsdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68184-68480-liebsdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68185-68660-liepvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68185-68660-liepvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68185-68660-liepvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68185-68660-liepvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68186-68480-ligsdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68186-68480-ligsdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68186-68480-ligsdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68186-68480-ligsdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68187-68480-linsdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68187-68480-linsdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68187-68480-linsdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68187-68480-linsdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68188-68610-linthal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68188-68610-linthal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68188-68610-linthal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68188-68610-linthal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68189-68280-logelheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68189-68280-logelheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68189-68280-logelheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68189-68280-logelheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68190-68480-lucelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68190-68480-lucelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68190-68480-lucelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68190-68480-lucelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68191-68720-luemschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68191-68720-luemschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68191-68720-luemschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68191-68720-luemschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68192-68210-valdieu_lutran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68192-68210-valdieu_lutran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68192-68210-valdieu_lutran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68192-68210-valdieu_lutran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68193-68140-luttenbach_pres_munster/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68193-68140-luttenbach_pres_munster/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68193-68140-luttenbach_pres_munster/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68193-68140-luttenbach_pres_munster/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68194-68480-lutter/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68194-68480-lutter/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68194-68480-lutter/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68194-68480-lutter/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68195-68460-lutterbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68195-68460-lutterbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68195-68460-lutterbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68195-68460-lutterbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68196-68210-magny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68196-68210-magny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68196-68210-magny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68196-68210-magny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68197-68510-magstatt_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68197-68510-magstatt_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68197-68510-magstatt_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68197-68510-magstatt_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68198-68510-magstatt_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68198-68510-magstatt_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68198-68510-magstatt_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68198-68510-magstatt_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68199-68550-malmerspach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68199-68550-malmerspach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68199-68550-malmerspach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68199-68550-malmerspach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68200-68210-manspach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68200-68210-manspach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68200-68210-manspach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68200-68210-manspach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68201-68290-masevaux_niederbruck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68201-68290-masevaux_niederbruck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68201-68290-masevaux_niederbruck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68201-68290-masevaux_niederbruck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68202-68210-mertzen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68202-68210-mertzen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68202-68210-mertzen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68202-68210-mertzen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68203-68500-merxheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68203-68500-merxheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68203-68500-merxheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68203-68500-merxheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68204-68380-metzeral/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68204-68380-metzeral/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68204-68380-metzeral/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68204-68380-metzeral/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68205-68890-meyenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68205-68890-meyenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68205-68890-meyenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68205-68890-meyenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68207-68730-michelbach_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68207-68730-michelbach_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68207-68730-michelbach_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68207-68730-michelbach_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68208-68220-michelbach_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68208-68220-michelbach_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68208-68220-michelbach_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68208-68220-michelbach_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68209-68630-mittelwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68209-68630-mittelwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68209-68630-mittelwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68209-68630-mittelwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68210-68380-mittlach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68210-68380-mittlach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68210-68380-mittlach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68210-68380-mittlach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68211-68470-mitzach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68211-68470-mitzach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68211-68470-mitzach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68211-68470-mitzach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68212-68480-moernach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68212-68480-moernach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68212-68480-moernach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68212-68480-moernach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68213-68470-mollau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68213-68470-mollau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68213-68470-mollau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68213-68470-mollau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68214-68210-montreux_jeune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68214-68210-montreux_jeune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68214-68210-montreux_jeune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68214-68210-montreux_jeune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68215-68210-montreux_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68215-68210-montreux_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68215-68210-montreux_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68215-68210-montreux_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68216-68580-mooslargue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68216-68580-mooslargue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68216-68580-mooslargue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68216-68580-mooslargue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68217-68690-moosch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68217-68690-moosch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68217-68690-moosch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68217-68690-moosch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68218-68790-morschwiller_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68218-68790-morschwiller_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68218-68790-morschwiller_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68218-68790-morschwiller_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68219-68780-le_haut_soultzbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68219-68780-le_haut_soultzbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68219-68780-le_haut_soultzbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68219-68780-le_haut_soultzbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68221-68640-muespach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68221-68640-muespach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68221-68640-muespach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68221-68640-muespach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68222-68640-muespach_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68222-68640-muespach_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68222-68640-muespach_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68222-68640-muespach_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68223-68380-muhlbach_sur_munster/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68223-68380-muhlbach_sur_munster/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68223-68380-muhlbach_sur_munster/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68223-68380-muhlbach_sur_munster/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68224-68200-mulhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68224-68200-mulhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68224-68200-mulhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68224-68200-mulhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68224-68100-mulhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68224-68100-mulhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68224-68100-mulhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68224-68100-mulhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68225-68740-munchhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68225-68740-munchhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68225-68740-munchhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68225-68740-munchhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68226-68140-munster/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68226-68140-munster/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68226-68140-munster/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68226-68140-munster/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68227-68320-muntzenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68227-68320-muntzenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68227-68320-muntzenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68227-68320-muntzenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68228-68250-munwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68228-68250-munwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68228-68250-munwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68228-68250-munwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68229-68530-murbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68229-68530-murbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68229-68530-murbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68229-68530-murbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68230-68740-nambsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68230-68740-nambsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68230-68740-nambsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68230-68740-nambsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68231-68600-neuf_brisach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68231-68600-neuf_brisach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68231-68600-neuf_brisach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68231-68600-neuf_brisach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68232-68220-neuwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68232-68220-neuwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68232-68220-neuwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68232-68220-neuwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68234-68127-niederentzen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68234-68127-niederentzen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68234-68127-niederentzen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68234-68127-niederentzen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68235-68127-niederhergheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68235-68127-niederhergheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68235-68127-niederhergheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68235-68127-niederhergheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68237-68230-niedermorschwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68237-68230-niedermorschwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68237-68230-niedermorschwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68237-68230-niedermorschwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68237-68410-niedermorschwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68237-68410-niedermorschwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68237-68410-niedermorschwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68237-68410-niedermorschwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68238-68680-niffer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68238-68680-niffer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68238-68680-niffer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68238-68680-niffer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68239-68290-oberbruck/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68239-68290-oberbruck/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68239-68290-oberbruck/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68239-68290-oberbruck/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68240-68960-illtal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68240-68960-illtal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68240-68960-illtal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68240-68960-illtal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68241-68127-oberentzen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68241-68127-oberentzen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68241-68127-oberentzen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68241-68127-oberentzen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68242-68127-oberhergheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68242-68127-oberhergheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68242-68127-oberhergheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68242-68127-oberhergheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68243-68480-oberlarg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68243-68480-oberlarg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68243-68480-oberlarg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68243-68480-oberlarg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68244-68420-obermorschwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68244-68420-obermorschwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68244-68420-obermorschwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68244-68420-obermorschwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68245-68130-obermorschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68245-68130-obermorschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68245-68130-obermorschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68245-68130-obermorschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68246-68600-obersaasheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68246-68600-obersaasheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68246-68600-obersaasheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68246-68600-obersaasheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68247-68830-oderen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68247-68830-oderen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68247-68830-oderen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68247-68830-oderen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68248-68480-oltingue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68248-68480-oltingue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68248-68480-oltingue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68248-68480-oltingue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68249-68370-orbey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68249-68370-orbey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68249-68370-orbey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68249-68370-orbey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68250-68500-orschwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68250-68500-orschwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68250-68500-orschwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68250-68500-orschwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68251-68570-osenbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68251-68570-osenbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68251-68570-osenbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68251-68570-osenbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68252-68150-ostheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68252-68150-ostheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68252-68150-ostheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68252-68150-ostheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68253-68490-ottmarsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68253-68490-ottmarsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68253-68490-ottmarsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68253-68490-ottmarsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68254-68490-petit_landau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68254-68490-petit_landau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68254-68490-petit_landau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68254-68490-petit_landau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68255-68250-pfaffenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68255-68250-pfaffenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68255-68250-pfaffenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68255-68250-pfaffenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68256-68120-pfastatt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68256-68120-pfastatt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68256-68120-pfastatt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68256-68120-pfastatt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68257-68480-pfetterhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68257-68480-pfetterhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68257-68480-pfetterhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68257-68480-pfetterhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68258-68840-pulversheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68258-68840-pulversheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68258-68840-pulversheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68258-68840-pulversheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68259-68480-raedersdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68259-68480-raedersdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68259-68480-raedersdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68259-68480-raedersdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68260-68190-raedersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68260-68190-raedersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68260-68190-raedersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68260-68190-raedersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68261-68800-rammersmatt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68261-68800-rammersmatt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68261-68800-rammersmatt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68261-68800-rammersmatt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68262-68470-ranspach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68262-68470-ranspach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68262-68470-ranspach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68262-68470-ranspach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68263-68730-ranspach_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68263-68730-ranspach_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68263-68730-ranspach_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68263-68730-ranspach_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68264-68220-ranspach_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68264-68220-ranspach_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68264-68220-ranspach_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68264-68220-ranspach_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68265-68510-rantzwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68265-68510-rantzwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68265-68510-rantzwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68265-68510-rantzwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68266-68890-reguisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68266-68890-reguisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68266-68890-reguisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68266-68890-reguisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68267-68950-reiningue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68267-68950-reiningue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68267-68950-reiningue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68267-68950-reiningue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68268-68210-retzwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68268-68210-retzwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68268-68210-retzwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68268-68210-retzwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68269-68150-ribeauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68269-68150-ribeauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68269-68150-ribeauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68269-68150-ribeauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68270-68120-richwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68270-68120-richwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68270-68120-richwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68270-68120-richwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68271-68400-riedisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68271-68400-riedisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68271-68400-riedisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68271-68400-riedisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68273-68640-riespach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68273-68640-riespach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68273-68640-riespach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68273-68640-riespach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68274-68500-rimbach_pres_guebwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68274-68500-rimbach_pres_guebwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68274-68500-rimbach_pres_guebwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68274-68500-rimbach_pres_guebwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68275-68290-rimbach_pres_masevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68275-68290-rimbach_pres_masevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68275-68290-rimbach_pres_masevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68275-68290-rimbach_pres_masevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68276-68500-rimbachzell/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68276-68500-rimbachzell/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68276-68500-rimbachzell/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68276-68500-rimbachzell/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68277-68340-riquewihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68277-68340-riquewihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68277-68340-riquewihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68277-68340-riquewihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68278-68170-rixheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68278-68170-rixheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68278-68170-rixheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68278-68170-rixheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68279-68800-roderen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68279-68800-roderen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68279-68800-roderen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68279-68800-roderen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68280-68590-rodern/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68280-68590-rodern/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68280-68590-rodern/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68280-68590-rodern/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68281-68740-roggenhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68281-68740-roggenhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68281-68740-roggenhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68281-68740-roggenhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68282-68210-romagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68282-68210-romagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68282-68210-romagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68282-68210-romagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68283-68660-rombach_le_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68283-68660-rombach_le_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68283-68660-rombach_le_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68283-68660-rombach_le_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68284-68480-roppentzwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68284-68480-roppentzwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68284-68480-roppentzwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68284-68480-roppentzwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68285-68590-rorschwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68285-68590-rorschwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68285-68590-rorschwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68285-68590-rorschwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68286-68128-rosenau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68286-68128-rosenau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68286-68128-rosenau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68286-68128-rosenau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68287-68250-rouffach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68287-68250-rouffach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68287-68250-rouffach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68287-68250-rouffach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68288-68560-ruederbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68288-68560-ruederbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68288-68560-ruederbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68288-68560-ruederbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68289-68270-ruelisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68289-68270-ruelisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68289-68270-ruelisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68289-68270-ruelisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68290-68740-rustenhart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68290-68740-rustenhart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68290-68740-rustenhart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68290-68740-rustenhart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68291-68740-rumersheim_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68291-68740-rumersheim_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68291-68740-rumersheim_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68291-68740-rumersheim_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68292-68550-saint_amarin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68292-68550-saint_amarin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68292-68550-saint_amarin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68292-68550-saint_amarin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68293-68210-saint_cosme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68293-68210-saint_cosme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68293-68210-saint_cosme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68293-68210-saint_cosme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68294-68160-sainte_croix_aux_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68294-68160-sainte_croix_aux_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68294-68160-sainte_croix_aux_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68294-68160-sainte_croix_aux_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68295-68127-sainte_croix_en_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68295-68127-sainte_croix_en_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68295-68127-sainte_croix_en_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68295-68127-sainte_croix_en_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68296-68590-saint_hippolyte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68296-68590-saint_hippolyte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68296-68590-saint_hippolyte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68296-68590-saint_hippolyte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68297-68300-saint_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68297-68300-saint_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68297-68300-saint_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68297-68300-saint_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68298-68160-sainte_marie_aux_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68298-68160-sainte_marie_aux_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68298-68160-sainte_marie_aux_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68298-68160-sainte_marie_aux_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68299-68210-saint_ulrich/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68299-68210-saint_ulrich/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68299-68210-saint_ulrich/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68299-68210-saint_ulrich/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68300-68390-sausheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68300-68390-sausheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68300-68390-sausheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68300-68390-sausheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68301-68440-schlierbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68301-68440-schlierbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68301-68440-schlierbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68301-68440-schlierbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68302-68520-schweighouse_thann/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68302-68520-schweighouse_thann/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68302-68520-schweighouse_thann/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68302-68520-schweighouse_thann/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68303-68130-schwoben/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68303-68130-schwoben/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68303-68130-schwoben/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68303-68130-schwoben/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68304-68780-sentheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68304-68780-sentheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68304-68780-sentheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68304-68780-sentheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68305-68580-seppois_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68305-68580-seppois_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68305-68580-seppois_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68305-68580-seppois_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68306-68580-seppois_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68306-68580-seppois_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68306-68580-seppois_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68306-68580-seppois_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68307-68290-sewen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68307-68290-sewen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68307-68290-sewen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68307-68290-sewen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68308-68290-sickert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68308-68290-sickert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68308-68290-sickert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68308-68290-sickert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68309-68510-sierentz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68309-68510-sierentz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68309-68510-sierentz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68309-68510-sierentz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68311-68380-sondernach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68311-68380-sondernach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68311-68380-sondernach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68311-68380-sondernach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68312-68480-sondersdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68312-68480-sondersdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68312-68480-sondersdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68312-68480-sondersdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68313-68780-soppe_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68313-68780-soppe_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68313-68780-soppe_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68313-68780-soppe_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68315-68360-soultz_haut_rhin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68315-68360-soultz_haut_rhin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68315-68360-soultz_haut_rhin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68315-68360-soultz_haut_rhin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68316-68230-soultzbach_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68316-68230-soultzbach_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68316-68230-soultzbach_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68316-68230-soultzbach_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68317-68140-soultzeren/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68317-68140-soultzeren/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68317-68140-soultzeren/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68317-68140-soultzeren/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68318-68570-soultzmatt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68318-68570-soultzmatt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68318-68570-soultzmatt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68318-68570-soultzmatt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68320-68720-spechbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68320-68720-spechbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68320-68720-spechbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68320-68720-spechbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68321-68850-staffelfelden/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68321-68850-staffelfelden/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68321-68850-staffelfelden/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68321-68850-staffelfelden/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68322-68700-steinbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68322-68700-steinbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68322-68700-steinbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68322-68700-steinbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68323-68440-steinbrunn_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68323-68440-steinbrunn_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68323-68440-steinbrunn_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68323-68440-steinbrunn_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68324-68440-steinbrunn_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68324-68440-steinbrunn_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68324-68440-steinbrunn_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68324-68440-steinbrunn_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68325-68640-steinsoultz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68325-68640-steinsoultz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68325-68640-steinsoultz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68325-68640-steinsoultz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68326-68780-sternenberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68326-68780-sternenberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68326-68780-sternenberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68326-68780-sternenberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68327-68510-stetten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68327-68510-stetten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68327-68510-stetten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68327-68510-stetten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68328-68470-storckensohn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68328-68470-storckensohn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68328-68470-storckensohn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68328-68470-storckensohn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68329-68140-stosswihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68329-68140-stosswihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68329-68140-stosswihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68329-68140-stosswihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68330-68580-strueth/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68330-68580-strueth/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68330-68580-strueth/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68330-68580-strueth/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68331-68280-sundhoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68331-68280-sundhoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68331-68280-sundhoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68331-68280-sundhoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68332-68720-tagolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68332-68720-tagolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68332-68720-tagolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68332-68720-tagolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68333-68130-tagsdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68333-68130-tagsdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68333-68130-tagsdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68333-68130-tagsdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68334-68800-thann/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68334-68800-thann/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68334-68800-thann/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68334-68800-thann/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68335-68590-thannenkirch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68335-68590-thannenkirch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68335-68590-thannenkirch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68335-68590-thannenkirch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68336-68210-traubach_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68336-68210-traubach_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68336-68210-traubach_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68336-68210-traubach_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68337-68210-traubach_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68337-68210-traubach_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68337-68210-traubach_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68337-68210-traubach_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68230-turckheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68230-turckheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68230-turckheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68230-turckheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68910-turckheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68910-turckheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68910-turckheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68910-turckheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68410-turckheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68410-turckheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68410-turckheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68338-68410-turckheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68340-68580-ueberstrass/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68340-68580-ueberstrass/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68340-68580-ueberstrass/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68340-68580-ueberstrass/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68341-68510-uffheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68341-68510-uffheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68341-68510-uffheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68341-68510-uffheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68342-68700-uffholtz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68342-68700-uffholtz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68342-68700-uffholtz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68342-68700-uffholtz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68343-68190-ungersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68343-68190-ungersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68343-68190-ungersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68343-68190-ungersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68344-68121-urbes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68344-68121-urbes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68344-68121-urbes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68344-68121-urbes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68345-68320-urschenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68345-68320-urschenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68345-68320-urschenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68345-68320-urschenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68347-68480-vieux_ferrette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68347-68480-vieux_ferrette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68347-68480-vieux_ferrette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68347-68480-vieux_ferrette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68348-68800-vieux_thann/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68348-68800-vieux_thann/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68348-68800-vieux_thann/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68348-68800-vieux_thann/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68349-68128-village_neuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68349-68128-village_neuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68349-68128-village_neuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68349-68128-village_neuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68350-68420-voegtlinshoffen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68350-68420-voegtlinshoffen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68350-68420-voegtlinshoffen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68350-68420-voegtlinshoffen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68351-68600-vogelgrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68351-68600-vogelgrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68351-68600-vogelgrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68351-68600-vogelgrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68352-68600-volgelsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68352-68600-volgelsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68352-68600-volgelsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68352-68600-volgelsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68353-68130-wahlbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68353-68130-wahlbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68353-68130-wahlbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68353-68130-wahlbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68354-68230-walbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68354-68230-walbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68354-68230-walbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68354-68230-walbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68355-68640-waldighofen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68355-68640-waldighofen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68355-68640-waldighofen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68355-68640-waldighofen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68356-68130-walheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68356-68130-walheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68356-68130-walheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68356-68130-walheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68357-68510-waltenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68357-68510-waltenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68357-68510-waltenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68357-68510-waltenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68358-68230-wasserbourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68358-68230-wasserbourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68358-68230-wasserbourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68358-68230-wasserbourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68359-68700-wattwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68359-68700-wattwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68359-68700-wattwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68359-68700-wattwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68360-68600-weckolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68360-68600-weckolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68360-68600-weckolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68360-68600-weckolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68361-68290-wegscheid/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68361-68290-wegscheid/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68361-68290-wegscheid/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68361-68290-wegscheid/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68362-68220-wentzwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68362-68220-wentzwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68362-68220-wentzwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68362-68220-wentzwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68363-68480-werentzhouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68363-68480-werentzhouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68363-68480-werentzhouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68363-68480-werentzhouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68364-68250-westhalten/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68364-68250-westhalten/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68364-68250-westhalten/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68364-68250-westhalten/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68365-68920-wettolsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68365-68920-wettolsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68365-68920-wettolsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68365-68920-wettolsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68366-68320-wickerschwihr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68366-68320-wickerschwihr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68366-68320-wickerschwihr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68366-68320-wickerschwihr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68367-68320-widensolen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68367-68320-widensolen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68367-68320-widensolen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68367-68320-widensolen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68368-68230-wihr_au_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68368-68230-wihr_au_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68368-68230-wihr_au_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68368-68230-wihr_au_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68370-68820-wildenstein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68370-68820-wildenstein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68370-68820-wildenstein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68370-68820-wildenstein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68371-68960-willer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68371-68960-willer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68371-68960-willer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68371-68960-willer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68372-68760-willer_sur_thur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68372-68760-willer_sur_thur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68372-68760-willer_sur_thur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68372-68760-willer_sur_thur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68373-68480-winkel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68373-68480-winkel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68373-68480-winkel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68373-68480-winkel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68374-68920-wintzenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68374-68920-wintzenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68374-68920-wintzenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68374-68920-wintzenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68374-68124-wintzenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68374-68124-wintzenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68374-68124-wintzenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68374-68124-wintzenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68375-68310-wittelsheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68375-68310-wittelsheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68375-68310-wittelsheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68375-68310-wittelsheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68376-68270-wittenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68376-68270-wittenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68376-68270-wittenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68376-68270-wittenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68377-68130-wittersdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68377-68130-wittersdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68377-68130-wittersdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68377-68130-wittersdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68378-68210-wolfersdorf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68378-68210-wolfersdorf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68378-68210-wolfersdorf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68378-68210-wolfersdorf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68379-68600-wolfgantzen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68379-68600-wolfgantzen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68379-68600-wolfgantzen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68379-68600-wolfgantzen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68380-68480-wolschwiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68380-68480-wolschwiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68380-68480-wolschwiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68380-68480-wolschwiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68381-68500-wuenheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68381-68500-wuenheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68381-68500-wuenheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68381-68500-wuenheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68382-68130-zaessingue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68382-68130-zaessingue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68382-68130-zaessingue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68382-68130-zaessingue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68383-68340-zellenberg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68383-68340-zellenberg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68383-68340-zellenberg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68383-68340-zellenberg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68384-68720-zillisheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68384-68720-zillisheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68384-68720-zillisheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68384-68720-zillisheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68385-68230-zimmerbach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68385-68230-zimmerbach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68385-68230-zimmerbach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68385-68230-zimmerbach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68386-68440-zimmersheim/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68386-68440-zimmersheim/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68386-68440-zimmersheim/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt68-haut_rhin/commune68386-68440-zimmersheim/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-69.xml
+++ b/public/sitemaps/sitemap-69.xml
@@ -5,564 +5,1124 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69001-69170-affoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69001-69170-affoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69001-69170-affoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69001-69170-affoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69002-69790-aigueperse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69002-69790-aigueperse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69002-69790-aigueperse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69002-69790-aigueperse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69003-69250-albigny_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69003-69250-albigny_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69003-69250-albigny_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69003-69250-albigny_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69004-69380-alix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69004-69380-alix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69004-69380-alix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69004-69380-alix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69005-69480-amberieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69005-69480-amberieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69005-69480-amberieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69005-69480-amberieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69006-69550-amplepuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69006-69550-amplepuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69006-69550-amplepuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69006-69550-amplepuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69007-69420-ampuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69007-69420-ampuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69007-69420-ampuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69007-69420-ampuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69008-69490-ancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69008-69490-ancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69008-69490-ancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69008-69490-ancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69009-69480-anse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69009-69480-anse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69009-69480-anse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69009-69480-anse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69010-69210-l_arbresle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69010-69210-l_arbresle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69010-69210-l_arbresle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69010-69210-l_arbresle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69012-69430-les_ardillats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69012-69430-les_ardillats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69012-69430-les_ardillats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69012-69430-les_ardillats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69013-69400-arnas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69013-69400-arnas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69013-69400-arnas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69013-69400-arnas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69014-69610-aveize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69014-69610-aveize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69014-69610-aveize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69014-69610-aveize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69016-69790-azolette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69016-69790-azolette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69016-69790-azolette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69016-69790-azolette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69017-69620-bagnols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69017-69620-bagnols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69017-69620-bagnols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69017-69620-bagnols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69018-69430-beaujeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69018-69430-beaujeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69018-69430-beaujeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69018-69430-beaujeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69019-69220-belleville_en_beaujolais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69019-69220-belleville_en_beaujolais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69019-69220-belleville_en_beaujolais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69019-69220-belleville_en_beaujolais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69020-69380-belmont_d_azergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69020-69380-belmont_d_azergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69020-69380-belmont_d_azergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69020-69380-belmont_d_azergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69021-69690-bessenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69021-69690-bessenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69021-69690-bessenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69021-69690-bessenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69022-69690-bibost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69022-69690-bibost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69022-69690-bibost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69022-69690-bibost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69023-69460-blace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69023-69460-blace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69023-69460-blace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69023-69460-blace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69024-69620-val_d_oingt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69024-69620-val_d_oingt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69024-69620-val_d_oingt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69024-69620-val_d_oingt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69026-69620-le_breuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69026-69620-le_breuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69026-69620-le_breuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69026-69620-le_breuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69027-69530-brignais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69027-69530-brignais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69027-69530-brignais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69027-69530-brignais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69028-69126-brindas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69028-69126-brindas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69028-69126-brindas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69028-69126-brindas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69029-69500-bron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69029-69500-bron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69029-69500-bron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69029-69500-bron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69030-69690-brullioles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69030-69690-brullioles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69030-69690-brullioles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69030-69690-brullioles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69031-69690-brussieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69031-69690-brussieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69031-69690-brussieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69031-69690-brussieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69032-69210-bully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69032-69210-bully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69032-69210-bully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69032-69210-bully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69033-69270-cailloux_sur_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69033-69270-cailloux_sur_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69033-69270-cailloux_sur_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69033-69270-cailloux_sur_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69034-69300-caluire_et_cuire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69034-69300-caluire_et_cuire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69034-69300-caluire_et_cuire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69034-69300-caluire_et_cuire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69035-69840-cenves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69035-69840-cenves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69035-69840-cenves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69035-69840-cenves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69036-69220-cercie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69036-69220-cercie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69036-69220-cercie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69036-69220-cercie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69037-69870-chambost_allieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69037-69870-chambost_allieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69037-69870-chambost_allieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69037-69870-chambost_allieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69038-69770-chambost_longessaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69038-69770-chambost_longessaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69038-69770-chambost_longessaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69038-69770-chambost_longessaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69039-69620-chamelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69039-69620-chamelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69039-69620-chamelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69039-69620-chamelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69040-69410-champagne_au_mont_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69040-69410-champagne_au_mont_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69040-69410-champagne_au_mont_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69040-69410-champagne_au_mont_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69042-69590-la_chapelle_sur_coise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69042-69590-la_chapelle_sur_coise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69042-69590-la_chapelle_sur_coise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69042-69590-la_chapelle_sur_coise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69043-69630-chaponost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69043-69630-chaponost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69043-69630-chaponost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69043-69630-chaponost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69044-69260-charbonnieres_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69044-69260-charbonnieres_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69044-69260-charbonnieres_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69044-69260-charbonnieres_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69045-69220-charentay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69045-69220-charentay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69045-69220-charentay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69045-69220-charentay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69046-69390-charly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69046-69390-charly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69046-69390-charly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69046-69390-charly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69047-69380-charnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69047-69380-charnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69047-69380-charnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69047-69380-charnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69049-69380-chasselay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69049-69380-chasselay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69049-69380-chasselay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69049-69380-chasselay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69050-69380-chatillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69050-69380-chatillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69050-69380-chatillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69050-69380-chatillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69051-69440-chaussan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69051-69440-chaussan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69051-69440-chaussan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69051-69440-chaussan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69052-69380-chazay_d_azergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69052-69380-chazay_d_azergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69052-69380-chazay_d_azergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69052-69380-chazay_d_azergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69053-69840-chenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69053-69840-chenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69053-69840-chenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69053-69840-chenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69054-69430-chenelette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69054-69430-chenelette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69054-69430-chenelette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69054-69430-chenelette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69055-69380-les_cheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69055-69380-les_cheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69055-69380-les_cheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69055-69380-les_cheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69056-69380-chessy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69056-69380-chessy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69056-69380-chessy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69056-69380-chessy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69057-69210-chevinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69057-69210-chevinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69057-69210-chevinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69057-69210-chevinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69058-69115-chiroubles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69058-69115-chiroubles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69058-69115-chiroubles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69058-69115-chiroubles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69059-69380-civrieux_d_azergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69059-69380-civrieux_d_azergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69059-69380-civrieux_d_azergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69059-69380-civrieux_d_azergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69060-69870-claveisolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69060-69870-claveisolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69060-69870-claveisolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69060-69870-claveisolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69061-69640-cogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69061-69640-cogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69061-69640-cogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69061-69640-cogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69062-69590-coise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69062-69590-coise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69062-69590-coise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69062-69590-coise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69063-69660-collonges_au_mont_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69063-69660-collonges_au_mont_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69063-69660-collonges_au_mont_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69063-69660-collonges_au_mont_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69064-69420-condrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69064-69420-condrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69064-69420-condrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69064-69420-condrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69065-69220-corcelles_en_beaujolais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69065-69220-corcelles_en_beaujolais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69065-69220-corcelles_en_beaujolais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69065-69220-corcelles_en_beaujolais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69066-69470-cours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69066-69470-cours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69066-69470-cours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69066-69470-cours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69067-69690-courzieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69067-69690-courzieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69067-69690-courzieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69067-69690-courzieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69068-69270-couzon_au_mont_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69068-69270-couzon_au_mont_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69068-69270-couzon_au_mont_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69068-69270-couzon_au_mont_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69069-69290-craponne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69069-69290-craponne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69069-69290-craponne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69069-69290-craponne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69070-69550-cublize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69070-69550-cublize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69070-69550-cublize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69070-69550-cublize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69071-69250-curis_au_mont_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69071-69250-curis_au_mont_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69071-69250-curis_au_mont_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69071-69250-curis_au_mont_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69072-69570-dardilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69072-69570-dardilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69072-69570-dardilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69072-69570-dardilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69074-69640-denice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69074-69640-denice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69074-69640-denice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69074-69640-denice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69075-69170-dieme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69075-69170-dieme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69075-69170-dieme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69075-69170-dieme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69076-69380-dommartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69076-69380-dommartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69076-69380-dommartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69076-69380-dommartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69077-69220-drace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69077-69220-drace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69077-69220-drace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69077-69220-drace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69078-69850-duerne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69078-69850-duerne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69078-69850-duerne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69078-69850-duerne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69080-69700-echalas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69080-69700-echalas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69080-69700-echalas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69080-69700-echalas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69081-69130-ecully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69081-69130-ecully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69081-69130-ecully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69081-69130-ecully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69082-69840-emeringes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69082-69840-emeringes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69082-69840-emeringes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69082-69840-emeringes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69083-69210-eveux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69083-69210-eveux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69083-69210-eveux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69083-69210-eveux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69084-69820-fleurie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69084-69820-fleurie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69084-69820-fleurie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69084-69820-fleurie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69085-69250-fleurieu_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69085-69250-fleurieu_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69085-69250-fleurieu_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69085-69250-fleurieu_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69086-69210-fleurieux_sur_l_arbresle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69086-69210-fleurieux_sur_l_arbresle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69086-69210-fleurieux_sur_l_arbresle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69086-69210-fleurieux_sur_l_arbresle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69087-69270-fontaines_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69087-69270-fontaines_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69087-69270-fontaines_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69087-69270-fontaines_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69088-69270-fontaines_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69088-69270-fontaines_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69088-69270-fontaines_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69088-69270-fontaines_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69089-69340-francheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69089-69340-francheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69089-69340-francheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69089-69340-francheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69090-69620-frontenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69090-69620-frontenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69090-69620-frontenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69090-69620-frontenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69091-69700-givors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69091-69700-givors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69091-69700-givors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69091-69700-givors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69092-69400-gleize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69092-69400-gleize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69092-69400-gleize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69092-69400-gleize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69093-69870-grandris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69093-69870-grandris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69093-69870-grandris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69093-69870-grandris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69094-69290-grezieu_la_varenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69094-69290-grezieu_la_varenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69094-69290-grezieu_la_varenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69094-69290-grezieu_la_varenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69095-69610-grezieu_le_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69095-69610-grezieu_le_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69095-69610-grezieu_le_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69095-69610-grezieu_le_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69096-69520-grigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69096-69520-grigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69096-69520-grigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69096-69520-grigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69097-69420-les_haies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69097-69420-les_haies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69097-69420-les_haies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69097-69420-les_haies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69098-69610-les_halles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69098-69610-les_halles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69098-69610-les_halles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69098-69610-les_halles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69099-69610-haute_rivoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69099-69610-haute_rivoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69099-69610-haute_rivoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69099-69610-haute_rivoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69100-69540-irigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69100-69540-irigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69100-69540-irigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69100-69540-irigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69102-69170-joux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69102-69170-joux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69102-69170-joux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69102-69170-joux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69103-69840-julienas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69103-69840-julienas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69103-69840-julienas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69103-69840-julienas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69104-69840-jullie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69104-69840-jullie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69104-69840-jullie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69104-69840-jullie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69105-69640-lacenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69105-69640-lacenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69105-69640-lacenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69105-69640-lacenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69106-69480-lachassagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69106-69480-lachassagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69106-69480-lachassagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69106-69480-lachassagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69107-69870-lamure_sur_azergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69107-69870-lamure_sur_azergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69107-69870-lamure_sur_azergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69107-69870-lamure_sur_azergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69108-69220-lancie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69108-69220-lancie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69108-69220-lancie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69108-69220-lancie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69109-69430-lantignie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69109-69430-lantignie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69109-69430-lantignie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69109-69430-lantignie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69110-69590-larajasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69110-69590-larajasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69110-69590-larajasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69110-69590-larajasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69111-69620-legny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69111-69620-legny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69111-69620-legny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69111-69620-legny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69112-69210-lentilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69112-69210-lentilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69112-69210-lentilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69112-69210-lentilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69113-69620-letra/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69113-69620-letra/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69113-69620-letra/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69113-69620-letra/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69115-69400-limas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69115-69400-limas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69115-69400-limas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69115-69400-limas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69116-69760-limonest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69116-69760-limonest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69116-69760-limonest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69116-69760-limonest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69117-69380-lissieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69117-69380-lissieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69117-69380-lissieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69117-69380-lissieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69118-69700-loire_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69118-69700-loire_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69118-69700-loire_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69118-69700-loire_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69119-69420-longes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69119-69420-longes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69119-69420-longes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69119-69420-longes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69120-69770-longessaigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69120-69770-longessaigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69120-69770-longessaigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69120-69770-longessaigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69121-69380-lozanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69121-69380-lozanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69121-69380-lozanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69121-69380-lozanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69122-69480-lucenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69122-69480-lucenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69122-69480-lucenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69122-69480-lucenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69001-lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69001-lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69001-lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69001-lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69002-lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69002-lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69002-lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69002-lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69003-lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69003-lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69003-lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69003-lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69004-lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69004-lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69004-lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69004-lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69005-lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69005-lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69005-lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69005-lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69006-lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69006-lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69006-lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69006-lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69007-lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69007-lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69007-lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69007-lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69008-lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69008-lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69008-lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69008-lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69009-lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69009-lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69009-lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69123-69009-lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69124-69430-marchampt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69124-69430-marchampt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69124-69430-marchampt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69124-69430-marchampt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69125-69380-marcilly_d_azergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69125-69380-marcilly_d_azergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69125-69380-marcilly_d_azergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69125-69380-marcilly_d_azergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69126-69480-marcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69126-69480-marcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69126-69480-marcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69126-69480-marcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69127-69280-marcy_l_etoile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69127-69280-marcy_l_etoile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69127-69280-marcy_l_etoile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69127-69280-marcy_l_etoile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69130-69550-meaux_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69130-69550-meaux_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69130-69550-meaux_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69130-69550-meaux_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69131-69510-messimy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69131-69510-messimy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69131-69510-messimy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69131-69510-messimy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69132-69610-meys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69132-69610-meys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69132-69610-meys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69132-69610-meys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69133-69390-millery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69133-69390-millery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69133-69390-millery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69133-69390-millery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69134-69620-moire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69134-69620-moire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69134-69620-moire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69134-69620-moire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69135-69860-deux_grosnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69135-69860-deux_grosnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69135-69860-deux_grosnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69135-69860-deux_grosnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69135-69430-deux_grosnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69135-69430-deux_grosnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69135-69430-deux_grosnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69135-69430-deux_grosnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69136-69700-montagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69136-69700-montagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69136-69700-montagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69136-69700-montagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69137-69640-montmelas_saint_sorlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69137-69640-montmelas_saint_sorlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69137-69640-montmelas_saint_sorlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69137-69640-montmelas_saint_sorlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69138-69610-montromant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69138-69610-montromant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69138-69610-montromant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69138-69610-montromant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69139-69770-montrottier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69139-69770-montrottier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69139-69770-montrottier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69139-69770-montrottier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69140-69480-morance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69140-69480-morance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69140-69480-morance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69140-69480-morance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69141-69440-mornant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69141-69440-mornant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69141-69440-mornant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69141-69440-mornant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69142-69350-la_mulatiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69142-69350-la_mulatiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69142-69350-la_mulatiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69142-69350-la_mulatiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69143-69250-neuville_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69143-69250-neuville_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69143-69250-neuville_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69143-69250-neuville_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69145-69460-odenas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69145-69460-odenas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69145-69460-odenas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69145-69460-odenas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69148-69530-orlienas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69148-69530-orlienas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69148-69530-orlienas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69148-69530-orlienas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69149-69600-oullins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69149-69600-oullins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69149-69600-oullins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69149-69600-oullins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69151-69460-le_perreon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69151-69460-le_perreon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69151-69460-le_perreon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69151-69460-le_perreon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69152-69310-pierre_benite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69152-69310-pierre_benite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69152-69310-pierre_benite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69152-69310-pierre_benite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69153-69250-poleymieux_au_mont_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69153-69250-poleymieux_au_mont_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69153-69250-poleymieux_au_mont_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69153-69250-poleymieux_au_mont_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69154-69290-pollionnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69154-69290-pollionnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69154-69290-pollionnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69154-69290-pollionnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69155-69590-pomeys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69155-69590-pomeys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69155-69590-pomeys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69155-69590-pomeys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69156-69480-pommiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69156-69480-pommiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69156-69480-pommiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69156-69480-pommiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69157-69490-vindry_sur_turdine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69157-69490-vindry_sur_turdine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69157-69490-vindry_sur_turdine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69157-69490-vindry_sur_turdine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69159-69400-porte_des_pierres_dorees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69159-69400-porte_des_pierres_dorees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69159-69400-porte_des_pierres_dorees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69159-69400-porte_des_pierres_dorees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69159-69640-porte_des_pierres_dorees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69159-69640-porte_des_pierres_dorees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69159-69640-porte_des_pierres_dorees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69159-69640-porte_des_pierres_dorees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69160-69870-poule_les_echarmeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69160-69870-poule_les_echarmeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69160-69870-poule_les_echarmeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69160-69870-poule_les_echarmeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69161-69790-propieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69161-69790-propieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69161-69790-propieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69161-69790-propieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69162-69430-quincie_en_beaujolais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69162-69430-quincie_en_beaujolais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69162-69430-quincie_en_beaujolais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69162-69430-quincie_en_beaujolais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69163-69650-quincieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69163-69650-quincieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69163-69650-quincieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69163-69650-quincieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69164-69470-ranchal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69164-69470-ranchal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69164-69470-ranchal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69164-69470-ranchal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69165-69430-regnie_durette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69165-69430-regnie_durette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69165-69430-regnie_durette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69165-69430-regnie_durette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69166-69440-riverie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69166-69440-riverie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69166-69440-riverie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69166-69440-riverie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69167-69640-rivolet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69167-69640-rivolet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69167-69640-rivolet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69167-69640-rivolet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69168-69270-rochetaillee_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69168-69270-rochetaillee_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69168-69270-rochetaillee_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69168-69270-rochetaillee_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69169-69550-ronno/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69169-69550-ronno/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69169-69550-ronno/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69169-69550-ronno/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69170-69510-rontalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69170-69510-rontalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69170-69510-rontalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69170-69510-rontalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69171-69210-sain_bel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69171-69210-sain_bel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69171-69210-sain_bel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69171-69210-sain_bel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69172-69460-salles_arbuissonnas_en_beaujolais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69172-69460-salles_arbuissonnas_en_beaujolais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69172-69460-salles_arbuissonnas_en_beaujolais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69172-69460-salles_arbuissonnas_en_beaujolais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69173-69490-sarcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69173-69490-sarcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69173-69490-sarcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69173-69490-sarcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69174-69170-les_sauvages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69174-69170-les_sauvages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69174-69170-les_sauvages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69174-69170-les_sauvages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69175-69210-savigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69175-69210-savigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69175-69210-savigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69175-69210-savigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69176-69510-soucieu_en_jarrest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69176-69510-soucieu_en_jarrest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69176-69510-soucieu_en_jarrest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69176-69510-soucieu_en_jarrest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69177-69210-sourcieux_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69177-69210-sourcieux_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69177-69210-sourcieux_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69177-69210-sourcieux_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69178-69610-souzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69178-69610-souzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69178-69610-souzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69178-69610-souzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69179-69700-beauvallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69179-69700-beauvallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69179-69700-beauvallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69179-69700-beauvallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69180-69440-saint_andre_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69180-69440-saint_andre_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69180-69440-saint_andre_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69180-69440-saint_andre_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69181-69170-saint_appolinaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69181-69170-saint_appolinaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69181-69170-saint_appolinaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69181-69170-saint_appolinaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69182-69790-saint_bonnet_des_bruyeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69182-69790-saint_bonnet_des_bruyeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69182-69790-saint_bonnet_des_bruyeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69182-69790-saint_bonnet_des_bruyeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69183-69870-saint_bonnet_le_troncy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69183-69870-saint_bonnet_le_troncy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69183-69870-saint_bonnet_le_troncy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69183-69870-saint_bonnet_le_troncy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69184-69440-sainte_catherine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69184-69440-sainte_catherine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69184-69440-sainte_catherine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69184-69440-sainte_catherine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69186-69790-saint_clement_de_vers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69186-69790-saint_clement_de_vers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69186-69790-saint_clement_de_vers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69186-69790-saint_clement_de_vers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69187-69930-saint_clement_les_places/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69187-69930-saint_clement_les_places/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69187-69930-saint_clement_les_places/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69187-69930-saint_clement_les_places/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69188-69170-saint_clement_sur_valsonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69188-69170-saint_clement_sur_valsonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69188-69170-saint_clement_sur_valsonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69188-69170-saint_clement_sur_valsonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69189-69560-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69189-69560-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69189-69560-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69189-69560-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69190-69280-sainte_consorce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69190-69280-sainte_consorce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69190-69280-sainte_consorce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69190-69280-sainte_consorce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69191-69450-saint_cyr_au_mont_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69191-69450-saint_cyr_au_mont_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69191-69450-saint_cyr_au_mont_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69191-69450-saint_cyr_au_mont_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69192-69870-saint_cyr_le_chatoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69192-69870-saint_cyr_le_chatoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69192-69870-saint_cyr_le_chatoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69192-69870-saint_cyr_le_chatoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69193-69560-saint_cyr_sur_le_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69193-69560-saint_cyr_sur_le_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69193-69560-saint_cyr_sur_le_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69193-69560-saint_cyr_sur_le_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69194-69370-saint_didier_au_mont_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69194-69370-saint_didier_au_mont_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69194-69370-saint_didier_au_mont_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69194-69370-saint_didier_au_mont_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69196-69430-saint_didier_sur_beaujeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69196-69430-saint_didier_sur_beaujeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69196-69430-saint_didier_sur_beaujeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69196-69430-saint_didier_sur_beaujeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69197-69460-saint_etienne_des_oullieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69197-69460-saint_etienne_des_oullieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69197-69460-saint_etienne_des_oullieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69197-69460-saint_etienne_des_oullieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69198-69460-saint_etienne_la_varenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69198-69460-saint_etienne_la_varenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69198-69460-saint_etienne_la_varenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69198-69460-saint_etienne_la_varenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69199-69190-saint_fons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69199-69190-saint_fons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69199-69190-saint_fons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69199-69190-saint_fons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69200-69490-saint_forgeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69200-69490-saint_forgeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69200-69490-saint_forgeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69200-69490-saint_forgeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69201-69610-sainte_foy_l_argentiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69201-69610-sainte_foy_l_argentiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69201-69610-sainte_foy_l_argentiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69201-69610-sainte_foy_l_argentiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69202-69110-sainte_foy_les_lyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69202-69110-sainte_foy_les_lyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69202-69110-sainte_foy_les_lyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69202-69110-sainte_foy_les_lyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69203-69610-saint_genis_l_argentiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69203-69610-saint_genis_l_argentiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69203-69610-saint_genis_l_argentiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69203-69610-saint_genis_l_argentiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69204-69230-saint_genis_laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69204-69230-saint_genis_laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69204-69230-saint_genis_laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69204-69230-saint_genis_laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69205-69290-saint_genis_les_ollieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69205-69290-saint_genis_les_ollieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69205-69290-saint_genis_les_ollieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69205-69290-saint_genis_les_ollieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69206-69830-saint_georges_de_reneins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69206-69830-saint_georges_de_reneins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69206-69830-saint_georges_de_reneins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69206-69830-saint_georges_de_reneins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69207-69650-saint_germain_au_mont_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69207-69650-saint_germain_au_mont_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69207-69650-saint_germain_au_mont_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69207-69650-saint_germain_au_mont_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69208-69210-saint_germain_nuelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69208-69210-saint_germain_nuelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69208-69210-saint_germain_nuelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69208-69210-saint_germain_nuelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69209-69790-saint_igny_de_vers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69209-69790-saint_igny_de_vers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69209-69790-saint_igny_de_vers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69209-69790-saint_igny_de_vers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69212-69380-saint_jean_des_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69212-69380-saint_jean_des_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69212-69380-saint_jean_des_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69212-69380-saint_jean_des_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69214-69550-saint_jean_la_bussiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69214-69550-saint_jean_la_bussiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69214-69550-saint_jean_la_bussiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69214-69550-saint_jean_la_bussiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69215-69640-saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69215-69640-saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69215-69640-saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69215-69640-saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69216-69690-saint_julien_sur_bibost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69216-69690-saint_julien_sur_bibost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69216-69690-saint_julien_sur_bibost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69216-69690-saint_julien_sur_bibost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69217-69870-saint_just_d_avray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69217-69870-saint_just_d_avray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69217-69870-saint_just_d_avray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69217-69870-saint_just_d_avray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69218-69220-saint_lager/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69218-69220-saint_lager/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69218-69220-saint_lager/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69218-69220-saint_lager/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69219-69440-saint_laurent_d_agny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69219-69440-saint_laurent_d_agny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69219-69440-saint_laurent_d_agny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69219-69440-saint_laurent_d_agny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69220-69930-saint_laurent_de_chamousset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69220-69930-saint_laurent_de_chamousset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69220-69930-saint_laurent_de_chamousset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69220-69930-saint_laurent_de_chamousset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69225-69170-saint_marcel_l_eclaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69225-69170-saint_marcel_l_eclaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69225-69170-saint_marcel_l_eclaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69225-69170-saint_marcel_l_eclaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69227-69850-saint_martin_en_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69227-69850-saint_martin_en_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69227-69850-saint_martin_en_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69227-69850-saint_martin_en_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69228-69440-chabaniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69228-69440-chabaniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69228-69440-chabaniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69228-69440-chabaniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69229-69870-saint_nizier_d_azergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69229-69870-saint_nizier_d_azergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69229-69870-saint_nizier_d_azergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69229-69870-saint_nizier_d_azergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69230-69620-sainte_paule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69230-69620-sainte_paule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69230-69620-sainte_paule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69230-69620-sainte_paule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69231-69210-saint_pierre_la_palud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69231-69210-saint_pierre_la_palud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69231-69210-saint_pierre_la_palud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69231-69210-saint_pierre_la_palud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69233-69270-saint_romain_au_mont_d_or/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69233-69270-saint_romain_au_mont_d_or/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69233-69270-saint_romain_au_mont_d_or/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69233-69270-saint_romain_au_mont_d_or/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69234-69490-saint_romain_de_popey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69234-69490-saint_romain_de_popey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69234-69490-saint_romain_de_popey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69234-69490-saint_romain_de_popey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69235-69560-saint_romain_en_gal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69235-69560-saint_romain_en_gal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69235-69560-saint_romain_en_gal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69235-69560-saint_romain_en_gal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69236-69700-saint_romain_en_gier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69236-69700-saint_romain_en_gier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69236-69700-saint_romain_en_gier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69236-69700-saint_romain_en_gier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69238-69590-saint_symphorien_sur_coise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69238-69590-saint_symphorien_sur_coise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69238-69590-saint_symphorien_sur_coise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69238-69590-saint_symphorien_sur_coise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69239-69620-saint_verand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69239-69620-saint_verand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69239-69620-saint_verand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69239-69620-saint_verand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69240-69240-saint_vincent_de_reins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69240-69240-saint_vincent_de_reins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69240-69240-saint_vincent_de_reins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69240-69240-saint_vincent_de_reins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69241-69440-taluyers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69241-69440-taluyers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69241-69440-taluyers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69241-69440-taluyers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69242-69220-taponas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69242-69220-taponas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69242-69220-taponas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69242-69220-taponas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69243-69170-tarare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69243-69170-tarare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69243-69170-tarare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69243-69170-tarare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69244-69160-tassin_la_demi_lune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69244-69160-tassin_la_demi_lune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69244-69160-tassin_la_demi_lune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69244-69160-tassin_la_demi_lune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69245-69620-ternand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69245-69620-ternand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69245-69620-ternand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69245-69620-ternand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69246-69620-theize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69246-69620-theize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69246-69620-theize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69246-69620-theize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69248-69240-thizy_les_bourgs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69248-69240-thizy_les_bourgs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69248-69240-thizy_les_bourgs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69248-69240-thizy_les_bourgs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69249-69510-thurins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69249-69510-thurins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69249-69510-thurins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69249-69510-thurins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69250-69890-la_tour_de_salvagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69250-69890-la_tour_de_salvagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69250-69890-la_tour_de_salvagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69250-69890-la_tour_de_salvagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69252-69420-treves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69252-69420-treves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69252-69420-treves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69252-69420-treves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69253-69420-tupin_et_semons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69253-69420-tupin_et_semons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69253-69420-tupin_et_semons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69253-69420-tupin_et_semons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69254-69170-valsonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69254-69170-valsonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69254-69170-valsonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69254-69170-valsonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69255-69670-vaugneray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69255-69670-vaugneray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69255-69670-vaugneray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69255-69670-vaugneray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69256-69120-vaulx_en_velin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69256-69120-vaulx_en_velin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69256-69120-vaulx_en_velin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69256-69120-vaulx_en_velin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69257-69460-vaux_en_beaujolais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69257-69460-vaux_en_beaujolais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69257-69460-vaux_en_beaujolais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69257-69460-vaux_en_beaujolais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69258-69820-vauxrenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69258-69820-vauxrenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69258-69820-vauxrenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69258-69820-vauxrenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69259-69200-venissieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69259-69200-venissieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69259-69200-venissieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69259-69200-venissieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69260-69390-vernaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69260-69390-vernaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69260-69390-vernaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69260-69390-vernaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69261-69430-vernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69261-69430-vernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69261-69430-vernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69261-69430-vernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69263-69770-villecheneve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69263-69770-villecheneve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69263-69770-villecheneve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69263-69770-villecheneve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69264-69400-villefranche_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69264-69400-villefranche_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69264-69400-villefranche_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69264-69400-villefranche_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69265-69640-ville_sur_jarnioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69265-69640-ville_sur_jarnioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69265-69640-ville_sur_jarnioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69265-69640-ville_sur_jarnioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69266-69100-villeurbanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69266-69100-villeurbanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69266-69100-villeurbanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69266-69100-villeurbanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69267-69910-villie_morgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69267-69910-villie_morgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69267-69910-villie_morgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69267-69910-villie_morgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69268-69390-vourles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69268-69390-vourles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69268-69390-vourles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69268-69390-vourles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69269-69510-yzeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69269-69510-yzeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69269-69510-yzeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69269-69510-yzeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69270-69970-chaponnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69270-69970-chaponnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69270-69970-chaponnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69270-69970-chaponnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69271-69680-chassieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69271-69680-chassieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69271-69680-chassieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69271-69680-chassieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69272-69360-communay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69272-69360-communay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69272-69360-communay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69272-69360-communay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69273-69960-corbas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69273-69960-corbas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69273-69960-corbas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69273-69960-corbas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69275-69150-decines_charpieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69275-69150-decines_charpieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69275-69150-decines_charpieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69275-69150-decines_charpieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69276-69320-feyzin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69276-69320-feyzin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69276-69320-feyzin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69276-69320-feyzin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69277-69740-genas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69277-69740-genas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69277-69740-genas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69277-69740-genas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69278-69730-genay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69278-69730-genay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69278-69730-genay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69278-69730-genay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69279-69330-jonage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69279-69330-jonage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69279-69330-jonage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69279-69330-jonage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69280-69330-jons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69280-69330-jons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69280-69330-jons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69280-69330-jons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69281-69970-marennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69281-69970-marennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69281-69970-marennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69281-69970-marennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69282-69330-meyzieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69282-69330-meyzieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69282-69330-meyzieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69282-69330-meyzieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69283-69780-mions/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69283-69780-mions/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69283-69780-mions/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69283-69780-mions/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69284-69250-montanay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69284-69250-montanay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69284-69250-montanay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69284-69250-montanay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69285-69330-pusignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69285-69330-pusignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69285-69330-pusignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69285-69330-pusignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69286-69140-rillieux_la_pape/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69286-69140-rillieux_la_pape/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69286-69140-rillieux_la_pape/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69286-69140-rillieux_la_pape/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69287-69720-saint_bonnet_de_mure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69287-69720-saint_bonnet_de_mure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69287-69720-saint_bonnet_de_mure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69287-69720-saint_bonnet_de_mure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69288-69720-saint_laurent_de_mure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69288-69720-saint_laurent_de_mure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69288-69720-saint_laurent_de_mure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69288-69720-saint_laurent_de_mure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69289-69780-saint_pierre_de_chandieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69289-69780-saint_pierre_de_chandieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69289-69780-saint_pierre_de_chandieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69289-69780-saint_pierre_de_chandieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69290-69800-saint_priest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69290-69800-saint_priest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69290-69800-saint_priest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69290-69800-saint_priest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69360-saint_symphorien_d_ozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69360-saint_symphorien_d_ozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69360-saint_symphorien_d_ozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69360-saint_symphorien_d_ozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69320-saint_symphorien_d_ozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69320-saint_symphorien_d_ozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69320-saint_symphorien_d_ozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69320-saint_symphorien_d_ozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69960-saint_symphorien_d_ozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69960-saint_symphorien_d_ozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69960-saint_symphorien_d_ozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69291-69960-saint_symphorien_d_ozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69292-69580-sathonay_camp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69292-69580-sathonay_camp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69292-69580-sathonay_camp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69292-69580-sathonay_camp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69293-69580-sathonay_village/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69293-69580-sathonay_village/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69293-69580-sathonay_village/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69293-69580-sathonay_village/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69294-69360-serezin_du_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69294-69360-serezin_du_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69294-69360-serezin_du_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69294-69360-serezin_du_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69295-69360-simandres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69295-69360-simandres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69295-69360-simandres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69295-69360-simandres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69296-69360-solaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69296-69360-solaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69296-69360-solaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69296-69360-solaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69297-69360-ternay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69297-69360-ternay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69297-69360-ternay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69297-69360-ternay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69298-69780-toussieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69298-69780-toussieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69298-69780-toussieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69298-69780-toussieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69299-69124-colombier_saugnieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69299-69124-colombier_saugnieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69299-69124-colombier_saugnieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt69-rhone/commune69299-69124-colombier_saugnieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-70.xml
+++ b/public/sitemaps/sitemap-70.xml
@@ -5,1090 +5,2176 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70001-70300-abelcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70001-70300-abelcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70001-70300-abelcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70001-70300-abelcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70002-70500-aboncourt_gesincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70002-70500-aboncourt_gesincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70002-70500-aboncourt_gesincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70002-70500-aboncourt_gesincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70003-70180-achey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70003-70180-achey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70003-70180-achey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70003-70180-achey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70004-70200-adelans_et_le_val_de_bithaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70004-70200-adelans_et_le_val_de_bithaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70004-70200-adelans_et_le_val_de_bithaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70004-70200-adelans_et_le_val_de_bithaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70005-70110-aillevans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70005-70110-aillevans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70005-70110-aillevans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70005-70110-aillevans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70006-70320-aillevillers_et_lyaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70006-70320-aillevillers_et_lyaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70006-70320-aillevillers_et_lyaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70006-70320-aillevillers_et_lyaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70007-70300-ailloncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70007-70300-ailloncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70007-70300-ailloncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70007-70300-ailloncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70008-70800-ainvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70008-70800-ainvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70008-70800-ainvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70008-70800-ainvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70009-70500-aisey_et_richecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70009-70500-aisey_et_richecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70009-70500-aisey_et_richecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70009-70500-aisey_et_richecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70010-70210-alaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70010-70210-alaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70010-70210-alaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70010-70210-alaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70011-70280-amage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70011-70280-amage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70011-70280-amage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70011-70280-amage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70012-70160-amance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70012-70160-amance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70012-70160-amance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70012-70160-amance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70013-70210-ambievillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70013-70210-ambievillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70013-70210-ambievillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70013-70210-ambievillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70014-70200-amblans_et_velotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70014-70200-amblans_et_velotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70014-70200-amblans_et_velotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70014-70200-amblans_et_velotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70015-70170-amoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70015-70170-amoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70015-70170-amoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70015-70170-amoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70016-70310-amont_et_effreney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70016-70310-amont_et_effreney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70016-70310-amont_et_effreney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70016-70310-amont_et_effreney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70017-70210-anchenoncourt_et_chazel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70017-70210-anchenoncourt_et_chazel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70017-70210-anchenoncourt_et_chazel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70017-70210-anchenoncourt_et_chazel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70018-70100-ancier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70018-70100-ancier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70018-70100-ancier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70018-70100-ancier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70019-70000-andelarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70019-70000-andelarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70019-70000-andelarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70019-70000-andelarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70020-70000-andelarrot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70020-70000-andelarrot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70020-70000-andelarrot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70020-70000-andelarrot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70021-70200-andornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70021-70200-andornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70021-70200-andornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70021-70200-andornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70022-70700-angirey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70022-70700-angirey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70022-70700-angirey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70022-70700-angirey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70023-70800-anjeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70023-70800-anjeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70023-70800-anjeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70023-70800-anjeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70024-70100-apremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70024-70100-apremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70024-70100-apremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70024-70100-apremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70025-70120-arbecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70025-70120-arbecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70025-70120-arbecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70025-70120-arbecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70026-70100-arc_les_gray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70026-70100-arc_les_gray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70026-70100-arc_les_gray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70026-70100-arc_les_gray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70027-70600-argillieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70027-70600-argillieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70027-70600-argillieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70027-70600-argillieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70028-70360-aroz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70028-70360-aroz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70028-70360-aroz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70028-70360-aroz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70029-70200-arpenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70029-70200-arpenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70029-70200-arpenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70029-70200-arpenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70030-70100-arsans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70030-70100-arsans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70030-70100-arsans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70030-70100-arsans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70031-70110-athesans_etroitefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70031-70110-athesans_etroitefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70031-70110-athesans_etroitefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70031-70110-athesans_etroitefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70032-70100-attricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70032-70100-attricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70032-70100-attricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70032-70100-attricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70035-70500-augicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70035-70500-augicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70035-70500-augicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70035-70500-augicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70036-70190-aulx_les_cromary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70036-70190-aulx_les_cromary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70036-70190-aulx_les_cromary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70036-70190-aulx_les_cromary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70037-70180-autet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70037-70180-autet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70037-70180-autet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70037-70180-autet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70038-70190-authoison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70038-70190-authoison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70038-70190-authoison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70038-70190-authoison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70039-70700-autoreille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70039-70700-autoreille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70039-70700-autoreille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70039-70700-autoreille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70040-70110-autrey_les_cerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70040-70110-autrey_les_cerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70040-70110-autrey_les_cerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70040-70110-autrey_les_cerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70041-70100-autrey_les_gray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70041-70100-autrey_les_gray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70041-70100-autrey_les_gray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70041-70100-autrey_les_gray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70042-70110-autrey_le_vay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70042-70110-autrey_le_vay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70042-70110-autrey_le_vay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70042-70110-autrey_le_vay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70043-70100-auvet_et_la_chapelotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70043-70100-auvet_et_la_chapelotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70043-70100-auvet_et_la_chapelotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70043-70100-auvet_et_la_chapelotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70044-70000-auxon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70044-70000-auxon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70044-70000-auxon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70044-70000-auxon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70045-70150-avrigney_virey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70045-70150-avrigney_virey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70045-70150-avrigney_virey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70045-70150-avrigney_virey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70046-70200-les_aynans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70046-70200-les_aynans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70046-70200-les_aynans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70046-70200-les_aynans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70047-70000-baignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70047-70000-baignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70047-70000-baignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70047-70000-baignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70048-70140-bard_les_pesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70048-70140-bard_les_pesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70048-70140-bard_les_pesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70048-70140-bard_les_pesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70049-70500-barges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70049-70500-barges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70049-70500-barges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70049-70500-barges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70050-70190-la_barre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70050-70190-la_barre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70050-70190-la_barre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70050-70190-la_barre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70051-70210-la_basse_vaivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70051-70210-la_basse_vaivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70051-70210-la_basse_vaivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70051-70210-la_basse_vaivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70052-70800-bassigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70052-70800-bassigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70052-70800-bassigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70052-70800-bassigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70053-70130-les_baties/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70053-70130-les_baties/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70053-70130-les_baties/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70053-70130-les_baties/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70054-70100-battrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70054-70100-battrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70054-70100-battrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70054-70100-battrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70055-70300-baudoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70055-70300-baudoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70055-70300-baudoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70055-70300-baudoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70056-70160-baulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70056-70160-baulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70056-70160-baulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70056-70160-baulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70057-70150-bay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70057-70150-bay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70057-70150-bay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70057-70150-bay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70058-70100-beaujeu_saint_vallier_pierrejux_et_quitteur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70058-70100-beaujeu_saint_vallier_pierrejux_et_quitteur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70058-70100-beaujeu_saint_vallier_pierrejux_et_quitteur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70058-70100-beaujeu_saint_vallier_pierrejux_et_quitteur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70059-70190-beaumotte_aubertans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70059-70190-beaumotte_aubertans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70059-70190-beaumotte_aubertans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70059-70190-beaumotte_aubertans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70060-70150-beaumotte_les_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70060-70150-beaumotte_les_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70060-70150-beaumotte_les_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70060-70150-beaumotte_les_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70061-70290-belfahy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70061-70290-belfahy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70061-70290-belfahy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70061-70290-belfahy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70062-70270-belmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70062-70270-belmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70062-70270-belmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70062-70270-belmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70063-70270-belonchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70063-70270-belonchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70063-70270-belonchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70063-70270-belonchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70064-70400-belverne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70064-70400-belverne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70064-70400-belverne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70064-70400-belverne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70065-70230-besnans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70065-70230-besnans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70065-70230-besnans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70065-70230-besnans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70066-70500-betaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70066-70500-betaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70066-70500-betaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70066-70500-betaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70067-70300-betoncourt_les_brotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70067-70300-betoncourt_les_brotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70067-70300-betoncourt_les_brotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70067-70300-betoncourt_les_brotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70069-70210-betoncourt_saint_pancras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70069-70210-betoncourt_saint_pancras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70069-70210-betoncourt_saint_pancras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70069-70210-betoncourt_saint_pancras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70070-70500-betoncourt_sur_mance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70070-70500-betoncourt_sur_mance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70070-70500-betoncourt_sur_mance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70070-70500-betoncourt_sur_mance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70071-70310-beulotte_saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70071-70310-beulotte_saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70071-70310-beulotte_saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70071-70310-beulotte_saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70072-70110-beveuge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70072-70110-beveuge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70072-70110-beveuge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70072-70110-beveuge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70074-70500-blondefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70074-70500-blondefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70074-70500-blondefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70074-70500-blondefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70075-70150-bonboillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70075-70150-bonboillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70075-70150-bonboillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70075-70150-bonboillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70076-70700-bonnevent_velloreille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70076-70700-bonnevent_velloreille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70076-70700-bonnevent_velloreille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70076-70700-bonnevent_velloreille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70077-70110-borey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70077-70110-borey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70077-70110-borey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70077-70110-borey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70078-70500-bougey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70078-70500-bougey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70078-70500-bougey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70078-70500-bougey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70079-70170-bougnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70079-70170-bougnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70079-70170-bougnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70079-70170-bougnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70080-70100-bouhans_et_feurg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70080-70100-bouhans_et_feurg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70080-70100-bouhans_et_feurg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70080-70100-bouhans_et_feurg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70081-70200-bouhans_les_lure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70081-70200-bouhans_les_lure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70081-70200-bouhans_les_lure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70081-70200-bouhans_les_lure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70082-70230-bouhans_les_montbozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70082-70230-bouhans_les_montbozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70082-70230-bouhans_les_montbozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70082-70230-bouhans_les_montbozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70083-70800-bouligney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70083-70800-bouligney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70083-70800-bouligney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70083-70800-bouligney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70084-70190-boulot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70084-70190-boulot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70084-70190-boulot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70084-70190-boulot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70085-70190-boult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70085-70190-boult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70085-70190-boult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70085-70190-boult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70086-70500-bourbevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70086-70500-bourbevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70086-70500-bourbevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70086-70500-bourbevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70087-70800-bourguignon_les_conflans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70087-70800-bourguignon_les_conflans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70087-70800-bourguignon_les_conflans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70087-70800-bourguignon_les_conflans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70088-70190-bourguignon_les_la_charite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70088-70190-bourguignon_les_la_charite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70088-70190-bourguignon_les_la_charite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70088-70190-bourguignon_les_la_charite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70089-70120-bourguignon_les_morey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70089-70120-bourguignon_les_morey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70089-70120-bourguignon_les_morey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70089-70120-bourguignon_les_morey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70090-70000-boursieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70090-70000-boursieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70090-70000-boursieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70090-70000-boursieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70091-70500-bousseraucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70091-70500-bousseraucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70091-70500-bousseraucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70091-70500-bousseraucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70092-70140-bresilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70092-70140-bresilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70092-70140-bresilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70092-70140-bresilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70093-70300-breuches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70093-70300-breuches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70093-70300-breuches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70093-70300-breuches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70094-70280-breuchotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70094-70280-breuchotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70094-70280-breuchotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70094-70280-breuchotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70095-70160-breurey_les_faverney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70095-70160-breurey_les_faverney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70095-70160-breurey_les_faverney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70095-70160-breurey_les_faverney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70096-70400-brevilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70096-70400-brevilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70096-70400-brevilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70096-70400-brevilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70097-70800-briaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70097-70800-briaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70097-70800-briaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70097-70800-briaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70098-70300-brotte_les_luxeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70098-70300-brotte_les_luxeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70098-70300-brotte_les_luxeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70098-70300-brotte_les_luxeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70099-70180-brotte_les_ray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70099-70180-brotte_les_ray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70099-70180-brotte_les_ray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70099-70180-brotte_les_ray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70100-70100-broye_les_loups_et_verfontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70100-70100-broye_les_loups_et_verfontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70100-70100-broye_les_loups_et_verfontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70100-70100-broye_les_loups_et_verfontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70101-70140-broye_aubigney_montseugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70101-70140-broye_aubigney_montseugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70101-70140-broye_aubigney_montseugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70101-70140-broye_aubigney_montseugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70102-70150-brussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70102-70150-brussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70102-70150-brussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70102-70150-brussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70103-70280-la_bruyere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70103-70280-la_bruyere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70103-70280-la_bruyere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70103-70280-la_bruyere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70104-70700-bucey_les_gy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70104-70700-bucey_les_gy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70104-70700-bucey_les_gy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70104-70700-bucey_les_gy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70105-70360-bucey_les_traves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70105-70360-bucey_les_traves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70105-70360-bucey_les_traves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70105-70360-bucey_les_traves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70106-70500-buffignecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70106-70500-buffignecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70106-70500-buffignecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70106-70500-buffignecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70107-70190-bussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70107-70190-bussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70107-70190-bussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70107-70190-bussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70109-70190-buthiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70109-70190-buthiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70109-70190-buthiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70109-70190-buthiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70111-70240-calmoutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70111-70240-calmoutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70111-70240-calmoutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70111-70240-calmoutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70112-70500-cemboing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70112-70500-cemboing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70112-70500-cemboing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70112-70500-cemboing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70113-70230-cenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70113-70230-cenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70113-70230-cenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70113-70230-cenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70114-70500-cendrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70114-70500-cendrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70114-70500-cendrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70114-70500-cendrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70115-70000-cerre_les_noroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70115-70000-cerre_les_noroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70115-70000-cerre_les_noroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70115-70000-cerre_les_noroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70116-70400-chagey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70116-70400-chagey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70116-70400-chagey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70116-70400-chagey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70117-70400-chalonvillars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70117-70400-chalonvillars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70117-70400-chalonvillars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70117-70400-chalonvillars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70118-70190-chambornay_les_bellevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70118-70190-chambornay_les_bellevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70118-70190-chambornay_les_bellevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70118-70190-chambornay_les_bellevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70119-70150-chambornay_les_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70119-70150-chambornay_les_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70119-70150-chambornay_les_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70119-70150-chambornay_les_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70120-70290-champagney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70120-70290-champagney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70120-70290-champagney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70120-70290-champagney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70121-70400-champey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70121-70400-champey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70121-70400-champey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70121-70400-champey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70122-70600-champlitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70122-70600-champlitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70122-70600-champlitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70122-70600-champlitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70124-70100-champtonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70124-70100-champtonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70124-70100-champtonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70124-70100-champtonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70125-70100-champvans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70125-70100-champvans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70125-70100-champvans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70125-70100-champvans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70126-70140-chancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70126-70140-chancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70126-70140-chancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70126-70140-chancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70127-70360-chantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70127-70360-chantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70127-70360-chantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70127-70360-chantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70128-70300-la_chapelle_les_luxeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70128-70300-la_chapelle_les_luxeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70128-70300-la_chapelle_les_luxeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70128-70300-la_chapelle_les_luxeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70129-70700-la_chapelle_saint_quillain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70129-70700-la_chapelle_saint_quillain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70129-70700-la_chapelle_saint_quillain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70129-70700-la_chapelle_saint_quillain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70130-70700-charcenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70130-70700-charcenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70130-70700-charcenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70130-70700-charcenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70132-70100-chargey_les_gray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70132-70100-chargey_les_gray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70132-70100-chargey_les_gray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70132-70100-chargey_les_gray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70133-70170-chargey_les_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70133-70170-chargey_les_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70133-70170-chargey_les_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70133-70170-chargey_les_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70134-70000-chariez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70134-70000-chariez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70134-70000-chariez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70134-70000-chariez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70135-70120-charmes_saint_valbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70135-70120-charmes_saint_valbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70135-70120-charmes_saint_valbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70135-70120-charmes_saint_valbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70136-70000-charmoille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70136-70000-charmoille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70136-70000-charmoille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70136-70000-charmoille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70137-70230-chassey_les_montbozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70137-70230-chassey_les_montbozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70137-70230-chassey_les_montbozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70137-70230-chassey_les_montbozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70138-70360-chassey_les_scey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70138-70360-chassey_les_scey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70138-70360-chassey_les_scey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70138-70360-chassey_les_scey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70140-70240-chateney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70140-70240-chateney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70140-70240-chateney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70140-70240-chateney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70141-70240-chatenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70141-70240-chatenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70141-70240-chatenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70141-70240-chatenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70142-70140-chaumercenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70142-70140-chaumercenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70142-70140-chaumercenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70142-70140-chaumercenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70143-70500-chauvirey_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70143-70500-chauvirey_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70143-70500-chauvirey_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70143-70500-chauvirey_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70144-70500-chauvirey_le_vieil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70144-70500-chauvirey_le_vieil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70144-70500-chauvirey_le_vieil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70144-70500-chauvirey_le_vieil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70145-70190-chaux_la_lotiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70145-70190-chaux_la_lotiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70145-70190-chaux_la_lotiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70145-70190-chaux_la_lotiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70146-70170-chaux_les_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70146-70170-chaux_les_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70146-70170-chaux_les_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70146-70170-chaux_les_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70147-70400-chavanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70147-70400-chavanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70147-70400-chavanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70147-70400-chavanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70148-70360-chemilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70148-70360-chemilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70148-70360-chemilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70148-70360-chemilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70149-70400-chenebier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70149-70400-chenebier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70149-70400-chenebier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70149-70400-chenebier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70150-70150-chenevrey_et_morogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70150-70150-chenevrey_et_morogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70150-70150-chenevrey_et_morogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70150-70150-chenevrey_et_morogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70151-70140-chevigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70151-70140-chevigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70151-70140-chevigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70151-70140-chevigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70152-70700-choye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70152-70700-choye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70152-70700-choye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70152-70700-choye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70153-70120-cintrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70153-70120-cintrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70153-70120-cintrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70153-70120-cintrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70154-70190-cirey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70154-70190-cirey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70154-70190-cirey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70154-70190-cirey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70155-70300-citers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70155-70300-citers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70155-70300-citers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70155-70300-citers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70156-70700-citey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70156-70700-citey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70156-70700-citey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70156-70700-citey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70157-70200-clairegoutte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70157-70200-clairegoutte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70157-70200-clairegoutte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70157-70200-clairegoutte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70158-70000-clans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70158-70000-clans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70158-70000-clans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70158-70000-clans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70159-70230-cognieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70159-70230-cognieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70159-70230-cognieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70159-70230-cognieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70160-70400-coisevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70160-70400-coisevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70160-70400-coisevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70160-70400-coisevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70162-70000-colombe_les_vesoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70162-70000-colombe_les_vesoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70162-70000-colombe_les_vesoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70162-70000-colombe_les_vesoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70163-70000-colombier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70163-70000-colombier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70163-70000-colombier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70163-70000-colombier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70164-70240-colombotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70164-70240-colombotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70164-70240-colombotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70164-70240-colombotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70165-70120-combeaufontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70165-70120-combeaufontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70165-70120-combeaufontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70165-70120-combeaufontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70166-70000-comberjon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70166-70000-comberjon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70166-70000-comberjon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70166-70000-comberjon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70167-70170-conflandey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70167-70170-conflandey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70167-70170-conflandey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70167-70170-conflandey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70168-70800-conflans_sur_lanterne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70168-70800-conflans_sur_lanterne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70168-70800-conflans_sur_lanterne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70168-70800-conflans_sur_lanterne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70169-70120-confracourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70169-70120-confracourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70169-70120-confracourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70169-70120-confracourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70170-70160-contreglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70170-70160-contreglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70170-70160-contreglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70170-70160-contreglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70171-70320-corbenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70171-70320-corbenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70171-70320-corbenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70171-70320-corbenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70172-70300-la_corbiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70172-70300-la_corbiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70172-70300-la_corbiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70172-70300-la_corbiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70174-70190-cordonnet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70174-70190-cordonnet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70174-70190-cordonnet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70174-70190-cordonnet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70175-70120-cornot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70175-70120-cornot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70175-70120-cornot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70175-70120-cornot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70176-70310-corravillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70176-70310-corravillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70176-70310-corravillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70176-70310-corravillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70177-70500-corre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70177-70500-corre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70177-70500-corre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70177-70500-corre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70178-70200-la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70178-70200-la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70178-70200-la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70178-70200-la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70179-70000-coulevon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70179-70000-coulevon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70179-70000-coulevon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70179-70000-coulevon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70180-70110-courchaton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70180-70110-courchaton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70180-70110-courchaton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70180-70110-courchaton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70181-70150-courcuire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70181-70150-courcuire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70181-70150-courcuire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70181-70150-courcuire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70182-70400-courmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70182-70400-courmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70182-70400-courmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70182-70400-courmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70183-70600-courtesoult_et_gatey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70183-70600-courtesoult_et_gatey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70183-70600-courtesoult_et_gatey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70183-70600-courtesoult_et_gatey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70184-70400-couthenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70184-70400-couthenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70184-70400-couthenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70184-70400-couthenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70185-70100-cresancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70185-70100-cresancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70185-70100-cresancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70185-70100-cresancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70186-70240-la_creuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70186-70240-la_creuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70186-70240-la_creuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70186-70240-la_creuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70187-70400-crevans_et_la_chapelle_les_granges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70187-70400-crevans_et_la_chapelle_les_granges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70187-70400-crevans_et_la_chapelle_les_granges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70187-70400-crevans_et_la_chapelle_les_granges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70188-70240-creveney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70188-70240-creveney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70188-70240-creveney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70188-70240-creveney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70189-70190-cromary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70189-70190-cromary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70189-70190-cromary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70189-70190-cromary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70190-70160-cubry_les_faverney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70190-70160-cubry_les_faverney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70190-70160-cubry_les_faverney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70190-70160-cubry_les_faverney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70192-70700-cugney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70192-70700-cugney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70192-70700-cugney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70192-70700-cugney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70193-70150-cult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70193-70150-cult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70193-70150-cult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70193-70150-cult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70194-70800-cuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70194-70800-cuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70194-70800-cuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70194-70800-cuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70195-70200-dambenoit_les_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70195-70200-dambenoit_les_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70195-70200-dambenoit_les_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70195-70200-dambenoit_les_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70196-70800-dampierre_les_conflans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70196-70800-dampierre_les_conflans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70196-70800-dampierre_les_conflans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70196-70800-dampierre_les_conflans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70197-70230-dampierre_sur_linotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70197-70230-dampierre_sur_linotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70197-70230-dampierre_sur_linotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70197-70230-dampierre_sur_linotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70198-70180-dampierre_sur_salon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70198-70180-dampierre_sur_salon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70198-70180-dampierre_sur_salon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70198-70180-dampierre_sur_salon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70199-70000-dampvalley_les_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70199-70000-dampvalley_les_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70199-70000-dampvalley_les_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70199-70000-dampvalley_les_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70200-70210-dampvalley_saint_pancras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70200-70210-dampvalley_saint_pancras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70200-70210-dampvalley_saint_pancras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70200-70210-dampvalley_saint_pancras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70201-70180-delain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70201-70180-delain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70201-70180-delain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70201-70180-delain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70202-70210-demangevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70202-70210-demangevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70202-70210-demangevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70202-70210-demangevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70203-70000-la_demie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70203-70000-la_demie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70203-70000-la_demie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70203-70000-la_demie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70204-70180-denevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70204-70180-denevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70204-70180-denevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70204-70180-denevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70205-70400-echavanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70205-70400-echavanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70205-70400-echavanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70205-70400-echavanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70206-70400-echenans_sous_mont_vaudois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70206-70400-echenans_sous_mont_vaudois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70206-70400-echenans_sous_mont_vaudois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70206-70400-echenans_sous_mont_vaudois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70207-70000-echenoz_la_meline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70207-70000-echenoz_la_meline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70207-70000-echenoz_la_meline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70207-70000-echenoz_la_meline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70208-70000-echenoz_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70208-70000-echenoz_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70208-70000-echenoz_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70208-70000-echenoz_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70210-70270-ecromagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70210-70270-ecromagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70210-70270-ecromagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70210-70270-ecromagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70211-70600-ecuelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70211-70600-ecuelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70211-70600-ecuelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70211-70600-ecuelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70213-70300-ehuns/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70213-70300-ehuns/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70213-70300-ehuns/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70213-70300-ehuns/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70214-70160-equevilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70214-70160-equevilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70214-70160-equevilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70214-70160-equevilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70215-70400-errevet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70215-70400-errevet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70215-70400-errevet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70215-70400-errevet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70216-70300-esboz_brest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70216-70300-esboz_brest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70216-70300-esboz_brest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70216-70300-esboz_brest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70217-70310-esmoulieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70217-70310-esmoulieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70217-70310-esmoulieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70217-70310-esmoulieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70218-70100-esmoulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70218-70100-esmoulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70218-70100-esmoulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70218-70100-esmoulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70219-70110-esprels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70219-70110-esprels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70219-70110-esprels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70219-70110-esprels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70220-70100-essertenne_et_cecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70220-70100-essertenne_et_cecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70220-70100-essertenne_et_cecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70220-70100-essertenne_et_cecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70221-70400-etobon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70221-70400-etobon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70221-70400-etobon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70221-70400-etobon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70222-70700-etrelles_et_la_montbleuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70222-70700-etrelles_et_la_montbleuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70222-70700-etrelles_et_la_montbleuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70222-70700-etrelles_et_la_montbleuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70224-70150-etuz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70224-70150-etuz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70224-70150-etuz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70224-70150-etuz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70225-70100-fahy_les_autrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70225-70100-fahy_les_autrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70225-70100-fahy_les_autrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70225-70100-fahy_les_autrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70226-70110-fallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70226-70110-fallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70226-70110-fallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70226-70110-fallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70227-70310-faucogney_et_la_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70227-70310-faucogney_et_la_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70227-70310-faucogney_et_la_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70227-70310-faucogney_et_la_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70228-70160-faverney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70228-70160-faverney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70228-70160-faverney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70228-70160-faverney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70229-70200-faymont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70229-70200-faymont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70229-70200-faymont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70229-70200-faymont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70230-70120-fedry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70230-70120-fedry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70230-70120-fedry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70230-70120-fedry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70231-70130-ferrieres_les_ray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70231-70130-ferrieres_les_ray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70231-70130-ferrieres_les_ray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70231-70130-ferrieres_les_ray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70232-70360-ferrieres_les_scey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70232-70360-ferrieres_les_scey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70232-70360-ferrieres_les_scey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70232-70360-ferrieres_les_scey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70233-70310-les_fessey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70233-70310-les_fessey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70233-70310-les_fessey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70233-70310-les_fessey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70234-70230-filain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70234-70230-filain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70234-70230-filain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70234-70230-filain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70235-70000-flagy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70235-70000-flagy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70235-70000-flagy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70235-70000-flagy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70236-70160-fleurey_les_faverney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70236-70160-fleurey_les_faverney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70236-70160-fleurey_les_faverney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70236-70160-fleurey_les_faverney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70237-70120-fleurey_les_lavoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70237-70120-fleurey_les_lavoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70237-70120-fleurey_les_lavoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70237-70120-fleurey_les_lavoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70238-70800-fleurey_les_saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70238-70800-fleurey_les_saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70238-70800-fleurey_les_saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70238-70800-fleurey_les_saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70239-70190-fondremand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70239-70190-fondremand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70239-70190-fondremand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70239-70190-fondremand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70240-70800-fontaine_les_luxeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70240-70800-fontaine_les_luxeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70240-70800-fontaine_les_luxeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70240-70800-fontaine_les_luxeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70242-70210-fontenois_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70242-70210-fontenois_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70242-70210-fontenois_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70242-70210-fontenois_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70243-70230-fontenois_les_montbozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70243-70230-fontenois_les_montbozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70243-70230-fontenois_les_montbozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70243-70230-fontenois_les_montbozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70244-70160-fouchecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70244-70160-fouchecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70244-70160-fouchecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70244-70160-fouchecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70245-70220-fougerolles_saint_valbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70245-70220-fougerolles_saint_valbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70245-70220-fougerolles_saint_valbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70245-70220-fougerolles_saint_valbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70245-70300-fougerolles_saint_valbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70245-70300-fougerolles_saint_valbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70245-70300-fougerolles_saint_valbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70245-70300-fougerolles_saint_valbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70247-70600-fouvent_saint_andoche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70247-70600-fouvent_saint_andoche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70247-70600-fouvent_saint_andoche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70247-70600-fouvent_saint_andoche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70248-70400-frahier_et_chatebier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70248-70400-frahier_et_chatebier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70248-70400-frahier_et_chatebier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70248-70400-frahier_et_chatebier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70249-70800-francalmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70249-70800-francalmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70249-70800-francalmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70249-70800-francalmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70250-70200-franchevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70250-70200-franchevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70250-70200-franchevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70250-70200-franchevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70251-70180-francourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70251-70180-francourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70251-70180-francourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70251-70180-francourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70252-70600-framont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70252-70600-framont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70252-70600-framont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70252-70600-framont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70253-70700-frasne_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70253-70700-frasne_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70253-70700-frasne_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70253-70700-frasne_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70254-70200-frederic_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70254-70200-frederic_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70254-70200-frederic_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70254-70200-frederic_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70255-70130-fresne_saint_mames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70255-70130-fresne_saint_mames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70255-70130-fresne_saint_mames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70255-70130-fresne_saint_mames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70256-70270-fresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70256-70270-fresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70256-70270-fresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70256-70270-fresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70257-70130-fretigney_et_velloreille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70257-70130-fretigney_et_velloreille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70257-70130-fretigney_et_velloreille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70257-70130-fretigney_et_velloreille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70258-70300-froideconche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70258-70300-froideconche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70258-70300-froideconche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70258-70300-froideconche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70259-70200-froideterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70259-70200-froideterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70259-70200-froideterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70259-70200-froideterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70260-70200-frotey_les_lure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70260-70200-frotey_les_lure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70260-70200-frotey_les_lure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70260-70200-frotey_les_lure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70261-70000-frotey_les_vesoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70261-70000-frotey_les_vesoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70261-70000-frotey_les_vesoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70261-70000-frotey_les_vesoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70262-70240-genevreuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70262-70240-genevreuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70262-70240-genevreuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70262-70240-genevreuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70263-70240-genevrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70263-70240-genevrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70263-70240-genevrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70263-70240-genevrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70264-70110-georfans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70264-70110-georfans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70264-70110-georfans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70264-70110-georfans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70265-70100-germigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70265-70100-germigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70265-70100-germigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70265-70100-germigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70267-70500-gevigney_et_mercey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70267-70500-gevigney_et_mercey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70267-70500-gevigney_et_mercey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70267-70500-gevigney_et_mercey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70268-70700-gezier_et_fontenelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70268-70700-gezier_et_fontenelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70268-70700-gezier_et_fontenelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70268-70700-gezier_et_fontenelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70269-70210-girefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70269-70210-girefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70269-70210-girefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70269-70210-girefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70271-70110-gouhenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70271-70110-gouhenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70271-70110-gouhenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70271-70110-gouhenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70272-70120-gourgeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70272-70120-gourgeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70272-70120-gourgeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70272-70120-gourgeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70273-70110-grammont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70273-70110-grammont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70273-70110-grammont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70273-70110-grammont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70274-70120-grandecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70274-70120-grandecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70274-70120-grandecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70274-70120-grandecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70275-70190-grandvelle_et_le_perrenot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70275-70190-grandvelle_et_le_perrenot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70275-70190-grandvelle_et_le_perrenot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70275-70190-grandvelle_et_le_perrenot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70276-70400-granges_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70276-70400-granges_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70276-70400-granges_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70276-70400-granges_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70277-70400-granges_le_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70277-70400-granges_le_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70277-70400-granges_le_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70277-70400-granges_le_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70278-70170-grattery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70278-70170-grattery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70278-70170-grattery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70278-70170-grattery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70279-70100-gray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70279-70100-gray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70279-70100-gray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70279-70100-gray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70280-70100-gray_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70280-70100-gray_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70280-70100-gray_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70280-70100-gray_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70282-70700-gy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70282-70700-gy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70282-70700-gy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70282-70700-gy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70283-70440-haut_du_them_chateau_lambert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70283-70440-haut_du_them_chateau_lambert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70283-70440-haut_du_them_chateau_lambert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70283-70440-haut_du_them_chateau_lambert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70284-70800-hautevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70284-70800-hautevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70284-70800-hautevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70284-70800-hautevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70285-70400-hericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70285-70400-hericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70285-70400-hericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70285-70400-hericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70286-70150-hugier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70286-70150-hugier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70286-70150-hugier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70286-70150-hugier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70287-70210-hurecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70287-70210-hurecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70287-70210-hurecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70287-70210-hurecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70288-70190-hyet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70288-70190-hyet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70288-70190-hyet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70288-70190-hyet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70289-70700-igny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70289-70700-igny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70289-70700-igny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70289-70700-igny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70290-70800-jasney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70290-70800-jasney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70290-70800-jasney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70290-70800-jasney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70291-70500-jonvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70291-70500-jonvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70291-70500-jonvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70291-70500-jonvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70292-70500-jussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70292-70500-jussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70292-70500-jussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70292-70500-jussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70293-70500-lambrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70293-70500-lambrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70293-70500-lambrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70293-70500-lambrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70294-70200-lantenot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70294-70200-lantenot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70294-70200-lantenot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70294-70200-lantenot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70295-70270-la_lanterne_et_les_armonts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70295-70270-la_lanterne_et_les_armonts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70295-70270-la_lanterne_et_les_armonts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70295-70270-la_lanterne_et_les_armonts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70296-70230-larians_et_munans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70296-70230-larians_et_munans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70296-70230-larians_et_munans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70296-70230-larians_et_munans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70297-70600-larret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70297-70600-larret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70297-70600-larret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70297-70600-larret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70298-70120-lavigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70298-70120-lavigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70298-70120-lavigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70298-70120-lavigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70299-70120-lavoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70299-70120-lavoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70299-70120-lavoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70299-70120-lavoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70301-70190-lieffrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70301-70190-lieffrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70301-70190-lieffrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70301-70190-lieffrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70302-70140-lieucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70302-70140-lieucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70302-70140-lieucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70302-70140-lieucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70303-70240-lievans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70303-70240-lievans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70303-70240-lievans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70303-70240-lievans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70304-70200-linexert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70304-70200-linexert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70304-70200-linexert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70304-70200-linexert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70305-70100-loeuilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70305-70100-loeuilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70305-70100-loeuilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70305-70100-loeuilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70306-70200-lomont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70306-70200-lomont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70306-70200-lomont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70306-70200-lomont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70307-70110-longevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70307-70110-longevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70307-70110-longevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70307-70110-longevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70308-70310-la_longine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70308-70310-la_longine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70308-70310-la_longine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70308-70310-la_longine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70309-70230-loulans_verchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70309-70230-loulans_verchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70309-70230-loulans_verchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70309-70230-loulans_verchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70310-70200-lure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70310-70200-lure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70310-70200-lure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70310-70200-lure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70311-70300-luxeuil_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70311-70300-luxeuil_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70311-70300-luxeuil_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70311-70300-luxeuil_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70312-70400-luze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70312-70400-luze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70312-70400-luze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70312-70400-luze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70313-70200-lyoffans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70313-70200-lyoffans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70313-70200-lyoffans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70313-70200-lyoffans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70314-70300-magnivray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70314-70300-magnivray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70314-70300-magnivray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70314-70300-magnivray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70315-70800-magnoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70315-70800-magnoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70315-70800-magnoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70315-70800-magnoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70316-70000-le_magnoray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70316-70000-le_magnoray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70316-70000-le_magnoray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70316-70000-le_magnoray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70317-70110-les_magny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70317-70110-les_magny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70317-70110-les_magny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70317-70110-les_magny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70318-70200-magny_danigon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70318-70200-magny_danigon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70318-70200-magny_danigon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70318-70200-magny_danigon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70318-70250-magny_danigon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70318-70250-magny_danigon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70318-70250-magny_danigon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70318-70250-magny_danigon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70319-70200-magny_jobert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70319-70200-magny_jobert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70319-70200-magny_jobert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70319-70200-magny_jobert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70320-70500-magny_les_jussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70320-70500-magny_les_jussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70320-70500-magny_les_jussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70320-70500-magny_les_jussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70321-70200-magny_vernois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70321-70200-magny_vernois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70321-70200-magny_vernois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70321-70200-magny_vernois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70322-70240-mailleroncourt_charette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70322-70240-mailleroncourt_charette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70322-70240-mailleroncourt_charette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70322-70240-mailleroncourt_charette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70323-70210-mailleroncourt_saint_pancras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70323-70210-mailleroncourt_saint_pancras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70323-70210-mailleroncourt_saint_pancras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70323-70210-mailleroncourt_saint_pancras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70324-70000-mailley_et_chazelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70324-70000-mailley_et_chazelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70324-70000-mailley_et_chazelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70324-70000-mailley_et_chazelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70325-70190-maizieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70325-70190-maizieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70325-70190-maizieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70325-70190-maizieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70326-70190-la_malachere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70326-70190-la_malachere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70326-70190-la_malachere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70326-70190-la_malachere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70327-70140-malans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70327-70140-malans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70327-70140-malans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70327-70140-malans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70328-70200-malbouhans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70328-70200-malbouhans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70328-70200-malbouhans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70328-70200-malbouhans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70328-70270-malbouhans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70328-70270-malbouhans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70328-70270-malbouhans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70328-70270-malbouhans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70329-70120-malvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70329-70120-malvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70329-70120-malvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70329-70120-malvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70330-70400-mandrevillars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70330-70400-mandrevillars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70330-70400-mandrevillars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70330-70400-mandrevillars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70331-70100-mantoche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70331-70100-mantoche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70331-70100-mantoche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70331-70100-mantoche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70332-70110-marast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70332-70110-marast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70332-70110-marast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70332-70110-marast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70334-70150-marnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70334-70150-marnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70334-70150-marnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70334-70150-marnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70335-70230-maussans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70335-70230-maussans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70335-70230-maussans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70335-70230-maussans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70336-70110-melecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70336-70110-melecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70336-70110-melecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70336-70110-melecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70337-70120-melin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70337-70120-melin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70337-70120-melin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70337-70120-melin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70338-70210-melincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70338-70210-melincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70338-70210-melincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70338-70210-melincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70339-70270-melisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70339-70270-melisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70339-70270-melisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70339-70270-melisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70340-70180-membrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70340-70180-membrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70340-70180-membrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70340-70180-membrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70341-70160-menoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70341-70160-menoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70341-70160-menoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70341-70160-menoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70342-70130-mercey_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70342-70130-mercey_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70342-70130-mercey_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70342-70130-mercey_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70343-70160-mersuay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70343-70160-mersuay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70343-70160-mersuay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70343-70160-mersuay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70344-70300-meurcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70344-70300-meurcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70344-70300-meurcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70344-70300-meurcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70347-70400-mignavillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70347-70400-mignavillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70347-70400-mignavillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70347-70400-mignavillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70348-70200-moffans_et_vacheresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70348-70200-moffans_et_vacheresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70348-70200-moffans_et_vacheresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70348-70200-moffans_et_vacheresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70349-70110-moimay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70349-70110-moimay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70349-70110-moimay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70349-70110-moimay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70350-70120-molay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70350-70120-molay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70350-70120-molay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70350-70120-molay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70351-70240-mollans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70351-70240-mollans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70351-70240-mollans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70351-70240-mollans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70352-70310-la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70352-70310-la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70352-70310-la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70352-70310-la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70353-70140-montagney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70353-70140-montagney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70353-70140-montagney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70353-70140-montagney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70355-70190-montarlot_les_rioz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70355-70190-montarlot_les_rioz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70355-70190-montarlot_les_rioz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70355-70190-montarlot_les_rioz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70356-70700-montboillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70356-70700-montboillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70356-70700-montboillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70356-70700-montboillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70357-70230-montbozon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70357-70230-montbozon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70357-70230-montbozon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70357-70230-montbozon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70358-70000-montcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70358-70000-montcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70358-70000-montcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70358-70000-montcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70359-70500-montcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70359-70500-montcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70359-70500-montcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70359-70500-montcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70360-70210-montdore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70360-70210-montdore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70360-70210-montdore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70360-70210-montdore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70361-70270-montessaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70361-70270-montessaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70361-70270-montessaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70361-70270-montessaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70362-70500-montigny_les_cherlieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70362-70500-montigny_les_cherlieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70362-70500-montigny_les_cherlieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70362-70500-montigny_les_cherlieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70363-70000-montigny_les_vesoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70363-70000-montigny_les_vesoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70363-70000-montigny_les_vesoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70363-70000-montigny_les_vesoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70364-70110-montjustin_et_velotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70364-70110-montjustin_et_velotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70364-70110-montjustin_et_velotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70364-70110-montjustin_et_velotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70366-70700-villers_chemin_et_mont_les_etrelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70366-70700-villers_chemin_et_mont_les_etrelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70366-70700-villers_chemin_et_mont_les_etrelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70366-70700-villers_chemin_et_mont_les_etrelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70367-70000-mont_le_vernois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70367-70000-mont_le_vernois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70367-70000-mont_le_vernois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70367-70000-mont_le_vernois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70368-70180-montot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70368-70180-montot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70368-70180-montot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70368-70180-montot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70369-70120-mont_saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70369-70120-mont_saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70369-70120-mont_saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70369-70120-mont_saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70371-70100-montureux_et_prantigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70371-70100-montureux_et_prantigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70371-70100-montureux_et_prantigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70371-70100-montureux_et_prantigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70372-70500-montureux_les_baulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70372-70500-montureux_les_baulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70372-70500-montureux_les_baulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70372-70500-montureux_les_baulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70373-70120-la_roche_morey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70373-70120-la_roche_morey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70373-70120-la_roche_morey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70373-70120-la_roche_morey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70374-70140-motey_besuche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70374-70140-motey_besuche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70374-70140-motey_besuche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70374-70140-motey_besuche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70376-70100-nantilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70376-70100-nantilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70376-70100-nantilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70376-70100-nantilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70378-70000-navenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70378-70000-navenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70378-70000-navenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70378-70000-navenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70380-70160-neurey_en_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70380-70160-neurey_en_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70380-70160-neurey_en_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70380-70160-neurey_en_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70381-70000-neurey_les_la_demie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70381-70000-neurey_les_la_demie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70381-70000-neurey_les_la_demie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70381-70000-neurey_les_la_demie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70383-70190-neuvelle_les_cromary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70383-70190-neuvelle_les_cromary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70383-70190-neuvelle_les_cromary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70383-70190-neuvelle_les_cromary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70384-70130-neuvelle_les_la_charite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70384-70130-neuvelle_les_la_charite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70384-70130-neuvelle_les_la_charite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70384-70130-neuvelle_les_la_charite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70385-70200-la_neuvelle_les_lure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70385-70200-la_neuvelle_les_lure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70385-70200-la_neuvelle_les_lure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70385-70200-la_neuvelle_les_lure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70386-70360-la_neuvelle_les_scey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70386-70360-la_neuvelle_les_scey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70386-70360-la_neuvelle_les_scey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70386-70360-la_neuvelle_les_scey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70387-70130-noidans_le_ferroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70387-70130-noidans_le_ferroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70387-70130-noidans_le_ferroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70387-70130-noidans_le_ferroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70388-70000-noidans_les_vesoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70388-70000-noidans_les_vesoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70388-70000-noidans_les_vesoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70388-70000-noidans_les_vesoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70389-70100-noiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70389-70100-noiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70389-70100-noiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70389-70100-noiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70390-70000-noroy_le_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70390-70000-noroy_le_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70390-70000-noroy_le_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70390-70000-noroy_le_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70392-70120-oigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70392-70120-oigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70392-70120-oigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70392-70120-oigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70393-70700-oiselay_et_grachaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70393-70700-oiselay_et_grachaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70393-70700-oiselay_et_grachaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70393-70700-oiselay_et_grachaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70394-70100-onay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70394-70100-onay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70394-70100-onay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70394-70100-onay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70395-70110-oppenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70395-70110-oppenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70395-70110-oppenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70395-70110-oppenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70396-70110-oricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70396-70110-oricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70396-70110-oricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70396-70110-oricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70397-70230-ormenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70397-70230-ormenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70397-70230-ormenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70397-70230-ormenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70398-70300-ormoiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70398-70300-ormoiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70398-70300-ormoiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70398-70300-ormoiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70399-70500-ormoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70399-70500-ormoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70399-70500-ormoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70399-70500-ormoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70400-70500-ouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70400-70500-ouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70400-70500-ouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70400-70500-ouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70401-70360-ovanches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70401-70360-ovanches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70401-70360-ovanches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70401-70360-ovanches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70402-70600-oyrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70402-70600-oyrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70402-70600-oyrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70402-70600-oyrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70403-70200-palante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70403-70200-palante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70403-70200-palante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70403-70200-palante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70404-70210-passavant_la_rochere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70404-70210-passavant_la_rochere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70404-70210-passavant_la_rochere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70404-70210-passavant_la_rochere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70405-70190-pennesieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70405-70190-pennesieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70405-70190-pennesieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70405-70190-pennesieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70406-70600-percey_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70406-70600-percey_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70406-70600-percey_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70406-70600-percey_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70407-70190-perrouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70407-70190-perrouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70407-70190-perrouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70407-70190-perrouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70408-70140-pesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70408-70140-pesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70408-70140-pesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70408-70140-pesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70409-70600-pierrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70409-70600-pierrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70409-70600-pierrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70409-70600-pierrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70410-70150-pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70410-70150-pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70410-70150-pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70410-70150-pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70411-70800-la_pisseure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70411-70800-la_pisseure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70411-70800-la_pisseure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70411-70800-la_pisseure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70412-70800-plainemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70412-70800-plainemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70412-70800-plainemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70412-70800-plainemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70413-70290-plancher_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70413-70290-plancher_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70413-70290-plancher_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70413-70290-plancher_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70414-70290-plancher_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70414-70290-plancher_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70414-70290-plancher_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70414-70290-plancher_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70415-70210-polaincourt_et_clairefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70415-70210-polaincourt_et_clairefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70415-70210-polaincourt_et_clairefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70415-70210-polaincourt_et_clairefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70416-70240-pomoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70416-70240-pomoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70416-70240-pomoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70416-70240-pomoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70417-70360-pontcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70417-70360-pontcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70417-70360-pontcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70417-70360-pontcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70418-70130-la_romaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70418-70130-la_romaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70418-70130-la_romaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70418-70130-la_romaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70419-70210-pont_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70419-70210-pont_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70419-70210-pont_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70419-70210-pont_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70420-70110-pont_sur_l_ognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70420-70110-pont_sur_l_ognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70420-70110-pont_sur_l_ognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70420-70110-pont_sur_l_ognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70421-70170-port_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70421-70170-port_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70421-70170-port_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70421-70170-port_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70422-70100-poyans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70422-70100-poyans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70422-70100-poyans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70422-70100-poyans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70423-70120-preigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70423-70120-preigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70423-70120-preigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70423-70120-preigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70425-70310-la_proiseliere_et_langle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70425-70310-la_proiseliere_et_langle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70425-70310-la_proiseliere_et_langle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70425-70310-la_proiseliere_et_langle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70426-70170-provenchere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70426-70170-provenchere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70426-70170-provenchere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70426-70170-provenchere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70427-70160-purgerot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70427-70160-purgerot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70427-70160-purgerot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70427-70160-purgerot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70428-70000-pusey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70428-70000-pusey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70428-70000-pusey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70428-70000-pusey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70429-70000-pusy_et_epenoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70429-70000-pusy_et_epenoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70429-70000-pusy_et_epenoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70429-70000-pusy_et_epenoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70430-70120-la_quarte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70430-70120-la_quarte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70430-70120-la_quarte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70430-70120-la_quarte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70431-70190-quenoche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70431-70190-quenoche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70431-70190-quenoche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70431-70190-quenoche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70432-70200-quers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70432-70200-quers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70432-70200-quers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70432-70200-quers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70433-70000-quincey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70433-70000-quincey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70433-70000-quincey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70433-70000-quincey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70435-70280-raddon_et_chapendu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70435-70280-raddon_et_chapendu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70435-70280-raddon_et_chapendu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70435-70280-raddon_et_chapendu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70436-70500-raincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70436-70500-raincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70436-70500-raincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70436-70500-raincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70437-70500-ranzevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70437-70500-ranzevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70437-70500-ranzevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70437-70500-ranzevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70438-70130-ray_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70438-70130-ray_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70438-70130-ray_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70438-70130-ray_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70439-70000-raze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70439-70000-raze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70439-70000-raze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70439-70000-raze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70440-70130-recologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70440-70130-recologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70440-70130-recologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70440-70130-recologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70441-70190-recologne_les_rioz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70441-70190-recologne_les_rioz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70441-70190-recologne_les_rioz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70441-70190-recologne_les_rioz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70442-70120-renaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70442-70120-renaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70442-70120-renaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70442-70120-renaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70443-70140-la_grande_resie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70443-70140-la_grande_resie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70443-70140-la_grande_resie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70443-70140-la_grande_resie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70444-70140-la_resie_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70444-70140-la_resie_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70444-70140-la_resie_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70444-70140-la_resie_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70445-70200-rignovelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70445-70200-rignovelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70445-70200-rignovelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70445-70200-rignovelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70446-70100-rigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70446-70100-rigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70446-70100-rigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70446-70100-rigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70447-70190-rioz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70447-70190-rioz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70447-70190-rioz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70447-70190-rioz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70448-70180-roche_et_raucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70448-70180-roche_et_raucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70448-70180-roche_et_raucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70448-70180-roche_et_raucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70449-70230-roche_sur_linotte_et_sorans_les_cordiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70449-70230-roche_sur_linotte_et_sorans_les_cordiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70449-70230-roche_sur_linotte_et_sorans_les_cordiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70449-70230-roche_sur_linotte_et_sorans_les_cordiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70450-70120-la_rochelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70450-70120-la_rochelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70450-70120-la_rochelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70450-70120-la_rochelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70451-70250-ronchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70451-70250-ronchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70451-70250-ronchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70451-70250-ronchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70452-70000-rosey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70452-70000-rosey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70452-70000-rosey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70452-70000-rosey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70453-70310-la_rosiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70453-70310-la_rosiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70453-70310-la_rosiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70453-70310-la_rosiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70454-70500-rosieres_sur_mance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70454-70500-rosieres_sur_mance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70454-70500-rosieres_sur_mance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70454-70500-rosieres_sur_mance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70455-70200-roye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70455-70200-roye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70455-70200-roye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70455-70200-roye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70456-70190-ruhans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70456-70190-ruhans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70456-70190-ruhans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70456-70190-ruhans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70457-70360-rupt_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70457-70360-rupt_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70457-70360-rupt_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70457-70360-rupt_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70459-70270-saint_barthelemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70459-70270-saint_barthelemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70459-70270-saint_barthelemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70459-70270-saint_barthelemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70460-70280-saint_bresson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70460-70280-saint_bresson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70460-70280-saint_bresson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70460-70280-saint_bresson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70461-70100-saint_broing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70461-70100-saint_broing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70461-70100-saint_broing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70461-70100-saint_broing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70462-70110-saint_ferjeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70462-70110-saint_ferjeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70462-70110-saint_ferjeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70462-70110-saint_ferjeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70463-70130-saint_gand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70463-70130-saint_gand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70463-70130-saint_gand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70463-70130-saint_gand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70464-70200-saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70464-70200-saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70464-70200-saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70464-70200-saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70466-70100-saint_loup_nantouard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70466-70100-saint_loup_nantouard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70466-70100-saint_loup_nantouard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70466-70100-saint_loup_nantouard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70467-70800-saint_loup_sur_semouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70467-70800-saint_loup_sur_semouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70467-70800-saint_loup_sur_semouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70467-70800-saint_loup_sur_semouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70468-70500-saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70468-70500-saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70468-70500-saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70468-70500-saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70469-70310-sainte_marie_en_chanois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70469-70310-sainte_marie_en_chanois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70469-70310-sainte_marie_en_chanois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70469-70310-sainte_marie_en_chanois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70470-70300-sainte_marie_en_chaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70470-70300-sainte_marie_en_chaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70470-70300-sainte_marie_en_chaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70470-70300-sainte_marie_en_chaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70471-70700-sainte_reine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70471-70700-sainte_reine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70471-70700-sainte_reine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70471-70700-sainte_reine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70472-70160-saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70472-70160-saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70472-70160-saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70472-70160-saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70473-70300-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70473-70300-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70473-70300-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70473-70300-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70474-70110-saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70474-70110-saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70474-70110-saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70474-70110-saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70476-70210-saponcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70476-70210-saponcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70476-70210-saponcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70476-70210-saponcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70477-70400-saulnot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70477-70400-saulnot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70477-70400-saulnot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70477-70400-saulnot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70478-70240-saulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70478-70240-saulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70478-70240-saulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70478-70240-saulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70479-70100-sauvigney_les_gray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70479-70100-sauvigney_les_gray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70479-70100-sauvigney_les_gray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70479-70100-sauvigney_les_gray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70480-70140-sauvigney_les_pesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70480-70140-sauvigney_les_pesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70480-70140-sauvigney_les_pesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70480-70140-sauvigney_les_pesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70481-70130-savoyeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70481-70130-savoyeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70481-70130-savoyeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70481-70130-savoyeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70482-70360-scey_sur_saone_et_saint_albin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70482-70360-scey_sur_saone_et_saint_albin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70482-70360-scey_sur_saone_et_saint_albin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70482-70360-scey_sur_saone_et_saint_albin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70483-70170-scye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70483-70170-scye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70483-70170-scye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70483-70170-scye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70484-70400-secenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70484-70400-secenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70484-70400-secenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70484-70400-secenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70485-70210-selles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70485-70210-selles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70485-70210-selles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70485-70210-selles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70486-70120-semmadon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70486-70120-semmadon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70486-70120-semmadon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70486-70120-semmadon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70487-70110-senargent_mignafans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70487-70110-senargent_mignafans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70487-70110-senargent_mignafans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70487-70110-senargent_mignafans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70488-70160-senoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70488-70160-senoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70488-70160-senoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70488-70160-senoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70489-70440-servance_miellin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70489-70440-servance_miellin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70489-70440-servance_miellin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70489-70440-servance_miellin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70490-70240-servigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70490-70240-servigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70490-70240-servigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70490-70240-servigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70491-70130-seveux_motey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70491-70130-seveux_motey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70491-70130-seveux_motey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70491-70130-seveux_motey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70492-70130-soing_cubry_charentenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70492-70130-soing_cubry_charentenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70492-70130-soing_cubry_charentenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70492-70130-soing_cubry_charentenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70493-70190-sorans_les_breurey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70493-70190-sorans_les_breurey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70493-70190-sorans_les_breurey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70493-70190-sorans_les_breurey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70494-70150-sornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70494-70150-sornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70494-70150-sornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70494-70150-sornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70496-70500-tartecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70496-70500-tartecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70496-70500-tartecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70496-70500-tartecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70498-70270-ternuay_melay_et_saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70498-70270-ternuay_melay_et_saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70498-70270-ternuay_melay_et_saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70498-70270-ternuay_melay_et_saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70499-70120-theuley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70499-70120-theuley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70499-70120-theuley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70499-70120-theuley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70500-70230-thieffrans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70500-70230-thieffrans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70500-70230-thieffrans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70500-70230-thieffrans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70501-70230-thienans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70501-70230-thienans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70501-70230-thienans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70501-70230-thienans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70502-70120-tincey_et_pontrebeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70502-70120-tincey_et_pontrebeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70502-70120-tincey_et_pontrebeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70502-70120-tincey_et_pontrebeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70503-70190-traitiefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70503-70190-traitiefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70503-70190-traitiefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70503-70190-traitiefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70504-70360-traves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70504-70360-traves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70504-70360-traves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70504-70360-traves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70505-70100-le_tremblois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70505-70100-le_tremblois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70505-70100-le_tremblois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70505-70100-le_tremblois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70506-70400-tremoins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70506-70400-tremoins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70506-70400-tremoins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70506-70400-tremoins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70507-70190-tresilley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70507-70190-tresilley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70507-70190-tresilley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70507-70190-tresilley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70509-70150-tromarey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70509-70150-tromarey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70509-70150-tromarey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70509-70150-tromarey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70510-70140-vadans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70510-70140-vadans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70510-70140-vadans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70510-70140-vadans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70511-70180-vaite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70511-70180-vaite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70511-70180-vaite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70511-70180-vaite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70512-70320-la_vaivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70512-70320-la_vaivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70512-70320-la_vaivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70512-70320-la_vaivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70513-70000-vaivre_et_montoille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70513-70000-vaivre_et_montoille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70513-70000-vaivre_et_montoille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70513-70000-vaivre_et_montoille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70514-70140-valay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70514-70140-valay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70514-70140-valay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70514-70140-valay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70515-70200-le_val_de_gouhenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70515-70200-le_val_de_gouhenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70515-70200-le_val_de_gouhenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70515-70200-le_val_de_gouhenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70516-70000-vallerois_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70516-70000-vallerois_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70516-70000-vallerois_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70516-70000-vallerois_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70517-70000-vallerois_lorioz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70517-70000-vallerois_lorioz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70517-70000-vallerois_lorioz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70517-70000-vallerois_lorioz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70518-70160-le_val_saint_eloi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70518-70160-le_val_saint_eloi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70518-70160-le_val_saint_eloi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70518-70160-le_val_saint_eloi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70519-70190-vandelans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70519-70190-vandelans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70519-70190-vandelans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70519-70190-vandelans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70520-70130-vanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70520-70130-vanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70520-70130-vanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70520-70130-vanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70521-70700-vantoux_et_longevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70521-70700-vantoux_et_longevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70521-70700-vantoux_et_longevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70521-70700-vantoux_et_longevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70522-70240-varogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70522-70240-varogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70522-70240-varogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70522-70240-varogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70523-70600-vars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70523-70600-vars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70523-70600-vars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70523-70600-vars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70524-70170-vauchoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70524-70170-vauchoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70524-70170-vauchoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70524-70170-vauchoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70525-70120-vauconcourt_nervezain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70525-70120-vauconcourt_nervezain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70525-70120-vauconcourt_nervezain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70525-70120-vauconcourt_nervezain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70526-70210-vauvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70526-70210-vauvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70526-70210-vauvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70526-70210-vauvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70527-70700-vaux_le_moncelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70527-70700-vaux_le_moncelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70527-70700-vaux_le_moncelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70527-70700-vaux_le_moncelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70528-70100-velesmes_echevanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70528-70100-velesmes_echevanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70528-70100-velesmes_echevanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70528-70100-velesmes_echevanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70529-70100-velet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70529-70100-velet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70529-70100-velet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70529-70100-velet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70530-70110-vellechevreux_et_courbenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70530-70110-vellechevreux_et_courbenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70530-70110-vellechevreux_et_courbenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70530-70110-vellechevreux_et_courbenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70531-70700-velleclaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70531-70700-velleclaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70531-70700-velleclaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70531-70700-velleclaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70532-70000-vellefaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70532-70000-vellefaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70532-70000-vellefaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70532-70000-vellefaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70533-70700-vellefrey_et_vellefrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70533-70700-vellefrey_et_vellefrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70533-70700-vellefrey_et_vellefrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70533-70700-vellefrey_et_vellefrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70534-70240-vellefrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70534-70240-vellefrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70534-70240-vellefrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70534-70240-vellefrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70535-70000-velleguindry_et_levrecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70535-70000-velleguindry_et_levrecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70535-70000-velleguindry_et_levrecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70535-70000-velleguindry_et_levrecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70536-70000-velle_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70536-70000-velle_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70536-70000-velle_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70536-70000-velle_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70537-70240-velleminfroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70537-70240-velleminfroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70537-70240-velleminfroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70537-70240-velleminfroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70538-70700-vellemoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70538-70700-vellemoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70538-70700-vellemoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70538-70700-vellemoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70539-70130-vellexon_queutrey_et_vaudey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70539-70130-vellexon_queutrey_et_vaudey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70539-70130-vellexon_queutrey_et_vaudey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70539-70130-vellexon_queutrey_et_vaudey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70540-70700-velloreille_les_choye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70540-70700-velloreille_les_choye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70540-70700-velloreille_les_choye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70540-70700-velloreille_les_choye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70541-70300-velorcey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70541-70300-velorcey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70541-70300-velorcey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70541-70300-velorcey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70542-70100-venere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70542-70100-venere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70542-70100-venere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70542-70100-venere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70544-70200-la_vergenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70544-70200-la_vergenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70544-70200-la_vergenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70544-70200-la_vergenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70545-70500-venisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70545-70500-venisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70545-70500-venisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70545-70500-venisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70546-70180-vereux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70546-70180-vereux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70546-70180-vereux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70546-70180-vereux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70547-70400-verlans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70547-70400-verlans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70547-70400-verlans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70547-70400-verlans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70548-70500-vernois_sur_mance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70548-70500-vernois_sur_mance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70548-70500-vernois_sur_mance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70548-70500-vernois_sur_mance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70549-70130-la_vernotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70549-70130-la_vernotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70549-70130-la_vernotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70549-70130-la_vernotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70550-70000-vesoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70550-70000-vesoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70550-70000-vesoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70550-70000-vesoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70552-70110-villafans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70552-70110-villafans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70552-70110-villafans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70552-70110-villafans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70553-70110-villargent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70553-70110-villargent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70553-70110-villargent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70553-70110-villargent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70554-70500-villars_le_pautel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70554-70500-villars_le_pautel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70554-70500-villars_le_pautel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70554-70500-villars_le_pautel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70555-70160-la_villedieu_en_fontenette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70555-70160-la_villedieu_en_fontenette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70555-70160-la_villedieu_en_fontenette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70555-70160-la_villedieu_en_fontenette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70557-70700-villefrancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70557-70700-villefrancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70557-70700-villefrancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70557-70700-villefrancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70558-70240-la_villeneuve_bellenoye_et_la_maize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70558-70240-la_villeneuve_bellenoye_et_la_maize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70558-70240-la_villeneuve_bellenoye_et_la_maize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70558-70240-la_villeneuve_bellenoye_et_la_maize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70559-70000-villeparois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70559-70000-villeparois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70559-70000-villeparois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70559-70000-villeparois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70560-70190-villers_bouton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70560-70190-villers_bouton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70560-70190-villers_bouton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70560-70190-villers_bouton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70561-70110-villersexel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70561-70110-villersexel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70561-70110-villersexel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70561-70110-villersexel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70562-70110-villers_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70562-70110-villers_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70562-70110-villers_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70562-70110-villers_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70563-70000-villers_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70563-70000-villers_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70563-70000-villers_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70563-70000-villers_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70564-70300-villers_les_luxeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70564-70300-villers_les_luxeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70564-70300-villers_les_luxeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70564-70300-villers_les_luxeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70565-70190-villers_pater/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70565-70190-villers_pater/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70565-70190-villers_pater/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70565-70190-villers_pater/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70566-70170-villers_sur_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70566-70170-villers_sur_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70566-70170-villers_sur_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70566-70170-villers_sur_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70567-70400-villers_sur_saulnot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70567-70400-villers_sur_saulnot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70567-70400-villers_sur_saulnot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70567-70400-villers_sur_saulnot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70568-70120-villers_vaudey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70568-70120-villers_vaudey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70568-70120-villers_vaudey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70568-70120-villers_vaudey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70569-70240-vilory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70569-70240-vilory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70569-70240-vilory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70569-70240-vilory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70571-70300-visoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70571-70300-visoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70571-70300-visoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70571-70300-visoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70572-70500-vitrey_sur_mance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70572-70500-vitrey_sur_mance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70572-70500-vitrey_sur_mance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70572-70500-vitrey_sur_mance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70573-70310-la_voivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70573-70310-la_voivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70573-70310-la_voivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70573-70310-la_voivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70574-70180-volon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70574-70180-volon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70574-70180-volon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70574-70180-volon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70575-70190-voray_sur_l_ognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70575-70190-voray_sur_l_ognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70575-70190-voray_sur_l_ognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70575-70190-voray_sur_l_ognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70576-70500-vougecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70576-70500-vougecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70576-70500-vougecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70576-70500-vougecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70577-70200-vouhenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70577-70200-vouhenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70577-70200-vouhenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70577-70200-vouhenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70578-70150-vregille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70578-70150-vregille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70578-70150-vregille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70578-70150-vregille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70579-70400-vyans_le_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70579-70400-vyans_le_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70579-70400-vyans_le_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70579-70400-vyans_le_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70580-70130-vy_le_ferroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70580-70130-vy_le_ferroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70580-70130-vy_le_ferroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70580-70130-vy_le_ferroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70581-70200-vy_les_lure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70581-70200-vy_les_lure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70581-70200-vy_les_lure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70581-70200-vy_les_lure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70582-70120-vy_les_rupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70582-70120-vy_les_rupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70582-70120-vy_les_rupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70582-70120-vy_les_rupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70583-70230-vy_les_filain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70583-70230-vy_les_filain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70583-70230-vy_les_filain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt70-haute_saone/commune70583-70230-vy_les_filain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-71.xml
+++ b/public/sitemaps/sitemap-71.xml
@@ -5,1148 +5,2292 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71001-71290-l_abergement_de_cuisery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71001-71290-l_abergement_de_cuisery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71001-71290-l_abergement_de_cuisery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71001-71290-l_abergement_de_cuisery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71002-71370-l_abergement_sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71002-71370-l_abergement_sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71002-71370-l_abergement_sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71002-71370-l_abergement_sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71003-71350-allerey_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71003-71350-allerey_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71003-71350-allerey_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71003-71350-allerey_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71004-71380-alleriot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71004-71380-alleriot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71004-71380-alleriot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71004-71380-alleriot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71005-71510-aluze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71005-71510-aluze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71005-71510-aluze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71005-71510-aluze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71006-71800-amanze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71006-71800-amanze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71006-71800-amanze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71006-71800-amanze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71007-71460-ameugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71007-71460-ameugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71007-71460-ameugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71007-71460-ameugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71008-71170-anglure_sous_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71008-71170-anglure_sous_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71008-71170-anglure_sous_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71008-71170-anglure_sous_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71009-71550-anost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71009-71550-anost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71009-71550-anost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71009-71550-anost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71010-71400-antully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71010-71400-antully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71010-71400-antully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71010-71400-antully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71011-71110-anzy_le_duc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71011-71110-anzy_le_duc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71011-71110-anzy_le_duc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71011-71110-anzy_le_duc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71012-71110-artaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71012-71110-artaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71012-71110-artaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71012-71110-artaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71013-71270-authumes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71013-71270-authumes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71013-71270-authumes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71013-71270-authumes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71014-71400-autun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71014-71400-autun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71014-71400-autun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71014-71400-autun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71015-71400-auxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71015-71400-auxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71015-71400-auxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71015-71400-auxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71016-71260-aze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71016-71260-aze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71016-71260-aze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71016-71260-aze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71016-71960-aze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71016-71960-aze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71016-71960-aze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71016-71960-aze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71017-71220-ballore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71017-71220-ballore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71017-71220-ballore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71017-71220-ballore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71018-71500-bantanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71018-71500-bantanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71018-71500-bantanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71018-71500-bantanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71019-71640-barizey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71019-71640-barizey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71019-71640-barizey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71019-71640-barizey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71020-71540-barnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71020-71540-barnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71020-71540-barnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71020-71540-barnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71021-71120-baron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71021-71120-baron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71021-71120-baron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71021-71120-baron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71022-71800-baudemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71022-71800-baudemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71022-71800-baudemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71022-71800-baudemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71023-71370-baudrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71023-71370-baudrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71023-71370-baudrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71023-71370-baudrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71024-71110-baugy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71024-71110-baugy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71024-71110-baugy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71024-71110-baugy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71025-71220-beaubery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71025-71220-beaubery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71025-71220-beaubery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71025-71220-beaubery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71026-71240-beaumont_sur_grosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71026-71240-beaumont_sur_grosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71026-71240-beaumont_sur_grosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71026-71240-beaumont_sur_grosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71027-71580-beaurepaire_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71027-71580-beaurepaire_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71027-71580-beaurepaire_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71027-71580-beaurepaire_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71028-71270-beauvernois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71028-71270-beauvernois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71028-71270-beauvernois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71028-71270-beauvernois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71029-71270-bellevesvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71029-71270-bellevesvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71029-71270-bellevesvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71029-71270-bellevesvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71030-71250-bergesserin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71030-71250-bergesserin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71030-71250-bergesserin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71030-71250-bergesserin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71031-71960-berze_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71031-71960-berze_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71031-71960-berze_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71031-71960-berze_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71032-71960-berze_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71032-71960-berze_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71032-71960-berze_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71032-71960-berze_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71033-71620-bey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71033-71620-bey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71033-71620-bey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71033-71620-bey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71034-71390-bissey_sous_cruchaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71034-71390-bissey_sous_cruchaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71034-71390-bissey_sous_cruchaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71034-71390-bissey_sous_cruchaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71035-71260-bissy_la_maconnaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71035-71260-bissy_la_maconnaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71035-71260-bissy_la_maconnaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71035-71260-bissy_la_maconnaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71036-71460-bissy_sous_uxelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71036-71460-bissy_sous_uxelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71036-71460-bissy_sous_uxelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71036-71460-bissy_sous_uxelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71037-71460-bissy_sur_fley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71037-71460-bissy_sur_fley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71037-71460-bissy_sur_fley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71037-71460-bissy_sur_fley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71038-71710-les_bizots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71038-71710-les_bizots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71038-71710-les_bizots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71038-71710-les_bizots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71039-71250-blanot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71039-71250-blanot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71039-71250-blanot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71039-71250-blanot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71040-71450-blanzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71040-71450-blanzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71040-71450-blanzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71040-71450-blanzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71041-71800-bois_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71041-71800-bois_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71041-71800-bois_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71041-71800-bois_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71042-71460-bonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71042-71460-bonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71042-71460-bonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71042-71460-bonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71043-71350-les_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71043-71350-les_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71043-71350-les_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71043-71350-les_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71044-71330-bosjean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71044-71330-bosjean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71044-71330-bosjean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71044-71330-bosjean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71045-71330-bouhans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71045-71330-bouhans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71045-71330-bouhans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71045-71330-bouhans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71046-71320-la_boulaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71046-71320-la_boulaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71046-71320-la_boulaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71046-71320-la_boulaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71047-71140-bourbon_lancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71047-71140-bourbon_lancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71047-71140-bourbon_lancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71047-71140-bourbon_lancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71048-71110-bourg_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71048-71110-bourg_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71048-71110-bourg_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71048-71110-bourg_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71050-71520-bourgvilain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71050-71520-bourgvilain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71050-71520-bourgvilain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71050-71520-bourgvilain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71051-71150-bouzeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71051-71150-bouzeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71051-71150-bouzeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71051-71150-bouzeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71052-71700-boyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71052-71700-boyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71052-71700-boyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71052-71700-boyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71054-71350-bragny_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71054-71350-bragny_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71054-71350-bragny_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71054-71350-bragny_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71056-71500-branges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71056-71500-branges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71056-71500-branges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71056-71500-branges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71057-71250-bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71057-71250-bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71057-71250-bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71057-71250-bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71058-71460-bresse_sur_grosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71058-71460-bresse_sur_grosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71058-71460-bresse_sur_grosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71058-71460-bresse_sur_grosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71059-71670-le_breuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71059-71670-le_breuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71059-71670-le_breuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71059-71670-le_breuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71060-71110-briant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71060-71110-briant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71060-71110-briant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71060-71110-briant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71061-71290-brienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71061-71290-brienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71061-71290-brienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71061-71290-brienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71062-71190-brion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71062-71190-brion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71062-71190-brion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71062-71190-brion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71063-71190-broye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71063-71190-broye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71063-71190-broye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71063-71190-broye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71064-71500-bruailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71064-71500-bruailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71064-71500-bruailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71064-71500-bruailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71065-71250-buffieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71065-71250-buffieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71065-71250-buffieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71065-71250-buffieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71066-71260-burgy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71066-71260-burgy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71066-71260-burgy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71066-71260-burgy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71067-71460-burnand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71067-71460-burnand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71067-71460-burnand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71067-71460-burnand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71068-71460-burzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71068-71460-burzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71068-71460-burzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71068-71460-burzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71069-71960-bussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71069-71960-bussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71069-71960-bussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71069-71960-bussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71070-71390-buxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71070-71390-buxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71070-71390-buxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71070-71390-buxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71071-71110-ceron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71071-71110-ceron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71071-71110-ceron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71071-71110-ceron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71072-71390-cersot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71072-71390-cersot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71072-71390-cersot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71072-71390-cersot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71073-71150-chagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71073-71150-chagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71073-71150-chagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71073-71150-chagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71074-71570-chaintre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71074-71570-chaintre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71074-71570-chaintre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71074-71570-chaintre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71075-71140-chalmoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71075-71140-chalmoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71075-71140-chalmoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71075-71140-chalmoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71076-71100-chalon_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71076-71100-chalon_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71076-71100-chalon_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71076-71100-chalon_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71077-71110-chambilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71077-71110-chambilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71077-71110-chambilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71077-71110-chambilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71078-71510-chamilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71078-71510-chamilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71078-71510-chamilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71078-71510-chamilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71079-71480-champagnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71079-71480-champagnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71079-71480-champagnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71079-71480-champagnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71080-71460-champagny_sous_uxelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71080-71460-champagny_sous_uxelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71080-71460-champagny_sous_uxelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71080-71460-champagny_sous_uxelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71081-71530-champforgeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71081-71530-champforgeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71081-71530-champforgeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71081-71530-champforgeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71082-71120-champlecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71082-71120-champlecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71082-71120-champlecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71082-71120-champlecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71084-71570-chanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71084-71570-chanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71084-71570-chanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71084-71570-chanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71085-21340-change/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71085-21340-change/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71085-21340-change/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71085-21340-change/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71086-71120-changy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71086-71120-changy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71086-71120-changy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71086-71120-changy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71087-71460-chapaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71087-71460-chapaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71087-71460-chapaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71087-71460-chapaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71088-71130-la_chapelle_au_mans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71088-71130-la_chapelle_au_mans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71088-71130-la_chapelle_au_mans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71088-71130-la_chapelle_au_mans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71089-71240-la_chapelle_de_bragny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71089-71240-la_chapelle_de_bragny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71089-71240-la_chapelle_de_bragny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71089-71240-la_chapelle_de_bragny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71090-71570-la_chapelle_de_guinchay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71090-71570-la_chapelle_de_guinchay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71090-71570-la_chapelle_de_guinchay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71090-71570-la_chapelle_de_guinchay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71091-71520-la_chapelle_du_mont_de_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71091-71520-la_chapelle_du_mont_de_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71091-71520-la_chapelle_du_mont_de_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71091-71520-la_chapelle_du_mont_de_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71092-71500-la_chapelle_naude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71092-71500-la_chapelle_naude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71092-71500-la_chapelle_naude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71092-71500-la_chapelle_naude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71093-71310-la_chapelle_saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71093-71310-la_chapelle_saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71093-71310-la_chapelle_saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71093-71310-la_chapelle_saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71094-71700-la_chapelle_sous_brancion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71094-71700-la_chapelle_sous_brancion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71094-71700-la_chapelle_sous_brancion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71094-71700-la_chapelle_sous_brancion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71095-71800-la_chapelle_sous_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71095-71800-la_chapelle_sous_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71095-71800-la_chapelle_sous_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71095-71800-la_chapelle_sous_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71096-71190-la_chapelle_sous_uchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71096-71190-la_chapelle_sous_uchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71096-71190-la_chapelle_sous_uchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71096-71190-la_chapelle_sous_uchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71097-71470-la_chapelle_thecle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71097-71470-la_chapelle_thecle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71097-71470-la_chapelle_thecle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71097-71470-la_chapelle_thecle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71098-71320-charbonnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71098-71320-charbonnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71098-71320-charbonnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71098-71320-charbonnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71099-71260-charbonnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71099-71260-charbonnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71099-71260-charbonnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71099-71260-charbonnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71100-71700-chardonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71100-71700-chardonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71100-71700-chardonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71100-71700-chardonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71101-71270-charette_varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71101-71270-charette_varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71101-71270-charette_varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71101-71270-charette_varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71102-71100-la_charmee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71102-71100-la_charmee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71102-71100-la_charmee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71102-71100-la_charmee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71103-71710-charmoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71103-71710-charmoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71103-71710-charmoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71103-71710-charmoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71104-71350-charnay_les_chalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71104-71350-charnay_les_chalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71104-71350-charnay_les_chalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71104-71350-charnay_les_chalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71105-71850-charnay_les_macon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71105-71850-charnay_les_macon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71105-71850-charnay_les_macon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71105-71850-charnay_les_macon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71106-71120-charolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71106-71120-charolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71106-71120-charolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71106-71120-charolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71107-71510-charrecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71107-71510-charrecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71107-71510-charrecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71107-71510-charrecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71108-71570-chasselas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71108-71570-chasselas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71108-71570-chasselas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71108-71570-chasselas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71109-71150-chassey_le_camp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71109-71150-chassey_le_camp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71109-71150-chassey_le_camp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71109-71150-chassey_le_camp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71110-71170-chassigny_sous_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71110-71170-chassigny_sous_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71110-71170-chassigny_sous_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71110-71170-chassigny_sous_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71111-71130-chassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71111-71130-chassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71111-71130-chassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71111-71130-chassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71112-71250-chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71112-71250-chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71112-71250-chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71112-71250-chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71113-71740-chateauneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71113-71740-chateauneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71113-71740-chateauneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71113-71740-chateauneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71115-71510-chatel_moron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71115-71510-chatel_moron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71115-71510-chatel_moron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71115-71510-chatel_moron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71116-71800-chatenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71116-71800-chatenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71116-71800-chatenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71116-71800-chatenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71117-71380-chatenoy_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71117-71380-chatenoy_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71117-71380-chatenoy_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71117-71380-chatenoy_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71118-71880-chatenoy_le_royal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71118-71880-chatenoy_le_royal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71118-71880-chatenoy_le_royal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71118-71880-chatenoy_le_royal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71119-71150-chaudenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71119-71150-chaudenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71119-71150-chaudenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71119-71150-chaudenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71120-71170-chauffailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71120-71170-chauffailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71120-71170-chauffailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71120-71170-chauffailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71121-71310-la_chaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71121-71310-la_chaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71121-71310-la_chaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71121-71310-la_chaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71122-71150-cheilly_les_maranges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71122-71150-cheilly_les_maranges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71122-71150-cheilly_les_maranges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71122-71150-cheilly_les_maranges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71123-71340-chenay_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71123-71340-chenay_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71123-71340-chenay_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71123-71340-chenay_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71124-71390-chenoves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71124-71390-chenoves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71124-71390-chenoves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71124-71390-chenoves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71125-71250-cherizet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71125-71250-cherizet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71125-71250-cherizet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71125-71250-cherizet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71126-71960-chevagny_les_chevrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71126-71960-chevagny_les_chevrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71126-71960-chevagny_les_chevrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71126-71960-chevagny_les_chevrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71127-71220-chevagny_sur_guye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71127-71220-chevagny_sur_guye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71127-71220-chevagny_sur_guye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71127-71220-chevagny_sur_guye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71128-71220-chiddes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71128-71220-chiddes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71128-71220-chiddes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71128-71220-chiddes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71129-71540-chissey_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71129-71540-chissey_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71129-71540-chissey_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71129-71540-chissey_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71130-71460-chissey_les_macon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71130-71460-chissey_les_macon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71130-71460-chissey_les_macon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71130-71460-chissey_les_macon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71131-71350-ciel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71131-71350-ciel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71131-71350-ciel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71131-71350-ciel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71132-71420-ciry_le_noble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71132-71420-ciry_le_noble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71132-71420-ciry_le_noble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71132-71420-ciry_le_noble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71133-71800-la_clayette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71133-71800-la_clayette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71133-71800-la_clayette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71133-71800-la_clayette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71134-71520-navour_sur_grosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71134-71520-navour_sur_grosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71134-71520-navour_sur_grosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71134-71520-navour_sur_grosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71135-71260-clesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71135-71260-clesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71135-71260-clesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71135-71260-clesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71136-71130-clessy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71136-71130-clessy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71136-71130-clessy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71136-71130-clessy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71137-71250-cluny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71137-71250-cluny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71137-71250-cluny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71137-71250-cluny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71139-71460-collonge_en_charollais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71139-71460-collonge_en_charollais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71139-71460-collonge_en_charollais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71139-71460-collonge_en_charollais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71140-71360-collonge_la_madeleine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71140-71360-collonge_la_madeleine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71140-71360-collonge_la_madeleine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71140-71360-collonge_la_madeleine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71141-71800-colombier_en_brionnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71141-71800-colombier_en_brionnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71141-71800-colombier_en_brionnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71141-71800-colombier_en_brionnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71142-71990-la_comelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71142-71990-la_comelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71142-71990-la_comelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71142-71990-la_comelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71143-71480-condal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71143-71480-condal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71143-71480-condal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71143-71480-condal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71144-71540-cordesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71144-71540-cordesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71144-71540-cordesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71144-71540-cordesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71145-71460-cormatin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71145-71460-cormatin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71145-71460-cormatin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71145-71460-cormatin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71146-71250-cortambert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71146-71250-cortambert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71146-71250-cortambert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71146-71250-cortambert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71147-71460-cortevaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71147-71460-cortevaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71147-71460-cortevaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71147-71460-cortevaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71148-71170-coublanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71148-71170-coublanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71148-71170-coublanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71148-71170-coublanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71149-71490-couches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71149-71490-couches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71149-71490-couches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71149-71490-couches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71150-71680-creches_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71150-71680-creches_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71150-71680-creches_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71150-71680-creches_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71151-71490-creot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71151-71490-creot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71151-71490-creot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71151-71490-creot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71152-71760-cressy_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71152-71760-cressy_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71152-71760-cressy_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71152-71760-cressy_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71153-71200-le_creusot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71153-71200-le_creusot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71153-71200-le_creusot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71153-71200-le_creusot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71154-71530-crissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71154-71530-crissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71154-71530-crissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71154-71530-crissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71155-71140-cronat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71155-71140-cronat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71155-71140-cronat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71155-71140-cronat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71156-71260-cruzille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71156-71260-cruzille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71156-71260-cruzille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71156-71260-cruzille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71157-71480-cuiseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71157-71480-cuiseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71157-71480-cuiseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71157-71480-cuiseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71158-71290-cuisery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71158-71290-cuisery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71158-71290-cuisery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71158-71290-cuisery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71159-71460-culles_les_roches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71159-71460-culles_les_roches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71159-71460-culles_les_roches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71159-71460-culles_les_roches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71160-71800-curbigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71160-71800-curbigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71160-71800-curbigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71160-71800-curbigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71161-71130-curdin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71161-71130-curdin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71161-71130-curdin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71161-71130-curdin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71162-71400-curgy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71162-71400-curgy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71162-71400-curgy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71162-71400-curgy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71163-71520-curtil_sous_buffieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71163-71520-curtil_sous_buffieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71163-71520-curtil_sous_buffieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71163-71520-curtil_sous_buffieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71164-71460-curtil_sous_burnand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71164-71460-curtil_sous_burnand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71164-71460-curtil_sous_burnand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71164-71460-curtil_sous_burnand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71165-71550-cussy_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71165-71550-cussy_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71165-71550-cussy_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71165-71550-cussy_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71166-71320-cuzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71166-71320-cuzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71166-71320-cuzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71166-71320-cuzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71167-71620-damerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71167-71620-damerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71167-71620-damerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71167-71620-damerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71168-71310-dampierre_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71168-71310-dampierre_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71168-71310-dampierre_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71168-71310-dampierre_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71169-71960-davaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71169-71960-davaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71169-71960-davaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71169-71960-davaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71170-71150-demigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71170-71150-demigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71170-71150-demigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71170-71150-demigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71171-71510-dennevy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71171-71510-dennevy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71171-71510-dennevy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71171-71510-dennevy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71172-71190-dettey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71172-71190-dettey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71172-71190-dettey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71172-71190-dettey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71173-71330-devrouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71173-71330-devrouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71173-71330-devrouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71173-71330-devrouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71174-71150-dezize_les_maranges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71174-71150-dezize_les_maranges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71174-71150-dezize_les_maranges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71174-71150-dezize_les_maranges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71175-71330-diconne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71175-71330-diconne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71175-71330-diconne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71175-71330-diconne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71176-71160-digoin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71176-71160-digoin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71176-71160-digoin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71176-71160-digoin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71177-71480-dommartin_les_cuiseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71177-71480-dommartin_les_cuiseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71177-71480-dommartin_les_cuiseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71177-71480-dommartin_les_cuiseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71178-71520-dompierre_les_ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71178-71520-dompierre_les_ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71178-71520-dompierre_les_ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71178-71520-dompierre_les_ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71179-71420-dompierre_sous_sanvignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71179-71420-dompierre_sous_sanvignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71179-71420-dompierre_sous_sanvignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71179-71420-dompierre_sous_sanvignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71181-71250-donzy_le_pertuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71181-71250-donzy_le_pertuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71181-71250-donzy_le_pertuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71181-71250-donzy_le_pertuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71182-71640-dracy_le_fort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71182-71640-dracy_le_fort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71182-71640-dracy_le_fort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71182-71640-dracy_le_fort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71183-71490-dracy_les_couches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71183-71490-dracy_les_couches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71183-71490-dracy_les_couches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71183-71490-dracy_les_couches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71184-71400-dracy_saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71184-71400-dracy_saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71184-71400-dracy_saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71184-71400-dracy_saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71185-71800-dyo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71185-71800-dyo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71185-71800-dyo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71185-71800-dyo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71186-71350-ecuelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71186-71350-ecuelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71186-71350-ecuelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71186-71350-ecuelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71187-71210-ecuisses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71187-71210-ecuisses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71187-71210-ecuisses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71187-71210-ecuisses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71188-71360-epertully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71188-71360-epertully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71188-71360-epertully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71188-71360-epertully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71189-71380-epervans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71189-71380-epervans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71189-71380-epervans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71189-71380-epervans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71190-71360-epinac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71190-71360-epinac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71190-71360-epinac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71190-71360-epinac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71191-71510-essertenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71191-71510-essertenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71191-71510-essertenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71191-71510-essertenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71192-71190-etang_sur_arroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71192-71190-etang_sur_arroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71192-71190-etang_sur_arroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71192-71190-etang_sur_arroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71193-71240-etrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71193-71240-etrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71193-71240-etrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71193-71240-etrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71194-71150-farges_les_chalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71194-71150-farges_les_chalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71194-71150-farges_les_chalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71194-71150-farges_les_chalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71195-71700-farges_les_macon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71195-71700-farges_les_macon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71195-71700-farges_les_macon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71195-71700-farges_les_macon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71196-71580-le_fay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71196-71580-le_fay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71196-71580-le_fay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71196-71580-le_fay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71198-71580-flacey_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71198-71580-flacey_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71198-71580-flacey_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71198-71580-flacey_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71199-71250-flagy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71199-71250-flagy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71199-71250-flagy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71199-71250-flagy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71200-71340-fleury_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71200-71340-fleury_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71200-71340-fleury_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71200-71340-fleury_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71201-71390-fley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71201-71390-fley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71201-71390-fley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71201-71390-fley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71202-71150-fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71202-71150-fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71202-71150-fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71202-71150-fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71203-71120-fontenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71203-71120-fontenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71203-71120-fontenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71203-71120-fontenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71204-71530-fragnes_la_loyere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71204-71530-fragnes_la_loyere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71204-71530-fragnes_la_loyere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71204-71530-fragnes_la_loyere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71205-71330-frangy_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71205-71330-frangy_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71205-71330-frangy_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71205-71330-frangy_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71206-71440-la_frette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71206-71440-la_frette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71206-71440-la_frette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71206-71440-la_frette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71207-71270-fretterans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71207-71270-fretterans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71207-71270-fretterans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71207-71270-fretterans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71208-71270-frontenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71208-71270-frontenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71208-71270-frontenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71208-71270-frontenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71209-71580-frontenaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71209-71580-frontenaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71209-71580-frontenaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71209-71580-frontenaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71210-71960-fuisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71210-71960-fuisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71210-71960-fuisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71210-71960-fuisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71212-71420-genelard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71212-71420-genelard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71212-71420-genelard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71212-71420-genelard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71213-71290-la_genete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71213-71290-la_genete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71213-71290-la_genete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71213-71290-la_genete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71214-71460-genouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71214-71460-genouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71214-71460-genouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71214-71460-genouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71215-71590-gergy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71215-71590-gergy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71215-71590-gergy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71215-71590-gergy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71216-71460-germagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71216-71460-germagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71216-71460-germagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71216-71460-germagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71217-71520-germolles_sur_grosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71217-71520-germolles_sur_grosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71217-71520-germolles_sur_grosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71217-71520-germolles_sur_grosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71218-71800-gibles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71218-71800-gibles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71218-71800-gibles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71218-71800-gibles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71219-71240-gigny_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71219-71240-gigny_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71219-71240-gigny_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71219-71240-gigny_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71220-71160-gilly_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71220-71160-gilly_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71220-71160-gilly_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71220-71160-gilly_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71221-71640-givry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71221-71640-givry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71221-71640-givry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71221-71640-givry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71222-71300-gourdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71222-71300-gourdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71222-71300-gourdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71222-71300-gourdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71223-71990-la_grande_verriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71223-71990-la_grande_verriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71223-71990-la_grande_verriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71223-71990-la_grande_verriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71224-71430-grandvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71224-71430-grandvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71224-71430-grandvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71224-71430-grandvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71225-71390-granges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71225-71390-granges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71225-71390-granges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71225-71390-granges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71226-71700-grevilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71226-71700-grevilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71226-71700-grevilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71226-71700-grevilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71227-71760-grury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71227-71760-grury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71227-71760-grury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71227-71760-grury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71228-71620-guerfand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71228-71620-guerfand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71228-71620-guerfand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71228-71620-guerfand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71229-71160-les_guerreaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71229-71160-les_guerreaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71229-71160-les_guerreaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71229-71160-les_guerreaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71230-71130-gueugnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71230-71130-gueugnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71230-71130-gueugnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71230-71130-gueugnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71231-71220-la_guiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71231-71220-la_guiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71231-71220-la_guiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71231-71220-la_guiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71232-71600-hautefond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71232-71600-hautefond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71232-71600-hautefond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71232-71600-hautefond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71233-71600-l_hopital_le_mercier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71233-71600-l_hopital_le_mercier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71233-71600-l_hopital_le_mercier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71233-71600-l_hopital_le_mercier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71234-71290-huilly_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71234-71290-huilly_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71234-71290-huilly_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71234-71290-huilly_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71235-71870-hurigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71235-71870-hurigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71235-71870-hurigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71235-71870-hurigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71236-71960-ige/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71236-71960-ige/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71236-71960-ige/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71236-71960-ige/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71237-71540-igornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71237-71540-igornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71237-71540-igornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71237-71540-igornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71238-71340-iguerande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71238-71340-iguerande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71238-71340-iguerande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71238-71340-iguerande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71239-71760-issy_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71239-71760-issy_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71239-71760-issy_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71239-71760-issy_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71240-71250-jalogny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71240-71250-jalogny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71240-71250-jalogny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71240-71250-jalogny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71241-71640-jambles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71241-71640-jambles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71241-71640-jambles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71241-71640-jambles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71242-71460-joncy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71242-71460-joncy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71242-71460-joncy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71242-71460-joncy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71243-71480-joudes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71243-71480-joudes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71243-71480-joudes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71243-71480-joudes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71244-71290-jouvencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71244-71290-jouvencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71244-71290-jouvencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71244-71290-jouvencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71245-71240-jugy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71245-71240-jugy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71245-71240-jugy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71245-71240-jugy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71246-71440-juif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71246-71440-juif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71246-71440-juif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71246-71440-juif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71247-71390-jully_les_buxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71247-71390-jully_les_buxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71247-71390-jully_les_buxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71247-71390-jully_les_buxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71248-71700-lacrost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71248-71700-lacrost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71248-71700-lacrost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71248-71700-lacrost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71249-71240-laives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71249-71240-laives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71249-71240-laives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71249-71240-laives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71250-71870-laize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71250-71870-laize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71250-71870-laize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71250-71870-laize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71251-71190-laizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71251-71190-laizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71251-71190-laizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71251-71190-laizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71252-71240-lalheue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71252-71240-lalheue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71252-71240-lalheue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71252-71240-lalheue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71253-71380-lans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71253-71380-lans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71253-71380-lans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71253-71380-lans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71254-71270-lays_sur_le_doubs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71254-71270-lays_sur_le_doubs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71254-71270-lays_sur_le_doubs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71254-71270-lays_sur_le_doubs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71255-71140-lesme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71255-71140-lesme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71255-71140-lesme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71255-71140-lesme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71256-71440-lessard_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71256-71440-lessard_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71256-71440-lessard_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71256-71440-lessard_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71257-71530-lessard_le_national/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71257-71530-lessard_le_national/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71257-71530-lessard_le_national/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71257-71530-lessard_le_national/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71258-71570-leynes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71258-71570-leynes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71258-71570-leynes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71258-71570-leynes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71259-71110-ligny_en_brionnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71259-71110-ligny_en_brionnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71259-71110-ligny_en_brionnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71259-71110-ligny_en_brionnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71261-71290-loisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71261-71290-loisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71261-71290-loisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71261-71290-loisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71262-71270-longepierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71262-71270-longepierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71262-71270-longepierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71262-71270-longepierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71263-71500-louhans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71263-71500-louhans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71263-71500-louhans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71263-71500-louhans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71264-71250-lournand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71264-71250-lournand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71264-71250-lournand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71264-71250-lournand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71266-71540-lucenay_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71266-71540-lucenay_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71266-71540-lucenay_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71266-71540-lucenay_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71267-71260-lugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71267-71260-lugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71267-71260-lugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71267-71260-lugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71268-71120-lugny_les_charolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71268-71120-lugny_les_charolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71268-71120-lugny_les_charolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71268-71120-lugny_les_charolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71269-71100-lux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71269-71100-lux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71269-71100-lux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71269-71100-lux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71270-71000-macon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71270-71000-macon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71270-71000-macon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71270-71000-macon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71271-71340-mailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71271-71340-mailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71271-71340-mailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71271-71340-mailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71272-71460-malay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71272-71460-malay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71272-71460-malay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71272-71460-malay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71273-71140-maltat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71273-71140-maltat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71273-71140-maltat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71273-71140-maltat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71274-71240-mancey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71274-71240-mancey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71274-71240-mancey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71274-71240-mancey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71275-71110-marcigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71275-71110-marcigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71275-71110-marcigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71275-71110-marcigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71276-71120-marcilly_la_gueurce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71276-71120-marcilly_la_gueurce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71276-71120-marcilly_la_gueurce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71276-71120-marcilly_la_gueurce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71277-71390-marcilly_les_buxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71277-71390-marcilly_les_buxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71277-71390-marcilly_les_buxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71277-71390-marcilly_les_buxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71300-marigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71300-marigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71300-marigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71300-marigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71460-marigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71460-marigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71460-marigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71460-marigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71210-marigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71210-marigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71210-marigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71278-71210-marigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71279-71220-le_rousset_marizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71279-71220-le_rousset_marizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71279-71220-le_rousset_marizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71279-71220-le_rousset_marizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71280-71760-marly_sous_issy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71280-71760-marly_sous_issy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71280-71760-marly_sous_issy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71280-71760-marly_sous_issy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71281-71420-marly_sur_arroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71281-71420-marly_sur_arroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71281-71420-marly_sur_arroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71281-71420-marly_sur_arroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71282-71710-marmagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71282-71710-marmagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71282-71710-marmagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71282-71710-marmagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71283-71240-marnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71283-71240-marnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71283-71240-marnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71283-71240-marnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71284-71700-martailly_les_brancion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71284-71700-martailly_les_brancion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71284-71700-martailly_les_brancion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71284-71700-martailly_les_brancion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71285-71220-martigny_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71285-71220-martigny_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71285-71220-martigny_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71285-71220-martigny_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71286-71300-mary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71286-71300-mary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71286-71300-mary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71286-71300-mary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71287-71250-massilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71287-71250-massilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71287-71250-massilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71287-71250-massilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71289-71520-matour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71289-71520-matour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71289-71520-matour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71289-71520-matour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71290-71250-mazille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71290-71250-mazille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71290-71250-mazille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71290-71250-mazille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71291-71340-melay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71291-71340-melay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71291-71340-melay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71291-71340-melay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71292-71640-mellecey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71292-71640-mellecey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71292-71640-mellecey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71292-71640-mellecey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71293-71470-menetreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71293-71470-menetreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71293-71470-menetreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71293-71470-menetreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71294-71640-mercurey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71294-71640-mercurey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71294-71640-mercurey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71294-71640-mercurey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71295-71310-mervans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71295-71310-mervans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71295-71310-mervans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71295-71310-mervans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71296-71390-messey_sur_grosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71296-71390-messey_sur_grosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71296-71390-messey_sur_grosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71296-71390-messey_sur_grosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71297-71190-mesvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71297-71190-mesvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71297-71190-mesvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71297-71190-mesvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71299-71960-milly_lamartine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71299-71960-milly_lamartine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71299-71960-milly_lamartine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71299-71960-milly_lamartine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71300-71480-le_miroir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71300-71480-le_miroir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71300-71480-le_miroir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71300-71480-le_miroir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71301-71140-mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71301-71140-mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71301-71140-mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71301-71140-mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71302-71390-montagny_les_buxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71302-71390-montagny_les_buxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71302-71390-montagny_les_buxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71302-71390-montagny_les_buxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71303-71500-montagny_pres_louhans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71303-71500-montagny_pres_louhans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71303-71500-montagny_pres_louhans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71303-71500-montagny_pres_louhans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71305-71260-montbellet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71305-71260-montbellet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71305-71260-montbellet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71305-71260-montbellet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71306-71300-montceau_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71306-71300-montceau_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71306-71300-montceau_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71306-71300-montceau_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71307-71110-montceaux_l_etoile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71307-71110-montceaux_l_etoile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71307-71110-montceaux_l_etoile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71307-71110-montceaux_l_etoile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71308-71240-montceaux_ragny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71308-71240-montceaux_ragny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71308-71240-montceaux_ragny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71308-71240-montceaux_ragny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71309-71710-montcenis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71309-71710-montcenis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71309-71710-montcenis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71309-71710-montcenis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71310-71210-montchanin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71310-71210-montchanin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71310-71210-montchanin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71310-71210-montchanin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71311-71500-montcony/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71311-71500-montcony/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71311-71500-montcony/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71311-71500-montcony/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71312-71620-montcoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71312-71620-montcoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71312-71620-montcoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71312-71620-montcoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71313-71400-monthelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71313-71400-monthelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71313-71400-monthelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71313-71400-monthelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71314-71310-montjay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71314-71310-montjay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71314-71310-montjay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71314-71310-montjay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71315-71270-mont_les_seurre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71315-71270-mont_les_seurre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71315-71270-mont_les_seurre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71315-71270-mont_les_seurre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71316-71520-montmelard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71316-71520-montmelard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71316-71520-montmelard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71316-71520-montmelard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71317-71320-montmort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71317-71320-montmort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71317-71320-montmort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71317-71320-montmort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71318-71470-montpont_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71318-71470-montpont_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71318-71470-montpont_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71318-71470-montpont_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71319-71440-montret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71319-71440-montret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71319-71440-montret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71319-71440-montret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71320-71300-mont_saint_vincent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71320-71300-mont_saint_vincent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71320-71300-mont_saint_vincent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71320-71300-mont_saint_vincent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71321-71510-morey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71321-71510-morey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71321-71510-morey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71321-71510-morey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71322-71360-morlet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71322-71360-morlet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71322-71360-morlet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71322-71360-morlet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71323-71220-mornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71323-71220-mornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71323-71220-mornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71323-71220-mornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71324-71390-moroges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71324-71390-moroges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71324-71390-moroges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71324-71390-moroges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71325-71160-la_motte_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71325-71160-la_motte_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71325-71160-la_motte_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71325-71160-la_motte_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71326-71270-mouthier_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71326-71270-mouthier_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71326-71270-mouthier_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71326-71270-mouthier_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71327-71170-mussy_sous_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71327-71170-mussy_sous_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71327-71170-mussy_sous_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71327-71170-mussy_sous_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71328-71240-nanton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71328-71240-nanton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71328-71240-nanton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71328-71240-nanton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71329-71270-navilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71329-71270-navilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71329-71270-navilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71329-71270-navilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71330-71130-neuvy_grandchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71330-71130-neuvy_grandchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71330-71130-neuvy_grandchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71330-71130-neuvy_grandchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71331-71600-nochize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71331-71600-nochize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71331-71600-nochize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71331-71600-nochize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71332-71290-ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71332-71290-ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71332-71290-ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71332-71290-ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71333-71380-oslon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71333-71380-oslon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71333-71380-oslon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71333-71380-oslon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71334-71420-oudry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71334-71420-oudry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71334-71420-oudry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71334-71420-oudry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71335-71800-ouroux_sous_le_bois_sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71335-71800-ouroux_sous_le_bois_sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71335-71800-ouroux_sous_le_bois_sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71335-71800-ouroux_sous_le_bois_sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71336-71370-ouroux_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71336-71370-ouroux_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71336-71370-ouroux_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71336-71370-ouroux_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71337-71800-oye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71337-71800-oye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71337-71800-oye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71337-71800-oye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71338-71700-ozenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71338-71700-ozenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71338-71700-ozenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71338-71700-ozenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71339-71120-ozolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71339-71120-ozolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71339-71120-ozolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71339-71120-ozolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71339-71800-ozolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71339-71800-ozolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71339-71800-ozolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71339-71800-ozolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71340-71430-palinges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71340-71430-palinges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71340-71430-palinges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71340-71430-palinges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71341-71350-palleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71341-71350-palleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71341-71350-palleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71341-71350-palleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71342-71600-paray_le_monial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71342-71600-paray_le_monial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71342-71600-paray_le_monial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71342-71600-paray_le_monial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71343-71150-paris_l_hopital/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71343-71150-paris_l_hopital/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71343-71150-paris_l_hopital/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71343-71150-paris_l_hopital/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71344-71220-passy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71344-71220-passy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71344-71220-passy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71344-71220-passy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71345-71260-peronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71345-71260-peronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71345-71260-peronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71345-71260-peronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71346-71420-perrecy_les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71346-71420-perrecy_les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71346-71420-perrecy_les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71346-71420-perrecy_les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71347-71510-perreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71347-71510-perreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71347-71510-perreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71347-71510-perreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71348-71160-perrigny_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71348-71160-perrigny_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71348-71160-perrigny_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71348-71160-perrigny_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71349-71400-la_petite_verriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71349-71400-la_petite_verriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71349-71400-la_petite_verriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71349-71400-la_petite_verriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71350-71960-pierreclos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71350-71960-pierreclos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71350-71960-pierreclos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71350-71960-pierreclos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71351-71270-pierre_de_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71351-71270-pierre_de_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71351-71270-pierre_de_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71351-71270-pierre_de_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71352-71330-le_planois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71352-71330-le_planois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71352-71330-le_planois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71352-71330-le_planois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71353-71700-plottes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71353-71700-plottes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71353-71700-plottes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71353-71700-plottes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71354-71600-poisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71354-71600-poisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71354-71600-poisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71354-71600-poisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71355-71270-pontoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71355-71270-pontoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71355-71270-pontoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71355-71270-pontoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71356-71230-pouilloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71356-71230-pouilloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71356-71230-pouilloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71356-71230-pouilloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71357-71270-pourlans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71357-71270-pourlans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71357-71270-pourlans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71357-71270-pourlans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71358-71220-pressy_sous_dondin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71358-71220-pressy_sous_dondin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71358-71220-pressy_sous_dondin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71358-71220-pressy_sous_dondin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71359-71290-prety/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71359-71290-prety/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71359-71290-prety/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71359-71290-prety/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71360-71960-prisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71360-71960-prisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71360-71960-prisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71360-71960-prisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71361-71800-prizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71361-71800-prizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71361-71800-prizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71361-71800-prizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71362-71570-pruzilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71362-71570-pruzilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71362-71570-pruzilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71362-71570-pruzilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71363-71460-le_puley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71363-71460-le_puley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71363-71460-le_puley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71363-71460-le_puley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71364-71310-la_racineuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71364-71310-la_racineuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71364-71310-la_racineuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71364-71310-la_racineuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71365-71290-rancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71365-71290-rancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71365-71290-rancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71365-71290-rancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71366-71290-ratenelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71366-71290-ratenelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71366-71290-ratenelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71366-71290-ratenelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71367-71500-ratte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71367-71500-ratte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71367-71500-ratte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71367-71500-ratte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71368-71540-reclesne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71368-71540-reclesne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71368-71540-reclesne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71368-71540-reclesne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71369-71150-remigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71369-71150-remigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71369-71150-remigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71369-71150-remigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71370-71160-rigny_sur_arroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71370-71160-rigny_sur_arroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71370-71160-rigny_sur_arroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71370-71160-rigny_sur_arroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71371-71960-la_roche_vineuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71371-71960-la_roche_vineuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71371-71960-la_roche_vineuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71371-71960-la_roche_vineuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71372-71570-romaneche_thorins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71372-71570-romaneche_thorins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71372-71570-romaneche_thorins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71372-71570-romaneche_thorins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71373-71470-romenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71373-71470-romenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71373-71470-romenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71373-71470-romenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71374-71390-rosey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71374-71390-rosey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71374-71390-rosey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71374-71390-rosey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71376-71550-roussillon_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71376-71550-roussillon_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71376-71550-roussillon_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71376-71550-roussillon_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71377-71700-royer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71377-71700-royer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71377-71700-royer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71377-71700-royer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71378-71150-rully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71378-71150-rully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71378-71150-rully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71378-71150-rully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71379-71580-sagy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71379-71580-sagy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71379-71580-sagy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71379-71580-sagy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71380-71580-saillenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71380-71580-saillenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71380-71580-saillenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71380-71580-saillenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71381-71250-sailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71381-71250-sailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71381-71250-sailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71381-71250-sailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71382-71160-saint_agnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71382-71160-saint_agnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71382-71160-saint_agnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71382-71160-saint_agnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71383-71260-saint_albain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71383-71260-saint_albain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71383-71260-saint_albain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71383-71260-saint_albain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71384-71240-saint_ambreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71384-71240-saint_ambreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71384-71240-saint_ambreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71384-71240-saint_ambreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71385-71570-saint_amour_bellevue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71385-71570-saint_amour_bellevue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71385-71570-saint_amour_bellevue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71385-71570-saint_amour_bellevue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71386-71440-saint_andre_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71386-71440-saint_andre_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71386-71440-saint_andre_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71386-71440-saint_andre_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71387-71220-saint_andre_le_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71387-71220-saint_andre_le_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71387-71220-saint_andre_le_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71387-71220-saint_andre_le_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71388-71430-saint_aubin_en_charollais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71388-71430-saint_aubin_en_charollais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71388-71430-saint_aubin_en_charollais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71388-71430-saint_aubin_en_charollais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71389-71140-saint_aubin_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71389-71140-saint_aubin_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71389-71140-saint_aubin_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71389-71140-saint_aubin_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71390-71300-saint_berain_sous_sanvignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71390-71300-saint_berain_sous_sanvignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71390-71300-saint_berain_sous_sanvignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71390-71300-saint_berain_sous_sanvignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71391-71510-saint_berain_sur_dheune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71391-71510-saint_berain_sur_dheune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71391-71510-saint_berain_sur_dheune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71391-71510-saint_berain_sur_dheune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71392-71390-saint_boil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71392-71390-saint_boil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71392-71390-saint_boil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71392-71390-saint_boil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71393-71340-saint_bonnet_de_cray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71393-71340-saint_bonnet_de_cray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71393-71340-saint_bonnet_de_cray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71393-71340-saint_bonnet_de_cray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71394-71220-saint_bonnet_de_joux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71394-71220-saint_bonnet_de_joux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71394-71220-saint_bonnet_de_joux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71394-71220-saint_bonnet_de_joux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71395-71430-saint_bonnet_de_vieille_vigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71395-71430-saint_bonnet_de_vieille_vigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71395-71430-saint_bonnet_de_vieille_vigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71395-71430-saint_bonnet_de_vieille_vigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71396-71310-saint_bonnet_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71396-71310-saint_bonnet_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71396-71310-saint_bonnet_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71396-71310-saint_bonnet_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71397-71250-sainte_cecile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71397-71250-sainte_cecile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71397-71250-sainte_cecile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71397-71250-sainte_cecile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71398-71370-saint_christophe_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71398-71370-saint_christophe_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71398-71370-saint_christophe_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71398-71370-saint_christophe_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71399-71800-saint_christophe_en_brionnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71399-71800-saint_christophe_en_brionnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71399-71800-saint_christophe_en_brionnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71399-71800-saint_christophe_en_brionnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71400-71460-saint_clement_sur_guye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71400-71460-saint_clement_sur_guye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71400-71460-saint_clement_sur_guye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71400-71460-saint_clement_sur_guye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71401-71470-sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71401-71470-sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71401-71470-sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71401-71470-sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71402-71240-saint_cyr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71402-71240-saint_cyr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71402-71240-saint_cyr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71402-71240-saint_cyr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71403-71640-saint_denis_de_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71403-71640-saint_denis_de_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71403-71640-saint_denis_de_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71403-71640-saint_denis_de_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71404-71390-saint_desert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71404-71390-saint_desert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71404-71390-saint_desert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71404-71390-saint_desert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71405-71620-saint_didier_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71405-71620-saint_didier_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71405-71620-saint_didier_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71405-71620-saint_didier_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71406-71110-saint_didier_en_brionnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71406-71110-saint_didier_en_brionnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71406-71110-saint_didier_en_brionnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71406-71110-saint_didier_en_brionnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71407-71190-saint_didier_sur_arroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71407-71190-saint_didier_sur_arroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71407-71190-saint_didier_sur_arroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71407-71190-saint_didier_sur_arroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71408-71740-saint_edmond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71408-71740-saint_edmond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71408-71740-saint_edmond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71408-71740-saint_edmond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71409-71490-saint_emiland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71409-71490-saint_emiland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71409-71490-saint_emiland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71409-71490-saint_emiland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71410-71370-saint_etienne_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71410-71370-saint_etienne_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71410-71370-saint_etienne_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71410-71370-saint_etienne_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71411-71320-saint_eugene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71411-71320-saint_eugene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71411-71320-saint_eugene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71411-71320-saint_eugene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71412-71210-saint_eusebe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71412-71210-saint_eusebe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71412-71210-saint_eusebe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71412-71210-saint_eusebe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71413-71670-saint_firmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71413-71670-saint_firmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71413-71670-saint_firmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71413-71670-saint_firmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71414-71400-saint_forgeot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71414-71400-saint_forgeot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71414-71400-saint_forgeot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71414-71400-saint_forgeot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71415-71110-sainte_foy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71415-71110-sainte_foy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71415-71110-sainte_foy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71415-71110-sainte_foy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71416-71260-saint_gengoux_de_scisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71416-71260-saint_gengoux_de_scisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71416-71260-saint_gengoux_de_scisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71416-71260-saint_gengoux_de_scisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71417-71460-saint_gengoux_le_national/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71417-71460-saint_gengoux_le_national/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71417-71460-saint_gengoux_le_national/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71417-71460-saint_gengoux_le_national/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71419-71330-saint_germain_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71419-71330-saint_germain_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71419-71330-saint_germain_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71419-71330-saint_germain_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71420-71370-saint_germain_du_plain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71420-71370-saint_germain_du_plain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71420-71370-saint_germain_du_plain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71420-71370-saint_germain_du_plain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71421-71800-saint_germain_en_brionnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71421-71800-saint_germain_en_brionnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71421-71800-saint_germain_en_brionnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71421-71800-saint_germain_en_brionnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71422-71390-saint_germain_les_buxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71422-71390-saint_germain_les_buxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71422-71390-saint_germain_les_buxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71422-71390-saint_germain_les_buxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71423-71350-saint_gervais_en_valliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71423-71350-saint_gervais_en_valliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71423-71350-saint_gervais_en_valliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71423-71350-saint_gervais_en_valliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71424-71490-saint_gervais_sur_couches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71424-71490-saint_gervais_sur_couches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71424-71490-saint_gervais_sur_couches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71424-71490-saint_gervais_sur_couches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71425-71510-saint_gilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71425-71510-saint_gilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71425-71510-saint_gilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71425-71510-saint_gilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71426-71390-sainte_helene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71426-71390-sainte_helene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71426-71390-sainte_helene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71426-71390-sainte_helene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71427-71460-saint_huruge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71427-71460-saint_huruge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71427-71460-saint_huruge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71427-71460-saint_huruge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71428-71170-saint_igny_de_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71428-71170-saint_igny_de_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71428-71170-saint_igny_de_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71428-71170-saint_igny_de_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71430-71640-saint_jean_de_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71430-71640-saint_jean_de_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71430-71640-saint_jean_de_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71430-71640-saint_jean_de_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71431-71490-saint_jean_de_trezy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71431-71490-saint_jean_de_trezy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71431-71490-saint_jean_de_trezy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71431-71490-saint_jean_de_trezy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71433-71800-saint_julien_de_civry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71433-71800-saint_julien_de_civry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71433-71800-saint_julien_de_civry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71433-71800-saint_julien_de_civry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71434-71110-saint_julien_de_jonzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71434-71110-saint_julien_de_jonzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71434-71110-saint_julien_de_jonzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71434-71110-saint_julien_de_jonzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71435-71210-saint_julien_sur_dheune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71435-71210-saint_julien_sur_dheune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71435-71210-saint_julien_sur_dheune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71435-71210-saint_julien_sur_dheune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71436-71210-saint_laurent_d_andenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71436-71210-saint_laurent_d_andenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71436-71210-saint_laurent_d_andenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71436-71210-saint_laurent_d_andenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71437-71800-saint_laurent_en_brionnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71437-71800-saint_laurent_en_brionnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71437-71800-saint_laurent_en_brionnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71437-71800-saint_laurent_en_brionnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71438-71360-saint_leger_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71438-71360-saint_leger_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71438-71360-saint_leger_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71438-71360-saint_leger_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71439-71600-saint_leger_les_paray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71439-71600-saint_leger_les_paray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71439-71600-saint_leger_les_paray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71439-71600-saint_leger_les_paray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71440-71990-saint_leger_sous_beuvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71440-71990-saint_leger_sous_beuvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71440-71990-saint_leger_sous_beuvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71440-71990-saint_leger_sous_beuvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71441-71520-saint_leger_sous_la_bussiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71441-71520-saint_leger_sous_la_bussiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71441-71520-saint_leger_sous_la_bussiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71441-71520-saint_leger_sous_la_bussiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71442-71510-saint_leger_sur_dheune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71442-71510-saint_leger_sur_dheune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71442-71510-saint_leger_sur_dheune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71442-71510-saint_leger_sur_dheune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71443-71350-saint_loup_geanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71443-71350-saint_loup_geanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71443-71350-saint_loup_geanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71443-71350-saint_loup_geanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71444-71240-saint_loup_de_varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71444-71240-saint_loup_de_varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71444-71240-saint_loup_de_varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71444-71240-saint_loup_de_varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71445-71380-saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71445-71380-saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71445-71380-saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71445-71380-saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71446-71460-saint_marcelin_de_cray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71446-71460-saint_marcelin_de_cray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71446-71460-saint_marcelin_de_cray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71446-71460-saint_marcelin_de_cray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71447-71640-saint_mard_de_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71447-71640-saint_mard_de_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71447-71640-saint_mard_de_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71447-71640-saint_mard_de_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71447-71510-saint_mard_de_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71447-71510-saint_mard_de_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71447-71510-saint_mard_de_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71447-71510-saint_mard_de_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71448-71118-saint_martin_belle_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71448-71118-saint_martin_belle_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71448-71118-saint_martin_belle_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71448-71118-saint_martin_belle_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71449-71390-saint_martin_d_auxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71449-71390-saint_martin_d_auxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71449-71390-saint_martin_d_auxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71449-71390-saint_martin_d_auxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71450-71490-saint_martin_de_commune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71450-71490-saint_martin_de_commune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71450-71490-saint_martin_de_commune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71450-71490-saint_martin_de_commune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71451-71740-saint_martin_de_lixy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71451-71740-saint_martin_de_lixy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71451-71740-saint_martin_de_lixy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71451-71740-saint_martin_de_lixy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71452-71220-saint_martin_de_salencey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71452-71220-saint_martin_de_salencey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71452-71220-saint_martin_de_salencey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71452-71220-saint_martin_de_salencey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71453-71110-saint_martin_du_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71453-71110-saint_martin_du_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71453-71110-saint_martin_du_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71453-71110-saint_martin_du_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71454-71580-saint_martin_du_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71454-71580-saint_martin_du_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71454-71580-saint_martin_du_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71454-71580-saint_martin_du_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71455-71460-saint_martin_du_tartre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71455-71460-saint_martin_du_tartre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71455-71460-saint_martin_du_tartre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71455-71460-saint_martin_du_tartre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71456-71620-saint_martin_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71456-71620-saint_martin_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71456-71620-saint_martin_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71456-71620-saint_martin_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71457-71350-saint_martin_en_gatinois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71457-71350-saint_martin_en_gatinois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71457-71350-saint_martin_en_gatinois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71457-71350-saint_martin_en_gatinois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71458-71460-saint_martin_la_patrouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71458-71460-saint_martin_la_patrouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71458-71460-saint_martin_la_patrouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71458-71460-saint_martin_la_patrouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71459-71640-saint_martin_sous_montaigu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71459-71640-saint_martin_sous_montaigu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71459-71640-saint_martin_sous_montaigu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71459-71640-saint_martin_sous_montaigu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71460-71260-saint_maurice_de_satonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71460-71260-saint_maurice_de_satonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71460-71260-saint_maurice_de_satonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71460-71260-saint_maurice_de_satonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71461-71460-saint_maurice_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71461-71460-saint_maurice_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71461-71460-saint_maurice_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71461-71460-saint_maurice_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71462-71620-saint_maurice_en_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71462-71620-saint_maurice_en_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71462-71620-saint_maurice_en_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71462-71620-saint_maurice_en_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71463-71740-saint_maurice_les_chateauneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71463-71740-saint_maurice_les_chateauneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71463-71740-saint_maurice_les_chateauneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71463-71740-saint_maurice_les_chateauneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71464-71490-saint_maurice_les_couches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71464-71490-saint_maurice_les_couches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71464-71490-saint_maurice_les_couches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71464-71490-saint_maurice_les_couches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71465-71460-saint_micaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71465-71460-saint_micaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71465-71460-saint_micaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71465-71460-saint_micaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71466-71190-saint_nizier_sur_arroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71466-71190-saint_nizier_sur_arroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71466-71190-saint_nizier_sur_arroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71466-71190-saint_nizier_sur_arroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71468-71670-saint_pierre_de_varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71468-71670-saint_pierre_de_varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71468-71670-saint_pierre_de_varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71468-71670-saint_pierre_de_varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71469-71520-saint_pierre_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71469-71520-saint_pierre_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71469-71520-saint_pierre_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71469-71520-saint_pierre_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71470-71520-saint_point/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71470-71520-saint_point/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71470-71520-saint_point/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71470-71520-saint_point/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71471-71390-saint_prive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71471-71390-saint_prive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71471-71390-saint_prive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71471-71390-saint_prive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71472-71990-saint_prix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71472-71990-saint_prix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71472-71990-saint_prix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71472-71990-saint_prix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71473-71800-saint_racho/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71473-71800-saint_racho/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71473-71800-saint_racho/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71473-71800-saint_racho/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71474-71320-sainte_radegonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71474-71320-sainte_radegonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71474-71320-sainte_radegonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71474-71320-sainte_radegonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71475-71100-saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71475-71100-saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71475-71100-saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71475-71100-saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71477-71230-saint_romain_sous_gourdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71477-71230-saint_romain_sous_gourdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71477-71230-saint_romain_sous_gourdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71477-71230-saint_romain_sous_gourdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71478-71420-saint_romain_sous_versigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71478-71420-saint_romain_sous_versigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71478-71420-saint_romain_sous_versigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71478-71420-saint_romain_sous_versigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71479-71200-saint_sernin_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71479-71200-saint_sernin_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71479-71200-saint_sernin_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71479-71200-saint_sernin_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71480-71510-saint_sernin_du_plain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71480-71510-saint_sernin_du_plain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71480-71510-saint_sernin_du_plain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71480-71510-saint_sernin_du_plain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71481-71570-saint_symphorien_d_ancelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71481-71570-saint_symphorien_d_ancelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71481-71570-saint_symphorien_d_ancelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71481-71570-saint_symphorien_d_ancelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71482-71710-saint_symphorien_de_marmagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71482-71710-saint_symphorien_de_marmagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71482-71710-saint_symphorien_de_marmagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71482-71710-saint_symphorien_de_marmagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71483-71800-saint_symphorien_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71483-71800-saint_symphorien_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71483-71800-saint_symphorien_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71483-71800-saint_symphorien_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71484-71500-saint_usuge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71484-71500-saint_usuge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71484-71500-saint_usuge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71484-71500-saint_usuge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71485-71390-saint_vallerin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71485-71390-saint_vallerin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71485-71390-saint_vallerin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71485-71390-saint_vallerin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71486-71230-saint_vallier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71486-71230-saint_vallier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71486-71230-saint_vallier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71486-71230-saint_vallier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71487-71570-saint_verand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71487-71570-saint_verand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71487-71570-saint_verand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71487-71570-saint_verand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71488-71250-saint_vincent_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71488-71250-saint_vincent_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71488-71250-saint_vincent_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71488-71250-saint_vincent_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71489-71440-saint_vincent_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71489-71440-saint_vincent_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71489-71440-saint_vincent_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71489-71440-saint_vincent_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71490-71430-saint_vincent_bragny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71490-71430-saint_vincent_bragny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71490-71430-saint_vincent_bragny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71490-71430-saint_vincent_bragny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71491-71600-saint_yan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71491-71600-saint_yan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71491-71600-saint_yan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71491-71600-saint_yan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71492-71460-saint_ythaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71492-71460-saint_ythaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71492-71460-saint_ythaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71492-71460-saint_ythaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71493-71360-saisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71493-71360-saisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71493-71360-saisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71493-71360-saisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71494-71260-la_salle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71494-71260-la_salle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71494-71260-la_salle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71494-71260-la_salle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71495-71250-salornay_sur_guye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71495-71250-salornay_sur_guye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71495-71250-salornay_sur_guye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71495-71250-salornay_sur_guye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71496-71150-sampigny_les_maranges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71496-71150-sampigny_les_maranges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71496-71150-sampigny_les_maranges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71496-71150-sampigny_les_maranges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71497-71000-sance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71497-71000-sance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71497-71000-sance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71497-71000-sance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71498-71460-santilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71498-71460-santilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71498-71460-santilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71498-71460-santilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71499-71410-sanvignes_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71499-71410-sanvignes_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71499-71410-sanvignes_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71499-71410-sanvignes_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71500-71110-sarry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71500-71110-sarry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71500-71110-sarry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71500-71110-sarry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71501-71390-sassangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71501-71390-sassangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71501-71390-sassangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71501-71390-sassangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71502-71530-sassenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71502-71530-sassenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71502-71530-sassenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71502-71530-sassenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71503-71390-saules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71503-71390-saules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71503-71390-saules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71503-71390-saules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71504-71350-saunieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71504-71350-saunieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71504-71350-saunieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71504-71350-saunieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71505-71460-savianges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71505-71460-savianges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71505-71460-savianges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71505-71460-savianges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71506-71580-savigny_en_revermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71506-71580-savigny_en_revermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71506-71580-savigny_en_revermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71506-71580-savigny_en_revermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71507-71460-savigny_sur_grosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71507-71460-savigny_sur_grosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71507-71460-savigny_sur_grosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71507-71460-savigny_sur_grosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71508-71440-savigny_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71508-71440-savigny_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71508-71440-savigny_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71508-71440-savigny_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71509-71400-la_celle_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71509-71400-la_celle_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71509-71400-la_celle_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71509-71400-la_celle_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71509-71550-la_celle_en_morvan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71509-71550-la_celle_en_morvan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71509-71550-la_celle_en_morvan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71509-71550-la_celle_en_morvan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71510-71110-semur_en_brionnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71510-71110-semur_en_brionnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71510-71110-semur_en_brionnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71510-71110-semur_en_brionnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71512-71240-sennecey_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71512-71240-sennecey_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71512-71240-sennecey_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71512-71240-sennecey_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71513-71260-senozan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71513-71260-senozan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71513-71260-senozan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71513-71260-senozan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71514-71330-sens_sur_seille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71514-71330-sens_sur_seille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71514-71330-sens_sur_seille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71514-71330-sens_sur_seille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71515-71460-sercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71515-71460-sercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71515-71460-sercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71515-71460-sercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71516-71310-serley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71516-71310-serley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71516-71310-serley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71516-71310-serley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71517-71350-sermesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71517-71350-sermesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71517-71350-sermesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71517-71350-sermesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71518-71960-serrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71518-71960-serrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71518-71960-serrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71518-71960-serrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71519-71310-serrigny_en_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71519-71310-serrigny_en_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71519-71310-serrigny_en_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71519-71310-serrigny_en_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71520-71100-sevrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71520-71100-sevrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71520-71100-sevrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71520-71100-sevrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71521-71250-sigy_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71521-71250-sigy_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71521-71250-sigy_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71521-71250-sigy_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71522-71290-simandre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71522-71290-simandre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71522-71290-simandre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71522-71290-simandre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71523-71330-simard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71523-71330-simard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71523-71330-simard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71523-71330-simard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71524-71220-sivignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71524-71220-sivignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71524-71220-sivignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71524-71220-sivignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71525-71960-sologny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71525-71960-sologny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71525-71960-sologny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71525-71960-sologny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71526-71960-solutre_pouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71526-71960-solutre_pouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71526-71960-solutre_pouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71526-71960-solutre_pouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71527-71540-sommant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71527-71540-sommant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71527-71540-sommant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71527-71540-sommant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71528-71500-sornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71528-71500-sornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71528-71500-sornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71528-71500-sornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71529-71220-suin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71529-71220-suin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71529-71220-suin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71529-71220-suin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71530-71360-sully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71530-71360-sully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71530-71360-sully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71530-71360-sully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71531-71190-la_tagniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71531-71190-la_tagniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71531-71190-la_tagniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71531-71190-la_tagniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71532-71250-taize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71532-71250-taize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71532-71250-taize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71532-71250-taize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71533-71740-tancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71533-71740-tancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71533-71740-tancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71533-71740-tancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71534-71330-le_tartre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71534-71330-le_tartre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71534-71330-le_tartre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71534-71330-le_tartre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71535-71400-tavernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71535-71400-tavernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71535-71400-tavernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71535-71400-tavernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71537-71190-thil_sur_arroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71537-71190-thil_sur_arroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71537-71190-thil_sur_arroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71537-71190-thil_sur_arroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71538-71440-thurey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71538-71440-thurey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71538-71440-thurey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71538-71440-thurey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71539-71490-tintry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71539-71490-tintry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71539-71490-tintry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71539-71490-tintry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71540-71210-torcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71540-71210-torcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71540-71210-torcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71540-71210-torcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71541-71270-torpes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71541-71270-torpes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71541-71270-torpes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71541-71270-torpes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71542-71320-toulon_sur_arroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71542-71320-toulon_sur_arroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71542-71320-toulon_sur_arroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71542-71320-toulon_sur_arroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71543-71700-tournus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71543-71700-tournus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71543-71700-tournus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71543-71700-tournus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71544-71350-toutenant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71544-71350-toutenant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71544-71350-toutenant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71544-71350-toutenant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71545-71520-tramayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71545-71520-tramayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71545-71520-tramayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71545-71520-tramayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71546-71520-trambly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71546-71520-trambly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71546-71520-trambly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71546-71520-trambly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71547-71520-trivy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71547-71520-trivy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71547-71520-trivy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71547-71520-trivy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71548-71440-tronchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71548-71440-tronchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71548-71440-tronchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71548-71440-tronchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71549-71290-la_truchere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71549-71290-la_truchere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71549-71290-la_truchere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71549-71290-la_truchere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71550-71700-uchizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71550-71700-uchizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71550-71700-uchizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71550-71700-uchizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71551-71190-uchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71551-71190-uchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71551-71190-uchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71551-71190-uchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71552-71130-uxeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71552-71130-uxeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71552-71130-uxeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71552-71130-uxeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71553-71800-vareilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71553-71800-vareilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71553-71800-vareilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71553-71800-vareilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71554-71110-varenne_l_arconce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71554-71110-varenne_l_arconce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71554-71110-varenne_l_arconce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71554-71110-varenne_l_arconce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71555-71240-varennes_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71555-71240-varennes_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71555-71240-varennes_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71555-71240-varennes_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71556-71000-varennes_les_macon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71556-71000-varennes_les_macon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71556-71000-varennes_les_macon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71556-71000-varennes_les_macon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71557-71600-varenne_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71557-71600-varenne_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71557-71600-varenne_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71557-71600-varenne_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71558-71480-varennes_saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71558-71480-varennes_saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71558-71480-varennes_saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71558-71480-varennes_saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71559-71800-varennes_sous_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71559-71800-varennes_sous_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71559-71800-varennes_sous_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71559-71800-varennes_sous_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71561-71800-vauban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71561-71800-vauban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71561-71800-vauban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71561-71800-vauban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71562-71120-vaudebarrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71562-71120-vaudebarrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71562-71120-vaudebarrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71562-71120-vaudebarrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71563-71460-vaux_en_pre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71563-71460-vaux_en_pre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71563-71460-vaux_en_pre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71563-71460-vaux_en_pre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71564-71120-vendenesse_les_charolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71564-71120-vendenesse_les_charolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71564-71120-vendenesse_les_charolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71564-71120-vendenesse_les_charolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71565-71130-vendenesse_sur_arroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71565-71130-vendenesse_sur_arroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71565-71130-vendenesse_sur_arroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71565-71130-vendenesse_sur_arroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71566-71350-verdun_sur_le_doubs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71566-71350-verdun_sur_le_doubs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71566-71350-verdun_sur_le_doubs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71566-71350-verdun_sur_le_doubs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71567-71960-vergisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71567-71960-vergisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71567-71960-vergisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71567-71960-vergisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71568-71440-verissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71568-71440-verissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71568-71440-verissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71568-71440-verissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71570-71590-verjux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71570-71590-verjux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71570-71590-verjux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71570-71590-verjux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71571-71220-verosvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71571-71220-verosvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71571-71220-verosvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71571-71220-verosvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71572-71240-vers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71572-71240-vers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71572-71240-vers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71572-71240-vers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71573-71110-versaugues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71573-71110-versaugues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71573-71110-versaugues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71573-71110-versaugues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71574-71960-verze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71574-71960-verze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71574-71960-verze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71574-71960-verze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71576-71700-le_villars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71576-71700-le_villars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71576-71700-le_villars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71576-71700-le_villars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71577-71620-villegaudin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71577-71620-villegaudin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71577-71620-villegaudin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71577-71620-villegaudin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71578-71270-clux_villeneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71578-71270-clux_villeneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71578-71270-clux_villeneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71578-71270-clux_villeneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71579-71390-villeneuve_en_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71579-71390-villeneuve_en_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71579-71390-villeneuve_en_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71579-71390-villeneuve_en_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71580-71500-vincelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71580-71500-vincelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71580-71500-vincelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71580-71500-vincelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71581-71110-vindecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71581-71110-vindecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71581-71110-vindecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71581-71110-vindecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71582-71250-la_vineuse_sur_fregande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71582-71250-la_vineuse_sur_fregande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71582-71250-la_vineuse_sur_fregande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71582-71250-la_vineuse_sur_fregande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71583-71680-vinzelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71583-71680-vinzelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71583-71680-vinzelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71583-71680-vinzelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71584-71260-vire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71584-71260-vire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71584-71260-vire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71584-71260-vire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71585-71530-virey_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71585-71530-virey_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71585-71530-virey_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71585-71530-virey_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71586-71120-viry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71586-71120-viry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71586-71120-viry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71586-71120-viry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71588-71600-vitry_en_charollais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71588-71600-vitry_en_charollais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71588-71600-vitry_en_charollais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71588-71600-vitry_en_charollais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71589-71140-vitry_sur_loire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71589-71140-vitry_sur_loire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71589-71140-vitry_sur_loire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71589-71140-vitry_sur_loire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71590-71600-volesvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71590-71600-volesvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71590-71600-volesvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71590-71600-volesvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71591-71260-fleurville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71591-71260-fleurville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71591-71260-fleurville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt71-saone_et_loire/commune71591-71260-fleurville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-72.xml
+++ b/public/sitemaps/sitemap-72.xml
@@ -5,720 +5,1436 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72001-72650-aigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72001-72650-aigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72001-72650-aigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72001-72650-aigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72002-72600-aillieres_beauvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72002-72600-aillieres_beauvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72002-72600-aillieres_beauvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72002-72600-aillieres_beauvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72003-72700-allonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72003-72700-allonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72003-72700-allonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72003-72700-allonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72004-72540-amne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72004-72540-amne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72004-72540-amne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72004-72540-amne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72005-72610-ancinnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72005-72610-ancinnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72005-72610-ancinnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72005-72610-ancinnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72006-72610-arconnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72006-72610-arconnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72006-72610-arconnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72006-72610-arconnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72007-72370-ardenay_sur_merize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72007-72370-ardenay_sur_merize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72007-72370-ardenay_sur_merize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72007-72370-ardenay_sur_merize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72008-72230-arnage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72008-72230-arnage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72008-72230-arnage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72008-72230-arnage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72009-72270-artheze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72009-72270-artheze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72009-72270-artheze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72009-72270-artheze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72010-72430-asnieres_sur_vegre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72010-72430-asnieres_sur_vegre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72010-72430-asnieres_sur_vegre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72010-72430-asnieres_sur_vegre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72011-72130-asse_le_boisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72011-72130-asse_le_boisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72011-72130-asse_le_boisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72011-72130-asse_le_boisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72012-72170-asse_le_riboul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72012-72170-asse_le_riboul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72012-72170-asse_le_riboul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72012-72170-asse_le_riboul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72013-72800-aubigne_racan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72013-72800-aubigne_racan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72013-72800-aubigne_racan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72013-72800-aubigne_racan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72015-72600-les_aulneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72015-72600-les_aulneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72015-72600-les_aulneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72015-72600-les_aulneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72016-72300-auvers_le_hamon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72016-72300-auvers_le_hamon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72016-72300-auvers_le_hamon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72016-72300-auvers_le_hamon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72017-72540-auvers_sous_montfaucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72017-72540-auvers_sous_montfaucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72017-72540-auvers_sous_montfaucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72017-72540-auvers_sous_montfaucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72018-72260-avesnes_en_saosnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72018-72260-avesnes_en_saosnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72018-72260-avesnes_en_saosnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72018-72260-avesnes_en_saosnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72019-72350-avesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72019-72350-avesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72019-72350-avesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72019-72350-avesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72020-72400-aveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72020-72400-aveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72020-72400-aveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72020-72400-aveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72021-72430-avoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72021-72430-avoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72021-72430-avoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72021-72430-avoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72022-72200-le_bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72022-72200-le_bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72022-72200-le_bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72022-72200-le_bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72023-72290-ballon_saint_mars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72023-72290-ballon_saint_mars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72023-72290-ballon_saint_mars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72023-72290-ballon_saint_mars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72024-72650-la_bazoge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72024-72650-la_bazoge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72024-72650-la_bazoge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72024-72650-la_bazoge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72025-72200-bazouges_cre_sur_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72025-72200-bazouges_cre_sur_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72025-72200-bazouges_cre_sur_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72025-72200-bazouges_cre_sur_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72026-72110-beaufay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72026-72110-beaufay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72026-72110-beaufay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72026-72110-beaufay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72027-72340-beaumont_sur_deme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72027-72340-beaumont_sur_deme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72027-72340-beaumont_sur_deme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72027-72340-beaumont_sur_deme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72028-72500-beaumont_pied_de_boeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72028-72500-beaumont_pied_de_boeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72028-72500-beaumont_pied_de_boeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72028-72500-beaumont_pied_de_boeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72029-72170-beaumont_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72029-72170-beaumont_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72029-72170-beaumont_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72029-72170-beaumont_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72031-72160-beille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72031-72160-beille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72031-72160-beille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72031-72160-beille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72032-72320-berfay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72032-72320-berfay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72032-72320-berfay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72032-72320-berfay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72034-72610-berus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72034-72610-berus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72034-72610-berus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72034-72610-berus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72035-72310-besse_sur_braye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72035-72310-besse_sur_braye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72035-72310-besse_sur_braye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72035-72310-besse_sur_braye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72036-72610-bethon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72036-72610-bethon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72036-72610-bethon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72036-72610-bethon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72037-72600-bleves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72037-72600-bleves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72037-72600-bleves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72037-72600-bleves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72038-72400-boesse_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72038-72400-boesse_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72038-72400-boesse_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72038-72400-boesse_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72039-72110-bonnetable/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72039-72110-bonnetable/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72039-72110-bonnetable/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72039-72110-bonnetable/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72040-72400-la_bosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72040-72400-la_bosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72040-72400-la_bosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72040-72400-la_bosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72041-72390-bouer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72041-72390-bouer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72041-72390-bouer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72041-72390-bouer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72042-72440-bouloire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72042-72440-bouloire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72042-72440-bouloire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72042-72440-bouloire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72043-72610-bourg_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72043-72610-bourg_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72043-72610-bourg_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72043-72610-bourg_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72044-72270-bousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72044-72270-bousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72044-72270-bousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72044-72270-bousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72045-72550-brains_sur_gee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72045-72550-brains_sur_gee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72045-72550-brains_sur_gee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72045-72550-brains_sur_gee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72046-72370-le_breil_sur_merize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72046-72370-le_breil_sur_merize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72046-72370-le_breil_sur_merize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72046-72370-le_breil_sur_merize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72047-72250-brette_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72047-72250-brette_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72047-72250-brette_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72047-72250-brette_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72048-72110-briosne_les_sables/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72048-72110-briosne_les_sables/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72048-72110-briosne_les_sables/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72048-72110-briosne_les_sables/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72049-72500-la_bruere_sur_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72049-72500-la_bruere_sur_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72049-72500-la_bruere_sur_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72049-72500-la_bruere_sur_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72050-72350-brulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72050-72350-brulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72050-72350-brulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72050-72350-brulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72051-72330-cerans_foulletourte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72051-72330-cerans_foulletourte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72051-72330-cerans_foulletourte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72051-72330-cerans_foulletourte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72052-72340-chahaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72052-72340-chahaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72052-72340-chahaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72052-72340-chahaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72053-72250-challes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72053-72250-challes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72053-72250-challes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72053-72250-challes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72054-72470-champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72054-72470-champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72054-72470-champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72054-72470-champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72056-72610-champfleur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72056-72610-champfleur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72056-72610-champfleur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72056-72610-champfleur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72057-72320-champrond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72057-72320-champrond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72057-72320-champrond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72057-72320-champrond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72058-72560-change/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72058-72560-change/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72058-72560-change/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72058-72560-change/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72059-72430-chantenay_villedieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72059-72430-chantenay_villedieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72059-72430-chantenay_villedieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72059-72430-chantenay_villedieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72060-72800-la_chapelle_aux_choux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72060-72800-la_chapelle_aux_choux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72060-72800-la_chapelle_aux_choux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72060-72800-la_chapelle_aux_choux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72061-72300-la_chapelle_d_aligne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72061-72300-la_chapelle_d_aligne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72061-72300-la_chapelle_d_aligne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72061-72300-la_chapelle_d_aligne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72062-72400-la_chapelle_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72062-72400-la_chapelle_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72062-72400-la_chapelle_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72062-72400-la_chapelle_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72064-72310-la_chapelle_huon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72064-72310-la_chapelle_huon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72064-72310-la_chapelle_huon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72064-72310-la_chapelle_huon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72065-72650-la_chapelle_saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72065-72650-la_chapelle_saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72065-72650-la_chapelle_saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72065-72650-la_chapelle_saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72066-72240-la_chapelle_saint_fray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72066-72240-la_chapelle_saint_fray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72066-72240-la_chapelle_saint_fray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72066-72240-la_chapelle_saint_fray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72067-72160-la_chapelle_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72067-72160-la_chapelle_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72067-72160-la_chapelle_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72067-72160-la_chapelle_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72068-72340-la_chartre_sur_le_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72068-72340-la_chartre_sur_le_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72068-72340-la_chartre_sur_le_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72068-72340-la_chartre_sur_le_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72070-72540-chassille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72070-72540-chassille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72070-72540-chassille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72070-72540-chassille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72071-72500-montval_sur_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72071-72500-montval_sur_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72071-72500-montval_sur_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72071-72500-montval_sur_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72072-72510-chateau_l_hermitage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72072-72510-chateau_l_hermitage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72072-72510-chateau_l_hermitage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72072-72510-chateau_l_hermitage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72073-72550-chaufour_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72073-72550-chaufour_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72073-72550-chaufour_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72073-72550-chaufour_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72074-72540-chemire_en_charnie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72074-72540-chemire_en_charnie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72074-72540-chemire_en_charnie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72074-72540-chemire_en_charnie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72075-72210-chemire_le_gaudin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72075-72210-chemire_le_gaudin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72075-72210-chemire_le_gaudin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72075-72210-chemire_le_gaudin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72076-72610-chenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72076-72610-chenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72076-72610-chenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72076-72610-chenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72077-72500-chenu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72077-72500-chenu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72077-72500-chenu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72077-72500-chenu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72078-72170-cherance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72078-72170-cherance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72078-72170-cherance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72078-72170-cherance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72079-72610-cherisay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72079-72610-cherisay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72079-72610-cherisay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72079-72610-cherisay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72080-72400-cherre_au/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72080-72400-cherre_au/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72080-72400-cherre_au/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72080-72400-cherre_au/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72083-72350-cheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72083-72350-cheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72083-72350-cheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72083-72350-cheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72084-72200-clermont_creans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72084-72200-clermont_creans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72084-72200-clermont_creans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72084-72200-clermont_creans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72085-72310-cogners/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72085-72310-cogners/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72085-72310-cogners/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72085-72310-cogners/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72086-72600-commerveil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72086-72600-commerveil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72086-72600-commerveil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72086-72600-commerveil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72087-72120-conflans_sur_anille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72087-72120-conflans_sur_anille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72087-72120-conflans_sur_anille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72087-72120-conflans_sur_anille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72088-72290-conge_sur_orne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72088-72290-conge_sur_orne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72088-72290-conge_sur_orne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72088-72290-conge_sur_orne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72089-72240-conlie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72089-72240-conlie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72089-72240-conlie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72089-72240-conlie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72090-72160-connerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72090-72160-connerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72090-72160-connerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72090-72160-connerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72091-72600-contilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72091-72600-contilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72091-72600-contilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72091-72600-contilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72093-72400-cormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72093-72400-cormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72093-72400-cormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72093-72400-cormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72094-72440-coudrecieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72094-72440-coudrecieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72094-72440-coudrecieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72094-72440-coudrecieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72095-72190-coulaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72095-72190-coulaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72095-72190-coulaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72095-72190-coulaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72096-72550-coulans_sur_gee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72096-72550-coulans_sur_gee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72096-72550-coulans_sur_gee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72096-72550-coulans_sur_gee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72098-72800-coulonge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72098-72800-coulonge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72098-72800-coulonge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72098-72800-coulonge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72099-72290-courceboeufs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72099-72290-courceboeufs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72099-72290-courceboeufs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72099-72290-courceboeufs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72100-72270-courcelles_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72100-72270-courcelles_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72100-72270-courcelles_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72100-72270-courcelles_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72101-72110-courcemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72101-72110-courcemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72101-72110-courcemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72101-72110-courcemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72102-72110-courcival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72102-72110-courcival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72102-72110-courcival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72102-72110-courcival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72103-72150-courdemanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72103-72150-courdemanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72103-72150-courdemanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72103-72150-courdemanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72104-72260-courgains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72104-72260-courgains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72104-72260-courgains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72104-72260-courgains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72105-72320-courgenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72105-72320-courgenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72105-72320-courgenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72105-72320-courgenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72106-72300-courtillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72106-72300-courtillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72106-72300-courtillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72106-72300-courtillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72107-72540-crannes_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72107-72540-crannes_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72107-72540-crannes_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72107-72540-crannes_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72109-72140-crisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72109-72140-crisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72109-72140-crisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72109-72140-crisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72110-72200-crosmieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72110-72200-crosmieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72110-72200-crosmieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72110-72200-crosmieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72111-72240-cures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72111-72240-cures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72111-72240-cures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72111-72240-cures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72112-72260-dangeul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72112-72260-dangeul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72112-72260-dangeul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72112-72260-dangeul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72113-72550-degre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72113-72550-degre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72113-72550-degre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72113-72550-degre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72114-72400-dehault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72114-72400-dehault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72114-72400-dehault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72114-72400-dehault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72115-72500-dissay_sous_courcillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72115-72500-dissay_sous_courcillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72115-72500-dissay_sous_courcillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72115-72500-dissay_sous_courcillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72118-72390-dollon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72118-72390-dollon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72118-72390-dollon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72118-72390-dollon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72119-72240-domfront_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72119-72240-domfront_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72119-72240-domfront_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72119-72240-domfront_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72120-72170-doucelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72120-72170-doucelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72120-72170-doucelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72120-72170-doucelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72121-72130-douillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72121-72130-douillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72121-72130-douillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72121-72130-douillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72122-72160-duneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72122-72160-duneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72122-72160-duneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72122-72160-duneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72123-72270-dureil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72123-72270-dureil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72123-72270-dureil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72123-72270-dureil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72124-72220-ecommoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72124-72220-ecommoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72124-72220-ecommoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72124-72220-ecommoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72125-72120-ecorpain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72125-72120-ecorpain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72125-72120-ecorpain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72125-72120-ecorpain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72126-72540-epineu_le_chevreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72126-72540-epineu_le_chevreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72126-72540-epineu_le_chevreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72126-72540-epineu_le_chevreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72127-72700-etival_les_le_mans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72127-72700-etival_les_le_mans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72127-72700-etival_les_le_mans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72127-72700-etival_les_le_mans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72128-72120-val_d’etangson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72128-72120-val_d’etangson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72128-72120-val_d’etangson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72128-72120-val_d’etangson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72129-72470-fatines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72129-72470-fatines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72129-72470-fatines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72129-72470-fatines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72130-72550-fay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72130-72550-fay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72130-72550-fay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72130-72550-fay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72131-72430-ferce_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72131-72430-ferce_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72131-72430-ferce_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72131-72430-ferce_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72132-72400-la_ferte_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72132-72400-la_ferte_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72132-72400-la_ferte_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72132-72400-la_ferte_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72133-72210-fille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72133-72210-fille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72133-72210-fille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72133-72210-fille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72134-72500-flee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72134-72500-flee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72134-72500-flee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72134-72500-flee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72135-72330-la_fontaine_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72135-72330-la_fontaine_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72135-72330-la_fontaine_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72135-72330-la_fontaine_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72136-72350-fontenay_sur_vegre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72136-72350-fontenay_sur_vegre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72136-72350-fontenay_sur_vegre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72136-72350-fontenay_sur_vegre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72137-72600-villeneuve_en_perseigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72137-72600-villeneuve_en_perseigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72137-72600-villeneuve_en_perseigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72137-72600-villeneuve_en_perseigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72137-72610-villeneuve_en_perseigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72137-72610-villeneuve_en_perseigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72137-72610-villeneuve_en_perseigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72137-72610-villeneuve_en_perseigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72138-72130-fresnay_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72138-72130-fresnay_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72138-72130-fresnay_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72138-72130-fresnay_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72139-72610-fye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72139-72610-fye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72139-72610-fye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72139-72610-fye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72141-72130-gesnes_le_gandelin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72141-72130-gesnes_le_gandelin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72141-72130-gesnes_le_gandelin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72141-72130-gesnes_le_gandelin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72142-72610-grandchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72142-72610-grandchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72142-72610-grandchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72142-72610-grandchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72143-72150-le_grand_luce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72143-72150-le_grand_luce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72143-72150-le_grand_luce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72143-72150-le_grand_luce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72144-72320-greez_sur_roc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72144-72320-greez_sur_roc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72144-72320-greez_sur_roc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72144-72320-greez_sur_roc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72145-72140-le_grez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72145-72140-le_grez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72145-72140-le_grez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72145-72140-le_grez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72146-72230-guecelard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72146-72230-guecelard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72146-72230-guecelard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72146-72230-guecelard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72147-72380-la_guierche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72147-72380-la_guierche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72147-72380-la_guierche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72147-72380-la_guierche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72148-72110-jauze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72148-72110-jauze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72148-72110-jauze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72148-72110-jauze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72149-72540-joue_en_charnie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72149-72540-joue_en_charnie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72149-72540-joue_en_charnie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72149-72540-joue_en_charnie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72150-72380-joue_l_abbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72150-72380-joue_l_abbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72150-72380-joue_l_abbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72150-72380-joue_l_abbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72151-72300-juigne_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72151-72300-juigne_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72151-72300-juigne_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72151-72300-juigne_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72152-72170-juille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72152-72170-juille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72152-72170-juille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72152-72170-juille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72153-72500-jupilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72153-72500-jupilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72153-72500-jupilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72153-72500-jupilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72154-72200-la_fleche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72154-72200-la_fleche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72154-72200-la_fleche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72154-72200-la_fleche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72155-72220-laigne_en_belin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72155-72220-laigne_en_belin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72155-72220-laigne_en_belin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72155-72220-laigne_en_belin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72156-72320-lamnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72156-72320-lamnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72156-72320-lamnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72156-72320-lamnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72157-72240-lavardin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72157-72240-lavardin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72157-72240-lavardin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72157-72240-lavardin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72158-72390-lavare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72158-72390-lavare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72158-72390-lavare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72158-72390-lavare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72160-72500-lavernat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72160-72500-lavernat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72160-72500-lavernat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72160-72500-lavernat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72161-72340-lhomme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72161-72340-lhomme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72161-72340-lhomme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72161-72340-lhomme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72163-72270-ligron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72163-72270-ligron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72163-72270-ligron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72163-72270-ligron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72164-72610-livet_en_saosnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72164-72610-livet_en_saosnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72164-72610-livet_en_saosnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72164-72610-livet_en_saosnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72165-72450-lombron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72165-72450-lombron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72165-72450-lombron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72165-72450-lombron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72166-72540-longnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72166-72540-longnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72166-72540-longnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72166-72540-longnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72167-72300-louailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72167-72300-louailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72167-72300-louailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72167-72300-louailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72168-72540-loue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72168-72540-loue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72168-72540-loue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72168-72540-loue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72169-72210-louplande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72169-72210-louplande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72169-72210-louplande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72169-72210-louplande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72170-72600-louvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72170-72600-louvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72170-72600-louvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72170-72600-louvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72171-72600-louzes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72171-72600-louzes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72171-72600-louzes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72171-72600-louzes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72172-72390-le_luart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72172-72390-le_luart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72172-72390-le_luart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72172-72390-le_luart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72173-72500-luceau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72173-72500-luceau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72173-72500-luceau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72173-72500-luceau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72174-72290-luce_sous_ballon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72174-72290-luce_sous_ballon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72174-72290-luce_sous_ballon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72174-72290-luce_sous_ballon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72175-72800-luche_pringe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72175-72800-luche_pringe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72175-72800-luche_pringe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72175-72800-luche_pringe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72176-72800-le_lude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72176-72800-le_lude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72176-72800-le_lude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72176-72800-le_lude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72177-72210-maigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72177-72210-maigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72177-72210-maigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72177-72210-maigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72178-72440-maisoncelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72178-72440-maisoncelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72178-72440-maisoncelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72178-72440-maisoncelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72179-72270-malicorne_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72179-72270-malicorne_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72179-72270-malicorne_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72179-72270-malicorne_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72180-72600-mamers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72180-72600-mamers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72180-72600-mamers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72180-72600-mamers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72181-72100-le_mans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72181-72100-le_mans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72181-72100-le_mans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72181-72100-le_mans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72181-72000-le_mans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72181-72000-le_mans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72181-72000-le_mans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72181-72000-le_mans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72182-72510-mansigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72182-72510-mansigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72182-72510-mansigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72182-72510-mansigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72183-72340-marcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72183-72340-marcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72183-72340-marcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72183-72340-marcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72184-72540-mareil_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72184-72540-mareil_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72184-72540-mareil_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72184-72540-mareil_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72185-72200-mareil_sur_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72185-72200-mareil_sur_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72185-72200-mareil_sur_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72185-72200-mareil_sur_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72186-72170-maresche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72186-72170-maresche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72186-72170-maresche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72186-72170-maresche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72187-72220-marigne_laille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72187-72220-marigne_laille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72187-72220-marigne_laille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72187-72220-marigne_laille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72188-72600-marollette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72188-72600-marollette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72188-72600-marollette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72188-72600-marollette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72189-72260-marolles_les_braults/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72189-72260-marolles_les_braults/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72189-72260-marolles_les_braults/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72189-72260-marolles_les_braults/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72190-72120-marolles_les_saint_calais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72190-72120-marolles_les_saint_calais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72190-72120-marolles_les_saint_calais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72190-72120-marolles_les_saint_calais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72191-72360-mayet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72191-72360-mayet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72191-72360-mayet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72191-72360-mayet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72192-72260-les_mees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72192-72260-les_mees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72192-72260-les_mees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72192-72260-les_mees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72193-72320-melleray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72193-72320-melleray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72193-72320-melleray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72193-72320-melleray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72194-72170-meurce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72194-72170-meurce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72194-72170-meurce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72194-72170-meurce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72195-72270-mezeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72195-72270-mezeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72195-72270-mezeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72195-72270-mezeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72196-72290-mezieres_sur_ponthouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72196-72290-mezieres_sur_ponthouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72196-72290-mezieres_sur_ponthouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72196-72290-mezieres_sur_ponthouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72197-72240-mezieres_sous_lavardin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72197-72240-mezieres_sous_lavardin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72197-72240-mezieres_sous_lavardin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72197-72240-mezieres_sous_lavardin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72198-72650-la_milesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72198-72650-la_milesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72198-72650-la_milesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72198-72650-la_milesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72199-72170-moitron_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72199-72170-moitron_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72199-72170-moitron_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72199-72170-moitron_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72200-72230-monce_en_belin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72200-72230-monce_en_belin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72200-72230-monce_en_belin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72200-72230-monce_en_belin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72201-72260-monce_en_saosnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72201-72260-monce_en_saosnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72201-72260-monce_en_saosnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72201-72260-monce_en_saosnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72202-72260-monhoudou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72202-72260-monhoudou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72202-72260-monhoudou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72202-72260-monhoudou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72204-72120-montaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72204-72120-montaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72204-72120-montaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72204-72120-montaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72205-72380-montbizot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72205-72380-montbizot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72205-72380-montbizot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72205-72380-montbizot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72208-72320-montmirail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72208-72320-montmirail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72208-72320-montmirail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72208-72320-montmirail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72209-72130-montreuil_le_chetif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72209-72130-montreuil_le_chetif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72209-72130-montreuil_le_chetif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72209-72130-montreuil_le_chetif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72210-72150-montreuil_le_henri/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72210-72150-montreuil_le_henri/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72210-72150-montreuil_le_henri/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72210-72150-montreuil_le_henri/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72211-72140-mont_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72211-72140-mont_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72211-72140-mont_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72211-72140-mont_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72212-72130-moulins_le_carbonnel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72212-72130-moulins_le_carbonnel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72212-72130-moulins_le_carbonnel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72212-72130-moulins_le_carbonnel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72213-72230-mulsanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72213-72230-mulsanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72213-72230-mulsanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72213-72230-mulsanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72214-72260-nauvay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72214-72260-nauvay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72214-72260-nauvay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72214-72260-nauvay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72215-72600-neufchatel_en_saosnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72215-72600-neufchatel_en_saosnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72215-72600-neufchatel_en_saosnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72215-72600-neufchatel_en_saosnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72216-72240-neuvillalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72216-72240-neuvillalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72216-72240-neuvillalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72216-72240-neuvillalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72217-72190-neuville_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72217-72190-neuville_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72217-72190-neuville_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72217-72190-neuville_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72218-72140-neuvillette_en_charnie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72218-72140-neuvillette_en_charnie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72218-72140-neuvillette_en_charnie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72218-72140-neuvillette_en_charnie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72219-72240-bernay_neuvy_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72219-72240-bernay_neuvy_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72219-72240-bernay_neuvy_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72219-72240-bernay_neuvy_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72220-72110-nogent_le_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72220-72110-nogent_le_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72220-72110-nogent_le_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72220-72110-nogent_le_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72221-72500-nogent_sur_loir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72221-72500-nogent_sur_loir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72221-72500-nogent_sur_loir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72221-72500-nogent_sur_loir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72222-72260-nouans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72222-72260-nouans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72222-72260-nouans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72222-72260-nouans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72223-72430-noyen_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72223-72430-noyen_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72223-72430-noyen_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72223-72430-noyen_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72224-72370-nuille_le_jalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72224-72370-nuille_le_jalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72224-72370-nuille_le_jalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72224-72370-nuille_le_jalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72225-72610-oisseau_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72225-72610-oisseau_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72225-72610-oisseau_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72225-72610-oisseau_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72226-72330-oize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72226-72330-oize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72226-72330-oize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72226-72330-oize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72227-72600-panon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72227-72600-panon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72227-72600-panon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72227-72600-panon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72228-72300-parce_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72228-72300-parce_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72228-72300-parce_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72228-72300-parce_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72229-72140-parennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72229-72140-parennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72229-72140-parennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72229-72140-parennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72230-72330-parigne_le_polin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72230-72330-parigne_le_polin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72230-72330-parigne_le_polin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72230-72330-parigne_le_polin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72231-72250-parigne_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72231-72250-parigne_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72231-72250-parigne_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72231-72250-parigne_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72232-72300-notre_dame_du_pe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72232-72300-notre_dame_du_pe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72232-72300-notre_dame_du_pe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72232-72300-notre_dame_du_pe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72233-72260-peray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72233-72260-peray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72233-72260-peray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72233-72260-peray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72234-72140-peze_le_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72234-72140-peze_le_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72234-72140-peze_le_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72234-72140-peze_le_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72235-72170-piace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72235-72170-piace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72235-72170-piace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72235-72170-piace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72236-72300-pince/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72236-72300-pince/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72236-72300-pince/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72236-72300-pince/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72237-72430-pirmil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72237-72430-pirmil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72237-72430-pirmil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72237-72430-pirmil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72238-72600-pizieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72238-72600-pizieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72238-72600-pizieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72238-72600-pizieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72239-72350-poille_sur_vegre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72239-72350-poille_sur_vegre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72239-72350-poille_sur_vegre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72239-72350-poille_sur_vegre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72241-72450-montfort_le_gesnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72241-72450-montfort_le_gesnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72241-72450-montfort_le_gesnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72241-72450-montfort_le_gesnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72243-72510-pontvallain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72243-72510-pontvallain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72243-72510-pontvallain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72243-72510-pontvallain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72244-72300-precigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72244-72300-precigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72244-72300-precigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72244-72300-precigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72245-72400-preval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72245-72400-preval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72245-72400-preval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72245-72400-preval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72246-72110-prevelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72246-72110-prevelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72246-72110-prevelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72246-72110-prevelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72247-72700-pruille_le_chetif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72247-72700-pruille_le_chetif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72247-72700-pruille_le_chetif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72247-72700-pruille_le_chetif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72248-72150-pruille_l_eguille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72248-72150-pruille_l_eguille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72248-72150-pruille_l_eguille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72248-72150-pruille_l_eguille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72249-72550-la_quinte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72249-72550-la_quinte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72249-72550-la_quinte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72249-72550-la_quinte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72250-72120-rahay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72250-72120-rahay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72250-72120-rahay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72250-72120-rahay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72251-72260-rene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72251-72260-rene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72251-72260-rene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72251-72260-rene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72252-72510-requeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72252-72510-requeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72252-72510-requeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72252-72510-requeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72253-72210-roeze_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72253-72210-roeze_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72253-72210-roeze_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72253-72210-roeze_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72254-72610-rouesse_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72254-72610-rouesse_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72254-72610-rouesse_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72254-72610-rouesse_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72255-72140-rouesse_vasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72255-72140-rouesse_vasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72255-72140-rouesse_vasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72255-72140-rouesse_vasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72256-72140-rouez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72256-72140-rouez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72256-72140-rouez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72256-72140-rouez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72257-72700-rouillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72257-72700-rouillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72257-72700-rouillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72257-72700-rouillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72259-72110-rouperroux_le_coquet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72259-72110-rouperroux_le_coquet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72259-72110-rouperroux_le_coquet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72259-72110-rouperroux_le_coquet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72260-72230-ruaudin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72260-72230-ruaudin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72260-72230-ruaudin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72260-72230-ruaudin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72261-72240-ruille_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72261-72240-ruille_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72261-72240-ruille_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72261-72240-ruille_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72262-72340-loir_en_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72262-72340-loir_en_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72262-72340-loir_en_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72262-72340-loir_en_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72262-72310-loir_en_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72262-72310-loir_en_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72262-72310-loir_en_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72262-72310-loir_en_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72264-72300-sable_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72264-72300-sable_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72264-72300-sable_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72264-72300-sable_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72265-72110-saint_aignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72265-72110-saint_aignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72265-72110-saint_aignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72265-72110-saint_aignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72266-72130-saint_aubin_de_locquenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72266-72130-saint_aubin_de_locquenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72266-72130-saint_aubin_de_locquenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72266-72130-saint_aubin_de_locquenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72267-72400-saint_aubin_des_coudrais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72267-72400-saint_aubin_des_coudrais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72267-72400-saint_aubin_des_coudrais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72267-72400-saint_aubin_des_coudrais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72268-72220-saint_biez_en_belin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72268-72220-saint_biez_en_belin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72268-72220-saint_biez_en_belin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72268-72220-saint_biez_en_belin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72269-72120-saint_calais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72269-72120-saint_calais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72269-72120-saint_calais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72269-72120-saint_calais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72270-72600-saint_calez_en_saosnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72270-72600-saint_calez_en_saosnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72270-72600-saint_calez_en_saosnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72270-72600-saint_calez_en_saosnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72271-72110-saint_celerin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72271-72110-saint_celerin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72271-72110-saint_celerin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72271-72110-saint_celerin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72272-72120-sainte_cerotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72272-72120-sainte_cerotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72272-72120-sainte_cerotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72272-72120-sainte_cerotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72273-72170-saint_christophe_du_jambet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72273-72170-saint_christophe_du_jambet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72273-72170-saint_christophe_du_jambet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72273-72170-saint_christophe_du_jambet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72274-72540-saint_christophe_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72274-72540-saint_christophe_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72274-72540-saint_christophe_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72274-72540-saint_christophe_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72275-72460-saint_corneille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72275-72460-saint_corneille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72275-72460-saint_corneille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72275-72460-saint_corneille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72276-72110-saint_cosme_en_vairais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72276-72110-saint_cosme_en_vairais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72276-72110-saint_cosme_en_vairais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72276-72110-saint_cosme_en_vairais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72277-72110-saint_denis_des_coudrais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72277-72110-saint_denis_des_coudrais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72277-72110-saint_denis_des_coudrais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72277-72110-saint_denis_des_coudrais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72278-72350-saint_denis_d_orques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72278-72350-saint_denis_d_orques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72278-72350-saint_denis_d_orques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72278-72350-saint_denis_d_orques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72279-72150-saint_georges_de_la_couee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72279-72150-saint_georges_de_la_couee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72279-72150-saint_georges_de_la_couee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72279-72150-saint_georges_de_la_couee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72280-72700-saint_georges_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72280-72700-saint_georges_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72280-72700-saint_georges_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72280-72700-saint_georges_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72281-72110-saint_georges_du_rosay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72281-72110-saint_georges_du_rosay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72281-72110-saint_georges_du_rosay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72281-72110-saint_georges_du_rosay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72282-72130-saint_georges_le_gaultier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72282-72130-saint_georges_le_gaultier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72282-72130-saint_georges_le_gaultier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72282-72130-saint_georges_le_gaultier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72283-72800-saint_germain_d_arce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72283-72800-saint_germain_d_arce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72283-72800-saint_germain_d_arce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72283-72800-saint_germain_d_arce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72286-72120-saint_gervais_de_vic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72286-72120-saint_gervais_de_vic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72286-72120-saint_gervais_de_vic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72286-72120-saint_gervais_de_vic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72287-72220-saint_gervais_en_belin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72287-72220-saint_gervais_en_belin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72287-72220-saint_gervais_en_belin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72287-72220-saint_gervais_en_belin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72289-72380-sainte_jamme_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72289-72380-sainte_jamme_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72289-72380-sainte_jamme_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72289-72380-sainte_jamme_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72290-72380-saint_jean_d_asse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72290-72380-saint_jean_d_asse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72290-72380-saint_jean_d_asse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72290-72380-saint_jean_d_asse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72291-72510-saint_jean_de_la_motte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72291-72510-saint_jean_de_la_motte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72291-72510-saint_jean_de_la_motte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72291-72510-saint_jean_de_la_motte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72292-72320-saint_jean_des_echelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72292-72320-saint_jean_des_echelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72292-72320-saint_jean_des_echelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72292-72320-saint_jean_des_echelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72293-72430-saint_jean_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72293-72430-saint_jean_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72293-72430-saint_jean_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72293-72430-saint_jean_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72294-72130-saint_leonard_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72294-72130-saint_leonard_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72294-72130-saint_leonard_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72294-72130-saint_leonard_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72295-72600-saint_longis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72295-72600-saint_longis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72295-72600-saint_longis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72295-72600-saint_longis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72296-72320-saint_maixent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72296-72320-saint_maixent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72296-72320-saint_maixent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72296-72320-saint_maixent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72297-72170-saint_marceau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72297-72170-saint_marceau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72297-72170-saint_marceau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72297-72170-saint_marceau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72298-72440-saint_mars_de_locquenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72298-72440-saint_mars_de_locquenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72298-72440-saint_mars_de_locquenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72298-72440-saint_mars_de_locquenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72299-72220-saint_mars_d_outille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72299-72220-saint_mars_d_outille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72299-72220-saint_mars_d_outille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72299-72220-saint_mars_d_outille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72300-72470-saint_mars_la_briere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72300-72470-saint_mars_la_briere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72300-72470-saint_mars_la_briere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72300-72470-saint_mars_la_briere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72302-72400-saint_martin_des_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72302-72400-saint_martin_des_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72302-72400-saint_martin_des_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72302-72400-saint_martin_des_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72303-72440-saint_michel_de_chavaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72303-72440-saint_michel_de_chavaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72303-72440-saint_michel_de_chavaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72303-72440-saint_michel_de_chavaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72305-72130-saint_ouen_de_mimbre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72305-72130-saint_ouen_de_mimbre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72305-72130-saint_ouen_de_mimbre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72305-72130-saint_ouen_de_mimbre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72306-72220-saint_ouen_en_belin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72306-72220-saint_ouen_en_belin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72306-72220-saint_ouen_en_belin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72306-72220-saint_ouen_en_belin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72307-72350-saint_ouen_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72307-72350-saint_ouen_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72307-72350-saint_ouen_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72307-72350-saint_ouen_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72308-72610-saint_paterne___le_chevain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72308-72610-saint_paterne___le_chevain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72308-72610-saint_paterne___le_chevain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72308-72610-saint_paterne___le_chevain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72309-72130-saint_paul_le_gaultier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72309-72130-saint_paul_le_gaultier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72309-72130-saint_paul_le_gaultier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72309-72130-saint_paul_le_gaultier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72310-72190-saint_pavace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72310-72190-saint_pavace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72310-72190-saint_pavace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72310-72190-saint_pavace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72311-72500-saint_pierre_de_cheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72311-72500-saint_pierre_de_cheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72311-72500-saint_pierre_de_cheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72311-72500-saint_pierre_de_cheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72312-72430-saint_pierre_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72312-72430-saint_pierre_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72312-72430-saint_pierre_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72312-72430-saint_pierre_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72313-72600-saint_pierre_des_ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72313-72600-saint_pierre_des_ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72313-72600-saint_pierre_des_ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72313-72600-saint_pierre_des_ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72314-72150-saint_pierre_du_lorouer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72314-72150-saint_pierre_du_lorouer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72314-72150-saint_pierre_du_lorouer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72314-72150-saint_pierre_du_lorouer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72315-72140-saint_remy_de_sille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72315-72140-saint_remy_de_sille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72315-72140-saint_remy_de_sille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72315-72140-saint_remy_de_sille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72316-72600-saint_remy_des_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72316-72600-saint_remy_des_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72316-72600-saint_remy_des_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72316-72600-saint_remy_des_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72317-72600-saint_remy_du_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72317-72600-saint_remy_du_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72317-72600-saint_remy_du_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72317-72600-saint_remy_du_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72319-72380-sainte_sabine_sur_longeve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72319-72380-sainte_sabine_sur_longeve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72319-72380-sainte_sabine_sur_longeve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72319-72380-sainte_sabine_sur_longeve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72320-72650-saint_saturnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72320-72650-saint_saturnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72320-72650-saint_saturnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72320-72650-saint_saturnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72321-72240-saint_symphorien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72321-72240-saint_symphorien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72321-72240-saint_symphorien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72321-72240-saint_symphorien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72322-72320-saint_ulphace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72322-72320-saint_ulphace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72322-72320-saint_ulphace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72322-72320-saint_ulphace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72323-72130-saint_victeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72323-72130-saint_victeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72323-72130-saint_victeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72323-72130-saint_victeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72324-72600-saint_vincent_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72324-72600-saint_vincent_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72324-72600-saint_vincent_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72324-72600-saint_vincent_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72325-72150-saint_vincent_du_lorouer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72325-72150-saint_vincent_du_lorouer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72325-72150-saint_vincent_du_lorouer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72325-72150-saint_vincent_du_lorouer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72326-72600-saosnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72326-72600-saosnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72326-72600-saosnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72326-72600-saosnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72327-72360-sarce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72327-72360-sarce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72327-72360-sarce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72327-72360-sarce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72328-72190-sarge_les_le_mans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72328-72190-sarge_les_le_mans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72328-72190-sarge_les_le_mans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72328-72190-sarge_les_le_mans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72329-72460-savigne_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72329-72460-savigne_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72329-72460-savigne_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72329-72460-savigne_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72330-72800-savigne_sous_le_lude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72330-72800-savigne_sous_le_lude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72330-72800-savigne_sous_le_lude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72330-72800-savigne_sous_le_lude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72331-72160-sceaux_sur_huisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72331-72160-sceaux_sur_huisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72331-72160-sceaux_sur_huisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72331-72160-sceaux_sur_huisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72332-72170-segrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72332-72170-segrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72332-72170-segrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72332-72170-segrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72333-72390-semur_en_vallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72333-72390-semur_en_vallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72333-72390-semur_en_vallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72333-72390-semur_en_vallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72334-72140-sille_le_guillaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72334-72140-sille_le_guillaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72334-72140-sille_le_guillaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72334-72140-sille_le_guillaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72335-72460-sille_le_philippe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72335-72460-sille_le_philippe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72335-72460-sille_le_philippe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72335-72460-sille_le_philippe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72336-72300-solesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72336-72300-solesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72336-72300-solesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72336-72300-solesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72337-72130-souge_le_ganelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72337-72130-souge_le_ganelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72337-72130-souge_le_ganelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72337-72130-souge_le_ganelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72338-72380-souille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72338-72380-souille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72338-72380-souille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72338-72380-souille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72339-72210-souligne_flace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72339-72210-souligne_flace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72339-72210-souligne_flace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72339-72210-souligne_flace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72340-72290-souligne_sous_ballon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72340-72290-souligne_sous_ballon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72340-72290-souligne_sous_ballon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72340-72290-souligne_sous_ballon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72341-72370-soulitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72341-72370-soulitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72341-72370-soulitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72341-72370-soulitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72342-72400-souvigne_sur_meme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72342-72400-souvigne_sur_meme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72342-72400-souvigne_sur_meme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72342-72400-souvigne_sur_meme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72343-72300-souvigne_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72343-72300-souvigne_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72343-72300-souvigne_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72343-72300-souvigne_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72344-72700-spay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72344-72700-spay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72344-72700-spay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72344-72700-spay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72345-72370-surfonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72345-72370-surfonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72345-72370-surfonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72345-72370-surfonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72346-72210-la_suze_sur_sarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72346-72210-la_suze_sur_sarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72346-72210-la_suze_sur_sarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72346-72210-la_suze_sur_sarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72347-72430-tasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72347-72430-tasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72347-72430-tasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72347-72430-tasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72348-72540-tassille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72348-72540-tassille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72348-72540-tassille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72348-72540-tassille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72349-72290-teille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72349-72290-teille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72349-72290-teille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72349-72290-teille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72350-72220-teloche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72350-72220-teloche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72350-72220-teloche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72350-72220-teloche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72351-72240-tennie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72351-72240-tennie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72351-72240-tennie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72351-72240-tennie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72352-72110-terrehault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72352-72110-terrehault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72352-72110-terrehault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72352-72110-terrehault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72353-72320-theligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72353-72320-theligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72353-72320-theligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72353-72320-theligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72354-72260-thoigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72354-72260-thoigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72354-72260-thoigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72354-72260-thoigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72355-72610-thoire_sous_contensor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72355-72610-thoire_sous_contensor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72355-72610-thoire_sous_contensor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72355-72610-thoire_sous_contensor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72356-72500-thoire_sur_dinan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72356-72500-thoire_sur_dinan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72356-72500-thoire_sur_dinan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72356-72500-thoire_sur_dinan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72357-72800-thoree_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72357-72800-thoree_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72357-72800-thoree_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72357-72800-thoree_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72358-72160-thorigne_sur_due/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72358-72160-thorigne_sur_due/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72358-72160-thorigne_sur_due/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72358-72160-thorigne_sur_due/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72359-72110-torce_en_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72359-72110-torce_en_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72359-72110-torce_en_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72359-72110-torce_en_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72360-72650-trange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72360-72650-trange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72360-72650-trange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72360-72650-trange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72361-72440-tresson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72361-72440-tresson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72361-72440-tresson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72361-72440-tresson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72362-72170-le_tronchet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72362-72170-le_tronchet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72362-72170-le_tronchet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72362-72170-le_tronchet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72363-72160-tuffe_val_de_la_cheronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72363-72160-tuffe_val_de_la_cheronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72363-72160-tuffe_val_de_la_cheronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72363-72160-tuffe_val_de_la_cheronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72364-72500-vaas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72364-72500-vaas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72364-72500-vaas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72364-72500-vaas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72366-72320-valennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72366-72320-valennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72366-72320-valennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72366-72320-valennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72367-72540-vallon_sur_gee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72367-72540-vallon_sur_gee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72367-72540-vallon_sur_gee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72367-72540-vallon_sur_gee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72368-72310-vance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72368-72310-vance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72368-72310-vance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72368-72310-vance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72369-72360-verneil_le_chetif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72369-72360-verneil_le_chetif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72369-72360-verneil_le_chetif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72369-72360-verneil_le_chetif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72370-72170-vernie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72370-72170-vernie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72370-72170-vernie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72370-72170-vernie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72372-72600-vezot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72372-72600-vezot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72372-72600-vezot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72372-72600-vezot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72373-72320-vibraye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72373-72320-vibraye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72373-72320-vibraye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72373-72320-vibraye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72374-72600-villaines_la_carelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72374-72600-villaines_la_carelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72374-72600-villaines_la_carelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72374-72600-villaines_la_carelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72375-72400-villaines_la_gonais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72375-72400-villaines_la_gonais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72375-72400-villaines_la_gonais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72375-72400-villaines_la_gonais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72376-72150-villaines_sous_luce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72376-72150-villaines_sous_luce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72376-72150-villaines_sous_luce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72376-72150-villaines_sous_luce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72377-72270-villaines_sous_malicorne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72377-72270-villaines_sous_malicorne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72377-72270-villaines_sous_malicorne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72377-72270-villaines_sous_malicorne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72378-72300-vion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72378-72300-vion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72378-72300-vion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72378-72300-vion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72379-72350-vire_en_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72379-72350-vire_en_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72379-72350-vire_en_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72379-72350-vire_en_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72380-72170-vivoin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72380-72170-vivoin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72380-72170-vivoin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72380-72170-vivoin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72381-72210-voivres_les_le_mans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72381-72210-voivres_les_le_mans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72381-72210-voivres_les_le_mans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72381-72210-voivres_les_le_mans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72382-72440-volnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72382-72440-volnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72382-72440-volnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72382-72440-volnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72383-72160-vouvray_sur_huisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72383-72160-vouvray_sur_huisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72383-72160-vouvray_sur_huisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72383-72160-vouvray_sur_huisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72385-72330-yvre_le_polin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72385-72330-yvre_le_polin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72385-72330-yvre_le_polin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72385-72330-yvre_le_polin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72386-72530-yvre_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72386-72530-yvre_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72386-72530-yvre_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt72-sarthe/commune72386-72530-yvre_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-73.xml
+++ b/public/sitemaps/sitemap-73.xml
@@ -5,562 +5,1120 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73001-73610-aiguebelette_le_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73001-73610-aiguebelette_le_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73001-73610-aiguebelette_le_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73001-73610-aiguebelette_le_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73003-73260-grand_aigueblanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73003-73260-grand_aigueblanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73003-73260-grand_aigueblanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73003-73260-grand_aigueblanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73004-73340-aillon_le_jeune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73004-73340-aillon_le_jeune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73004-73340-aillon_le_jeune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73004-73340-aillon_le_jeune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73005-73340-aillon_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73005-73340-aillon_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73005-73340-aillon_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73005-73340-aillon_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73006-73210-aime_la_plagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73006-73210-aime_la_plagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73006-73210-aime_la_plagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73006-73210-aime_la_plagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73007-73220-aiton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73007-73220-aiton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73007-73220-aiton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73007-73220-aiton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73008-73100-aix_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73008-73100-aix_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73008-73100-aix_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73008-73100-aix_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73010-73410-entrelacs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73010-73410-entrelacs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73010-73410-entrelacs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73010-73410-entrelacs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73011-73200-albertville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73011-73200-albertville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73011-73200-albertville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73011-73200-albertville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73012-73300-albiez_le_jeune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73012-73300-albiez_le_jeune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73012-73300-albiez_le_jeune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73012-73300-albiez_le_jeune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73013-73300-albiez_montrond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73013-73300-albiez_montrond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73013-73300-albiez_montrond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73013-73300-albiez_montrond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73014-73200-allondaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73014-73200-allondaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73014-73200-allondaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73014-73200-allondaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73015-73550-les_allues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73015-73550-les_allues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73015-73550-les_allues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73015-73550-les_allues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73017-73190-apremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73017-73190-apremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73017-73190-apremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73017-73190-apremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73018-73800-arbin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73018-73800-arbin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73018-73800-arbin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73018-73800-arbin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73019-73220-argentine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73019-73220-argentine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73019-73220-argentine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73019-73220-argentine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73020-73340-arith/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73020-73340-arith/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73020-73340-arith/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73020-73340-arith/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73021-73110-arvillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73021-73110-arvillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73021-73110-arvillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73021-73110-arvillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73022-73610-attignat_oncin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73022-73610-attignat_oncin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73022-73610-attignat_oncin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73022-73610-attignat_oncin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73023-73500-aussois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73023-73500-aussois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73023-73500-aussois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73023-73500-aussois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73024-73260-les_avanchers_valmorel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73024-73260-les_avanchers_valmorel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73024-73260-les_avanchers_valmorel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73024-73260-les_avanchers_valmorel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73025-73240-avressieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73025-73240-avressieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73025-73240-avressieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73025-73240-avressieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73026-73500-avrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73026-73500-avrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73026-73500-avrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73026-73500-avrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73027-73470-ayn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73027-73470-ayn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73027-73470-ayn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73027-73470-ayn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73028-73170-la_balme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73028-73170-la_balme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73028-73170-la_balme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73028-73170-la_balme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73029-73000-barberaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73029-73000-barberaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73029-73000-barberaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73029-73000-barberaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73030-73230-barby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73030-73230-barby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73030-73230-barby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73030-73230-barby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73031-73000-bassens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73031-73000-bassens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73031-73000-bassens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73031-73000-bassens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73032-73540-la_bathie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73032-73540-la_bathie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73032-73540-la_bathie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73032-73540-la_bathie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73033-73360-la_bauche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73033-73360-la_bauche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73033-73360-la_bauche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73033-73360-la_bauche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73034-73270-beaufort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73034-73270-beaufort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73034-73270-beaufort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73034-73270-beaufort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73036-73340-bellecombe_en_bauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73036-73340-bellecombe_en_bauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73036-73340-bellecombe_en_bauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73036-73340-bellecombe_en_bauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73039-73330-belmont_tramonet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73039-73330-belmont_tramonet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73039-73330-belmont_tramonet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73039-73330-belmont_tramonet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73040-73480-bessans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73040-73480-bessans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73040-73480-bessans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73040-73480-bessans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73041-73390-betton_bettonet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73041-73390-betton_bettonet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73041-73390-betton_bettonet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73041-73390-betton_bettonet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73042-73170-billieme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73042-73170-billieme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73042-73170-billieme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73042-73170-billieme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73043-73410-la_biolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73043-73410-la_biolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73043-73410-la_biolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73043-73410-la_biolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73047-73480-bonneval_sur_arc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73047-73480-bonneval_sur_arc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73047-73480-bonneval_sur_arc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73047-73480-bonneval_sur_arc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73048-73460-bonvillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73048-73460-bonvillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73048-73460-bonvillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73048-73460-bonvillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73049-73220-bonvillaret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73049-73220-bonvillaret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73049-73220-bonvillaret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73049-73220-bonvillaret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73050-73370-bourdeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73050-73370-bourdeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73050-73370-bourdeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73050-73370-bourdeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73051-73370-le_bourget_du_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73051-73370-le_bourget_du_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73051-73370-le_bourget_du_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73051-73370-le_bourget_du_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73052-73110-bourget_en_huile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73052-73110-bourget_en_huile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73052-73110-bourget_en_huile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73052-73110-bourget_en_huile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73053-73390-bourgneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73053-73390-bourgneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73053-73390-bourgneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73053-73390-bourgneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73054-73700-bourg_saint_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73054-73700-bourg_saint_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73054-73700-bourg_saint_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73054-73700-bourg_saint_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73055-73350-bozel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73055-73350-bozel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73055-73350-bozel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73055-73350-bozel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73057-73570-brides_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73057-73570-brides_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73057-73570-brides_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73057-73570-brides_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73058-73520-la_bridoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73058-73520-la_bridoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73058-73520-la_bridoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73058-73520-la_bridoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73059-73100-brison_saint_innocent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73059-73100-brison_saint_innocent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73059-73100-brison_saint_innocent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73059-73100-brison_saint_innocent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73061-73200-cesarches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73061-73200-cesarches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73061-73200-cesarches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73061-73200-cesarches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73063-73730-cevins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73063-73730-cevins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73063-73730-cevins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73063-73730-cevins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73064-73190-challes_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73064-73190-challes_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73064-73190-challes_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73064-73190-challes_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73065-73000-chambery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73065-73000-chambery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73065-73000-chambery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73065-73000-chambery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73067-73130-la_chambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73067-73130-la_chambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73067-73130-la_chambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73067-73130-la_chambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73068-73390-chamousset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73068-73390-chamousset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73068-73390-chamousset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73068-73390-chamousset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73069-73390-chamoux_sur_gelon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73069-73390-chamoux_sur_gelon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73069-73390-chamoux_sur_gelon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73069-73390-chamoux_sur_gelon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73070-73240-champagneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73070-73240-champagneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73070-73240-champagneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73070-73240-champagneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73071-73350-champagny_en_vanoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73071-73350-champagny_en_vanoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73071-73350-champagny_en_vanoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73071-73350-champagny_en_vanoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73072-73390-champ_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73072-73390-champ_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73072-73390-champ_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73072-73390-champ_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73073-73310-chanaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73073-73310-chanaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73073-73310-chanaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73073-73310-chanaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73074-73660-la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73074-73660-la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73074-73660-la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73074-73660-la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73075-73110-la_chapelle_blanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73075-73110-la_chapelle_blanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73075-73110-la_chapelle_blanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73075-73110-la_chapelle_blanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73076-73370-la_chapelle_du_mont_du_chat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73076-73370-la_chapelle_du_mont_du_chat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73076-73370-la_chapelle_du_mont_du_chat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73076-73370-la_chapelle_du_mont_du_chat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73077-73700-les_chapelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73077-73700-les_chapelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73077-73700-les_chapelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73077-73700-les_chapelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73078-73170-la_chapelle_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73078-73170-la_chapelle_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73078-73170-la_chapelle_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73078-73170-la_chapelle_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73079-73390-chateauneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73079-73390-chateauneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73079-73390-chateauneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73079-73390-chateauneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73081-73630-le_chatelard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73081-73630-le_chatelard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73081-73630-le_chatelard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73081-73630-le_chatelard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73082-73800-la_chavanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73082-73800-la_chavanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73082-73800-la_chavanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73082-73800-la_chavanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73083-73660-les_chavannes_en_maurienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73083-73660-les_chavannes_en_maurienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73083-73660-les_chavannes_en_maurienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73083-73660-les_chavannes_en_maurienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73084-73800-chignin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73084-73800-chignin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73084-73800-chignin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73084-73800-chignin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73085-73310-chindrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73085-73310-chindrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73085-73310-chindrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73085-73310-chindrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73086-73460-clery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73086-73460-clery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73086-73460-clery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73086-73460-clery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73087-73160-cognin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73087-73160-cognin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73087-73160-cognin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73087-73160-cognin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73590-cohennoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73590-cohennoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73590-cohennoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73590-cohennoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73400-cohennoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73400-cohennoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73400-cohennoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73400-cohennoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73200-cohennoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73200-cohennoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73200-cohennoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73088-73200-cohennoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73089-73800-coise_saint_jean_pied_gauthier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73089-73800-coise_saint_jean_pied_gauthier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73089-73800-coise_saint_jean_pied_gauthier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73089-73800-coise_saint_jean_pied_gauthier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73090-73630-la_compote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73090-73630-la_compote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73090-73630-la_compote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73090-73630-la_compote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73091-73310-conjux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73091-73310-conjux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73091-73310-conjux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73091-73310-conjux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73092-73160-corbel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73092-73160-corbel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73092-73160-corbel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73092-73160-corbel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73094-73590-crest_voland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73094-73590-crest_voland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73094-73590-crest_voland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73094-73590-crest_voland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73095-73110-la_croix_de_la_rochette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73095-73110-la_croix_de_la_rochette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73095-73110-la_croix_de_la_rochette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73095-73110-la_croix_de_la_rochette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73096-73800-cruet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73096-73800-cruet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73096-73800-cruet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73096-73800-cruet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73097-73190-curienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73097-73190-curienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73097-73190-curienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73097-73190-curienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73098-73230-les_deserts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73098-73230-les_deserts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73098-73230-les_deserts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73098-73230-les_deserts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73099-73110-detrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73099-73110-detrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73099-73110-detrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73099-73110-detrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73100-73330-domessin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73100-73330-domessin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73100-73330-domessin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73100-73330-domessin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73101-73630-doucy_en_bauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73101-73630-doucy_en_bauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73101-73630-doucy_en_bauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73101-73630-doucy_en_bauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73103-73420-drumettaz_clarafond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73103-73420-drumettaz_clarafond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73103-73420-drumettaz_clarafond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73103-73420-drumettaz_clarafond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73104-73610-dullin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73104-73610-dullin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73104-73610-dullin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73104-73610-dullin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73105-73360-les_echelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73105-73360-les_echelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73105-73360-les_echelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73105-73360-les_echelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73106-73630-ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73106-73630-ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73106-73630-ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73106-73630-ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73107-73670-entremont_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73107-73670-entremont_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73107-73670-entremont_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73107-73670-entremont_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73109-73220-epierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73109-73220-epierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73109-73220-epierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73109-73220-epierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73110-73540-esserts_blay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73110-73540-esserts_blay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73110-73540-esserts_blay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73110-73540-esserts_blay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73113-73350-feissons_sur_salins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73113-73350-feissons_sur_salins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73113-73350-feissons_sur_salins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73113-73350-feissons_sur_salins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73114-73590-flumet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73114-73590-flumet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73114-73590-flumet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73114-73590-flumet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73116-73300-fontcouverte_la_toussuire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73116-73300-fontcouverte_la_toussuire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73116-73300-fontcouverte_la_toussuire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73116-73300-fontcouverte_la_toussuire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73117-73500-fourneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73117-73500-fourneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73117-73500-fourneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73117-73500-fourneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73119-73500-freney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73119-73500-freney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73119-73500-freney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73119-73500-freney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73120-73250-freterive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73120-73250-freterive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73120-73250-freterive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73120-73250-freterive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73121-73460-frontenex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73121-73460-frontenex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73121-73460-frontenex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73121-73460-frontenex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73122-73470-gerbaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73122-73470-gerbaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73122-73470-gerbaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73122-73470-gerbaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73123-73590-la_giettaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73123-73590-la_giettaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73123-73590-la_giettaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73123-73590-la_giettaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73124-73200-gilly_sur_isere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73124-73200-gilly_sur_isere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73124-73200-gilly_sur_isere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73124-73200-gilly_sur_isere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73128-73100-gresy_sur_aix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73128-73100-gresy_sur_aix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73128-73100-gresy_sur_aix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73128-73100-gresy_sur_aix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73129-73460-gresy_sur_isere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73129-73460-gresy_sur_isere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73129-73460-gresy_sur_isere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73129-73460-gresy_sur_isere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73130-73200-grignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73130-73200-grignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73130-73200-grignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73130-73200-grignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73131-73600-hautecour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73131-73600-hautecour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73131-73600-hautecour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73131-73600-hautecour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73132-73620-hauteluce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73132-73620-hauteluce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73132-73620-hauteluce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73132-73620-hauteluce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73133-73390-hauteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73133-73390-hauteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73133-73390-hauteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73133-73390-hauteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73135-73300-la_tour_en_maurienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73135-73300-la_tour_en_maurienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73135-73300-la_tour_en_maurienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73135-73300-la_tour_en_maurienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73137-73000-jacob_bellecombette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73137-73000-jacob_bellecombette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73137-73000-jacob_bellecombette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73137-73000-jacob_bellecombette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73138-73300-jarrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73138-73300-jarrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73138-73300-jarrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73138-73300-jarrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73139-73630-jarsy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73139-73630-jarsy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73139-73630-jarsy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73139-73630-jarsy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73140-73170-jongieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73140-73170-jongieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73140-73170-jongieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73140-73170-jongieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73141-73800-laissaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73141-73800-laissaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73141-73800-laissaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73141-73800-laissaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73142-73210-landry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73142-73210-landry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73142-73210-landry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73142-73210-landry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73145-73610-lepin_le_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73145-73610-lepin_le_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73145-73610-lepin_le_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73145-73610-lepin_le_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73146-73340-lescheraines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73146-73340-lescheraines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73146-73340-lescheraines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73146-73340-lescheraines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73147-73170-loisieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73147-73170-loisieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73147-73170-loisieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73147-73170-loisieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73149-73170-lucey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73149-73170-lucey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73149-73170-lucey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73149-73170-lucey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73150-73210-la_plagne_tarentaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73150-73210-la_plagne_tarentaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73150-73210-la_plagne_tarentaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73150-73210-la_plagne_tarentaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73151-73800-porte_de_savoie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73151-73800-porte_de_savoie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73151-73800-porte_de_savoie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73151-73800-porte_de_savoie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73152-73470-marcieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73152-73470-marcieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73152-73470-marcieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73152-73470-marcieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73153-73400-marthod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73153-73400-marthod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73153-73400-marthod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73153-73400-marthod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73154-73200-mercury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73154-73200-mercury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73154-73200-mercury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73154-73200-mercury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73155-73420-mery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73155-73420-mery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73155-73420-mery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73155-73420-mery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73156-73170-meyrieux_trouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73156-73170-meyrieux_trouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73156-73170-meyrieux_trouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73156-73170-meyrieux_trouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73157-73500-modane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73157-73500-modane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73157-73500-modane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73157-73500-modane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73159-73800-les_mollettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73159-73800-les_mollettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73159-73800-les_mollettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73159-73800-les_mollettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73160-73000-montagnole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73160-73000-montagnole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73160-73000-montagnole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73160-73000-montagnole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73161-73350-montagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73161-73350-montagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73161-73350-montagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73161-73350-montagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73162-73460-montailleur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73162-73460-montailleur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73162-73460-montailleur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73162-73460-montailleur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73164-73100-montcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73164-73100-montcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73164-73100-montcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73164-73100-montcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73166-73390-montendry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73166-73390-montendry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73166-73390-montendry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73166-73390-montendry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73168-73220-montgilbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73168-73220-montgilbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73168-73220-montgilbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73168-73220-montgilbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73170-73200-monthion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73170-73200-monthion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73170-73200-monthion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73170-73200-monthion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73171-73800-montmelian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73171-73800-montmelian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73171-73800-montmelian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73171-73800-montmelian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73173-73870-montricher_albanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73173-73870-montricher_albanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73173-73870-montricher_albanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73173-73870-montricher_albanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73175-73220-montsapey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73175-73220-montsapey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73175-73220-montsapey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73175-73220-montsapey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73176-73700-montvalezan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73176-73700-montvalezan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73176-73700-montvalezan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73176-73700-montvalezan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73177-73300-montvernier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73177-73300-montvernier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73177-73300-montvernier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73177-73300-montvernier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73178-73340-la_motte_en_bauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73178-73340-la_motte_en_bauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73178-73340-la_motte_en_bauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73178-73340-la_motte_en_bauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73179-73290-la_motte_servolex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73179-73290-la_motte_servolex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73179-73290-la_motte_servolex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73179-73290-la_motte_servolex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73180-73310-motz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73180-73310-motz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73180-73310-motz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73180-73310-motz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73181-73600-moutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73181-73600-moutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73181-73600-moutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73181-73600-moutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73182-73100-mouxy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73182-73100-mouxy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73182-73100-mouxy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73182-73100-mouxy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73183-73800-myans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73183-73800-myans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73183-73800-myans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73183-73800-myans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73184-73470-nances/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73184-73470-nances/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73184-73470-nances/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73184-73470-nances/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73186-73590-notre_dame_de_bellecombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73186-73590-notre_dame_de_bellecombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73186-73590-notre_dame_de_bellecombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73186-73590-notre_dame_de_bellecombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73187-73260-la_lechere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73187-73260-la_lechere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73187-73260-la_lechere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73187-73260-la_lechere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73188-73460-notre_dame_des_millieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73188-73460-notre_dame_des_millieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73188-73460-notre_dame_des_millieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73188-73460-notre_dame_des_millieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73189-73130-notre_dame_du_cruet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73189-73130-notre_dame_du_cruet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73189-73130-notre_dame_du_cruet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73189-73130-notre_dame_du_cruet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73190-73600-notre_dame_du_pre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73190-73600-notre_dame_du_pre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73190-73600-notre_dame_du_pre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73190-73600-notre_dame_du_pre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73191-73470-novalaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73191-73470-novalaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73191-73470-novalaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73191-73470-novalaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73192-73340-le_noyer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73192-73340-le_noyer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73192-73340-le_noyer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73192-73340-le_noyer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73193-73310-ontex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73193-73310-ontex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73193-73310-ontex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73193-73310-ontex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73194-73140-orelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73194-73140-orelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73194-73140-orelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73194-73140-orelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73196-73200-pallud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73196-73200-pallud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73196-73200-pallud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73196-73200-pallud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73197-73210-peisey_nancroix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73197-73210-peisey_nancroix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73197-73210-peisey_nancroix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73197-73210-peisey_nancroix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73200-73800-planaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73200-73800-planaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73200-73800-planaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73200-73800-planaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73201-73350-planay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73201-73350-planay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73201-73350-planay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73201-73350-planay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73202-73200-plancherine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73202-73200-plancherine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73202-73200-plancherine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73202-73200-plancherine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73204-73330-le_pont_de_beauvoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73204-73330-le_pont_de_beauvoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73204-73330-le_pont_de_beauvoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73204-73330-le_pont_de_beauvoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73205-73110-le_pontet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73205-73110-le_pontet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73205-73110-le_pontet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73205-73110-le_pontet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73206-73710-pralognan_la_vanoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73206-73710-pralognan_la_vanoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73206-73710-pralognan_la_vanoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73206-73710-pralognan_la_vanoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73207-73110-presle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73207-73110-presle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73207-73110-presle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73207-73110-presle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73208-73100-pugny_chatenod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73208-73100-pugny_chatenod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73208-73100-pugny_chatenod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73208-73100-pugny_chatenod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73210-73190-puygros/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73210-73190-puygros/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73210-73190-puygros/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73210-73190-puygros/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73211-73720-queige/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73211-73720-queige/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73211-73720-queige/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73211-73720-queige/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73212-73220-val_d’arc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73212-73220-val_d’arc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73212-73220-val_d’arc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73212-73220-val_d’arc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73213-73490-la_ravoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73213-73490-la_ravoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73213-73490-la_ravoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73213-73490-la_ravoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73214-73240-rochefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73214-73240-rochefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73214-73240-rochefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73214-73240-rochefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73215-73110-valgelon_la_rochette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73215-73110-valgelon_la_rochette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73215-73110-valgelon_la_rochette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73215-73110-valgelon_la_rochette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73216-73730-rognaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73216-73730-rognaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73216-73730-rognaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73216-73730-rognaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73217-73110-rotherens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73217-73110-rotherens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73217-73110-rotherens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73217-73110-rotherens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73218-73310-ruffieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73218-73310-ruffieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73218-73310-ruffieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73218-73310-ruffieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73219-73610-saint_alban_de_montbel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73219-73610-saint_alban_de_montbel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73219-73610-saint_alban_de_montbel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73219-73610-saint_alban_de_montbel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73220-73220-saint_alban_d_hurtieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73220-73220-saint_alban_d_hurtieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73220-73220-saint_alban_d_hurtieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73220-73220-saint_alban_d_hurtieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73221-73130-saint_alban_des_villards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73221-73130-saint_alban_des_villards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73221-73130-saint_alban_des_villards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73221-73130-saint_alban_des_villards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73222-73230-saint_alban_leysse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73222-73230-saint_alban_leysse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73222-73230-saint_alban_leysse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73222-73230-saint_alban_leysse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73223-73500-saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73223-73500-saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73223-73500-saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73223-73500-saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73224-73130-saint_avre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73224-73130-saint_avre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73224-73130-saint_avre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73224-73130-saint_avre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73225-73190-saint_baldoph/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73225-73190-saint_baldoph/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73225-73190-saint_baldoph/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73225-73190-saint_baldoph/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73226-73520-saint_beron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73226-73520-saint_beron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73226-73520-saint_beron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73226-73520-saint_beron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73227-73120-courchevel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73227-73120-courchevel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73227-73120-courchevel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73227-73120-courchevel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73227-73600-courchevel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73227-73600-courchevel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73227-73600-courchevel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73227-73600-courchevel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73228-73160-saint_cassin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73228-73160-saint_cassin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73228-73160-saint_cassin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73228-73160-saint_cassin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73229-73360-saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73229-73360-saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73229-73360-saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73229-73360-saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73230-73130-saint_colomban_des_villards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73230-73130-saint_colomban_des_villards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73230-73130-saint_colomban_des_villards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73230-73130-saint_colomban_des_villards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73231-73130-saint_etienne_de_cuines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73231-73130-saint_etienne_de_cuines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73231-73130-saint_etienne_de_cuines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73231-73130-saint_etienne_de_cuines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73232-73640-sainte_foy_tarentaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73232-73640-sainte_foy_tarentaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73232-73640-sainte_foy_tarentaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73232-73640-sainte_foy_tarentaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73233-73360-saint_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73233-73360-saint_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73233-73360-saint_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73233-73360-saint_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73234-73340-saint_francois_de_sales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73234-73340-saint_francois_de_sales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73234-73340-saint_francois_de_sales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73234-73340-saint_francois_de_sales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73235-73130-saint_francois_longchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73235-73130-saint_francois_longchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73235-73130-saint_francois_longchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73235-73130-saint_francois_longchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73236-73240-saint_genix_les_villages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73236-73240-saint_genix_les_villages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73236-73240-saint_genix_les_villages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73236-73240-saint_genix_les_villages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73237-73220-saint_georges_d_hurtieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73237-73220-saint_georges_d_hurtieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73237-73220-saint_georges_d_hurtieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73237-73220-saint_georges_d_hurtieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73240-73800-sainte_helene_du_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73240-73800-sainte_helene_du_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73240-73800-sainte_helene_du_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73240-73800-sainte_helene_du_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73241-73460-sainte_helene_sur_isere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73241-73460-sainte_helene_sur_isere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73241-73460-sainte_helene_sur_isere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73241-73460-sainte_helene_sur_isere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73242-73530-saint_jean_d_arves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73242-73530-saint_jean_d_arves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73242-73530-saint_jean_d_arves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73242-73530-saint_jean_d_arves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73243-73230-saint_jean_d_arvey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73243-73230-saint_jean_d_arvey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73243-73230-saint_jean_d_arvey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73243-73230-saint_jean_d_arvey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73245-73170-saint_jean_de_chevelu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73245-73170-saint_jean_de_chevelu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73245-73170-saint_jean_de_chevelu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73245-73170-saint_jean_de_chevelu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73246-73160-saint_jean_de_couz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73246-73160-saint_jean_de_couz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73246-73160-saint_jean_de_couz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73246-73160-saint_jean_de_couz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73247-73250-saint_jean_de_la_porte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73247-73250-saint_jean_de_la_porte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73247-73250-saint_jean_de_la_porte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73247-73250-saint_jean_de_la_porte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73248-73300-saint_jean_de_maurienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73248-73300-saint_jean_de_maurienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73248-73300-saint_jean_de_maurienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73248-73300-saint_jean_de_maurienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73249-73190-saint_jeoire_prieure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73249-73190-saint_jeoire_prieure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73249-73190-saint_jeoire_prieure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73249-73190-saint_jeoire_prieure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73250-73870-saint_julien_mont_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73250-73870-saint_julien_mont_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73250-73870-saint_julien_mont_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73250-73870-saint_julien_mont_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73252-73220-saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73252-73220-saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73252-73220-saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73252-73220-saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73253-73600-saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73253-73600-saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73253-73600-saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73253-73600-saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73254-73240-sainte_marie_d_alvey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73254-73240-sainte_marie_d_alvey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73254-73240-sainte_marie_d_alvey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73254-73240-sainte_marie_d_alvey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73255-73130-sainte_marie_de_cuines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73255-73130-sainte_marie_de_cuines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73255-73130-sainte_marie_de_cuines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73255-73130-sainte_marie_de_cuines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73256-73140-saint_martin_d_arc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73256-73140-saint_martin_d_arc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73256-73140-saint_martin_d_arc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73256-73140-saint_martin_d_arc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73257-73440-les_belleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73257-73440-les_belleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73257-73440-les_belleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73257-73440-les_belleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73257-73600-les_belleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73257-73600-les_belleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73257-73600-les_belleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73257-73600-les_belleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73258-73140-saint_martin_de_la_porte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73258-73140-saint_martin_de_la_porte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73258-73140-saint_martin_de_la_porte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73258-73140-saint_martin_de_la_porte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73259-73130-saint_martin_sur_la_chambre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73259-73130-saint_martin_sur_la_chambre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73259-73130-saint_martin_sur_la_chambre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73259-73130-saint_martin_sur_la_chambre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73261-73140-saint_michel_de_maurienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73261-73140-saint_michel_de_maurienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73261-73140-saint_michel_de_maurienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73261-73140-saint_michel_de_maurienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73262-73590-saint_nicolas_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73262-73590-saint_nicolas_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73262-73590-saint_nicolas_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73262-73590-saint_nicolas_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73263-73100-saint_offenge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73263-73100-saint_offenge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73263-73100-saint_offenge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73263-73100-saint_offenge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73265-73410-saint_ours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73265-73410-saint_ours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73265-73410-saint_ours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73265-73410-saint_ours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73267-73300-saint_pancrace/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73267-73300-saint_pancrace/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73267-73300-saint_pancrace/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73267-73300-saint_pancrace/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73268-73730-saint_paul_sur_isere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73268-73730-saint_paul_sur_isere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73268-73730-saint_paul_sur_isere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73268-73730-saint_paul_sur_isere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73269-73170-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73269-73170-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73269-73170-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73269-73170-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73270-73250-saint_pierre_d_albigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73270-73250-saint_pierre_d_albigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73270-73250-saint_pierre_d_albigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73270-73250-saint_pierre_d_albigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73271-73170-saint_pierre_d_alvey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73271-73170-saint_pierre_d_alvey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73271-73170-saint_pierre_d_alvey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73271-73170-saint_pierre_d_alvey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73272-73220-saint_pierre_de_belleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73272-73220-saint_pierre_de_belleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73272-73220-saint_pierre_de_belleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73272-73220-saint_pierre_de_belleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73273-73310-saint_pierre_de_curtille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73273-73310-saint_pierre_de_curtille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73273-73310-saint_pierre_de_curtille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73273-73310-saint_pierre_de_curtille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73274-73670-saint_pierre_d_entremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73274-73670-saint_pierre_d_entremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73274-73670-saint_pierre_d_entremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73274-73670-saint_pierre_d_entremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73275-73360-saint_pierre_de_genebroz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73275-73360-saint_pierre_de_genebroz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73275-73360-saint_pierre_de_genebroz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73275-73360-saint_pierre_de_genebroz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73276-73800-saint_pierre_de_soucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73276-73800-saint_pierre_de_soucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73276-73800-saint_pierre_de_soucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73276-73800-saint_pierre_de_soucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73277-73630-sainte_reine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73277-73630-sainte_reine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73277-73630-sainte_reine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73277-73630-sainte_reine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73278-73660-saint_remy_de_maurienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73278-73660-saint_remy_de_maurienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73278-73660-saint_remy_de_maurienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73278-73660-saint_remy_de_maurienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73280-73530-saint_sorlin_d_arves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73280-73530-saint_sorlin_d_arves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73280-73530-saint_sorlin_d_arves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73280-73530-saint_sorlin_d_arves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73281-73160-saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73281-73160-saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73281-73160-saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73281-73160-saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73282-73160-saint_thibaud_de_couz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73282-73160-saint_thibaud_de_couz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73282-73160-saint_thibaud_de_couz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73282-73160-saint_thibaud_de_couz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73283-73460-saint_vital/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73283-73460-saint_vital/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73283-73460-saint_vital/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73283-73460-saint_vital/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73284-73600-salins_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73284-73600-salins_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73284-73600-salins_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73284-73600-salins_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73285-73700-seez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73285-73700-seez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73285-73700-seez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73285-73700-seez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73286-73310-serrieres_en_chautagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73286-73310-serrieres_en_chautagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73286-73310-serrieres_en_chautagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73286-73310-serrieres_en_chautagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73288-73000-sonnaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73288-73000-sonnaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73288-73000-sonnaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73288-73000-sonnaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73289-73110-la_table/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73289-73110-la_table/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73289-73110-la_table/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73289-73110-la_table/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73290-73500-val_cenis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73290-73500-val_cenis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73290-73500-val_cenis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73290-73500-val_cenis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73290-73480-val_cenis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73290-73480-val_cenis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73290-73480-val_cenis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73290-73480-val_cenis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73292-73200-thenesol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73292-73200-thenesol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73292-73200-thenesol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73292-73200-thenesol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73293-73230-thoiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73293-73230-thoiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73293-73230-thoiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73293-73230-thoiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73294-73190-la_thuile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73294-73190-la_thuile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73294-73190-la_thuile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73294-73190-la_thuile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73296-73320-tignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73296-73320-tignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73296-73320-tignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73296-73320-tignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73297-73460-tournon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73297-73460-tournon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73297-73460-tournon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73297-73460-tournon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73298-73790-tours_en_savoie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73298-73790-tours_en_savoie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73298-73790-tours_en_savoie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73298-73790-tours_en_savoie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73299-73170-traize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73299-73170-traize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73299-73170-traize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73299-73170-traize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73300-73100-tresserve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73300-73100-tresserve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73300-73100-tresserve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73300-73100-tresserve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73301-73100-trevignin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73301-73100-trevignin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73301-73100-trevignin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73301-73100-trevignin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73302-73110-la_trinite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73302-73110-la_trinite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73302-73110-la_trinite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73302-73110-la_trinite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73303-73400-ugine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73303-73400-ugine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73303-73400-ugine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73303-73400-ugine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73304-73150-val_d_isere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73304-73150-val_d_isere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73304-73150-val_d_isere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73304-73150-val_d_isere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73306-73450-valloire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73306-73450-valloire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73306-73450-valloire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73306-73450-valloire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73307-73450-valmeinier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73307-73450-valmeinier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73307-73450-valmeinier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73307-73450-valmeinier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73308-73200-venthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73308-73200-venthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73308-73200-venthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73308-73200-venthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73309-73330-verel_de_montbel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73309-73330-verel_de_montbel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73309-73330-verel_de_montbel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73309-73330-verel_de_montbel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73310-73230-verel_pragondran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73310-73230-verel_pragondran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73310-73230-verel_pragondran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73310-73230-verel_pragondran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73311-73110-le_verneil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73311-73110-le_verneil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73311-73110-le_verneil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73311-73110-le_verneil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73312-73460-verrens_arvey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73312-73460-verrens_arvey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73312-73460-verrens_arvey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73312-73460-verrens_arvey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73313-73170-verthemex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73313-73170-verthemex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73313-73170-verthemex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73313-73170-verthemex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73314-73800-villard_d_hery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73314-73800-villard_d_hery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73314-73800-villard_d_hery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73314-73800-villard_d_hery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73315-73390-villard_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73315-73390-villard_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73315-73390-villard_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73315-73390-villard_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73316-73110-villard_sallet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73316-73110-villard_sallet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73316-73110-villard_sallet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73316-73110-villard_sallet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73317-73270-villard_sur_doron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73317-73270-villard_sur_doron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73317-73270-villard_sur_doron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73317-73270-villard_sur_doron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73318-73300-villarembert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73318-73300-villarembert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73318-73300-villarembert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73318-73300-villarembert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73320-73300-villargondran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73320-73300-villargondran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73320-73300-villargondran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73320-73300-villargondran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73322-73500-villarodin_bourget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73322-73500-villarodin_bourget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73322-73500-villarodin_bourget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73322-73500-villarodin_bourget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73323-73640-villaroger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73323-73640-villaroger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73323-73640-villaroger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73323-73640-villaroger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73324-73110-villaroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73324-73110-villaroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73324-73110-villaroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73324-73110-villaroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73326-73160-vimines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73326-73160-vimines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73326-73160-vimines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73326-73160-vimines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73327-73310-vions/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73327-73310-vions/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73327-73310-vions/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73327-73310-vions/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73328-73420-viviers_du_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73328-73420-viviers_du_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73328-73420-viviers_du_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73328-73420-viviers_du_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73329-73420-voglans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73329-73420-voglans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73329-73420-voglans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73329-73420-voglans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73330-73170-yenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73330-73170-yenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73330-73170-yenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt73-savoie/commune73330-73170-yenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-74.xml
+++ b/public/sitemaps/sitemap-74.xml
@@ -5,588 +5,1172 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74001-74360-abondance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74001-74360-abondance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74001-74360-abondance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74001-74360-abondance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74002-74540-alby_sur_cheran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74002-74540-alby_sur_cheran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74002-74540-alby_sur_cheran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74002-74540-alby_sur_cheran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74003-74290-alex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74003-74290-alex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74003-74290-alex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74003-74290-alex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74004-74540-alleves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74004-74540-alleves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74004-74540-alleves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74004-74540-alleves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74005-74200-allinges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74005-74200-allinges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74005-74200-allinges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74005-74200-allinges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74006-74350-allonzier_la_caille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74006-74350-allonzier_la_caille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74006-74350-allonzier_la_caille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74006-74350-allonzier_la_caille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74007-74800-amancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74007-74800-amancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74007-74800-amancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74007-74800-amancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74008-74100-ambilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74008-74100-ambilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74008-74100-ambilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74008-74100-ambilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74009-74350-andilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74009-74350-andilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74009-74350-andilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74009-74350-andilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74960-annecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74960-annecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74960-annecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74960-annecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74370-annecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74370-annecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74370-annecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74370-annecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74600-annecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74600-annecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74600-annecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74600-annecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74000-annecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74000-annecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74000-annecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74000-annecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74940-annecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74940-annecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74940-annecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74010-74940-annecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74012-74100-annemasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74012-74100-annemasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74012-74100-annemasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74012-74100-annemasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74013-74200-anthy_sur_leman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74013-74200-anthy_sur_leman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74013-74200-anthy_sur_leman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74013-74200-anthy_sur_leman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74014-74300-araches_la_frasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74014-74300-araches_la_frasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74014-74300-araches_la_frasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74014-74300-araches_la_frasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74015-74930-arbusigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74015-74930-arbusigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74015-74930-arbusigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74015-74930-arbusigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74016-74160-archamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74016-74160-archamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74016-74160-archamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74016-74160-archamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74018-74800-arenthon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74018-74800-arenthon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74018-74800-arenthon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74018-74800-arenthon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74019-74370-argonay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74019-74370-argonay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74019-74370-argonay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74019-74370-argonay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74020-74200-armoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74020-74200-armoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74020-74200-armoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74020-74200-armoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74021-74380-arthaz_pont_notre_dame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74021-74380-arthaz_pont_notre_dame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74021-74380-arthaz_pont_notre_dame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74021-74380-arthaz_pont_notre_dame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74024-74130-ayse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74024-74130-ayse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74024-74130-ayse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74024-74130-ayse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74025-74140-ballaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74025-74140-ballaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74025-74140-ballaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74025-74140-ballaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74026-74330-la_balme_de_sillingy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74026-74330-la_balme_de_sillingy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74026-74330-la_balme_de_sillingy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74026-74330-la_balme_de_sillingy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74027-74230-la_balme_de_thuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74027-74230-la_balme_de_thuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74027-74230-la_balme_de_thuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74027-74230-la_balme_de_thuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74029-74910-bassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74029-74910-bassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74029-74910-bassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74029-74910-bassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74030-74430-la_baume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74030-74430-la_baume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74030-74430-la_baume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74030-74430-la_baume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74031-74160-beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74031-74160-beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74031-74160-beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74031-74160-beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74032-74470-bellevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74032-74470-bellevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74032-74470-bellevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74032-74470-bellevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74033-74500-bernex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74033-74500-bernex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74033-74500-bernex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74033-74500-bernex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74034-74430-le_biot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74034-74430-le_biot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74034-74430-le_biot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74034-74430-le_biot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74035-74150-bloye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74035-74150-bloye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74035-74150-bloye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74035-74150-bloye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74036-74290-bluffy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74036-74290-bluffy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74036-74290-bluffy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74036-74290-bluffy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74037-74420-boege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74037-74420-boege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74037-74420-boege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74037-74420-boege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74038-74250-bogeve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74038-74250-bogeve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74038-74250-bogeve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74038-74250-bogeve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74040-74380-bonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74040-74380-bonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74040-74380-bonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74040-74380-bonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74041-74360-bonnevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74041-74360-bonnevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74041-74360-bonnevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74041-74360-bonnevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74042-74130-bonneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74042-74130-bonneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74042-74130-bonneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74042-74130-bonneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74043-74890-bons_en_chablais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74043-74890-bons_en_chablais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74043-74890-bons_en_chablais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74043-74890-bons_en_chablais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74044-74160-bossey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74044-74160-bossey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74044-74160-bossey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74044-74160-bossey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74045-74230-le_bouchet_mont_charvin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74045-74230-le_bouchet_mont_charvin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74045-74230-le_bouchet_mont_charvin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74045-74230-le_bouchet_mont_charvin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74046-74150-boussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74046-74150-boussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74046-74150-boussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74046-74150-boussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74048-74890-brenthonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74048-74890-brenthonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74048-74890-brenthonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74048-74890-brenthonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74049-74130-brizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74049-74130-brizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74049-74130-brizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74049-74130-brizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74050-74420-burdignin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74050-74420-burdignin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74050-74420-burdignin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74050-74420-burdignin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74051-74350-cercier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74051-74350-cercier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74051-74350-cercier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74051-74350-cercier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74052-74350-cernex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74052-74350-cernex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74052-74350-cernex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74052-74350-cernex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74053-74550-cervens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74053-74550-cervens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74053-74550-cervens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74053-74550-cervens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74054-74540-chainaz_les_frasses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74054-74540-chainaz_les_frasses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74054-74540-chainaz_les_frasses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74054-74540-chainaz_les_frasses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74055-74910-challonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74055-74910-challonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74055-74910-challonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74055-74910-challonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74056-74400-chamonix_mont_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74056-74400-chamonix_mont_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74056-74400-chamonix_mont_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74056-74400-chamonix_mont_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74057-74500-champanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74057-74500-champanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74057-74500-champanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74057-74500-champanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74058-74360-la_chapelle_d_abondance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74058-74360-la_chapelle_d_abondance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74058-74360-la_chapelle_d_abondance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74058-74360-la_chapelle_d_abondance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74059-74800-la_chapelle_rambaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74059-74800-la_chapelle_rambaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74059-74800-la_chapelle_rambaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74059-74800-la_chapelle_rambaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74060-74410-la_chapelle_saint_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74060-74410-la_chapelle_saint_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74060-74410-la_chapelle_saint_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74060-74410-la_chapelle_saint_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74061-74540-chapeiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74061-74540-chapeiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74061-74540-chapeiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74061-74540-chapeiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74062-74370-charvonnex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74062-74370-charvonnex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74062-74370-charvonnex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74062-74370-charvonnex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74063-74390-chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74063-74390-chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74063-74390-chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74063-74390-chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74064-74300-chatillon_sur_cluses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74064-74300-chatillon_sur_cluses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74064-74300-chatillon_sur_cluses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74064-74300-chatillon_sur_cluses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74065-74270-chaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74065-74270-chaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74065-74270-chaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74065-74270-chaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74066-74270-chavannaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74066-74270-chavannaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74066-74270-chavannaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74066-74270-chavannaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74067-74650-chavanod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74067-74650-chavanod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74067-74650-chavanod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74067-74650-chavanod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74068-74270-chene_en_semine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74068-74270-chene_en_semine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74068-74270-chene_en_semine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74068-74270-chene_en_semine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74069-74520-chenex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74069-74520-chenex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74069-74520-chenex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74069-74520-chenex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74070-74140-chens_sur_leman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74070-74140-chens_sur_leman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74070-74140-chens_sur_leman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74070-74140-chens_sur_leman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74071-74270-chessenaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74071-74270-chessenaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74071-74270-chessenaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74071-74270-chessenaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74072-74210-chevaline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74072-74210-chevaline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74072-74210-chevaline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74072-74210-chevaline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74073-74500-chevenoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74073-74500-chevenoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74073-74500-chevenoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74073-74500-chevenoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74074-74520-chevrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74074-74520-chevrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74074-74520-chevrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74074-74520-chevrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74075-74270-chilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74075-74270-chilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74075-74270-chilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74075-74270-chilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74076-74330-choisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74076-74330-choisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74076-74330-choisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74076-74330-choisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74077-74270-clarafond_arcine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74077-74270-clarafond_arcine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74077-74270-clarafond_arcine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74077-74270-clarafond_arcine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74078-74270-clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74078-74270-clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74078-74270-clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74078-74270-clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74079-74230-les_clefs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74079-74230-les_clefs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74079-74230-les_clefs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74079-74230-les_clefs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74080-74220-la_clusaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74080-74220-la_clusaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74080-74220-la_clusaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74080-74220-la_clusaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74081-74300-cluses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74081-74300-cluses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74081-74300-cluses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74081-74300-cluses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74082-74160-collonges_sous_saleve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74082-74160-collonges_sous_saleve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74082-74160-collonges_sous_saleve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74082-74160-collonges_sous_saleve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74083-74920-combloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74083-74920-combloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74083-74920-combloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74083-74920-combloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74085-74170-les_contamines_montjoie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74085-74170-les_contamines_montjoie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74085-74170-les_contamines_montjoie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74085-74170-les_contamines_montjoie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74086-74270-contamine_sarzin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74086-74270-contamine_sarzin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74086-74270-contamine_sarzin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74086-74270-contamine_sarzin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74087-74130-contamine_sur_arve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74087-74130-contamine_sur_arve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74087-74130-contamine_sur_arve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74087-74130-contamine_sur_arve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74088-74350-copponex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74088-74350-copponex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74088-74350-copponex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74088-74350-copponex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74089-74700-cordon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74089-74700-cordon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74089-74700-cordon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74089-74700-cordon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74090-74800-cornier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74090-74800-cornier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74090-74800-cornier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74090-74800-cornier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74091-74110-la_cote_d_arbroz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74091-74110-la_cote_d_arbroz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74091-74110-la_cote_d_arbroz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74091-74110-la_cote_d_arbroz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74094-74380-cranves_sales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74094-74380-cranves_sales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74094-74380-cranves_sales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74094-74380-cranves_sales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74095-74150-crempigny_bonneguete/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74095-74150-crempigny_bonneguete/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74095-74150-crempigny_bonneguete/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74095-74150-crempigny_bonneguete/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74096-74350-cruseilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74096-74350-cruseilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74096-74350-cruseilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74096-74350-cruseilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74097-74540-cusy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74097-74540-cusy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74097-74540-cusy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74097-74540-cusy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74098-74350-cuvat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74098-74350-cuvat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74098-74350-cuvat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74098-74350-cuvat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74099-74120-demi_quartier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74099-74120-demi_quartier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74099-74120-demi_quartier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74099-74120-demi_quartier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74100-74270-desingy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74100-74270-desingy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74100-74270-desingy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74100-74270-desingy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74101-74520-dingy_en_vuache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74101-74520-dingy_en_vuache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74101-74520-dingy_en_vuache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74101-74520-dingy_en_vuache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74102-74230-dingy_saint_clair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74102-74230-dingy_saint_clair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74102-74230-dingy_saint_clair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74102-74230-dingy_saint_clair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74103-74700-domancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74103-74700-domancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74103-74700-domancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74103-74700-domancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74104-74210-doussard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74104-74210-doussard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74104-74210-doussard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74104-74210-doussard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74105-74140-douvaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74105-74140-douvaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74105-74140-douvaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74105-74140-douvaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74106-74550-draillant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74106-74550-draillant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74106-74550-draillant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74106-74550-draillant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74107-74270-droisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74107-74270-droisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74107-74270-droisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74107-74270-droisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74108-74410-duingt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74108-74410-duingt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74108-74410-duingt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74108-74410-duingt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74109-01200-eloise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74109-01200-eloise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74109-01200-eloise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74109-01200-eloise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74111-74410-entrevernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74111-74410-entrevernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74111-74410-entrevernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74111-74410-entrevernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74112-74330-epagny_metz_tessy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74112-74330-epagny_metz_tessy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74112-74330-epagny_metz_tessy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74112-74330-epagny_metz_tessy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74112-74370-epagny_metz_tessy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74112-74370-epagny_metz_tessy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74112-74370-epagny_metz_tessy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74112-74370-epagny_metz_tessy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74114-74110-essert_romand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74114-74110-essert_romand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74114-74110-essert_romand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74114-74110-essert_romand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74116-74800-etaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74116-74800-etaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74116-74800-etaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74116-74800-etaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74117-74150-etercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74117-74150-etercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74117-74150-etercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74117-74150-etercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74118-74100-etrembieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74118-74100-etrembieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74118-74100-etrembieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74118-74100-etrembieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74119-74500-evian_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74119-74500-evian_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74119-74500-evian_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74119-74500-evian_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74121-74140-excenevex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74121-74140-excenevex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74121-74140-excenevex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74121-74140-excenevex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74122-74130-faucigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74122-74130-faucigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74122-74130-faucigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74122-74130-faucigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74123-74210-faverges_seythenex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74123-74210-faverges_seythenex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74123-74210-faverges_seythenex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74123-74210-faverges_seythenex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74124-74160-feigeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74124-74160-feigeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74124-74160-feigeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74124-74160-feigeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74126-74890-fessy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74126-74890-fessy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74126-74890-fessy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74126-74890-fessy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74127-74500-feternes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74127-74500-feternes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74127-74500-feternes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74127-74500-feternes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74128-74250-fillinges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74128-74250-fillinges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74128-74250-fillinges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74128-74250-fillinges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74129-74200-la_forclaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74129-74200-la_forclaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74129-74200-la_forclaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74129-74200-la_forclaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74130-74910-franclens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74130-74910-franclens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74130-74910-franclens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74130-74910-franclens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74131-74270-frangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74131-74270-frangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74131-74270-frangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74131-74270-frangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74133-74240-gaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74133-74240-gaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74133-74240-gaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74133-74240-gaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74134-74260-les_gets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74134-74260-les_gets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74134-74260-les_gets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74134-74260-les_gets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74135-74210-giez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74135-74210-giez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74135-74210-giez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74135-74210-giez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74136-74450-le_grand_bornand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74136-74450-le_grand_bornand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74136-74450-le_grand_bornand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74136-74450-le_grand_bornand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74137-74570-groisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74137-74570-groisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74137-74570-groisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74137-74570-groisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74138-74540-gruffy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74138-74540-gruffy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74138-74540-gruffy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74138-74540-gruffy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74139-74420-habere_lullin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74139-74420-habere_lullin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74139-74420-habere_lullin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74139-74420-habere_lullin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74140-74420-habere_poche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74140-74420-habere_poche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74140-74420-habere_poche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74140-74420-habere_poche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74141-74150-hauteville_sur_fier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74141-74150-hauteville_sur_fier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74141-74150-hauteville_sur_fier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74141-74150-hauteville_sur_fier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74142-74540-hery_sur_alby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74142-74540-hery_sur_alby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74142-74540-hery_sur_alby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74142-74540-hery_sur_alby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74143-74310-les_houches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74143-74310-les_houches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74143-74310-les_houches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74143-74310-les_houches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74144-74520-jonzier_epagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74144-74520-jonzier_epagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74144-74520-jonzier_epagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74144-74520-jonzier_epagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74145-74100-juvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74145-74100-juvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74145-74100-juvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74145-74100-juvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74146-74500-larringes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74146-74500-larringes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74146-74500-larringes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74146-74500-larringes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74147-74210-lathuile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74147-74210-lathuile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74147-74210-lathuile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74147-74210-lathuile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74148-74320-leschaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74148-74320-leschaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74148-74320-leschaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74148-74320-leschaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74150-74140-loisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74150-74140-loisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74150-74140-loisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74150-74140-loisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74151-74150-lornay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74151-74150-lornay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74151-74150-lornay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74151-74150-lornay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74152-74330-lovagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74152-74330-lovagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74152-74330-lovagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74152-74330-lovagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74153-74380-lucinges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74153-74380-lucinges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74153-74380-lucinges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74153-74380-lucinges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74154-74500-lugrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74154-74500-lugrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74154-74500-lugrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74154-74500-lugrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74155-74470-lullin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74155-74470-lullin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74155-74470-lullin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74155-74470-lullin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74156-74890-lully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74156-74890-lully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74156-74890-lully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74156-74890-lully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74157-74200-lyaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74157-74200-lyaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74157-74200-lyaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74157-74200-lyaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74158-74140-machilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74158-74140-machilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74158-74140-machilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74158-74140-machilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74159-74300-magland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74159-74300-magland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74159-74300-magland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74159-74300-magland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74160-74230-manigod/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74160-74230-manigod/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74160-74230-manigod/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74160-74230-manigod/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74161-74150-marcellaz_albanais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74161-74150-marcellaz_albanais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74161-74150-marcellaz_albanais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74161-74150-marcellaz_albanais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74162-74250-marcellaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74162-74250-marcellaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74162-74250-marcellaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74162-74250-marcellaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74163-74200-margencel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74163-74200-margencel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74163-74200-margencel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74163-74200-margencel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74164-74970-marignier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74164-74970-marignier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74164-74970-marignier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74164-74970-marignier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74165-74150-marigny_saint_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74165-74150-marigny_saint_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74165-74150-marigny_saint_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74165-74150-marigny_saint_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74166-74200-marin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74166-74200-marin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74166-74200-marin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74166-74200-marin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74167-74210-val_de_chaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74167-74210-val_de_chaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74167-74210-val_de_chaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74167-74210-val_de_chaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74168-74270-marlioz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74168-74270-marlioz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74168-74270-marlioz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74168-74270-marlioz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74169-74460-marnaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74169-74460-marnaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74169-74460-marnaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74169-74460-marnaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74170-74150-massingy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74170-74150-massingy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74170-74150-massingy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74170-74150-massingy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74171-74140-massongy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74171-74140-massongy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74171-74140-massongy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74171-74140-massongy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74172-74500-maxilly_sur_leman/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74172-74500-maxilly_sur_leman/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74172-74500-maxilly_sur_leman/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74172-74500-maxilly_sur_leman/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74173-74120-megeve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74173-74120-megeve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74173-74120-megeve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74173-74120-megeve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74174-74490-megevette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74174-74490-megevette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74174-74490-megevette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74174-74490-megevette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74175-74500-meillerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74175-74500-meillerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74175-74500-meillerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74175-74500-meillerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74176-74290-menthon_saint_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74176-74290-menthon_saint_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74176-74290-menthon_saint_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74176-74290-menthon_saint_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74177-74350-menthonnex_en_bornes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74177-74350-menthonnex_en_bornes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74177-74350-menthonnex_en_bornes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74177-74350-menthonnex_en_bornes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74178-74270-menthonnex_sous_clermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74178-74270-menthonnex_sous_clermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74178-74270-menthonnex_sous_clermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74178-74270-menthonnex_sous_clermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74179-74330-mesigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74179-74330-mesigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74179-74330-mesigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74179-74330-mesigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74180-74140-messery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74180-74140-messery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74180-74140-messery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74180-74140-messery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74183-74440-mieussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74183-74440-mieussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74183-74440-mieussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74183-74440-mieussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74184-74270-minzier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74184-74270-minzier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74184-74270-minzier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74184-74270-minzier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74185-74560-monnetier_mornex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74185-74560-monnetier_mornex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74185-74560-monnetier_mornex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74185-74560-monnetier_mornex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74186-74600-montagny_les_lanches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74186-74600-montagny_les_lanches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74186-74600-montagny_les_lanches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74186-74600-montagny_les_lanches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74188-74110-montriond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74188-74110-montriond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74188-74110-montriond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74188-74110-montriond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74189-74130-mont_saxonnex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74189-74130-mont_saxonnex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74189-74130-mont_saxonnex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74189-74130-mont_saxonnex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74190-74440-morillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74190-74440-morillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74190-74440-morillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74190-74440-morillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74191-74110-morzine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74191-74110-morzine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74191-74110-morzine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74191-74110-morzine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74192-74150-moye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74192-74150-moye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74192-74150-moye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74192-74150-moye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74193-74560-la_muraz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74193-74560-la_muraz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74193-74560-la_muraz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74193-74560-la_muraz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74194-74540-mures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74194-74540-mures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74194-74540-mures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74194-74540-mures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74195-74270-musieges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74195-74270-musieges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74195-74270-musieges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74195-74270-musieges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74196-74300-nancy_sur_cluses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74196-74300-nancy_sur_cluses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74196-74300-nancy_sur_cluses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74196-74300-nancy_sur_cluses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74197-74380-nangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74197-74380-nangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74197-74380-nangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74197-74380-nangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74198-74370-naves_parmelan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74198-74370-naves_parmelan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74198-74370-naves_parmelan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74198-74370-naves_parmelan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74199-74140-nernier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74199-74140-nernier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74199-74140-nernier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74199-74140-nernier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74200-74500-neuvecelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74200-74500-neuvecelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74200-74500-neuvecelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74200-74500-neuvecelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74201-74160-neydens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74201-74160-neydens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74201-74160-neydens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74201-74160-neydens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74202-74330-nonglard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74202-74330-nonglard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74202-74330-nonglard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74202-74330-nonglard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74203-74500-novel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74203-74500-novel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74203-74500-novel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74203-74500-novel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74205-74490-onnion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74205-74490-onnion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74205-74490-onnion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74205-74490-onnion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74206-74550-orcier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74206-74550-orcier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74206-74550-orcier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74206-74550-orcier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74480-passy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74480-passy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74480-passy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74480-passy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74790-passy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74790-passy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74790-passy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74790-passy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74190-passy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74190-passy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74190-passy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74190-passy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74310-passy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74310-passy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74310-passy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74310-passy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74700-passy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74700-passy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74700-passy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74700-passy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74170-passy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74170-passy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74170-passy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74208-74170-passy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74209-74250-peillonnex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74209-74250-peillonnex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74209-74250-peillonnex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74209-74250-peillonnex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74210-74550-perrignier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74210-74550-perrignier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74210-74550-perrignier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74210-74550-perrignier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74211-74930-pers_jussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74211-74930-pers_jussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74211-74930-pers_jussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74211-74930-pers_jussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74212-74130-glieres_val_de_borne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74212-74130-glieres_val_de_borne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74212-74130-glieres_val_de_borne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74212-74130-glieres_val_de_borne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74213-74330-poisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74213-74330-poisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74213-74330-poisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74213-74330-poisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74215-74120-praz_sur_arly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74215-74120-praz_sur_arly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74215-74120-praz_sur_arly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74215-74120-praz_sur_arly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74216-74160-presilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74216-74160-presilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74216-74160-presilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74216-74160-presilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74218-74500-publier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74218-74500-publier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74218-74500-publier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74218-74500-publier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74219-74600-quintal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74219-74600-quintal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74219-74600-quintal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74219-74600-quintal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74220-74930-reignier_esery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74220-74930-reignier_esery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74220-74930-reignier_esery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74220-74930-reignier_esery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74221-74950-le_reposoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74221-74950-le_reposoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74221-74950-le_reposoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74221-74950-le_reposoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74222-74200-reyvroz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74222-74200-reyvroz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74222-74200-reyvroz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74222-74200-reyvroz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74223-74440-la_riviere_enverse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74223-74440-la_riviere_enverse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74223-74440-la_riviere_enverse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74223-74440-la_riviere_enverse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74224-74800-la_roche_sur_foron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74224-74800-la_roche_sur_foron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74224-74800-la_roche_sur_foron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74224-74800-la_roche_sur_foron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74225-74150-rumilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74225-74150-rumilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74225-74150-rumilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74225-74150-rumilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74226-74420-saint_andre_de_boege/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74226-74420-saint_andre_de_boege/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74226-74420-saint_andre_de_boege/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74226-74420-saint_andre_de_boege/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74228-74350-saint_blaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74228-74350-saint_blaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74228-74350-saint_blaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74228-74350-saint_blaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74229-74140-saint_cergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74229-74140-saint_cergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74229-74140-saint_cergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74229-74140-saint_cergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74231-74150-saint_eusebe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74231-74150-saint_eusebe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74231-74150-saint_eusebe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74231-74150-saint_eusebe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74232-74410-saint_eustache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74232-74410-saint_eustache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74232-74410-saint_eustache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74232-74410-saint_eustache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74233-74540-saint_felix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74233-74540-saint_felix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74233-74540-saint_felix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74233-74540-saint_felix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74234-74210-saint_ferreol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74234-74210-saint_ferreol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74234-74210-saint_ferreol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74234-74210-saint_ferreol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74235-74910-saint_germain_sur_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74235-74910-saint_germain_sur_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74235-74910-saint_germain_sur_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74235-74910-saint_germain_sur_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74236-74170-saint_gervais_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74236-74170-saint_gervais_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74236-74170-saint_gervais_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74236-74170-saint_gervais_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74237-74500-saint_gingolph/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74237-74500-saint_gingolph/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74237-74500-saint_gingolph/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74237-74500-saint_gingolph/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74238-74430-saint_jean_d_aulps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74238-74430-saint_jean_d_aulps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74238-74430-saint_jean_d_aulps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74238-74430-saint_jean_d_aulps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74239-74450-saint_jean_de_sixt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74239-74450-saint_jean_de_sixt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74239-74450-saint_jean_de_sixt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74239-74450-saint_jean_de_sixt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74240-74250-saint_jean_de_tholome/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74240-74250-saint_jean_de_tholome/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74240-74250-saint_jean_de_tholome/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74240-74250-saint_jean_de_tholome/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74241-74490-saint_jeoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74241-74490-saint_jeoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74241-74490-saint_jeoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74241-74490-saint_jeoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74242-74410-saint_jorioz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74242-74410-saint_jorioz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74242-74410-saint_jorioz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74242-74410-saint_jorioz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74243-74160-saint_julien_en_genevois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74243-74160-saint_julien_en_genevois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74243-74160-saint_julien_en_genevois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74243-74160-saint_julien_en_genevois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74244-74800-saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74244-74800-saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74244-74800-saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74244-74800-saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74249-74500-saint_paul_en_chablais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74249-74500-saint_paul_en_chablais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74249-74500-saint_paul_en_chablais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74249-74500-saint_paul_en_chablais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74250-74800-saint_pierre_en_faucigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74250-74800-saint_pierre_en_faucigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74250-74800-saint_pierre_en_faucigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74250-74800-saint_pierre_en_faucigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74252-74300-saint_sigismond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74252-74300-saint_sigismond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74252-74300-saint_sigismond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74252-74300-saint_sigismond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74253-74800-saint_sixt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74253-74800-saint_sixt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74253-74800-saint_sixt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74253-74800-saint_sixt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74254-74540-saint_sylvestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74254-74540-saint_sylvestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74254-74540-saint_sylvestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74254-74540-saint_sylvestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74255-74150-sales/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74255-74150-sales/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74255-74150-sales/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74255-74150-sales/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74256-74700-sallanches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74256-74700-sallanches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74256-74700-sallanches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74256-74700-sallanches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74257-74270-sallenoves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74257-74270-sallenoves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74257-74270-sallenoves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74257-74270-sallenoves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74258-74340-samoens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74258-74340-samoens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74258-74340-samoens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74258-74340-samoens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74259-74350-le_sappey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74259-74350-le_sappey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74259-74350-le_sappey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74259-74350-le_sappey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74260-74520-savigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74260-74520-savigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74260-74520-savigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74260-74520-savigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74261-74420-saxel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74261-74420-saxel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74261-74420-saxel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74261-74420-saxel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74262-74930-scientrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74262-74930-scientrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74262-74930-scientrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74262-74930-scientrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74263-74140-sciez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74263-74140-sciez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74263-74140-sciez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74263-74140-sciez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74264-74950-scionzier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74264-74950-scionzier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74264-74950-scionzier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74264-74950-scionzier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74265-74230-serraval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74265-74230-serraval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74265-74230-serraval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74265-74230-serraval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74266-74310-servoz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74266-74310-servoz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74266-74310-servoz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74266-74310-servoz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74267-74320-sevrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74267-74320-sevrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74267-74320-sevrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74267-74320-sevrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74269-74910-seyssel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74269-74910-seyssel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74269-74910-seyssel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74269-74910-seyssel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74271-74430-seytroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74271-74430-seytroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74271-74430-seytroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74271-74430-seytroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74272-74330-sillingy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74272-74330-sillingy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74272-74330-sillingy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74272-74330-sillingy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74273-74740-sixt_fer_a_cheval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74273-74740-sixt_fer_a_cheval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74273-74740-sixt_fer_a_cheval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74273-74740-sixt_fer_a_cheval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74275-74290-talloires_montmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74275-74290-talloires_montmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74275-74290-talloires_montmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74275-74290-talloires_montmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74275-74210-talloires_montmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74275-74210-talloires_montmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74275-74210-talloires_montmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74275-74210-talloires_montmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74276-74440-taninges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74276-74440-taninges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74276-74440-taninges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74276-74440-taninges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74278-74300-thyez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74278-74300-thyez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74278-74300-thyez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74278-74300-thyez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74279-74500-thollon_les_memises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74279-74500-thollon_les_memises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74279-74500-thollon_les_memises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74279-74500-thollon_les_memises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74280-74230-thones/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74280-74230-thones/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74280-74230-thones/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74280-74230-thones/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74281-74200-thonon_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74281-74200-thonon_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74281-74200-thonon_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74281-74200-thonon_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74282-74570-filliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74282-74570-filliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74282-74570-filliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74282-74570-filliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74282-74370-filliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74282-74370-filliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74282-74370-filliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74282-74370-filliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74283-74150-thusy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74283-74150-thusy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74283-74150-thusy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74283-74150-thusy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74284-74250-la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74284-74250-la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74284-74250-la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74284-74250-la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74285-74910-usinens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74285-74910-usinens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74285-74910-usinens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74285-74910-usinens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74286-74360-vacheresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74286-74360-vacheresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74286-74360-vacheresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74286-74360-vacheresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74287-74470-vailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74287-74470-vailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74287-74470-vailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74287-74470-vailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74288-74520-valleiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74288-74520-valleiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74288-74520-valleiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74288-74520-valleiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74289-74150-vallieres_sur_fier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74289-74150-vallieres_sur_fier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74289-74150-vallieres_sur_fier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74289-74150-vallieres_sur_fier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74290-74660-vallorcine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74290-74660-vallorcine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74290-74660-vallorcine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74290-74660-vallorcine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74291-74270-vanzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74291-74270-vanzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74291-74270-vanzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74291-74270-vanzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74292-74150-vaulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74292-74150-vaulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74292-74150-vaulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74292-74150-vaulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74293-74140-veigy_foncenex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74293-74140-veigy_foncenex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74293-74140-veigy_foncenex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74293-74140-veigy_foncenex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74294-74440-verchaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74294-74440-verchaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74294-74440-verchaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74294-74440-verchaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74295-74200-la_vernaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74295-74200-la_vernaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74295-74200-la_vernaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74295-74200-la_vernaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74296-74160-vers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74296-74160-vers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74296-74160-vers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74296-74160-vers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74297-74150-versonnex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74297-74150-versonnex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74297-74150-versonnex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74297-74150-versonnex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74298-74100-vetraz_monthoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74298-74100-vetraz_monthoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74298-74100-vetraz_monthoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74298-74100-vetraz_monthoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74299-74290-veyrier_du_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74299-74290-veyrier_du_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74299-74290-veyrier_du_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74299-74290-veyrier_du_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74301-74420-villard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74301-74420-villard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74301-74420-villard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74301-74420-villard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74302-74230-les_villards_sur_thones/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74302-74230-les_villards_sur_thones/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74302-74230-les_villards_sur_thones/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74302-74230-les_villards_sur_thones/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74303-74370-villaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74303-74370-villaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74303-74370-villaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74303-74370-villaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74304-74250-ville_en_sallaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74304-74250-ville_en_sallaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74304-74250-ville_en_sallaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74304-74250-ville_en_sallaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74305-74100-ville_la_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74305-74100-ville_la_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74305-74100-ville_la_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74305-74100-ville_la_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74306-74350-villy_le_bouveret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74306-74350-villy_le_bouveret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74306-74350-villy_le_bouveret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74306-74350-villy_le_bouveret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74307-74350-villy_le_pelloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74307-74350-villy_le_pelloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74307-74350-villy_le_pelloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74307-74350-villy_le_pelloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74308-74500-vinzier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74308-74500-vinzier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74308-74500-vinzier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74308-74500-vinzier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74309-74580-viry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74309-74580-viry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74309-74580-viry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74309-74580-viry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74310-74540-viuz_la_chiesaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74310-74540-viuz_la_chiesaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74310-74540-viuz_la_chiesaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74310-74540-viuz_la_chiesaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74311-74250-viuz_en_sallaz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74311-74250-viuz_en_sallaz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74311-74250-viuz_en_sallaz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74311-74250-viuz_en_sallaz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74312-74130-vougy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74312-74130-vougy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74312-74130-vougy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74312-74130-vougy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74313-74350-vovray_en_bornes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74313-74350-vovray_en_bornes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74313-74350-vovray_en_bornes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74313-74350-vovray_en_bornes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74314-74520-vulbens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74314-74520-vulbens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74314-74520-vulbens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74314-74520-vulbens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74315-74140-yvoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74315-74140-yvoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74315-74140-yvoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt74-haute_savoie/commune74315-74140-yvoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-75.xml
+++ b/public/sitemaps/sitemap-75.xml
@@ -5,46 +5,88 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75001-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75001-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75001-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75001-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75002-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75002-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75002-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75002-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75003-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75003-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75003-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75003-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75004-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75004-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75004-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75004-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75005-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75005-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75005-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75005-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75006-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75006-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75006-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75006-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75007-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75007-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75007-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75007-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75008-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75008-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75008-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75008-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75009-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75009-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75009-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75009-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75010-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75010-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75010-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75010-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75011-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75011-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75011-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75011-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75012-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75012-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75012-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75012-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75013-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75013-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75013-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75013-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75014-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75014-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75014-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75014-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75015-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75015-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75015-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75015-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75016-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75016-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75016-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75016-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75017-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75017-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75017-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75017-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75018-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75018-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75018-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75018-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75019-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75019-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75019-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75019-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75020-paris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75020-paris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75020-paris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt75-paris/commune75056-75020-paris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-76.xml
+++ b/public/sitemaps/sitemap-76.xml
@@ -5,1454 +5,2904 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76001-76190-allouville_bellefosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76001-76190-allouville_bellefosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76001-76190-allouville_bellefosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76001-76190-allouville_bellefosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76002-76640-alvimare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76002-76640-alvimare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76002-76640-alvimare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76002-76640-alvimare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76004-76550-ambrumesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76004-76550-ambrumesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76004-76550-ambrumesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76004-76550-ambrumesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76005-76920-amfreville_la_mi_voie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76005-76920-amfreville_la_mi_voie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76005-76920-amfreville_la_mi_voie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76005-76920-amfreville_la_mi_voie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76006-76560-amfreville_les_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76006-76560-amfreville_les_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76006-76560-amfreville_les_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76006-76560-amfreville_les_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76007-76710-anceaumeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76007-76710-anceaumeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76007-76710-anceaumeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76007-76710-anceaumeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76008-76370-ancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76008-76370-ancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76008-76370-ancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76008-76370-ancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76009-76560-ancourteville_sur_hericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76009-76560-ancourteville_sur_hericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76009-76560-ancourteville_sur_hericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76009-76560-ancourteville_sur_hericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76010-76760-ancretieville_saint_victor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76010-76760-ancretieville_saint_victor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76010-76760-ancretieville_saint_victor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76010-76760-ancretieville_saint_victor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76011-76540-ancretteville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76011-76540-ancretteville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76011-76540-ancretteville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76011-76540-ancretteville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76012-76110-angerville_bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76012-76110-angerville_bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76012-76110-angerville_bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76012-76110-angerville_bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76013-76540-angerville_la_martel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76013-76540-angerville_la_martel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76013-76540-angerville_la_martel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76013-76540-angerville_la_martel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76014-76280-angerville_l_orcher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76014-76280-angerville_l_orcher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76014-76280-angerville_l_orcher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76014-76280-angerville_l_orcher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76015-76740-angiens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76015-76740-angiens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76015-76740-angiens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76015-76740-angiens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76016-76740-anglesqueville_la_bras_long/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76016-76740-anglesqueville_la_bras_long/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76016-76740-anglesqueville_la_bras_long/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76016-76740-anglesqueville_la_bras_long/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76017-76280-anglesqueville_l_esneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76017-76280-anglesqueville_l_esneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76017-76280-anglesqueville_l_esneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76017-76280-anglesqueville_l_esneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76018-76890-val_de_saane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76018-76890-val_de_saane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76018-76890-val_de_saane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76018-76890-val_de_saane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76019-76590-anneville_sur_scie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76019-76590-anneville_sur_scie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76019-76590-anneville_sur_scie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76019-76590-anneville_sur_scie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76020-76480-anneville_ambourville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76020-76480-anneville_ambourville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76020-76480-anneville_ambourville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76020-76480-anneville_ambourville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76021-76110-annouville_vilmesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76021-76110-annouville_vilmesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76021-76110-annouville_vilmesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76021-76110-annouville_vilmesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76022-76490-anquetierville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76022-76490-anquetierville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76022-76490-anquetierville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76022-76490-anquetierville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76023-76560-anveville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76023-76560-anveville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76023-76560-anveville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76023-76560-anveville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76024-76680-ardouval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76024-76680-ardouval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76024-76680-ardouval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76024-76680-ardouval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76025-76780-argueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76025-76780-argueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76025-76780-argueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76025-76780-argueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76026-76880-arques_la_bataille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76026-76880-arques_la_bataille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76026-76880-arques_la_bataille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76026-76880-arques_la_bataille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76028-76390-aubeguimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76028-76390-aubeguimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76028-76390-aubeguimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76028-76390-aubeguimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76029-76340-aubermesnil_aux_erables/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76029-76340-aubermesnil_aux_erables/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76029-76340-aubermesnil_aux_erables/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76029-76340-aubermesnil_aux_erables/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76030-76550-aubermesnil_beaumais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76030-76550-aubermesnil_beaumais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76030-76550-aubermesnil_beaumais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76030-76550-aubermesnil_beaumais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76032-76450-auberville_la_manuel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76032-76450-auberville_la_manuel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76032-76450-auberville_la_manuel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76032-76450-auberville_la_manuel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76033-76110-auberville_la_renault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76033-76110-auberville_la_renault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76033-76110-auberville_la_renault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76033-76110-auberville_la_renault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76034-76720-val_de_scie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76034-76720-val_de_scie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76034-76720-val_de_scie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76034-76720-val_de_scie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76034-76850-val_de_scie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76034-76850-val_de_scie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76034-76850-val_de_scie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76034-76850-val_de_scie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76035-76390-aumale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76035-76390-aumale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76035-76390-aumale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76035-76390-aumale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76036-76730-auppegard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76036-76730-auppegard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76036-76730-auppegard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76036-76730-auppegard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76038-76690-authieux_ratieville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76038-76690-authieux_ratieville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76038-76690-authieux_ratieville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76038-76690-authieux_ratieville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76039-76520-les_authieux_sur_le_port_saint_ouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76039-76520-les_authieux_sur_le_port_saint_ouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76039-76520-les_authieux_sur_le_port_saint_ouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76039-76520-les_authieux_sur_le_port_saint_ouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76040-76740-autigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76040-76740-autigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76040-76740-autigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76040-76740-autigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76041-76190-les_hauts_de_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76041-76190-les_hauts_de_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76041-76190-les_hauts_de_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76041-76190-les_hauts_de_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76042-76270-auvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76042-76270-auvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76042-76270-auvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76042-76270-auvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76043-76190-auzebosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76043-76190-auzebosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76043-76190-auzebosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76043-76190-auzebosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76045-76760-auzouville_l_esneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76045-76760-auzouville_l_esneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76045-76760-auzouville_l_esneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76045-76760-auzouville_l_esneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76046-76116-auzouville_sur_ry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76046-76116-auzouville_sur_ry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76046-76116-auzouville_sur_ry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76046-76116-auzouville_sur_ry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76047-76730-auzouville_sur_saane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76047-76730-auzouville_sur_saane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76047-76730-auzouville_sur_saane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76047-76730-auzouville_sur_saane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76048-76220-avesnes_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76048-76220-avesnes_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76048-76220-avesnes_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76048-76220-avesnes_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76049-76630-avesnes_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76049-76630-avesnes_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76049-76630-avesnes_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76049-76630-avesnes_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76050-76730-avremesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76050-76730-avremesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76050-76730-avremesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76050-76730-avremesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76051-76730-bacqueville_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76051-76730-bacqueville_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76051-76730-bacqueville_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76051-76730-bacqueville_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76052-76660-bailleul_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76052-76660-bailleul_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76052-76660-bailleul_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76052-76660-bailleul_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76053-76660-baillolet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76053-76660-baillolet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76053-76660-baillolet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76053-76660-baillolet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76054-76630-bailly_en_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76054-76630-bailly_en_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76054-76630-bailly_en_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76054-76630-bailly_en_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76055-76190-baons_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76055-76190-baons_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76055-76190-baons_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76055-76190-baons_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76056-76480-bardouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76056-76480-bardouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76056-76480-bardouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76056-76480-bardouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76057-76360-barentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76057-76360-barentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76057-76360-barentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76057-76360-barentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76058-76260-baromesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76058-76260-baromesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76058-76260-baromesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76058-76260-baromesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76059-76340-bazinval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76059-76340-bazinval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76059-76340-bazinval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76059-76340-bazinval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76060-76440-beaubec_la_rosiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76060-76440-beaubec_la_rosiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76060-76440-beaubec_la_rosiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76060-76440-beaubec_la_rosiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76062-76850-beaumont_le_hareng/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76062-76850-beaumont_le_hareng/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76062-76850-beaumont_le_hareng/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76062-76850-beaumont_le_hareng/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76063-76890-beauval_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76063-76890-beauval_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76063-76890-beauval_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76063-76890-beauval_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76064-76280-beaurepaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76064-76280-beaurepaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76064-76280-beaurepaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76064-76280-beaurepaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76065-76870-beaussault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76065-76870-beaussault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76065-76870-beaussault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76065-76870-beaussault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76066-76890-beautot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76066-76890-beautot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76066-76890-beautot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76066-76890-beautot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76067-76220-beauvoir_en_lyons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76067-76220-beauvoir_en_lyons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76067-76220-beauvoir_en_lyons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76067-76220-beauvoir_en_lyons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76068-76110-bec_de_mortagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76068-76110-bec_de_mortagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76068-76110-bec_de_mortagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76068-76110-bec_de_mortagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76069-76240-belbeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76069-76240-belbeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76069-76240-belbeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76069-76240-belbeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76070-76680-bellencombre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76070-76680-bellencombre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76070-76680-bellencombre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76070-76680-bellencombre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76071-76630-bellengreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76071-76630-bellengreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76071-76630-bellengreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76071-76630-bellengreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76072-76890-belleville_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76072-76890-belleville_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76072-76890-belleville_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76072-76890-belleville_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76074-76440-la_belliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76074-76440-la_belliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76074-76440-la_belliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76074-76440-la_belliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76075-76590-belmesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76075-76590-belmesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76075-76590-belmesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76075-76590-belmesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76076-76110-benarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76076-76110-benarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76076-76110-benarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76076-76110-benarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76077-76560-benesville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76077-76560-benesville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76077-76560-benesville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76077-76560-benesville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76079-76790-benouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76079-76790-benouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76079-76790-benouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76079-76790-benouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76082-76210-bernieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76082-76210-bernieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76082-76210-bernieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76082-76210-bernieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76083-76450-bertheauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76083-76450-bertheauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76083-76450-bertheauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76083-76450-bertheauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76084-76450-bertreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76084-76450-bertreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76084-76450-bertreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76084-76450-bertreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76085-76590-bertreville_saint_ouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76085-76590-bertreville_saint_ouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76085-76590-bertreville_saint_ouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76085-76590-bertreville_saint_ouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76086-76890-bertrimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76086-76890-bertrimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76086-76890-bertrimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76086-76890-bertrimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76087-76560-berville_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76087-76560-berville_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76087-76560-berville_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76087-76560-berville_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76088-76480-berville_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76088-76480-berville_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76088-76480-berville_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76088-76480-berville_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76090-76210-beuzeville_la_grenier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76090-76210-beuzeville_la_grenier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76090-76210-beuzeville_la_grenier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76090-76210-beuzeville_la_grenier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76091-76450-beuzeville_la_guerard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76091-76450-beuzeville_la_guerard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76091-76450-beuzeville_la_guerard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76091-76450-beuzeville_la_guerard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76092-76210-beuzevillette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76092-76210-beuzevillette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76092-76210-beuzevillette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76092-76210-beuzevillette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76093-76220-bezancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76093-76220-bezancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76093-76220-bezancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76093-76220-bezancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76094-76750-bierville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76094-76750-bierville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76094-76750-bierville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76094-76750-bierville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76095-76420-bihorel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76095-76420-bihorel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76095-76420-bihorel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76095-76420-bihorel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76096-76890-biville_la_baignarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76096-76890-biville_la_baignarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76096-76890-biville_la_baignarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76096-76890-biville_la_baignarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76097-76730-biville_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76097-76730-biville_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76097-76730-biville_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76097-76730-biville_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76099-76190-blacqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76099-76190-blacqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76099-76190-blacqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76099-76190-blacqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76100-76116-blainville_crevon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76100-76116-blainville_crevon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76100-76116-blainville_crevon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76100-76116-blainville_crevon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76101-76340-blangy_sur_bresle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76101-76340-blangy_sur_bresle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76101-76340-blangy_sur_bresle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76101-76340-blangy_sur_bresle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76103-76240-bonsecours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76103-76240-bonsecours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76103-76240-bonsecours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76103-76240-bonsecours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76104-76460-blosseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76104-76460-blosseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76104-76460-blosseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76104-76460-blosseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76105-76690-le_bocasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76105-76690-le_bocasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76105-76690-le_bocasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76105-76690-le_bocasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76106-76160-bois_d_ennebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76106-76160-bois_d_ennebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76106-76160-bois_d_ennebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76106-76160-bois_d_ennebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76107-76750-bois_guilbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76107-76750-bois_guilbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76107-76750-bois_guilbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76107-76750-bois_guilbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76108-76230-bois_guillaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76108-76230-bois_guillaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76108-76230-bois_guillaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76108-76230-bois_guillaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76108-76420-bois_guillaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76108-76420-bois_guillaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76108-76420-bois_guillaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76108-76420-bois_guillaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76109-76750-bois_heroult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76109-76750-bois_heroult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76109-76750-bois_heroult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76109-76750-bois_heroult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76110-76190-bois_himont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76110-76190-bois_himont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76110-76190-bois_himont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76110-76190-bois_himont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76111-76160-bois_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76111-76160-bois_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76111-76160-bois_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76111-76160-bois_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76112-76590-le_bois_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76112-76590-le_bois_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76112-76590-le_bois_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76112-76590-le_bois_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76113-76750-boissay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76113-76750-boissay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76113-76750-boissay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76113-76750-boissay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76114-76210-bolbec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76114-76210-bolbec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76114-76210-bolbec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76114-76210-bolbec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76115-76210-bolleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76115-76210-bolleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76115-76210-bolleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76115-76210-bolleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76116-76520-boos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76116-76520-boos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76116-76520-boos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76116-76520-boos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76117-76790-bordeaux_saint_clair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76117-76790-bordeaux_saint_clair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76117-76790-bordeaux_saint_clair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76117-76790-bordeaux_saint_clair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76118-76110-bornambusc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76118-76110-bornambusc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76118-76110-bornambusc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76118-76110-bornambusc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76119-76680-bosc_berenger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76119-76680-bosc_berenger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76119-76680-bosc_berenger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76119-76680-bosc_berenger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76120-76750-bosc_bordel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76120-76750-bosc_bordel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76120-76750-bosc_bordel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76120-76750-bosc_bordel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76121-76750-bosc_edeline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76121-76750-bosc_edeline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76121-76750-bosc_edeline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76121-76750-bosc_edeline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76122-76270-callengeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76122-76270-callengeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76122-76270-callengeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76122-76270-callengeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76123-76710-bosc_guerard_saint_adrien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76123-76710-bosc_guerard_saint_adrien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76123-76710-bosc_guerard_saint_adrien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76123-76710-bosc_guerard_saint_adrien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76124-76220-bosc_hyons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76124-76220-bosc_hyons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76124-76220-bosc_hyons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76124-76220-bosc_hyons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76125-76850-bosc_le_hard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76125-76850-bosc_le_hard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76125-76850-bosc_le_hard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76125-76850-bosc_le_hard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76126-76680-bosc_mesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76126-76680-bosc_mesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76126-76680-bosc_mesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76126-76680-bosc_mesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76128-76450-bosville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76128-76450-bosville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76128-76450-bosville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76128-76450-bosville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76129-76560-boudeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76129-76560-boudeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76129-76560-boudeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76129-76560-boudeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76130-76270-bouelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76130-76270-bouelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76130-76270-bouelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76130-76270-bouelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76131-76530-la_bouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76131-76530-la_bouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76131-76530-la_bouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76131-76530-la_bouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76132-76760-bourdainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76132-76760-bourdainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76132-76760-bourdainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76132-76760-bourdainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76133-76740-le_bourg_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76133-76740-le_bourg_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76133-76740-le_bourg_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76133-76740-le_bourg_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76134-76740-bourville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76134-76740-bourville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76134-76740-bourville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76134-76740-bourville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76135-76360-bouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76135-76360-bouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76135-76360-bouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76135-76360-bouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76136-76730-brachy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76136-76730-brachy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76136-76730-brachy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76136-76730-brachy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76138-76850-bracquetuit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76138-76850-bracquetuit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76138-76850-bracquetuit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76138-76850-bracquetuit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76139-76680-bradiancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76139-76680-bradiancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76139-76680-bradiancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76139-76680-bradiancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76140-76740-brametot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76140-76740-brametot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76140-76740-brametot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76140-76740-brametot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76141-76110-breaute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76141-76110-breaute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76141-76110-breaute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76141-76110-breaute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76142-76220-bremontier_merval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76142-76220-bremontier_merval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76142-76220-bremontier_merval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76142-76220-bremontier_merval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76143-76110-bretteville_du_grand_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76143-76110-bretteville_du_grand_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76143-76110-bretteville_du_grand_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76143-76110-bretteville_du_grand_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76144-76560-bretteville_saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76144-76560-bretteville_saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76144-76560-bretteville_saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76144-76560-bretteville_saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76146-76750-buchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76146-76750-buchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76146-76750-buchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76146-76750-buchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76147-76270-bully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76147-76270-bully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76147-76270-bully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76147-76270-bully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76148-76660-bures_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76148-76660-bures_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76148-76660-bures_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76148-76660-bures_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76149-76890-butot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76149-76890-butot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76149-76890-butot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76149-76890-butot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76151-76460-cailleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76151-76460-cailleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76151-76460-cailleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76151-76460-cailleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76152-76690-cailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76152-76690-cailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76152-76690-cailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76152-76690-cailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76153-76890-calleville_les_deux_eglises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76153-76890-calleville_les_deux_eglises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76153-76890-calleville_les_deux_eglises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76153-76890-calleville_les_deux_eglises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76154-76340-campneuseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76154-76340-campneuseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76154-76340-campneuseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76154-76340-campneuseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76155-76260-canehan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76155-76260-canehan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76155-76260-canehan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76155-76260-canehan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76156-76450-canouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76156-76450-canouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76156-76450-canouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76156-76450-canouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76157-76380-canteleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76157-76380-canteleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76157-76380-canteleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76157-76380-canteleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76158-76560-canville_les_deux_eglises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76158-76560-canville_les_deux_eglises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76158-76560-canville_les_deux_eglises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76158-76560-canville_les_deux_eglises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76159-76450-cany_barville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76159-76450-cany_barville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76159-76450-cany_barville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76159-76450-cany_barville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76160-76190-carville_la_folletiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76160-76190-carville_la_folletiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76160-76190-carville_la_folletiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76160-76190-carville_la_folletiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76161-76560-carville_pot_de_fer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76161-76560-carville_pot_de_fer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76161-76560-carville_pot_de_fer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76161-76560-carville_pot_de_fer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76162-76590-le_catelier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76162-76590-le_catelier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76162-76590-le_catelier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76162-76590-le_catelier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76163-76116-catenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76163-76116-catenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76163-76116-catenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76163-76116-catenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76164-76490-rives_en_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76164-76490-rives_en_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76164-76490-rives_en_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76164-76490-rives_en_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76165-76320-caudebec_les_elbeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76165-76320-caudebec_les_elbeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76165-76320-caudebec_les_elbeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76165-76320-caudebec_les_elbeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76166-76390-le_caule_sainte_beuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76166-76390-le_caule_sainte_beuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76166-76390-le_caule_sainte_beuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76166-76390-le_caule_sainte_beuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76167-76930-cauville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76167-76930-cauville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76167-76930-cauville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76167-76930-cauville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76168-76590-les_cent_acres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76168-76590-les_cent_acres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76168-76590-les_cent_acres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76168-76590-les_cent_acres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76169-76430-la_cerlangue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76169-76430-la_cerlangue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76169-76430-la_cerlangue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76169-76430-la_cerlangue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76170-76590-la_chapelle_du_bourgay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76170-76590-la_chapelle_du_bourgay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76170-76590-la_chapelle_du_bourgay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76170-76590-la_chapelle_du_bourgay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76171-76780-la_chapelle_saint_ouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76171-76780-la_chapelle_saint_ouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76171-76780-la_chapelle_saint_ouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76171-76780-la_chapelle_saint_ouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76172-76740-la_chapelle_sur_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76172-76740-la_chapelle_sur_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76172-76740-la_chapelle_sur_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76172-76740-la_chapelle_sur_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76173-76590-la_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76173-76590-la_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76173-76590-la_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76173-76590-la_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76174-76570-cideville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76174-76570-cideville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76174-76570-cideville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76174-76570-cideville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76175-76660-clais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76175-76660-clais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76175-76660-clais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76175-76660-clais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76176-76450-clasville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76176-76450-clasville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76176-76450-clasville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76176-76450-clasville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76177-76690-claville_motteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76177-76690-claville_motteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76177-76690-claville_motteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76177-76690-claville_motteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76178-76410-cleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76178-76410-cleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76178-76410-cleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76178-76410-cleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76179-76690-cleres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76179-76690-cleres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76179-76690-cleres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76179-76690-cleres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76180-76450-cleuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76180-76450-cleuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76180-76450-cleuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76180-76450-cleuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76181-76640-cleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76181-76640-cleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76181-76640-cleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76181-76640-cleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76182-76640-cliponville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76182-76640-cliponville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76182-76640-cliponville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76182-76640-cliponville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76183-76400-colleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76183-76400-colleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76183-76400-colleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76183-76400-colleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76184-76550-colmesnil_manneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76184-76550-colmesnil_manneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76184-76550-colmesnil_manneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76184-76550-colmesnil_manneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76185-76440-compainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76185-76440-compainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76185-76440-compainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76185-76440-compainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76186-76390-conteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76186-76390-conteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76186-76390-conteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76186-76390-conteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76187-76400-contremoulins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76187-76400-contremoulins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76187-76400-contremoulins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76187-76400-contremoulins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76188-76850-cottevrard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76188-76850-cottevrard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76188-76850-cottevrard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76188-76850-cottevrard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76189-76450-crasville_la_mallet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76189-76450-crasville_la_mallet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76189-76450-crasville_la_mallet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76189-76450-crasville_la_mallet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76190-76740-crasville_la_rocquefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76190-76740-crasville_la_rocquefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76190-76740-crasville_la_rocquefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76190-76740-crasville_la_rocquefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76192-76910-criel_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76192-76910-criel_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76192-76910-criel_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76192-76910-criel_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76193-76850-la_crique/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76193-76850-la_crique/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76193-76850-la_crique/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76193-76850-la_crique/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76194-76111-criquebeuf_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76194-76111-criquebeuf_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76194-76111-criquebeuf_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76194-76111-criquebeuf_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76195-76540-criquetot_le_mauconduit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76195-76540-criquetot_le_mauconduit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76195-76540-criquetot_le_mauconduit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76195-76540-criquetot_le_mauconduit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76196-76280-criquetot_l_esneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76196-76280-criquetot_l_esneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76196-76280-criquetot_l_esneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76196-76280-criquetot_l_esneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76197-76590-criquetot_sur_longueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76197-76590-criquetot_sur_longueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76197-76590-criquetot_sur_longueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76197-76590-criquetot_sur_longueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76198-76760-criquetot_sur_ouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76198-76760-criquetot_sur_ouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76198-76760-criquetot_sur_ouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76198-76760-criquetot_sur_ouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76199-76390-criquiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76199-76390-criquiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76199-76390-criquiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76199-76390-criquiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76200-76680-critot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76200-76680-critot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76200-76680-critot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76200-76680-critot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76201-76780-croisy_sur_andelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76201-76780-croisy_sur_andelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76201-76780-croisy_sur_andelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76201-76780-croisy_sur_andelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76202-76660-croixdalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76202-76660-croixdalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76202-76660-croixdalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76202-76660-croixdalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76203-76190-croix_mare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76203-76190-croix_mare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76203-76190-croix_mare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76203-76190-croix_mare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76204-76720-cropus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76204-76720-cropus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76204-76720-cropus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76204-76720-cropus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76205-76590-crosville_sur_scie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76205-76590-crosville_sur_scie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76205-76590-crosville_sur_scie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76205-76590-crosville_sur_scie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76206-76280-cuverville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76206-76280-cuverville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76206-76280-cuverville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76206-76280-cuverville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76207-76260-cuverville_sur_yeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76207-76260-cuverville_sur_yeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76207-76260-cuverville_sur_yeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76207-76260-cuverville_sur_yeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76208-76220-cuy_saint_fiacre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76208-76220-cuy_saint_fiacre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76208-76220-cuy_saint_fiacre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76208-76220-cuy_saint_fiacre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76209-76220-dampierre_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76209-76220-dampierre_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76209-76220-dampierre_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76209-76220-dampierre_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76210-76510-dampierre_saint_nicolas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76210-76510-dampierre_saint_nicolas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76210-76510-dampierre_saint_nicolas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76210-76510-dampierre_saint_nicolas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76211-76340-dancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76211-76340-dancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76211-76340-dancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76211-76340-dancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76212-76160-darnetal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76212-76160-darnetal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76212-76160-darnetal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76212-76160-darnetal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76213-76110-daubeuf_serville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76213-76110-daubeuf_serville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76213-76110-daubeuf_serville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76213-76110-daubeuf_serville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76214-76590-denestanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76214-76590-denestanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76214-76590-denestanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76214-76590-denestanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76216-76250-deville_les_rouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76216-76250-deville_les_rouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76216-76250-deville_les_rouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76216-76250-deville_les_rouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76217-76200-dieppe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76217-76200-dieppe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76217-76200-dieppe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76217-76200-dieppe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76217-76370-dieppe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76217-76370-dieppe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76217-76370-dieppe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76217-76370-dieppe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76218-76220-doudeauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76218-76220-doudeauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76218-76220-doudeauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76218-76220-doudeauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76219-76560-doudeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76219-76560-doudeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76219-76560-doudeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76219-76560-doudeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76220-76630-douvrend/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76220-76630-douvrend/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76220-76630-douvrend/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76220-76630-douvrend/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76221-76460-drosay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76221-76460-drosay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76221-76460-drosay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76221-76460-drosay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76222-76480-duclair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76222-76480-duclair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76222-76480-duclair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76222-76480-duclair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76223-76190-ecalles_alix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76223-76190-ecalles_alix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76223-76190-ecalles_alix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76223-76190-ecalles_alix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76224-76110-ecrainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76224-76110-ecrainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76224-76110-ecrainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76224-76110-ecrainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76225-76190-ecretteville_les_baons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76225-76190-ecretteville_les_baons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76225-76190-ecretteville_les_baons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76225-76190-ecretteville_les_baons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76226-76540-ecretteville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76226-76540-ecretteville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76226-76540-ecretteville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76226-76540-ecretteville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76227-76760-ectot_l_auber/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76227-76760-ectot_l_auber/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76227-76760-ectot_l_auber/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76227-76760-ectot_l_auber/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76228-76970-ectot_les_baons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76228-76970-ectot_les_baons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76228-76970-ectot_les_baons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76228-76970-ectot_les_baons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76229-76220-elbeuf_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76229-76220-elbeuf_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76229-76220-elbeuf_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76229-76220-elbeuf_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76230-76780-elbeuf_sur_andelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76230-76780-elbeuf_sur_andelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76230-76780-elbeuf_sur_andelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76230-76780-elbeuf_sur_andelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-76500-elbeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-76500-elbeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-76500-elbeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-76500-elbeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-27370-elbeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-27370-elbeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-27370-elbeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-27370-elbeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-76410-elbeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-76410-elbeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-76410-elbeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76231-76410-elbeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76232-76540-eletot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76232-76540-eletot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76232-76540-eletot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76232-76540-eletot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76233-76390-ellecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76233-76390-ellecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76233-76390-ellecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76233-76390-ellecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76234-76570-emanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76234-76570-emanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76234-76570-emanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76234-76570-emanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76235-76630-envermeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76235-76630-envermeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76235-76630-envermeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76235-76630-envermeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76236-76640-envronville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76236-76640-envronville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76236-76640-envronville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76236-76640-envronville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76237-76480-epinay_sur_duclair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76237-76480-epinay_sur_duclair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76237-76480-epinay_sur_duclair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76237-76480-epinay_sur_duclair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76238-76133-epouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76238-76133-epouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76238-76133-epouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76238-76133-epouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76239-76430-epretot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76239-76430-epretot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76239-76430-epretot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76239-76430-epretot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76240-76400-epreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76240-76400-epreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76240-76400-epreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76240-76400-epreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76241-76740-ermenouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76241-76740-ermenouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76241-76740-ermenouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76241-76740-ermenouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76242-76220-ernemont_la_villette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76242-76220-ernemont_la_villette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76242-76220-ernemont_la_villette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76242-76220-ernemont_la_villette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76243-76750-ernemont_sur_buchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76243-76750-ernemont_sur_buchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76243-76750-ernemont_sur_buchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76243-76750-ernemont_sur_buchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76244-76270-esclavelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76244-76270-esclavelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76244-76270-esclavelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76244-76270-esclavelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76245-76710-eslettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76245-76710-eslettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76245-76710-eslettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76245-76710-eslettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76247-76690-esteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76247-76690-esteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76247-76690-esteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76247-76690-esteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76249-76850-etaimpuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76249-76850-etaimpuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76249-76850-etaimpuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76249-76850-etaimpuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76250-76430-etainhus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76250-76430-etainhus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76250-76430-etainhus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76250-76430-etainhus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76251-76560-etalleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76251-76560-etalleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76251-76560-etalleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76251-76560-etalleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76252-76260-etalondes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76252-76260-etalondes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76252-76260-etalondes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76252-76260-etalondes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76253-76190-etoutteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76253-76190-etoutteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76253-76190-etoutteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76253-76190-etoutteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76254-76790-etretat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76254-76790-etretat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76254-76790-etretat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76254-76790-etretat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76255-76260-eu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76255-76260-eu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76255-76260-eu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76255-76260-eu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76257-76340-fallencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76257-76340-fallencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76257-76340-fallencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76257-76340-fallencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76258-76640-terres_de_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76258-76640-terres_de_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76258-76640-terres_de_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76258-76640-terres_de_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76259-76400-fecamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76259-76400-fecamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76259-76400-fecamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76259-76400-fecamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76260-76220-ferrieres_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76260-76220-ferrieres_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76260-76220-ferrieres_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76260-76220-ferrieres_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76261-76440-la_ferte_saint_samson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76261-76440-la_ferte_saint_samson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76261-76440-la_ferte_saint_samson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76261-76440-la_ferte_saint_samson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76262-76270-fesques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76262-76270-fesques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76262-76270-fesques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76262-76270-fesques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76263-76220-la_feuillie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76263-76220-la_feuillie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76263-76220-la_feuillie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76263-76220-la_feuillie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76264-76970-flamanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76264-76970-flamanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76264-76970-flamanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76264-76970-flamanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76265-76270-flamets_fretils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76265-76270-flamets_fretils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76265-76270-flamets_fretils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76265-76270-flamets_fretils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76266-76260-flocques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76266-76260-flocques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76266-76260-flocques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76266-76260-flocques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76268-76280-fongueusemare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76268-76280-fongueusemare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76268-76280-fongueusemare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76268-76280-fongueusemare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76269-76440-fontaine_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76269-76440-fontaine_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76269-76440-fontaine_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76269-76440-fontaine_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76270-76290-fontaine_la_mallet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76270-76290-fontaine_la_mallet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76270-76290-fontaine_la_mallet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76270-76290-fontaine_la_mallet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76271-76690-fontaine_le_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76271-76690-fontaine_le_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76271-76690-fontaine_le_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76271-76690-fontaine_le_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76272-76740-fontaine_le_dun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76272-76740-fontaine_le_dun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76272-76740-fontaine_le_dun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76272-76740-fontaine_le_dun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76273-76160-fontaine_sous_preaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76273-76160-fontaine_sous_preaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76273-76160-fontaine_sous_preaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76273-76160-fontaine_sous_preaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76274-76890-la_fontelaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76274-76890-la_fontelaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76274-76890-la_fontelaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76274-76890-la_fontelaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76275-76290-fontenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76275-76290-fontenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76275-76290-fontenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76275-76290-fontenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76276-76440-forges_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76276-76440-forges_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76276-76440-forges_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76276-76440-forges_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76278-76340-foucarmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76278-76340-foucarmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76278-76340-foucarmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76278-76340-foucarmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76279-76640-foucart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76279-76640-foucart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76279-76640-foucart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76279-76640-foucart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76280-76660-freauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76280-76660-freauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76280-76660-freauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76280-76660-freauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76281-76170-la_frenaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76281-76170-la_frenaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76281-76170-la_frenaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76281-76170-la_frenaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76282-76410-freneuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76282-76410-freneuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76282-76410-freneuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76282-76410-freneuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76283-76270-fresles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76283-76270-fresles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76283-76270-fresles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76283-76270-fresles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76284-76850-fresnay_le_long/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76284-76850-fresnay_le_long/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76284-76850-fresnay_le_long/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76284-76850-fresnay_le_long/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76285-76520-fresne_le_plan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76285-76520-fresne_le_plan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76285-76520-fresne_le_plan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76285-76520-fresne_le_plan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76286-76660-fresnoy_folny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76286-76660-fresnoy_folny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76286-76660-fresnoy_folny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76286-76660-fresnoy_folny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76287-76570-fresquiennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76287-76570-fresquiennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76287-76570-fresquiennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76287-76570-fresquiennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76288-76510-freulleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76288-76510-freulleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76288-76510-freulleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76288-76510-freulleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76289-76190-saint_martin_de_l_if/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76289-76190-saint_martin_de_l_if/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76289-76190-saint_martin_de_l_if/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76289-76190-saint_martin_de_l_if/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76290-76690-frichemesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76290-76690-frichemesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76290-76690-frichemesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76290-76690-frichemesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76291-76400-froberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76291-76400-froberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76291-76400-froberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76291-76400-froberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76292-76780-fry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76292-76780-fry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76292-76780-fry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76292-76780-fry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76293-76560-fultot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76293-76560-fultot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76293-76560-fultot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76293-76560-fultot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76294-76740-la_gaillarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76294-76740-la_gaillarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76294-76740-la_gaillarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76294-76740-la_gaillarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76295-76870-gaillefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76295-76870-gaillefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76295-76870-gaillefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76295-76870-gaillefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76296-76700-gainneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76296-76700-gainneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76296-76700-gainneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76296-76700-gainneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76297-76220-gancourt_saint_etienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76297-76220-gancourt_saint_etienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76297-76220-gancourt_saint_etienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76297-76220-gancourt_saint_etienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76298-76400-ganzeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76298-76400-ganzeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76298-76400-ganzeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76298-76400-ganzeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76299-76540-gerponville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76299-76540-gerponville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76299-76540-gerponville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76299-76540-gerponville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76300-76790-gerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76300-76790-gerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76300-76790-gerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76300-76790-gerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76302-76110-goderville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76302-76110-goderville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76302-76110-goderville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76302-76110-goderville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76303-76430-gommerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76303-76430-gommerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76303-76430-gommerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76303-76430-gommerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76304-76110-gonfreville_caillot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76304-76110-gonfreville_caillot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76304-76110-gonfreville_caillot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76304-76110-gonfreville_caillot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76305-76700-gonfreville_l_orcher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76305-76700-gonfreville_l_orcher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76305-76700-gonfreville_l_orcher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76305-76700-gonfreville_l_orcher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76306-76730-gonnetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76306-76730-gonnetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76306-76730-gonnetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76306-76730-gonnetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76307-76280-gonneville_la_mallet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76307-76280-gonneville_la_mallet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76307-76280-gonneville_la_mallet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76307-76280-gonneville_la_mallet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76308-76590-gonneville_sur_scie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76308-76590-gonneville_sur_scie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76308-76590-gonneville_sur_scie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76308-76590-gonneville_sur_scie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76309-76560-gonzeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76309-76560-gonzeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76309-76560-gonzeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76309-76560-gonzeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76311-76570-goupillieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76311-76570-goupillieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76311-76570-goupillieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76311-76570-goupillieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76312-76220-gournay_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76312-76220-gournay_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76312-76220-gournay_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76312-76220-gournay_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76313-76520-gouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76313-76520-gouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76313-76520-gouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76313-76520-gouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76314-76430-graimbouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76314-76430-graimbouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76314-76430-graimbouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76314-76430-graimbouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76315-76450-grainville_la_teinturiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76315-76450-grainville_la_teinturiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76315-76450-grainville_la_teinturiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76315-76450-grainville_la_teinturiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76316-76116-grainville_sur_ry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76316-76116-grainville_sur_ry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76316-76116-grainville_sur_ry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76316-76116-grainville_sur_ry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76317-76110-grainville_ymauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76317-76110-grainville_ymauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76317-76110-grainville_ymauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76317-76110-grainville_ymauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76318-76170-grand_camp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76318-76170-grand_camp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76318-76170-grand_camp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76318-76170-grand_camp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76319-76530-grand_couronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76319-76530-grand_couronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76319-76530-grand_couronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76319-76530-grand_couronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76320-76660-grandcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76320-76660-grandcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76320-76660-grandcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76320-76660-grandcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76321-76950-les_grandes_ventes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76321-76950-les_grandes_ventes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76321-76950-les_grandes_ventes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76321-76950-les_grandes_ventes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76322-76120-le_grand_quevilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76322-76120-le_grand_quevilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76322-76120-le_grand_quevilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76322-76120-le_grand_quevilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76323-76270-graval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76323-76270-graval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76323-76270-graval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76323-76270-graval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76324-76370-greges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76324-76370-greges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76324-76370-greges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76324-76370-greges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76325-76970-gremonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76325-76970-gremonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76325-76970-gremonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76325-76970-gremonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76327-76810-greuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76327-76810-greuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76327-76810-greuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76327-76810-greuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76328-76850-grigneuseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76328-76850-grigneuseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76328-76850-grigneuseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76328-76850-grigneuseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76329-76210-gruchet_le_valasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76329-76210-gruchet_le_valasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76329-76210-gruchet_le_valasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76329-76210-gruchet_le_valasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76330-76810-gruchet_saint_simeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76330-76810-gruchet_saint_simeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76330-76810-gruchet_saint_simeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76330-76810-gruchet_saint_simeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76331-76690-grugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76331-76690-grugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76331-76690-grugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76331-76690-grugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76332-76440-grumesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76332-76440-grumesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76332-76440-grumesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76332-76440-grumesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76333-76340-guerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76333-76340-guerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76333-76340-guerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76333-76340-guerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76334-76730-gueures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76334-76730-gueures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76334-76730-gueures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76334-76730-gueures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76335-76890-gueutteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76335-76890-gueutteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76335-76890-gueutteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76335-76890-gueutteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76336-76460-gueutteville_les_gres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76336-76460-gueutteville_les_gres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76336-76460-gueutteville_les_gres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76336-76460-gueutteville_les_gres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76338-76780-la_hallotiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76338-76780-la_hallotiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76338-76780-la_hallotiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76338-76780-la_hallotiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76339-76450-le_hanouard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76339-76450-le_hanouard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76339-76450-le_hanouard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76339-76450-le_hanouard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76340-76560-harcanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76340-76560-harcanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76340-76560-harcanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76340-76560-harcanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76341-76700-harfleur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76341-76700-harfleur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76341-76700-harfleur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76341-76700-harfleur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76342-76640-hattenville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76342-76640-hattenville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76342-76640-hattenville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76342-76640-hattenville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76343-76440-haucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76343-76440-haucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76343-76440-haucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76343-76440-haucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76344-76390-haudricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76344-76390-haudricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76344-76390-haudricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76344-76390-haudricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76345-76440-haussez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76345-76440-haussez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76345-76440-haussez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76345-76440-haussez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76346-76450-hautot_l_auvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76346-76450-hautot_l_auvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76346-76450-hautot_l_auvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76346-76450-hautot_l_auvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76347-76190-hautot_le_vatois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76347-76190-hautot_le_vatois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76347-76190-hautot_le_vatois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76347-76190-hautot_le_vatois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76348-76190-hautot_saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76348-76190-hautot_saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76348-76190-hautot_saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76348-76190-hautot_saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76349-76550-hautot_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76349-76550-hautot_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76349-76550-hautot_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76349-76550-hautot_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76350-76113-hautot_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76350-76113-hautot_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76350-76113-hautot_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76350-76113-hautot_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76610-le_havre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76610-le_havre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76610-le_havre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76610-le_havre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76600-le_havre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76600-le_havre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76600-le_havre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76600-le_havre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76620-le_havre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76620-le_havre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76620-le_havre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76351-76620-le_havre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76352-76780-la_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76352-76780-la_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76352-76780-la_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76352-76780-la_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76353-76740-heberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76353-76740-heberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76353-76740-heberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76353-76740-heberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76354-76840-henouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76354-76840-henouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76354-76840-henouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76354-76840-henouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76355-76560-hericourt_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76355-76560-hericourt_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76355-76560-hericourt_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76355-76560-hericourt_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76356-76730-hermanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76356-76730-hermanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76356-76730-hermanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76356-76730-hermanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76357-76280-hermeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76357-76280-hermeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76357-76280-hermeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76357-76280-hermeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76358-76780-le_heron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76358-76780-le_heron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76358-76780-le_heron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76358-76780-le_heron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76359-76750-heronchelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76359-76750-heronchelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76359-76750-heronchelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76359-76750-heronchelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76360-76720-heugleville_sur_scie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76360-76720-heugleville_sur_scie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76360-76720-heugleville_sur_scie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76360-76720-heugleville_sur_scie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76361-76280-heuqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76361-76280-heuqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76361-76280-heuqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76361-76280-heuqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76362-76940-heurteauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76362-76940-heurteauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76362-76940-heurteauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76362-76940-heurteauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76363-76340-hodeng_au_bosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76363-76340-hodeng_au_bosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76363-76340-hodeng_au_bosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76363-76340-hodeng_au_bosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76364-76780-hodeng_hodenger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76364-76780-hodeng_hodenger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76364-76780-hodeng_hodenger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76364-76780-hodeng_hodenger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76365-76740-houdetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76365-76740-houdetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76365-76740-houdetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76365-76740-houdetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76366-76770-le_houlme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76366-76770-le_houlme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76366-76770-le_houlme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76366-76770-le_houlme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76367-76770-houppeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76367-76770-houppeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76367-76770-houppeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76367-76770-houppeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76368-76110-houquetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76368-76110-houquetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76368-76110-houquetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76368-76110-houquetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76369-76690-la_houssaye_beranger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76369-76690-la_houssaye_beranger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76369-76690-la_houssaye_beranger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76369-76690-la_houssaye_beranger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76370-76570-hugleville_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76370-76570-hugleville_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76370-76570-hugleville_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76370-76570-hugleville_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76371-76630-les_ifs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76371-76630-les_ifs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76371-76630-les_ifs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76371-76630-les_ifs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76372-76390-illois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76372-76390-illois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76372-76390-illois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76372-76390-illois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76373-76890-imbleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76373-76890-imbleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76373-76890-imbleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76373-76890-imbleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76374-76117-incheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76374-76117-incheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76374-76117-incheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76374-76117-incheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76375-76460-ingouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76375-76460-ingouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76375-76460-ingouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76375-76460-ingouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76377-76230-isneauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76377-76230-isneauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76377-76230-isneauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76377-76230-isneauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76378-76480-jumieges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76378-76480-jumieges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76378-76480-jumieges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76378-76480-jumieges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76379-76730-lamberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76379-76730-lamberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76379-76730-lamberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76379-76730-lamberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76380-76730-lammerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76380-76730-lammerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76380-76730-lammerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76380-76730-lammerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76381-76390-landes_vieilles_et_neuves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76381-76390-landes_vieilles_et_neuves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76381-76390-landes_vieilles_et_neuves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76381-76390-landes_vieilles_et_neuves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76382-76210-lanquetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76382-76210-lanquetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76382-76210-lanquetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76382-76210-lanquetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76383-76730-lestanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76383-76730-lestanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76383-76730-lestanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76383-76730-lestanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76384-76170-lillebonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76384-76170-lillebonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76384-76170-lillebonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76384-76170-lillebonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76385-76570-limesy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76385-76570-limesy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76385-76570-limesy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76385-76570-limesy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76386-76540-limpiville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76386-76540-limpiville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76386-76540-limpiville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76386-76540-limpiville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76387-76760-lindebeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76387-76760-lindebeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76387-76760-lindebeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76387-76760-lindebeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76388-76210-lintot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76388-76210-lintot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76388-76210-lintot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76388-76210-lintot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76389-76590-lintot_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76389-76590-lintot_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76389-76590-lintot_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76389-76590-lintot_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76390-76790-les_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76390-76790-les_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76390-76790-les_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76390-76790-les_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76391-76500-la_londe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76391-76500-la_londe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76391-76500-la_londe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76391-76500-la_londe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76392-76660-londinieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76392-76660-londinieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76392-76660-londinieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76392-76660-londinieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76393-76440-longmesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76393-76440-longmesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76393-76440-longmesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76393-76440-longmesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76394-76260-longroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76394-76260-longroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76394-76260-longroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76394-76260-longroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76395-76860-longueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76395-76860-longueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76395-76860-longueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76395-76860-longueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76396-76750-longuerue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76396-76750-longuerue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76396-76750-longuerue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76396-76750-longuerue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76397-76590-longueville_sur_scie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76397-76590-longueville_sur_scie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76397-76590-longueville_sur_scie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76397-76590-longueville_sur_scie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76398-76490-louvetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76398-76490-louvetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76398-76490-louvetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76398-76490-louvetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76399-76270-lucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76399-76270-lucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76399-76270-lucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76399-76270-lucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76400-76810-luneray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76400-76810-luneray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76400-76810-luneray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76400-76810-luneray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76401-76940-arelaune_en_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76401-76940-arelaune_en_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76401-76940-arelaune_en_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76401-76940-arelaune_en_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76402-76770-malaunay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76402-76770-malaunay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76402-76770-malaunay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76402-76770-malaunay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76403-76450-malleville_les_gres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76403-76450-malleville_les_gres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76403-76450-malleville_les_gres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76403-76450-malleville_les_gres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76404-76133-maneglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76404-76133-maneglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76404-76133-maneglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76404-76133-maneglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76405-76590-manehouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76405-76590-manehouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76405-76590-manehouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76405-76590-manehouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76406-76400-maniquerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76406-76400-maniquerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76406-76400-maniquerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76406-76400-maniquerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76407-76460-manneville_es_plains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76407-76460-manneville_es_plains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76407-76460-manneville_es_plains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76407-76460-manneville_es_plains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76408-76110-manneville_la_goupil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76408-76110-manneville_la_goupil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76408-76110-manneville_la_goupil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76408-76110-manneville_la_goupil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76409-76290-mannevillette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76409-76290-mannevillette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76409-76290-mannevillette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76409-76290-mannevillette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76410-76150-maromme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76410-76150-maromme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76410-76150-maromme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76410-76150-maromme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76411-76390-marques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76411-76390-marques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76411-76390-marques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76411-76390-marques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76412-76116-martainville_epreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76412-76116-martainville_epreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76412-76116-martainville_epreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76412-76116-martainville_epreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76413-76880-martigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76413-76880-martigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76413-76880-martigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76413-76880-martigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76414-76370-martin_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76414-76370-martin_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76414-76370-martin_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76414-76370-martin_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76415-76270-massy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76415-76270-massy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76415-76270-massy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76415-76270-massy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76416-76680-mathonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76416-76680-mathonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76416-76680-mathonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76416-76680-mathonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76417-76680-maucomble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76417-76680-maucomble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76417-76680-maucomble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76417-76680-maucomble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76418-76490-maulevrier_sainte_gertrude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76418-76490-maulevrier_sainte_gertrude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76418-76490-maulevrier_sainte_gertrude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76418-76490-maulevrier_sainte_gertrude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76419-76530-mauny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76419-76530-mauny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76419-76530-mauny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76419-76530-mauny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76420-76440-mauquenchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76420-76440-mauquenchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76420-76440-mauquenchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76420-76440-mauquenchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76421-76170-melamare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76421-76170-melamare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76421-76170-melamare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76421-76170-melamare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76422-76260-melleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76422-76260-melleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76422-76260-melleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76422-76260-melleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76423-76220-menerval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76423-76220-menerval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76423-76220-menerval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76423-76220-menerval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76424-76270-menonval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76424-76270-menonval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76424-76270-menonval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76424-76270-menonval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76425-76110-mentheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76425-76110-mentheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76425-76110-mentheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76425-76110-mentheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76426-76780-mesangueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76426-76780-mesangueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76426-76780-mesangueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76426-76780-mesangueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76427-76270-mesnieres_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76427-76270-mesnieres_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76427-76270-mesnieres_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76427-76270-mesnieres_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76428-76460-le_mesnil_durdent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76428-76460-le_mesnil_durdent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76428-76460-le_mesnil_durdent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76428-76460-le_mesnil_durdent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76429-76240-le_mesnil_esnard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76429-76240-le_mesnil_esnard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76429-76240-le_mesnil_esnard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76429-76240-le_mesnil_esnard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76430-76660-mesnil_follemprise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76430-76660-mesnil_follemprise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76430-76660-mesnil_follemprise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76430-76660-mesnil_follemprise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76431-76780-le_mesnil_lieubray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76431-76780-le_mesnil_lieubray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76431-76780-le_mesnil_lieubray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76431-76780-le_mesnil_lieubray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76432-76440-mesnil_mauger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76432-76440-mesnil_mauger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76432-76440-mesnil_mauger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76432-76440-mesnil_mauger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76433-76570-mesnil_panneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76433-76570-mesnil_panneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76433-76570-mesnil_panneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76433-76570-mesnil_panneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76434-76520-mesnil_raoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76434-76520-mesnil_raoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76434-76520-mesnil_raoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76434-76520-mesnil_raoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76435-76260-le_mesnil_reaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76435-76260-le_mesnil_reaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76435-76260-le_mesnil_reaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76435-76260-le_mesnil_reaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76436-76480-le_mesnil_sous_jumieges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76436-76480-le_mesnil_sous_jumieges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76436-76480-le_mesnil_sous_jumieges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76436-76480-le_mesnil_sous_jumieges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76437-76510-meulers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76437-76510-meulers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76437-76510-meulers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76437-76510-meulers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76438-76260-millebosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76438-76260-millebosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76438-76260-millebosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76438-76260-millebosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76439-76210-mirville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76439-76210-mirville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76439-76210-mirville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76439-76210-mirville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76440-76220-molagnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76440-76220-molagnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76440-76220-molagnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76440-76220-molagnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76441-76340-monchaux_soreng/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76441-76340-monchaux_soreng/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76441-76340-monchaux_soreng/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76441-76340-monchaux_soreng/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76442-76260-monchy_sur_eu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76442-76260-monchy_sur_eu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76442-76260-monchy_sur_eu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76442-76260-monchy_sur_eu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76443-76690-mont_cauvaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76443-76690-mont_cauvaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76443-76690-mont_cauvaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76443-76690-mont_cauvaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76445-76680-monterolier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76445-76680-monterolier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76445-76680-monterolier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76445-76680-monterolier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76446-76380-montigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76446-76380-montigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76446-76380-montigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76446-76380-montigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76447-76290-montivilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76447-76290-montivilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76447-76290-montivilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76447-76290-montivilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76448-76520-montmain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76448-76520-montmain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76448-76520-montmain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76448-76520-montmain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76449-76850-montreuil_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76449-76850-montreuil_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76449-76850-montreuil_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76449-76850-montreuil_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76450-76220-montroty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76450-76220-montroty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76450-76220-montroty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76450-76220-montroty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76451-76130-mont_saint_aignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76451-76130-mont_saint_aignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76451-76130-mont_saint_aignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76451-76130-mont_saint_aignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76452-76710-montville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76452-76710-montville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76452-76710-montville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76452-76710-montville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76453-76750-morgny_la_pommeraye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76453-76750-morgny_la_pommeraye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76453-76750-morgny_la_pommeraye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76453-76750-morgny_la_pommeraye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76454-76270-mortemer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76454-76270-mortemer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76454-76270-mortemer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76454-76270-mortemer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76455-76780-morville_sur_andelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76455-76780-morville_sur_andelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76455-76780-morville_sur_andelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76455-76780-morville_sur_andelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76456-76970-motteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76456-76970-motteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76456-76970-motteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76456-76970-motteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76457-76530-moulineaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76457-76530-moulineaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76457-76530-moulineaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76457-76530-moulineaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76458-76590-muchedent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76458-76590-muchedent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76458-76590-muchedent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76458-76590-muchedent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76459-76270-nesle_hodeng/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76459-76270-nesle_hodeng/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76459-76270-nesle_hodeng/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76459-76270-nesle_hodeng/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76460-76340-nesle_normandeuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76460-76340-nesle_normandeuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76460-76340-nesle_normandeuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76460-76340-nesle_normandeuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76461-76680-neufbosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76461-76680-neufbosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76461-76680-neufbosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76461-76680-neufbosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76462-76270-neufchatel_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76462-76270-neufchatel_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76462-76270-neufchatel_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76462-76270-neufchatel_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76463-76220-neuf_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76463-76220-neuf_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76463-76220-neuf_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76463-76220-neuf_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76464-76520-la_neuville_chant_d_oisel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76464-76520-la_neuville_chant_d_oisel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76464-76520-la_neuville_chant_d_oisel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76464-76520-la_neuville_chant_d_oisel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76465-76270-neuville_ferrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76465-76270-neuville_ferrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76465-76270-neuville_ferrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76465-76270-neuville_ferrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76467-76460-neville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76467-76460-neville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76467-76460-neville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76467-76460-neville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76468-76210-nointot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76468-76210-nointot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76468-76210-nointot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76468-76210-nointot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76469-76780-nolleval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76469-76780-nolleval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76469-76780-nolleval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76469-76780-nolleval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76470-76640-normanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76470-76640-normanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76470-76640-normanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76470-76640-normanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76471-76330-norville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76471-76330-norville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76471-76330-norville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76471-76330-norville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76472-76510-notre_dame_d_aliermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76472-76510-notre_dame_d_aliermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76472-76510-notre_dame_d_aliermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76472-76510-notre_dame_d_aliermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76473-76940-notre_dame_de_bliquetuit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76473-76940-notre_dame_de_bliquetuit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76473-76940-notre_dame_de_bliquetuit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76473-76940-notre_dame_de_bliquetuit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76474-76960-notre_dame_de_bondeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76474-76960-notre_dame_de_bondeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76474-76960-notre_dame_de_bondeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76474-76960-notre_dame_de_bondeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76474-76130-notre_dame_de_bondeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76474-76130-notre_dame_de_bondeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76474-76130-notre_dame_de_bondeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76474-76130-notre_dame_de_bondeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76475-76520-franqueville_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76475-76520-franqueville_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76475-76520-franqueville_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76475-76520-franqueville_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76476-76330-port_jerome_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76476-76330-port_jerome_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76476-76330-port_jerome_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76476-76330-port_jerome_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76476-76170-port_jerome_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76476-76170-port_jerome_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76476-76170-port_jerome_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76476-76170-port_jerome_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76477-76133-notre_dame_du_bec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76477-76133-notre_dame_du_bec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76477-76133-notre_dame_du_bec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76477-76133-notre_dame_du_bec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76478-76590-notre_dame_du_parc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76478-76590-notre_dame_du_parc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76478-76590-notre_dame_du_parc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76478-76590-notre_dame_du_parc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76479-76390-nullemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76479-76390-nullemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76479-76390-nullemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76479-76390-nullemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76480-76450-ocqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76480-76450-ocqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76480-76450-ocqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76480-76450-ocqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76481-76930-octeville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76481-76930-octeville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76481-76930-octeville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76481-76930-octeville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76482-76550-offranville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76482-76550-offranville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76482-76550-offranville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76482-76550-offranville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76483-76560-oherville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76483-76560-oherville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76483-76560-oherville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76483-76560-oherville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76484-76350-oissel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76484-76350-oissel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76484-76350-oissel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76484-76350-oissel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76485-76730-omonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76485-76730-omonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76485-76730-omonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76485-76730-omonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76486-76500-orival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76486-76500-orival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76486-76500-orival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76486-76500-orival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76487-76660-osmoy_saint_valery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76487-76660-osmoy_saint_valery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76487-76660-osmoy_saint_valery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76487-76660-osmoy_saint_valery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76488-76450-ouainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76488-76450-ouainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76488-76450-ouainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76488-76450-ouainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76489-76430-oudalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76489-76430-oudalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76489-76430-oudalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76489-76430-oudalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76490-76450-ourville_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76490-76450-ourville_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76490-76450-ourville_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76490-76450-ourville_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76491-76760-ouville_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76491-76760-ouville_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76491-76760-ouville_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76491-76760-ouville_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76492-76860-ouville_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76492-76860-ouville_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76492-76860-ouville_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76492-76860-ouville_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76493-76450-paluel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76493-76450-paluel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76493-76450-paluel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76493-76450-paluel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76494-76210-parc_d_anxtot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76494-76210-parc_d_anxtot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76494-76210-parc_d_anxtot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76494-76210-parc_d_anxtot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76495-76570-pavilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76495-76570-pavilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76495-76570-pavilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76495-76570-pavilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76497-76650-petit_couronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76497-76650-petit_couronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76497-76650-petit_couronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76497-76650-petit_couronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76498-76140-le_petit_quevilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76498-76140-le_petit_quevilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76498-76140-le_petit_quevilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76498-76140-le_petit_quevilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76499-76330-petiville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76499-76330-petiville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76499-76330-petiville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76499-76330-petiville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76500-76340-pierrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76500-76340-pierrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76500-76340-pierrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76500-76340-pierrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76501-76280-pierrefiques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76501-76280-pierrefiques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76501-76280-pierrefiques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76501-76280-pierrefiques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76502-76750-pierreval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76502-76750-pierreval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76502-76750-pierreval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76502-76750-pierreval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76503-76360-pissy_poville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76503-76360-pissy_poville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76503-76360-pissy_poville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76503-76360-pissy_poville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76504-76460-pleine_seve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76504-76460-pleine_seve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76504-76460-pleine_seve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76504-76460-pleine_seve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76505-76440-pommereux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76505-76440-pommereux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76505-76440-pommereux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76505-76440-pommereux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76506-76680-pommereval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76506-76680-pommereval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76506-76680-pommereval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76506-76680-pommereval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76507-76260-ponts_et_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76507-76260-ponts_et_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76507-76260-ponts_et_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76507-76260-ponts_et_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76508-76280-la_poterie_cap_d_antifer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76508-76280-la_poterie_cap_d_antifer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76508-76280-la_poterie_cap_d_antifer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76508-76280-la_poterie_cap_d_antifer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76509-76160-preaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76509-76160-preaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76509-76160-preaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76509-76160-preaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76510-76560-pretot_vicquemare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76510-76560-pretot_vicquemare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76510-76560-pretot_vicquemare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76510-76560-pretot_vicquemare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76511-76660-preuseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76511-76660-preuseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76511-76660-preuseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76511-76660-preuseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76512-76660-puisenval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76512-76660-puisenval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76512-76660-puisenval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76512-76660-puisenval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76513-76840-quevillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76513-76840-quevillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76513-76840-quevillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76513-76840-quevillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76514-76520-quevreville_la_poterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76514-76520-quevreville_la_poterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76514-76520-quevreville_la_poterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76514-76520-quevreville_la_poterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76515-76860-quiberville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76515-76860-quiberville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76515-76860-quiberville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76515-76860-quiberville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76516-76270-quievrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76516-76270-quievrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76516-76270-quievrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76516-76270-quievrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76517-76230-quincampoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76517-76230-quincampoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76517-76230-quincampoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76517-76230-quincampoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76518-76210-raffetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76518-76210-raffetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76518-76210-raffetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76518-76210-raffetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76519-76730-rainfreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76519-76730-rainfreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76519-76730-rainfreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76519-76730-rainfreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76520-76340-realcamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76520-76340-realcamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76520-76340-realcamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76520-76340-realcamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76521-76750-rebets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76521-76750-rebets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76521-76750-rebets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76521-76750-rebets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76522-76430-la_remuee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76522-76430-la_remuee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76522-76430-la_remuee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76522-76430-la_remuee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76523-76340-retonval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76523-76340-retonval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76523-76340-retonval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76523-76340-retonval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76524-76560-reuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76524-76560-reuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76524-76560-reuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76524-76560-reuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76526-76510-ricarville_du_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76526-76510-ricarville_du_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76526-76510-ricarville_du_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76526-76510-ricarville_du_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76527-76390-richemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76527-76390-richemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76527-76390-richemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76527-76390-richemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76528-76340-rieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76528-76340-rieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76528-76340-rieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76528-76340-rieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76529-76540-riville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76529-76540-riville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76529-76540-riville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76529-76540-riville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76530-76560-robertot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76530-76560-robertot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76530-76560-robertot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76530-76560-robertot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76531-76640-rocquefort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76531-76640-rocquefort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76531-76640-rocquefort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76531-76640-rocquefort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76532-76680-rocquemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76532-76680-rocquemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76532-76680-rocquemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76532-76680-rocquemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76533-76700-rogerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76533-76700-rogerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76533-76700-rogerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76533-76700-rogerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76534-76133-rolleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76534-76133-rolleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76534-76133-rolleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76534-76133-rolleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76535-76440-roncherolles_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76535-76440-roncherolles_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76535-76440-roncherolles_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76535-76440-roncherolles_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76536-76160-roncherolles_sur_le_vivier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76536-76160-roncherolles_sur_le_vivier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76536-76160-roncherolles_sur_le_vivier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76536-76160-roncherolles_sur_le_vivier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76537-76390-ronchois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76537-76390-ronchois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76537-76390-ronchois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76537-76390-ronchois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76538-76680-rosay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76538-76680-rosay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76538-76680-rosay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76538-76680-rosay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76000-rouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76000-rouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76000-rouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76000-rouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76100-rouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76100-rouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76100-rouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76100-rouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76600-rouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76600-rouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76600-rouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76540-76600-rouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76541-76480-roumare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76541-76480-roumare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76541-76480-roumare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76541-76480-roumare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76542-76560-routes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76542-76560-routes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76542-76560-routes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76542-76560-routes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76543-76210-rouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76543-76210-rouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76543-76210-rouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76543-76210-rouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76544-76440-rouvray_catillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76544-76440-rouvray_catillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76544-76440-rouvray_catillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76544-76440-rouvray_catillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76370-rouxmesnil_bouteilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76370-rouxmesnil_bouteilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76370-rouxmesnil_bouteilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76370-rouxmesnil_bouteilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76200-rouxmesnil_bouteilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76200-rouxmesnil_bouteilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76200-rouxmesnil_bouteilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76200-rouxmesnil_bouteilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76550-rouxmesnil_bouteilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76550-rouxmesnil_bouteilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76550-rouxmesnil_bouteilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76545-76550-rouxmesnil_bouteilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76546-76730-royville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76546-76730-royville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76546-76730-royville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76546-76730-royville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76547-76690-la_rue_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76547-76690-la_rue_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76547-76690-la_rue_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76547-76690-la_rue_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76548-76116-ry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76548-76116-ry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76548-76116-ry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76548-76116-ry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76549-76730-saane_saint_just/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76549-76730-saane_saint_just/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76549-76730-saane_saint_just/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76549-76730-saane_saint_just/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76550-76113-sahurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76550-76113-sahurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76550-76113-sahurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76550-76113-sahurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76551-76430-sainneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76551-76430-sainneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76551-76430-sainneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76551-76430-sainneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76552-76310-sainte_adresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76552-76310-sainte_adresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76552-76310-sainte_adresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76552-76310-sainte_adresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76553-76660-sainte_agathe_d_aliermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76553-76660-sainte_agathe_d_aliermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76553-76660-sainte_agathe_d_aliermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76553-76660-sainte_agathe_d_aliermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76554-76116-saint_aignan_sur_ry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76554-76116-saint_aignan_sur_ry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76554-76116-saint_aignan_sur_ry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76554-76116-saint_aignan_sur_ry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76555-76690-saint_andre_sur_cailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76555-76690-saint_andre_sur_cailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76555-76690-saint_andre_sur_cailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76555-76690-saint_andre_sur_cailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76556-76170-saint_antoine_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76556-76170-saint_antoine_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76556-76170-saint_antoine_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76556-76170-saint_antoine_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76557-76490-saint_arnoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76557-76490-saint_arnoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76557-76490-saint_arnoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76557-76490-saint_arnoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76558-76520-saint_aubin_celloville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76558-76520-saint_aubin_celloville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76558-76520-saint_aubin_celloville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76558-76520-saint_aubin_celloville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76559-76190-saint_aubin_de_cretot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76559-76190-saint_aubin_de_cretot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76559-76190-saint_aubin_de_cretot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76559-76190-saint_aubin_de_cretot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76560-76160-saint_aubin_epinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76560-76160-saint_aubin_epinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76560-76160-saint_aubin_epinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76560-76160-saint_aubin_epinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76561-76410-saint_aubin_les_elbeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76561-76410-saint_aubin_les_elbeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76561-76410-saint_aubin_les_elbeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76561-76410-saint_aubin_les_elbeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76562-76510-saint_aubin_le_cauf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76562-76510-saint_aubin_le_cauf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76562-76510-saint_aubin_le_cauf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76562-76510-saint_aubin_le_cauf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76563-76430-saint_aubin_routot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76563-76430-saint_aubin_routot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76563-76430-saint_aubin_routot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76563-76430-saint_aubin_routot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76564-76740-saint_aubin_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76564-76740-saint_aubin_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76564-76740-saint_aubin_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76564-76740-saint_aubin_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76565-76550-saint_aubin_sur_scie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76565-76550-saint_aubin_sur_scie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76565-76550-saint_aubin_sur_scie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76565-76550-saint_aubin_sur_scie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76566-76570-sainte_austreberthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76566-76570-sainte_austreberthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76566-76570-sainte_austreberthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76566-76570-sainte_austreberthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76567-76270-sainte_beuve_en_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76567-76270-sainte_beuve_en_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76567-76270-sainte_beuve_en_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76567-76270-sainte_beuve_en_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76568-76190-saint_clair_sur_les_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76568-76190-saint_clair_sur_les_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76568-76190-saint_clair_sur_les_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76568-76190-saint_clair_sur_les_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76569-76460-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76569-76460-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76569-76460-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76569-76460-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76570-76590-saint_crespin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76570-76590-saint_crespin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76570-76590-saint_crespin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76570-76590-saint_crespin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76571-76750-sainte_croix_sur_buchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76571-76750-sainte_croix_sur_buchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76571-76750-sainte_croix_sur_buchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76571-76750-sainte_croix_sur_buchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76572-76860-saint_denis_d_aclon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76572-76860-saint_denis_d_aclon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76572-76860-saint_denis_d_aclon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76572-76860-saint_denis_d_aclon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76573-76116-saint_denis_le_thiboult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76573-76116-saint_denis_le_thiboult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76573-76116-saint_denis_le_thiboult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76573-76116-saint_denis_le_thiboult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76574-76890-saint_denis_sur_scie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76574-76890-saint_denis_sur_scie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76574-76890-saint_denis_sur_scie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76574-76890-saint_denis_sur_scie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76575-76800-saint_etienne_du_rouvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76575-76800-saint_etienne_du_rouvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76575-76800-saint_etienne_du_rouvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76575-76800-saint_etienne_du_rouvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76576-76210-saint_eustache_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76576-76210-saint_eustache_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76576-76210-saint_eustache_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76576-76210-saint_eustache_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76577-76590-sainte_foy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76577-76590-sainte_foy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76577-76590-sainte_foy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76577-76590-sainte_foy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76578-76440-sainte_genevieve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76578-76440-sainte_genevieve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76578-76440-sainte_genevieve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76578-76440-sainte_genevieve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76580-76690-saint_georges_sur_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76580-76690-saint_georges_sur_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76580-76690-saint_georges_sur_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76580-76690-saint_georges_sur_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76581-76750-saint_germain_des_essourts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76581-76750-saint_germain_des_essourts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76581-76750-saint_germain_des_essourts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76581-76750-saint_germain_des_essourts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76582-76590-saint_germain_d_etables/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76582-76590-saint_germain_d_etables/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76582-76590-saint_germain_d_etables/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76582-76590-saint_germain_d_etables/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76583-76690-saint_germain_sous_cailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76583-76690-saint_germain_sous_cailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76583-76690-saint_germain_sous_cailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76583-76690-saint_germain_sous_cailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76584-76270-saint_germain_sur_eaulne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76584-76270-saint_germain_sur_eaulne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76584-76270-saint_germain_sur_eaulne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76584-76270-saint_germain_sur_eaulne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76585-76490-saint_gilles_de_cretot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76585-76490-saint_gilles_de_cretot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76585-76490-saint_gilles_de_cretot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76585-76490-saint_gilles_de_cretot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76586-76430-saint_gilles_de_la_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76586-76430-saint_gilles_de_la_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76586-76430-saint_gilles_de_la_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76586-76430-saint_gilles_de_la_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76587-76400-sainte_helene_bondeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76587-76400-sainte_helene_bondeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76587-76400-sainte_helene_bondeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76587-76400-sainte_helene_bondeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76588-76680-saint_hellier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76588-76680-saint_hellier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76588-76680-saint_hellier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76588-76680-saint_hellier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76589-76590-saint_honore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76589-76590-saint_honore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76589-76590-saint_honore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76589-76590-saint_honore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76590-76510-saint_jacques_d_aliermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76590-76510-saint_jacques_d_aliermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76590-76510-saint_jacques_d_aliermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76590-76510-saint_jacques_d_aliermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76591-76160-saint_jacques_sur_darnetal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76591-76160-saint_jacques_sur_darnetal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76591-76160-saint_jacques_sur_darnetal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76591-76160-saint_jacques_sur_darnetal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76592-76170-saint_jean_de_folleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76592-76170-saint_jean_de_folleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76592-76170-saint_jean_de_folleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76592-76170-saint_jean_de_folleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76593-76210-saint_jean_de_la_neuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76593-76210-saint_jean_de_la_neuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76593-76210-saint_jean_de_la_neuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76593-76210-saint_jean_de_la_neuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76594-76150-saint_jean_du_cardonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76594-76150-saint_jean_du_cardonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76594-76150-saint_jean_du_cardonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76594-76150-saint_jean_du_cardonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76595-76280-saint_jouin_bruneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76595-76280-saint_jouin_bruneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76595-76280-saint_jouin_bruneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76595-76280-saint_jouin_bruneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76596-76700-saint_laurent_de_brevedent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76596-76700-saint_laurent_de_brevedent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76596-76700-saint_laurent_de_brevedent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76596-76700-saint_laurent_de_brevedent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76597-76560-saint_laurent_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76597-76560-saint_laurent_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76597-76560-saint_laurent_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76597-76560-saint_laurent_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76598-76340-saint_leger_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76598-76340-saint_leger_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76598-76340-saint_leger_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76598-76340-saint_leger_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76599-76160-saint_leger_du_bourg_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76599-76160-saint_leger_du_bourg_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76599-76160-saint_leger_du_bourg_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76599-76160-saint_leger_du_bourg_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76600-76400-saint_leonard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76600-76400-saint_leonard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76600-76400-saint_leonard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76600-76400-saint_leonard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76601-76780-saint_lucien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76601-76780-saint_lucien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76601-76780-saint_lucien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76601-76780-saint_lucien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76602-76890-saint_maclou_de_folleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76602-76890-saint_maclou_de_folleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76602-76890-saint_maclou_de_folleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76602-76890-saint_maclou_de_folleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76603-76110-saint_maclou_la_briere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76603-76110-saint_maclou_la_briere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76603-76110-saint_maclou_la_briere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76603-76110-saint_maclou_la_briere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76604-76730-saint_mards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76604-76730-saint_mards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76604-76730-saint_mards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76604-76730-saint_mards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76605-76119-sainte_marguerite_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76605-76119-sainte_marguerite_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76605-76119-sainte_marguerite_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76605-76119-sainte_marguerite_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76606-76390-morienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76606-76390-morienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76606-76390-morienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76606-76390-morienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76608-76480-sainte_marguerite_sur_duclair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76608-76480-sainte_marguerite_sur_duclair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76608-76480-sainte_marguerite_sur_duclair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76608-76480-sainte_marguerite_sur_duclair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76609-76280-sainte_marie_au_bosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76609-76280-sainte_marie_au_bosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76609-76280-sainte_marie_au_bosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76609-76280-sainte_marie_au_bosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76610-76190-sainte_marie_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76610-76190-sainte_marie_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76610-76190-sainte_marie_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76610-76190-sainte_marie_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76611-76760-saint_martin_aux_arbres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76611-76760-saint_martin_aux_arbres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76611-76760-saint_martin_aux_arbres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76611-76760-saint_martin_aux_arbres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76612-76340-saint_martin_au_bosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76612-76340-saint_martin_au_bosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76612-76340-saint_martin_au_bosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76612-76340-saint_martin_au_bosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76613-76450-saint_martin_aux_buneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76613-76450-saint_martin_aux_buneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76613-76450-saint_martin_aux_buneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76613-76450-saint_martin_aux_buneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76613-76540-saint_martin_aux_buneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76613-76540-saint_martin_aux_buneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76613-76540-saint_martin_aux_buneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76613-76540-saint_martin_aux_buneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76614-76840-saint_martin_de_boscherville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76614-76840-saint_martin_de_boscherville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76614-76840-saint_martin_de_boscherville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76614-76840-saint_martin_de_boscherville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76615-76133-saint_martin_du_bec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76615-76133-saint_martin_du_bec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76615-76133-saint_martin_du_bec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76615-76133-saint_martin_du_bec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76616-76290-saint_martin_du_manoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76616-76290-saint_martin_du_manoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76616-76290-saint_martin_du_manoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76616-76290-saint_martin_du_manoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76617-76160-saint_martin_du_vivier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76617-76160-saint_martin_du_vivier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76617-76160-saint_martin_du_vivier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76617-76160-saint_martin_du_vivier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76370-petit_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76370-petit_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76370-petit_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76370-petit_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76630-petit_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76630-petit_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76630-petit_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76630-petit_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76910-petit_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76910-petit_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76910-petit_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76618-76910-petit_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76619-76260-saint_martin_le_gaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76619-76260-saint_martin_le_gaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76619-76260-saint_martin_le_gaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76619-76260-saint_martin_le_gaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76620-76270-saint_martin_l_hortier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76620-76270-saint_martin_l_hortier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76620-76270-saint_martin_l_hortier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76620-76270-saint_martin_l_hortier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76621-76680-saint_martin_osmonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76621-76680-saint_martin_osmonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76621-76680-saint_martin_osmonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76621-76680-saint_martin_osmonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76622-76330-saint_maurice_d_etelan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76622-76330-saint_maurice_d_etelan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76622-76330-saint_maurice_d_etelan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76622-76330-saint_maurice_d_etelan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76623-76440-saint_michel_d_halescourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76623-76440-saint_michel_d_halescourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76623-76440-saint_michel_d_halescourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76623-76440-saint_michel_d_halescourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76624-76510-saint_nicolas_d_aliermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76624-76510-saint_nicolas_d_aliermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76624-76510-saint_nicolas_d_aliermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76624-76510-saint_nicolas_d_aliermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76626-76490-saint_nicolas_de_la_haie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76626-76490-saint_nicolas_de_la_haie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76626-76490-saint_nicolas_de_la_haie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76626-76490-saint_nicolas_de_la_haie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76627-76170-saint_nicolas_de_la_taille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76627-76170-saint_nicolas_de_la_taille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76627-76170-saint_nicolas_de_la_taille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76627-76170-saint_nicolas_de_la_taille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76628-76890-saint_ouen_du_breuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76628-76890-saint_ouen_du_breuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76628-76890-saint_ouen_du_breuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76628-76890-saint_ouen_du_breuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76629-76730-saint_ouen_le_mauger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76629-76730-saint_ouen_le_mauger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76629-76730-saint_ouen_le_mauger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76629-76730-saint_ouen_le_mauger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76630-76630-saint_ouen_sous_bailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76630-76630-saint_ouen_sous_bailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76630-76630-saint_ouen_sous_bailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76630-76630-saint_ouen_sous_bailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76631-76480-saint_paer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76631-76480-saint_paer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76631-76480-saint_paer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76631-76480-saint_paer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76632-76890-saint_pierre_benouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76632-76890-saint_pierre_benouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76632-76890-saint_pierre_benouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76632-76890-saint_pierre_benouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76634-76113-saint_pierre_de_manneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76634-76113-saint_pierre_de_manneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76634-76113-saint_pierre_de_manneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76634-76113-saint_pierre_de_manneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76635-76660-saint_pierre_des_jonquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76635-76660-saint_pierre_des_jonquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76635-76660-saint_pierre_des_jonquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76635-76660-saint_pierre_des_jonquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76636-76480-saint_pierre_de_varengeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76636-76480-saint_pierre_de_varengeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76636-76480-saint_pierre_de_varengeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76636-76480-saint_pierre_de_varengeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76637-76540-saint_pierre_en_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76637-76540-saint_pierre_en_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76637-76540-saint_pierre_en_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76637-76540-saint_pierre_en_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76638-76260-saint_pierre_en_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76638-76260-saint_pierre_en_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76638-76260-saint_pierre_en_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76638-76260-saint_pierre_en_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76640-76320-saint_pierre_les_elbeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76640-76320-saint_pierre_les_elbeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76640-76320-saint_pierre_les_elbeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76640-76320-saint_pierre_les_elbeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76641-76740-saint_pierre_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76641-76740-saint_pierre_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76641-76740-saint_pierre_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76641-76740-saint_pierre_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76642-76740-saint_pierre_le_viger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76642-76740-saint_pierre_le_viger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76642-76740-saint_pierre_le_viger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76642-76740-saint_pierre_le_viger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76644-76260-saint_remy_boscrocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76644-76260-saint_remy_boscrocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76644-76260-saint_remy_boscrocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76644-76260-saint_remy_boscrocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76645-76340-saint_riquier_en_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76645-76340-saint_riquier_en_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76645-76340-saint_riquier_en_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76645-76340-saint_riquier_en_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76646-76460-saint_riquier_es_plains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76646-76460-saint_riquier_es_plains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76646-76460-saint_riquier_es_plains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76646-76460-saint_riquier_es_plains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76647-76430-saint_romain_de_colbosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76647-76430-saint_romain_de_colbosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76647-76430-saint_romain_de_colbosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76647-76430-saint_romain_de_colbosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76648-76680-saint_saens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76648-76680-saint_saens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76648-76680-saint_saens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76648-76680-saint_saens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76649-76270-saint_saire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76649-76270-saint_saire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76649-76270-saint_saire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76649-76270-saint_saire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76650-76110-saint_sauveur_d_emalleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76650-76110-saint_sauveur_d_emalleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76650-76110-saint_sauveur_d_emalleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76650-76110-saint_sauveur_d_emalleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76651-76460-saint_sylvain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76651-76460-saint_sylvain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76651-76460-saint_sylvain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76651-76460-saint_sylvain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76652-76510-saint_vaast_d_equiqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76652-76510-saint_vaast_d_equiqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76652-76510-saint_vaast_d_equiqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76652-76510-saint_vaast_d_equiqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76653-76450-saint_vaast_dieppedalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76653-76450-saint_vaast_dieppedalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76653-76450-saint_vaast_dieppedalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76653-76450-saint_vaast_dieppedalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76654-76890-saint_vaast_du_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76654-76890-saint_vaast_du_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76654-76890-saint_vaast_du_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76654-76890-saint_vaast_du_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76655-76460-saint_valery_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76655-76460-saint_valery_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76655-76460-saint_valery_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76655-76460-saint_valery_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76656-76890-saint_victor_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76656-76890-saint_victor_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76656-76890-saint_victor_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76656-76890-saint_victor_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76657-76430-saint_vigor_d_ymonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76657-76430-saint_vigor_d_ymonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76657-76430-saint_vigor_d_ymonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76657-76430-saint_vigor_d_ymonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76658-76430-saint_vincent_cramesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76658-76430-saint_vincent_cramesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76658-76430-saint_vincent_cramesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76658-76430-saint_vincent_cramesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76660-76430-sandouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76660-76430-sandouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76660-76430-sandouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76660-76430-sandouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76662-76730-sassetot_le_malgarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76662-76730-sassetot_le_malgarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76662-76730-sassetot_le_malgarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76662-76730-sassetot_le_malgarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76663-76540-sassetot_le_mauconduit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76663-76540-sassetot_le_mauconduit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76663-76540-sassetot_le_mauconduit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76663-76540-sassetot_le_mauconduit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76664-76450-sasseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76664-76450-sasseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76664-76450-sasseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76664-76450-sasseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76665-76630-sauchay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76665-76630-sauchay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76665-76630-sauchay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76665-76630-sauchay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76666-76440-saumont_la_poterie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76666-76440-saumont_la_poterie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76666-76440-saumont_la_poterie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76666-76440-saumont_la_poterie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76667-76550-sauqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76667-76550-sauqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76667-76550-sauqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76667-76550-sauqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76668-76760-saussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76668-76760-saussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76668-76760-saussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76668-76760-saussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76669-76110-sausseuzemare_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76669-76110-sausseuzemare_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76669-76110-sausseuzemare_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76669-76110-sausseuzemare_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76670-76400-senneville_sur_fecamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76670-76400-senneville_sur_fecamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76670-76400-senneville_sur_fecamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76670-76400-senneville_sur_fecamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76671-76260-sept_meules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76671-76260-sept_meules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76671-76260-sept_meules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76671-76260-sept_meules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76672-76440-serqueux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76672-76440-serqueux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76672-76440-serqueux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76672-76440-serqueux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76673-76116-servaville_salmonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76673-76116-servaville_salmonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76673-76116-servaville_salmonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76673-76116-servaville_salmonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76675-76690-sierville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76675-76690-sierville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76675-76690-sierville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76675-76690-sierville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76676-76780-sigy_en_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76676-76780-sigy_en_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76676-76780-sigy_en_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76676-76780-sigy_en_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76677-76660-smermesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76677-76660-smermesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76677-76660-smermesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76677-76660-smermesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76678-76440-sommery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76678-76440-sommery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76678-76440-sommery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76678-76440-sommery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76679-76560-sommesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76679-76560-sommesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76679-76560-sommesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76679-76560-sommesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76680-76540-sorquainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76680-76540-sorquainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76680-76540-sorquainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76680-76540-sorquainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76681-76300-sotteville_les_rouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76681-76300-sotteville_les_rouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76681-76300-sotteville_les_rouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76681-76300-sotteville_les_rouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76682-76410-sotteville_sous_le_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76682-76410-sotteville_sous_le_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76682-76410-sotteville_sous_le_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76682-76410-sotteville_sous_le_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76683-76740-sotteville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76683-76740-sotteville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76683-76740-sotteville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76683-76740-sotteville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76684-76430-tancarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76684-76430-tancarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76684-76430-tancarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76684-76430-tancarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76685-76540-therouldeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76685-76540-therouldeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76685-76540-therouldeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76685-76540-therouldeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76686-76540-theuville_aux_maillots/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76686-76540-theuville_aux_maillots/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76686-76540-theuville_aux_maillots/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76686-76540-theuville_aux_maillots/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76688-76540-thiergeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76688-76540-thiergeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76688-76540-thiergeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76688-76540-thiergeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76689-76540-thietreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76689-76540-thietreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76689-76540-thietreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76689-76540-thietreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76690-76730-thil_manneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76690-76730-thil_manneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76690-76730-thil_manneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76690-76730-thil_manneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76691-76440-le_thil_riberpre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76691-76440-le_thil_riberpre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76691-76440-le_thil_riberpre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76691-76440-le_thil_riberpre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76692-76450-thiouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76692-76450-thiouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76692-76450-thiouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76692-76450-thiouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76693-76790-le_tilleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76693-76790-le_tilleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76693-76790-le_tilleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76693-76790-le_tilleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76694-76730-tocqueville_en_caux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76694-76730-tocqueville_en_caux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76694-76730-tocqueville_en_caux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76694-76730-tocqueville_en_caux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76695-76110-tocqueville_les_murs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76695-76110-tocqueville_les_murs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76695-76110-tocqueville_les_murs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76695-76110-tocqueville_les_murs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76697-76590-torcy_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76697-76590-torcy_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76697-76590-torcy_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76697-76590-torcy_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76698-76590-torcy_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76698-76590-torcy_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76698-76590-torcy_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76698-76590-torcy_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76699-76560-le_torp_mesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76699-76560-le_torp_mesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76699-76560-le_torp_mesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76699-76560-le_torp_mesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76700-76890-totes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76700-76890-totes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76700-76890-totes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76700-76890-totes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76702-76190-touffreville_la_corbeline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76702-76190-touffreville_la_corbeline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76702-76190-touffreville_la_corbeline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76702-76190-touffreville_la_corbeline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76703-76910-touffreville_sur_eu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76703-76910-touffreville_sur_eu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76703-76910-touffreville_sur_eu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76703-76910-touffreville_sur_eu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76705-76410-tourville_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76705-76410-tourville_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76705-76410-tourville_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76705-76410-tourville_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76706-76400-tourville_les_ifs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76706-76400-tourville_les_ifs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76706-76400-tourville_les_ifs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76706-76400-tourville_les_ifs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76707-76550-tourville_sur_arques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76707-76550-tourville_sur_arques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76707-76550-tourville_sur_arques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76707-76550-tourville_sur_arques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76708-76400-toussaint/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76708-76400-toussaint/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76708-76400-toussaint/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76708-76400-toussaint/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76709-76580-le_trait/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76709-76580-le_trait/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76709-76580-le_trait/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76709-76580-le_trait/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76710-76640-tremauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76710-76640-tremauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76710-76640-tremauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76710-76640-tremauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76711-76470-le_treport/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76711-76470-le_treport/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76711-76470-le_treport/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76711-76470-le_treport/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76712-76170-la_trinite_du_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76712-76170-la_trinite_du_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76712-76170-la_trinite_du_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76712-76170-la_trinite_du_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76714-76430-les_trois_pierres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76714-76430-les_trois_pierres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76714-76430-les_trois_pierres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76714-76430-les_trois_pierres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76715-76210-trouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76715-76210-trouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76715-76210-trouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76715-76210-trouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76716-76280-turretot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76716-76280-turretot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76716-76280-turretot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76716-76280-turretot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76717-76380-val_de_la_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76717-76380-val_de_la_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76717-76380-val_de_la_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76717-76380-val_de_la_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76718-76190-valliquerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76718-76190-valliquerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76718-76190-valliquerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76718-76190-valliquerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76719-76540-valmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76719-76540-valmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76719-76540-valmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76719-76540-valmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76720-76119-varengeville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76720-76119-varengeville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76720-76119-varengeville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76720-76119-varengeville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76721-76890-varneville_bretteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76721-76890-varneville_bretteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76721-76890-varneville_bretteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76721-76890-varneville_bretteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76723-76890-vassonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76723-76890-vassonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76723-76890-vassonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76723-76890-vassonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76724-76270-vatierville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76724-76270-vatierville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76724-76270-vatierville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76724-76270-vatierville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76725-76110-vattetot_sous_beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76725-76110-vattetot_sous_beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76725-76110-vattetot_sous_beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76725-76110-vattetot_sous_beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76726-76111-vattetot_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76726-76111-vattetot_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76726-76111-vattetot_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76726-76111-vattetot_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76727-76940-vatteville_la_rue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76727-76940-vatteville_la_rue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76727-76940-vatteville_la_rue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76727-76940-vatteville_la_rue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76728-76150-la_vaupaliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76728-76150-la_vaupaliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76728-76150-la_vaupaliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76728-76150-la_vaupaliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76730-76560-veauville_les_quelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76730-76560-veauville_les_quelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76730-76560-veauville_les_quelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76730-76560-veauville_les_quelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76731-76730-venestanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76731-76730-venestanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76731-76730-venestanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76731-76730-venestanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76732-76450-butot_venesville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76732-76450-butot_venesville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76732-76450-butot_venesville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76732-76450-butot_venesville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76733-76680-ventes_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76733-76680-ventes_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76733-76680-ventes_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76733-76680-ventes_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76734-76280-vergetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76734-76280-vergetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76734-76280-vergetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76734-76280-vergetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76735-76980-veules_les_roses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76735-76980-veules_les_roses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76735-76980-veules_les_roses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76735-76980-veules_les_roses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76736-76450-veulettes_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76736-76450-veulettes_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76736-76450-veulettes_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76736-76450-veulettes_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76737-76760-vibeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76737-76760-vibeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76737-76760-vibeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76737-76760-vibeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76738-76750-vieux_manoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76738-76750-vieux_manoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76738-76750-vieux_manoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76738-76750-vieux_manoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76739-76390-vieux_rouen_sur_bresle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76739-76390-vieux_rouen_sur_bresle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76739-76390-vieux_rouen_sur_bresle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76739-76390-vieux_rouen_sur_bresle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76740-76160-la_vieux_rue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76740-76160-la_vieux_rue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76740-76160-la_vieux_rue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76740-76160-la_vieux_rue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76741-76280-villainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76741-76280-villainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76741-76280-villainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76741-76280-villainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76743-76360-villers_ecalles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76743-76360-villers_ecalles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76743-76360-villers_ecalles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76743-76360-villers_ecalles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76744-76340-villers_sous_foucarmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76744-76340-villers_sous_foucarmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76744-76340-villers_sous_foucarmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76744-76340-villers_sous_foucarmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76745-76260-villy_sur_yeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76745-76260-villy_sur_yeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76745-76260-villy_sur_yeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76745-76260-villy_sur_yeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76746-76540-vinnemerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76746-76540-vinnemerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76746-76540-vinnemerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76746-76540-vinnemerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76747-76110-virville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76747-76110-virville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76747-76110-virville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76747-76110-virville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76748-76450-vittefleur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76748-76450-vittefleur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76748-76450-vittefleur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76748-76450-vittefleur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76749-76660-wanchy_capval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76749-76660-wanchy_capval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76749-76660-wanchy_capval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76749-76660-wanchy_capval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76750-76480-yainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76750-76480-yainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76750-76480-yainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76750-76480-yainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76751-76640-yebleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76751-76640-yebleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76751-76640-yebleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76751-76640-yebleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76752-76760-yerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76752-76760-yerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76752-76760-yerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76752-76760-yerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76753-76520-ymare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76753-76520-ymare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76753-76520-ymare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76753-76520-ymare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76754-76111-yport/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76754-76111-yport/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76754-76111-yport/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76754-76111-yport/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76755-76540-ypreville_biville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76755-76540-ypreville_biville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76755-76540-ypreville_biville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76755-76540-ypreville_biville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76756-76690-yquebeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76756-76690-yquebeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76756-76690-yquebeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76756-76690-yquebeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76757-76560-yvecrique/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76757-76560-yvecrique/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76757-76560-yvecrique/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76757-76560-yvecrique/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76758-76190-yvetot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76758-76190-yvetot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76758-76190-yvetot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76758-76190-yvetot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76759-76530-yville_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76759-76530-yville_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76759-76530-yville_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt76-seine_maritime/commune76759-76530-yville_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-77.xml
+++ b/public/sitemaps/sitemap-77.xml
@@ -5,1020 +5,2036 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77001-77760-acheres_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77001-77760-acheres_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77001-77760-acheres_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77001-77760-acheres_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77002-77120-amillis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77002-77120-amillis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77002-77120-amillis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77002-77120-amillis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77003-77760-amponville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77003-77760-amponville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77003-77760-amponville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77003-77760-amponville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77004-77390-andrezel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77004-77390-andrezel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77004-77390-andrezel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77004-77390-andrezel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77005-77410-annet_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77005-77410-annet_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77005-77410-annet_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77005-77410-annet_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77006-77630-arbonne_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77006-77630-arbonne_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77006-77630-arbonne_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77006-77630-arbonne_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77007-77390-argentieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77007-77390-argentieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77007-77390-argentieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77007-77390-argentieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77008-77440-armentieres_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77008-77440-armentieres_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77008-77440-armentieres_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77008-77440-armentieres_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77009-77890-arville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77009-77890-arville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77009-77890-arville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77009-77890-arville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77010-77720-aubepierre_ozouer_le_repos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77010-77720-aubepierre_ozouer_le_repos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77010-77720-aubepierre_ozouer_le_repos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77010-77720-aubepierre_ozouer_le_repos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77011-77570-aufferville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77011-77570-aufferville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77011-77570-aufferville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77011-77570-aufferville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77012-77560-augers_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77012-77560-augers_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77012-77560-augers_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77012-77560-augers_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77013-77120-aulnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77013-77120-aulnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77013-77120-aulnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77013-77120-aulnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77014-77210-avon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77014-77210-avon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77014-77210-avon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77014-77210-avon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77015-77480-baby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77015-77480-baby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77015-77480-baby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77015-77480-baby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77016-77167-bagneaux_sur_loing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77016-77167-bagneaux_sur_loing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77016-77167-bagneaux_sur_loing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77016-77167-bagneaux_sur_loing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77018-77700-bailly_romainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77018-77700-bailly_romainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77018-77700-bailly_romainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77018-77700-bailly_romainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77019-77118-balloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77019-77118-balloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77019-77118-balloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77019-77118-balloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77020-77970-bannost_villegagnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77020-77970-bannost_villegagnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77020-77970-bannost_villegagnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77020-77970-bannost_villegagnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77021-77130-barbey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77021-77130-barbey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77021-77130-barbey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77021-77130-barbey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77022-77630-barbizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77022-77630-barbizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77022-77630-barbizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77022-77630-barbizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77023-77910-barcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77023-77910-barcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77023-77910-barcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77023-77910-barcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77024-77750-bassevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77024-77750-bassevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77024-77750-bassevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77024-77750-bassevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77025-77118-bazoches_les_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77025-77118-bazoches_les_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77025-77118-bazoches_les_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77025-77118-bazoches_les_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77026-77560-beauchery_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77026-77560-beauchery_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77026-77560-beauchery_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77026-77560-beauchery_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77027-77890-beaumont_du_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77027-77890-beaumont_du_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77027-77890-beaumont_du_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77027-77890-beaumont_du_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77029-77390-beauvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77029-77390-beauvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77029-77390-beauvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77029-77390-beauvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77030-77510-bellot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77030-77510-bellot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77030-77510-bellot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77030-77510-bellot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77031-77540-bernay_vilbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77031-77540-bernay_vilbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77031-77540-bernay_vilbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77031-77540-bernay_vilbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77032-77320-beton_bazoches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77032-77320-beton_bazoches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77032-77320-beton_bazoches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77032-77320-beton_bazoches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77033-77970-bezalles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77033-77970-bezalles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77033-77970-bezalles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77033-77970-bezalles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77034-77115-blandy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77034-77115-blandy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77034-77115-blandy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77034-77115-blandy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77035-77940-blennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77035-77940-blennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77035-77940-blennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77035-77940-blennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77036-77970-boisdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77036-77970-boisdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77036-77970-boisdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77036-77970-boisdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77037-77590-bois_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77037-77590-bois_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77037-77590-bois_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77037-77590-bois_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77038-77350-boissettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77038-77350-boissettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77038-77350-boissettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77038-77350-boissettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77039-77350-boissise_la_bertrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77039-77350-boissise_la_bertrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77039-77350-boissise_la_bertrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77039-77350-boissise_la_bertrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77040-77310-boissise_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77040-77310-boissise_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77040-77310-boissise_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77040-77310-boissise_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77041-77760-boissy_aux_cailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77041-77760-boissy_aux_cailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77041-77760-boissy_aux_cailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77041-77760-boissy_aux_cailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77042-77169-boissy_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77042-77169-boissy_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77042-77169-boissy_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77042-77169-boissy_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77043-77750-boitron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77043-77750-boitron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77043-77750-boitron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77043-77750-boitron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77044-77720-bombon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77044-77720-bombon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77044-77720-bombon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77044-77720-bombon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77045-77570-bougligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77045-77570-bougligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77045-77570-bougligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77045-77570-bougligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77046-77760-boulancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77046-77760-boulancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77046-77760-boulancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77046-77760-boulancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77047-77580-bouleurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77047-77580-bouleurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77047-77580-bouleurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77047-77580-bouleurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77048-77780-bourron_marlotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77048-77780-bourron_marlotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77048-77780-bourron_marlotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77048-77780-bourron_marlotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77049-77470-boutigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77049-77470-boutigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77049-77470-boutigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77049-77470-boutigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77050-77620-bransles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77050-77620-bransles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77050-77620-bransles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77050-77620-bransles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77051-77480-bray_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77051-77480-bray_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77051-77480-bray_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77051-77480-bray_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77052-77720-breau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77052-77720-breau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77052-77720-breau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77052-77720-breau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77053-77170-brie_comte_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77053-77170-brie_comte_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77053-77170-brie_comte_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77053-77170-brie_comte_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77054-77940-la_brosse_montceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77054-77940-la_brosse_montceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77054-77940-la_brosse_montceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77054-77940-la_brosse_montceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77055-77177-brou_sur_chantereine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77055-77177-brou_sur_chantereine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77055-77177-brou_sur_chantereine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77055-77177-brou_sur_chantereine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77056-77760-burcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77056-77760-burcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77056-77760-burcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77056-77760-burcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77057-77750-bussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77057-77750-bussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77057-77750-bussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77057-77750-bussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77058-77600-bussy_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77058-77600-bussy_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77058-77600-bussy_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77058-77600-bussy_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77059-77600-bussy_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77059-77600-bussy_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77059-77600-bussy_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77059-77600-bussy_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77060-77760-buthiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77060-77760-buthiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77060-77760-buthiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77060-77760-buthiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77061-77130-cannes_ecluse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77061-77130-cannes_ecluse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77061-77130-cannes_ecluse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77061-77130-cannes_ecluse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77062-77400-carnetin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77062-77400-carnetin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77062-77400-carnetin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77062-77400-carnetin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77063-77515-la_celle_sur_morin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77063-77515-la_celle_sur_morin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77063-77515-la_celle_sur_morin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77063-77515-la_celle_sur_morin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77065-77930-cely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77065-77930-cely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77065-77930-cely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77065-77930-cely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77066-77320-cerneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77066-77320-cerneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77066-77320-cerneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77066-77320-cerneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77067-77240-cesson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77067-77240-cesson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77067-77240-cesson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77067-77240-cesson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77068-77520-cessoy_en_montois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77068-77520-cessoy_en_montois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77068-77520-cessoy_en_montois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77068-77520-cessoy_en_montois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77069-77930-chailly_en_biere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77069-77930-chailly_en_biere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77069-77930-chailly_en_biere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77069-77930-chailly_en_biere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77070-77120-chailly_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77070-77120-chailly_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77070-77120-chailly_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77070-77120-chailly_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77071-77460-chaintreaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77071-77460-chaintreaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77071-77460-chaintreaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77071-77460-chaintreaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77072-77171-chalautre_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77072-77171-chalautre_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77072-77171-chalautre_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77072-77171-chalautre_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77073-77160-chalautre_la_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77073-77160-chalautre_la_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77073-77160-chalautre_la_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77073-77160-chalautre_la_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77075-77144-chalifert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77075-77144-chalifert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77075-77144-chalifert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77075-77144-chalifert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77076-77650-chalmaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77076-77650-chalmaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77076-77650-chalmaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77076-77650-chalmaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77077-77910-chambry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77077-77910-chambry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77077-77910-chambry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77077-77910-chambry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77078-77260-chamigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77078-77260-chamigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77078-77260-chamigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77078-77260-chamigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77079-77430-champagne_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77079-77430-champagne_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77079-77430-champagne_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77079-77430-champagne_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77080-77560-champcenest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77080-77560-champcenest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77080-77560-champcenest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77080-77560-champcenest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77081-77390-champdeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77081-77390-champdeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77081-77390-champdeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77081-77390-champdeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77082-77720-champeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77082-77720-champeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77082-77720-champeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77082-77720-champeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77083-77420-champs_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77083-77420-champs_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77083-77420-champs_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77083-77420-champs_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77084-77660-changis_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77084-77660-changis_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77084-77660-changis_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77084-77660-changis_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77085-77600-chanteloup_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77085-77600-chanteloup_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77085-77600-chanteloup_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77085-77600-chanteloup_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77086-77720-la_chapelle_gauthier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77086-77720-la_chapelle_gauthier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77086-77720-la_chapelle_gauthier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77086-77720-la_chapelle_gauthier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77087-77540-la_chapelle_iger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77087-77540-la_chapelle_iger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77087-77540-la_chapelle_iger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77087-77540-la_chapelle_iger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77088-77760-la_chapelle_la_reine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77088-77760-la_chapelle_la_reine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77088-77760-la_chapelle_la_reine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77088-77760-la_chapelle_la_reine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77089-77370-la_chapelle_rablais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77089-77370-la_chapelle_rablais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77089-77370-la_chapelle_rablais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77089-77370-la_chapelle_rablais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77090-77160-la_chapelle_saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77090-77160-la_chapelle_saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77090-77160-la_chapelle_saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77090-77160-la_chapelle_saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77091-77610-les_chapelles_bourbon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77091-77610-les_chapelles_bourbon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77091-77610-les_chapelles_bourbon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77091-77610-les_chapelles_bourbon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77093-77320-la_chapelle_moutils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77093-77320-la_chapelle_moutils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77093-77320-la_chapelle_moutils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77093-77320-la_chapelle_moutils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77094-77410-charmentray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77094-77410-charmentray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77094-77410-charmentray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77094-77410-charmentray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77095-77410-charny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77095-77410-charny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77095-77410-charny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77095-77410-charny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77096-77590-chartrettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77096-77590-chartrettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77096-77590-chartrettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77096-77590-chartrettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77097-77320-chartronges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77097-77320-chartronges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77097-77320-chartronges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77097-77320-chartronges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77098-77370-chateaubleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77098-77370-chateaubleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77098-77370-chateaubleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77098-77370-chateaubleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77099-77570-chateau_landon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77099-77570-chateau_landon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77099-77570-chateau_landon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77099-77570-chateau_landon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77100-77820-le_chatelet_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77100-77820-le_chatelet_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77100-77820-le_chatelet_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77100-77820-le_chatelet_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77101-77126-chatenay_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77101-77126-chatenay_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77101-77126-chatenay_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77101-77126-chatenay_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77102-77167-chatenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77102-77167-chatenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77102-77167-chatenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77102-77167-chatenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77103-77820-chatillon_la_borde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77103-77820-chatillon_la_borde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77103-77820-chatillon_la_borde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77103-77820-chatillon_la_borde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77104-77610-chatres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77104-77610-chatres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77104-77610-chatres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77104-77610-chatres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77106-77169-chauffry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77106-77169-chauffry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77106-77169-chauffry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77106-77169-chauffry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77107-77390-chaumes_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77107-77390-chaumes_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77107-77390-chaumes_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77107-77390-chaumes_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77108-77500-chelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77108-77500-chelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77108-77500-chelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77108-77500-chelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77109-77160-chenoise_cucharmoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77109-77160-chenoise_cucharmoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77109-77160-chenoise_cucharmoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77109-77160-chenoise_cucharmoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77110-77570-chenou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77110-77570-chenou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77110-77570-chenou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77110-77570-chenou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77111-77700-chessy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77111-77700-chessy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77111-77700-chessy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77111-77700-chessy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77112-77760-chevrainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77112-77760-chevrainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77112-77760-chevrainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77112-77760-chevrainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77113-77320-chevru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77113-77320-chevru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77113-77320-chevru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77113-77320-chevru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77114-77173-chevry_cossigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77114-77173-chevry_cossigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77114-77173-chevry_cossigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77114-77173-chevry_cossigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77115-77710-chevry_en_sereine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77115-77710-chevry_en_sereine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77115-77710-chevry_en_sereine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77115-77710-chevry_en_sereine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77116-77320-choisy_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77116-77320-choisy_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77116-77320-choisy_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77116-77320-choisy_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77117-77730-citry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77117-77730-citry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77117-77730-citry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77117-77730-citry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77118-77410-claye_souilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77118-77410-claye_souilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77118-77410-claye_souilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77118-77410-claye_souilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77119-77370-clos_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77119-77370-clos_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77119-77370-clos_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77119-77370-clos_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77120-77440-cocherel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77120-77440-cocherel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77120-77440-cocherel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77120-77440-cocherel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77121-77090-collegien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77121-77090-collegien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77121-77090-collegien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77121-77090-collegien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77122-77380-combs_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77122-77380-combs_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77122-77380-combs_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77122-77380-combs_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77123-77290-compans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77123-77290-compans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77123-77290-compans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77123-77290-compans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77124-77600-conches_sur_gondoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77124-77600-conches_sur_gondoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77124-77600-conches_sur_gondoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77124-77600-conches_sur_gondoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77125-77450-conde_sainte_libiaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77125-77450-conde_sainte_libiaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77125-77450-conde_sainte_libiaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77125-77450-conde_sainte_libiaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77126-77440-congis_sur_therouanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77126-77440-congis_sur_therouanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77126-77440-congis_sur_therouanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77126-77440-congis_sur_therouanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77127-77170-coubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77127-77170-coubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77127-77170-coubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77127-77170-coubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77128-77860-couilly_pont_aux_dames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77128-77860-couilly_pont_aux_dames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77128-77860-couilly_pont_aux_dames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77128-77860-couilly_pont_aux_dames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77129-77840-coulombs_en_valois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77129-77840-coulombs_en_valois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77129-77840-coulombs_en_valois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77129-77840-coulombs_en_valois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77130-77580-coulommes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77130-77580-coulommes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77130-77580-coulommes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77130-77580-coulommes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77131-77120-coulommiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77131-77120-coulommiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77131-77120-coulommiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77131-77120-coulommiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77132-77700-coupvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77132-77700-coupvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77132-77700-coupvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77132-77700-coupvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77133-77126-courcelles_en_bassee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77133-77126-courcelles_en_bassee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77133-77126-courcelles_en_bassee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77133-77126-courcelles_en_bassee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77134-77560-courchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77134-77560-courchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77134-77560-courchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77134-77560-courchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77135-77540-courpalay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77135-77540-courpalay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77135-77540-courpalay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77135-77540-courpalay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77136-77390-courquetaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77136-77390-courquetaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77136-77390-courquetaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77136-77390-courquetaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77137-77560-courtacon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77137-77560-courtacon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77137-77560-courtacon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77137-77560-courtacon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77138-77390-courtomer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77138-77390-courtomer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77138-77390-courtomer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77138-77390-courtomer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77139-77181-courtry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77139-77181-courtry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77139-77181-courtry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77139-77181-courtry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77140-77154-coutencon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77140-77154-coutencon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77140-77154-coutencon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77140-77154-coutencon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77141-77580-coutevroult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77141-77580-coutevroult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77141-77580-coutevroult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77141-77580-coutevroult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77142-77580-crecy_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77142-77580-crecy_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77142-77580-crecy_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77142-77580-crecy_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77143-77124-cregy_les_meaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77143-77124-cregy_les_meaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77143-77124-cregy_les_meaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77143-77124-cregy_les_meaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77144-77610-crevecoeur_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77144-77610-crevecoeur_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77144-77610-crevecoeur_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77144-77610-crevecoeur_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77145-77390-crisenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77145-77390-crisenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77145-77390-crisenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77145-77390-crisenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77146-77183-croissy_beaubourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77146-77183-croissy_beaubourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77146-77183-croissy_beaubourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77146-77183-croissy_beaubourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77147-77370-la_croix_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77147-77370-la_croix_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77147-77370-la_croix_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77147-77370-la_croix_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77148-77840-crouy_sur_ourcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77148-77840-crouy_sur_ourcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77148-77840-crouy_sur_ourcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77148-77840-crouy_sur_ourcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77150-77165-cuisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77150-77165-cuisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77150-77165-cuisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77150-77165-cuisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77151-77320-dagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77151-77320-dagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77151-77320-dagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77151-77320-dagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77152-77190-dammarie_les_lys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77152-77190-dammarie_les_lys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77152-77190-dammarie_les_lys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77152-77190-dammarie_les_lys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77153-77230-dammartin_en_goele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77153-77230-dammartin_en_goele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77153-77230-dammartin_en_goele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77153-77230-dammartin_en_goele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77154-77163-dammartin_sur_tigeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77154-77163-dammartin_sur_tigeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77154-77163-dammartin_sur_tigeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77154-77163-dammartin_sur_tigeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77155-77400-dampmart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77155-77400-dampmart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77155-77400-dampmart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77155-77400-dampmart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77156-77140-darvault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77156-77140-darvault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77156-77140-darvault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77156-77140-darvault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77157-77440-dhuisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77157-77440-dhuisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77157-77440-dhuisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77157-77440-dhuisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77158-77940-diant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77158-77940-diant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77158-77940-diant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77158-77940-diant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77159-77520-donnemarie_dontilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77159-77520-donnemarie_dontilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77159-77520-donnemarie_dontilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77159-77520-donnemarie_dontilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77161-77130-dormelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77161-77130-dormelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77161-77130-dormelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77161-77130-dormelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77162-77510-doue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77162-77510-doue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77162-77510-doue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77162-77510-doue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77163-77139-douy_la_ramee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77163-77139-douy_la_ramee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77163-77139-douy_la_ramee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77163-77139-douy_la_ramee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77164-77830-echouboulains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77164-77830-echouboulains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77164-77830-echouboulains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77164-77830-echouboulains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77165-77820-les_ecrennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77165-77820-les_ecrennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77165-77820-les_ecrennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77165-77820-les_ecrennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77167-77126-egligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77167-77126-egligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77167-77126-egligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77167-77126-egligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77168-77620-egreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77168-77620-egreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77168-77620-egreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77168-77620-egreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77169-77184-emerainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77169-77184-emerainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77169-77184-emerainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77169-77184-emerainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77171-77450-esbly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77171-77450-esbly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77171-77450-esbly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77171-77450-esbly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77172-77940-esmans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77172-77940-esmans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77172-77940-esmans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77172-77940-esmans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77173-77139-etrepilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77173-77139-etrepilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77173-77139-etrepilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77173-77139-etrepilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77174-77157-everly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77174-77157-everly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77174-77157-everly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77174-77157-everly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77175-77166-evry_gregy_sur_yerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77175-77166-evry_gregy_sur_yerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77175-77166-evry_gregy_sur_yerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77175-77166-evry_gregy_sur_yerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77176-77515-faremoutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77176-77515-faremoutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77176-77515-faremoutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77176-77515-faremoutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77177-77220-favieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77177-77220-favieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77177-77220-favieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77177-77220-favieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77178-77167-faÿ_les_nemours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77178-77167-faÿ_les_nemours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77178-77167-faÿ_les_nemours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77178-77167-faÿ_les_nemours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77179-77133-fericy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77179-77133-fericy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77179-77133-fericy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77179-77133-fericy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77180-77150-ferolles_attilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77180-77150-ferolles_attilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77180-77150-ferolles_attilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77180-77150-ferolles_attilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77181-77164-ferrieres_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77181-77164-ferrieres_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77181-77164-ferrieres_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77181-77164-ferrieres_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77182-77320-la_ferte_gaucher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77182-77320-la_ferte_gaucher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77182-77320-la_ferte_gaucher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77182-77320-la_ferte_gaucher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77183-77260-la_ferte_sous_jouarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77183-77260-la_ferte_sous_jouarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77183-77260-la_ferte_sous_jouarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77183-77260-la_ferte_sous_jouarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77184-77940-flagy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77184-77940-flagy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77184-77940-flagy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77184-77940-flagy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77185-77930-fleury_en_biere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77185-77930-fleury_en_biere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77185-77930-fleury_en_biere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77185-77930-fleury_en_biere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77186-77300-fontainebleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77186-77300-fontainebleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77186-77300-fontainebleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77186-77300-fontainebleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77187-77480-fontaine_fourches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77187-77480-fontaine_fourches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77187-77480-fontaine_fourches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77187-77480-fontaine_fourches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77188-77590-fontaine_le_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77188-77590-fontaine_le_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77188-77590-fontaine_le_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77188-77590-fontaine_le_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77190-77370-fontains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77190-77370-fontains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77190-77370-fontains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77190-77370-fontains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77191-77370-fontenailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77191-77370-fontenailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77191-77370-fontenailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77191-77370-fontenailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77192-77610-fontenay_tresigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77192-77610-fontenay_tresigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77192-77610-fontenay_tresigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77192-77610-fontenay_tresigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77193-77165-forfry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77193-77165-forfry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77193-77165-forfry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77193-77165-forfry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77194-77130-forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77194-77130-forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77194-77130-forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77194-77130-forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77195-77390-fouju/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77195-77390-fouju/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77195-77390-fouju/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77195-77390-fouju/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77196-77410-fresnes_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77196-77410-fresnes_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77196-77410-fresnes_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77196-77410-fresnes_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77197-77320-fretoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77197-77320-fretoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77197-77320-fretoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77197-77320-fretoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77198-77760-fromont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77198-77760-fromont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77198-77760-fromont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77198-77760-fromont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77199-77470-fublaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77199-77470-fublaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77199-77470-fublaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77199-77470-fublaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77200-77890-garentreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77200-77890-garentreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77200-77890-garentreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77200-77890-garentreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77201-77370-gastins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77201-77370-gastins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77201-77370-gastins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77201-77370-gastins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77202-77690-la_genevraye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77202-77690-la_genevraye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77202-77690-la_genevraye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77202-77690-la_genevraye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77203-77910-germigny_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77203-77910-germigny_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77203-77910-germigny_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77203-77910-germigny_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77204-77840-germigny_sous_coulombs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77204-77840-germigny_sous_coulombs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77204-77840-germigny_sous_coulombs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77204-77840-germigny_sous_coulombs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77205-77165-gesvres_le_chapitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77205-77165-gesvres_le_chapitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77205-77165-gesvres_le_chapitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77205-77165-gesvres_le_chapitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77206-77120-giremoutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77206-77120-giremoutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77206-77120-giremoutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77206-77120-giremoutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77207-77890-gironville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77207-77890-gironville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77207-77890-gironville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77207-77890-gironville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77208-77114-gouaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77208-77114-gouaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77208-77114-gouaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77208-77114-gouaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77209-77400-gouvernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77209-77400-gouvernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77209-77400-gouvernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77209-77400-gouvernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77210-77130-la_grande_paroisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77210-77130-la_grande_paroisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77210-77130-la_grande_paroisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77210-77130-la_grande_paroisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77211-77720-grandpuits_bailly_carrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77211-77720-grandpuits_bailly_carrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77211-77720-grandpuits_bailly_carrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77211-77720-grandpuits_bailly_carrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77212-77118-gravon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77212-77118-gravon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77212-77118-gravon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77212-77118-gravon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77214-77410-gressy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77214-77410-gressy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77214-77410-gressy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77214-77410-gressy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77215-77220-gretz_armainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77215-77220-gretz_armainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77215-77220-gretz_armainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77215-77220-gretz_armainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77216-77880-grez_sur_loing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77216-77880-grez_sur_loing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77216-77880-grez_sur_loing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77216-77880-grez_sur_loing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77217-77166-grisy_suisnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77217-77166-grisy_suisnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77217-77166-grisy_suisnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77217-77166-grisy_suisnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77218-77480-grisy_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77218-77480-grisy_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77218-77480-grisy_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77218-77480-grisy_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77219-77580-guerard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77219-77580-guerard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77219-77580-guerard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77219-77580-guerard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77220-77760-guercheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77220-77760-guercheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77220-77760-guercheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77220-77760-guercheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77221-77600-guermantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77221-77600-guermantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77221-77600-guermantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77221-77600-guermantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77222-77390-guignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77222-77390-guignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77222-77390-guignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77222-77390-guignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77223-77520-gurcy_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77223-77520-gurcy_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77223-77520-gurcy_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77223-77520-gurcy_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77224-77515-hautefeuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77224-77515-hautefeuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77224-77515-hautefeuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77224-77515-hautefeuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77225-77580-la_haute_maison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77225-77580-la_haute_maison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77225-77580-la_haute_maison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77225-77580-la_haute_maison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77226-77850-hericy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77226-77850-hericy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77226-77850-hericy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77226-77850-hericy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77227-77114-herme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77227-77114-herme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77227-77114-herme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77227-77114-herme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77228-77510-hondevilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77228-77510-hondevilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77228-77510-hondevilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77228-77510-hondevilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77229-77610-la_houssaye_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77229-77610-la_houssaye_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77229-77610-la_houssaye_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77229-77610-la_houssaye_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77230-77890-ichy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77230-77890-ichy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77230-77890-ichy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77230-77890-ichy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77231-77440-isles_les_meldeuses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77231-77440-isles_les_meldeuses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77231-77440-isles_les_meldeuses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77231-77440-isles_les_meldeuses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77232-77450-isles_les_villenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77232-77450-isles_les_villenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77232-77450-isles_les_villenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77232-77450-isles_les_villenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77233-77165-iverny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77233-77165-iverny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77233-77165-iverny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77233-77165-iverny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77234-77450-jablines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77234-77450-jablines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77234-77450-jablines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77234-77450-jablines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77235-77440-jaignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77235-77440-jaignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77235-77440-jaignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77235-77440-jaignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77236-77480-jaulnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77236-77480-jaulnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77236-77480-jaulnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77236-77480-jaulnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77237-77600-jossigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77237-77600-jossigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77237-77600-jossigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77237-77600-jossigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77238-77640-jouarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77238-77640-jouarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77238-77640-jouarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77238-77640-jouarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77239-77970-jouy_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77239-77970-jouy_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77239-77970-jouy_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77239-77970-jouy_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77240-77320-jouy_sur_morin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77240-77320-jouy_sur_morin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77240-77320-jouy_sur_morin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77240-77320-jouy_sur_morin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77241-77230-juilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77241-77230-juilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77241-77230-juilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77241-77230-juilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77242-77650-jutigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77242-77650-jutigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77242-77650-jutigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77242-77650-jutigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77243-77400-lagny_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77243-77400-lagny_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77243-77400-lagny_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77243-77400-lagny_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77244-77760-larchant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77244-77760-larchant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77244-77760-larchant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77244-77760-larchant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77245-77148-laval_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77245-77148-laval_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77245-77148-laval_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77245-77148-laval_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77246-77171-lechelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77246-77171-lechelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77246-77171-lechelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77246-77171-lechelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77247-77320-lescherolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77247-77320-lescherolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77247-77320-lescherolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77247-77320-lescherolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77248-77450-lesches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77248-77450-lesches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77248-77450-lesches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77248-77450-lesches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77249-77150-lesigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77249-77150-lesigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77249-77150-lesigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77249-77150-lesigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77250-77320-leudon_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77250-77320-leudon_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77250-77320-leudon_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77250-77320-leudon_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77251-77127-lieusaint/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77251-77127-lieusaint/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77251-77127-lieusaint/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77251-77127-lieusaint/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77252-77550-limoges_fourches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77252-77550-limoges_fourches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77252-77550-limoges_fourches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77252-77550-limoges_fourches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77253-77550-lissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77253-77550-lissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77253-77550-lissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77253-77550-lissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77254-77220-liverdy_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77254-77220-liverdy_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77254-77220-liverdy_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77254-77220-liverdy_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77255-77000-livry_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77255-77000-livry_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77255-77000-livry_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77255-77000-livry_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77256-77650-lizines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77256-77650-lizines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77256-77650-lizines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77256-77650-lizines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77257-77440-lizy_sur_ourcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77257-77440-lizy_sur_ourcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77257-77440-lizy_sur_ourcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77257-77440-lizy_sur_ourcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77258-77185-lognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77258-77185-lognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77258-77185-lognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77258-77185-lognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77259-77230-longperrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77259-77230-longperrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77259-77230-longperrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77259-77230-longperrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77260-77650-longueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77260-77650-longueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77260-77650-longueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77260-77650-longueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77261-77710-lorrez_le_bocage_preaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77261-77710-lorrez_le_bocage_preaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77261-77710-lorrez_le_bocage_preaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77261-77710-lorrez_le_bocage_preaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77262-77560-louan_villegruis_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77262-77560-louan_villegruis_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77262-77560-louan_villegruis_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77262-77560-louan_villegruis_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77263-77520-luisetaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77263-77520-luisetaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77263-77520-luisetaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77263-77520-luisetaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77264-77540-lumigny_nesles_ormeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77264-77540-lumigny_nesles_ormeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77264-77540-lumigny_nesles_ormeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77264-77540-lumigny_nesles_ormeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77265-77138-luzancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77265-77138-luzancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77265-77138-luzancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77265-77138-luzancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77266-77133-machault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77266-77133-machault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77266-77133-machault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77266-77133-machault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77267-77570-la_madeleine_sur_loing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77267-77570-la_madeleine_sur_loing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77267-77570-la_madeleine_sur_loing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77267-77570-la_madeleine_sur_loing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77268-77700-magny_le_hongre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77268-77700-magny_le_hongre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77268-77700-magny_le_hongre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77268-77700-magny_le_hongre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77269-77950-maincy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77269-77950-maincy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77269-77950-maincy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77269-77950-maincy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77270-77580-maisoncelles_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77270-77580-maisoncelles_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77270-77580-maisoncelles_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77270-77580-maisoncelles_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77271-77570-maisoncelles_en_gatinais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77271-77570-maisoncelles_en_gatinais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77271-77570-maisoncelles_en_gatinais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77271-77570-maisoncelles_en_gatinais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77272-77370-maison_rouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77272-77370-maison_rouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77272-77370-maison_rouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77272-77370-maison_rouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77273-77230-marchemoret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77273-77230-marchemoret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77273-77230-marchemoret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77273-77230-marchemoret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77274-77139-marcilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77274-77139-marcilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77274-77139-marcilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77274-77139-marcilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77275-77560-les_marets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77275-77560-les_marets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77275-77560-les_marets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77275-77560-les_marets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77276-77100-mareuil_les_meaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77276-77100-mareuil_les_meaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77276-77100-mareuil_les_meaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77276-77100-mareuil_les_meaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77277-77610-marles_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77277-77610-marles_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77277-77610-marles_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77277-77610-marles_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77278-77120-marolles_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77278-77120-marolles_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77278-77120-marolles_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77278-77120-marolles_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77279-77130-marolles_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77279-77130-marolles_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77279-77130-marolles_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77279-77130-marolles_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77280-77440-mary_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77280-77440-mary_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77280-77440-mary_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77280-77440-mary_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77281-77120-mauperthuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77281-77120-mauperthuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77281-77120-mauperthuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77281-77120-mauperthuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77282-77990-mauregard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77282-77990-mauregard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77282-77990-mauregard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77282-77990-mauregard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77283-77145-may_en_multien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77283-77145-may_en_multien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77283-77145-may_en_multien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77283-77145-may_en_multien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77284-77100-meaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77284-77100-meaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77284-77100-meaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77284-77100-meaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77285-77350-le_mee_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77285-77350-le_mee_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77285-77350-le_mee_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77285-77350-le_mee_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77286-77520-meigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77286-77520-meigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77286-77520-meigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77286-77520-meigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77287-77320-meilleray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77287-77320-meilleray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77287-77320-meilleray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77287-77320-meilleray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77288-77000-melun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77288-77000-melun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77288-77000-melun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77288-77000-melun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77289-77171-melz_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77289-77171-melz_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77289-77171-melz_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77289-77171-melz_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77290-77730-mery_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77290-77730-mery_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77290-77730-mery_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77290-77730-mery_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77291-77990-le_mesnil_amelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77291-77990-le_mesnil_amelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77291-77990-le_mesnil_amelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77291-77990-le_mesnil_amelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77292-77410-messy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77292-77410-messy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77292-77410-messy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77292-77410-messy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77293-77130-misy_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77293-77130-misy_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77293-77130-misy_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77293-77130-misy_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77294-77290-mitry_mory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77294-77290-mitry_mory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77294-77290-mitry_mory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77294-77290-mitry_mory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77295-77950-moisenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77295-77950-moisenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77295-77950-moisenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77295-77950-moisenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77296-77550-moissy_cramayel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77296-77550-moissy_cramayel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77296-77550-moissy_cramayel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77296-77550-moissy_cramayel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77297-77570-mondreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77297-77570-mondreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77297-77570-mondreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77297-77570-mondreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77298-77520-mons_en_montois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77298-77520-mons_en_montois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77298-77520-mons_en_montois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77298-77520-mons_en_montois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77300-77470-montceaux_les_meaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77300-77470-montceaux_les_meaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77300-77470-montceaux_les_meaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77300-77470-montceaux_les_meaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77301-77151-montceaux_les_provins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77301-77151-montceaux_les_provins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77301-77151-montceaux_les_provins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77301-77151-montceaux_les_provins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77302-77140-montcourt_fromonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77302-77140-montcourt_fromonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77302-77140-montcourt_fromonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77302-77140-montcourt_fromonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77303-77320-montdauphin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77303-77320-montdauphin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77303-77320-montdauphin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77303-77320-montdauphin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77304-77320-montenils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77304-77320-montenils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77304-77320-montenils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77304-77320-montenils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77305-77130-montereau_fault_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77305-77130-montereau_fault_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77305-77130-montereau_fault_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77305-77130-montereau_fault_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77306-77950-montereau_sur_le_jard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77306-77950-montereau_sur_le_jard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77306-77950-montereau_sur_le_jard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77306-77950-montereau_sur_le_jard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77307-77144-montevrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77307-77144-montevrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77307-77144-montevrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77307-77144-montevrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77308-77230-montge_en_goele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77308-77230-montge_en_goele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77308-77230-montge_en_goele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77308-77230-montge_en_goele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77309-77122-monthyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77309-77122-monthyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77309-77122-monthyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77309-77122-monthyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77310-77480-montigny_le_guesdier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77310-77480-montigny_le_guesdier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77310-77480-montigny_le_guesdier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77310-77480-montigny_le_guesdier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77311-77520-montigny_lencoup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77311-77520-montigny_lencoup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77311-77520-montigny_lencoup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77311-77520-montigny_lencoup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77312-77690-montigny_sur_loing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77312-77690-montigny_sur_loing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77312-77690-montigny_sur_loing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77312-77690-montigny_sur_loing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77313-77940-montmachoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77313-77940-montmachoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77313-77940-montmachoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77313-77940-montmachoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77314-77320-montolivet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77314-77320-montolivet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77314-77320-montolivet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77314-77320-montolivet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77315-77450-montry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77315-77450-montry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77315-77450-montry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77315-77450-montry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77316-77250-moret_loing_et_orvanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77316-77250-moret_loing_et_orvanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77316-77250-moret_loing_et_orvanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77316-77250-moret_loing_et_orvanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77317-77720-mormant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77317-77720-mormant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77317-77720-mormant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77317-77720-mormant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77318-77163-mortcerf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77318-77163-mortcerf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77318-77163-mortcerf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77318-77163-mortcerf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77319-77160-mortery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77319-77160-mortery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77319-77160-mortery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77319-77160-mortery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77320-77120-mouroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77320-77120-mouroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77320-77120-mouroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77320-77120-mouroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77321-77480-mousseaux_les_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77321-77480-mousseaux_les_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77321-77480-mousseaux_les_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77321-77480-mousseaux_les_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77322-77230-moussy_le_neuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77322-77230-moussy_le_neuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77322-77230-moussy_le_neuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77322-77230-moussy_le_neuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77323-77230-moussy_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77323-77230-moussy_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77323-77230-moussy_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77323-77230-moussy_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77325-77480-mouy_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77325-77480-mouy_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77325-77480-mouy_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77325-77480-mouy_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77326-77176-nandy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77326-77176-nandy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77326-77176-nandy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77326-77176-nandy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77327-77370-nangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77327-77370-nangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77327-77370-nangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77327-77370-nangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77328-77760-nanteau_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77328-77760-nanteau_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77328-77760-nanteau_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77328-77760-nanteau_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77329-77710-nanteau_sur_lunain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77329-77710-nanteau_sur_lunain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77329-77710-nanteau_sur_lunain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77329-77710-nanteau_sur_lunain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77330-77100-nanteuil_les_meaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77330-77100-nanteuil_les_meaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77330-77100-nanteuil_les_meaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77330-77100-nanteuil_les_meaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77331-77730-nanteuil_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77331-77730-nanteuil_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77331-77730-nanteuil_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77331-77730-nanteuil_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77332-77230-nantouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77332-77230-nantouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77332-77230-nantouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77332-77230-nantouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77333-77140-nemours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77333-77140-nemours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77333-77140-nemours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77333-77140-nemours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77335-77124-chauconin_neufmontiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77335-77124-chauconin_neufmontiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77335-77124-chauconin_neufmontiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77335-77124-chauconin_neufmontiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77336-77610-neufmoutiers_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77336-77610-neufmoutiers_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77336-77610-neufmoutiers_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77336-77610-neufmoutiers_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77337-77186-noisiel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77337-77186-noisiel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77337-77186-noisiel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77337-77186-noisiel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77338-77940-noisy_rudignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77338-77940-noisy_rudignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77338-77940-noisy_rudignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77338-77940-noisy_rudignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77339-77123-noisy_sur_ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77339-77123-noisy_sur_ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77339-77123-noisy_sur_ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77339-77123-noisy_sur_ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77340-77140-nonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77340-77140-nonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77340-77140-nonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77340-77140-nonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77341-77114-noyen_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77341-77114-noyen_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77341-77114-noyen_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77341-77114-noyen_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77342-77890-obsonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77342-77890-obsonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77342-77890-obsonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77342-77890-obsonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77343-77440-ocquerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77343-77440-ocquerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77343-77440-ocquerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77343-77440-ocquerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77344-77178-oissery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77344-77178-oissery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77344-77178-oissery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77344-77178-oissery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77345-77750-orly_sur_morin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77345-77750-orly_sur_morin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77345-77750-orly_sur_morin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77345-77750-orly_sur_morin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77347-77134-les_ormes_sur_voulzie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77347-77134-les_ormes_sur_voulzie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77347-77134-les_ormes_sur_voulzie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77347-77134-les_ormes_sur_voulzie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77348-77167-ormesson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77348-77167-ormesson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77348-77167-ormesson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77348-77167-ormesson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77349-77280-othis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77349-77280-othis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77349-77280-othis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77349-77280-othis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77350-77330-ozoir_la_ferriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77350-77330-ozoir_la_ferriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77350-77330-ozoir_la_ferriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77350-77330-ozoir_la_ferriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77352-77390-ozouer_le_voulgis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77352-77390-ozouer_le_voulgis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77352-77390-ozouer_le_voulgis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77352-77390-ozouer_le_voulgis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77353-77710-paley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77353-77710-paley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77353-77710-paley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77353-77710-paley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77354-77830-pamfou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77354-77830-pamfou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77354-77830-pamfou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77354-77830-pamfou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77355-77520-paroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77355-77520-paroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77355-77520-paroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77355-77520-paroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77356-77480-passy_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77356-77480-passy_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77356-77480-passy_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77356-77480-passy_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77357-77970-pecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77357-77970-pecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77357-77970-pecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77357-77970-pecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77358-77124-penchard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77358-77124-penchard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77358-77124-penchard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77358-77124-penchard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77359-77930-perthes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77359-77930-perthes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77359-77930-perthes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77359-77930-perthes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77360-77131-pezarches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77360-77131-pezarches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77360-77131-pezarches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77360-77131-pezarches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77361-77580-pierre_levee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77361-77580-pierre_levee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77361-77580-pierre_levee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77361-77580-pierre_levee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77363-77181-le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77363-77181-le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77363-77181-le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77363-77181-le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77364-77165-le_plessis_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77364-77165-le_plessis_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77364-77165-le_plessis_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77364-77165-le_plessis_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77365-77540-le_plessis_feu_aussoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77365-77540-le_plessis_feu_aussoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77365-77540-le_plessis_feu_aussoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77365-77540-le_plessis_feu_aussoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77366-77165-le_plessis_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77366-77165-le_plessis_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77366-77165-le_plessis_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77366-77165-le_plessis_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77367-77440-le_plessis_placy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77367-77440-le_plessis_placy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77367-77440-le_plessis_placy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77367-77440-le_plessis_placy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77368-77160-poigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77368-77160-poigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77368-77160-poigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77368-77160-poigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77369-77470-poincy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77369-77470-poincy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77369-77470-poincy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77369-77470-poincy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77370-77167-poligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77370-77167-poligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77370-77167-poligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77370-77167-poligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77371-77515-pommeuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77371-77515-pommeuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77371-77515-pommeuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77371-77515-pommeuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77372-77400-pomponne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77372-77400-pomponne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77372-77400-pomponne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77372-77400-pomponne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77373-77340-pontault_combault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77373-77340-pontault_combault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77373-77340-pontault_combault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77373-77340-pontault_combault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77374-77135-pontcarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77374-77135-pontcarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77374-77135-pontcarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77374-77135-pontcarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77376-77410-precy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77376-77410-precy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77376-77410-precy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77376-77410-precy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77377-77220-presles_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77377-77220-presles_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77377-77220-presles_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77377-77220-presles_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77378-77310-pringy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77378-77310-pringy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77378-77310-pringy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77378-77310-pringy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77379-77160-provins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77379-77160-provins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77379-77160-provins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77379-77160-provins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77380-77139-puisieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77380-77139-puisieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77380-77139-puisieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77380-77139-puisieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77381-77720-quiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77381-77720-quiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77381-77720-quiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77381-77720-quiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77382-77860-quincy_voisins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77382-77860-quincy_voisins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77382-77860-quincy_voisins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77382-77860-quincy_voisins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77383-77370-rampillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77383-77370-rampillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77383-77370-rampillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77383-77370-rampillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77384-77550-reau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77384-77550-reau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77384-77550-reau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77384-77550-reau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77385-77510-rebais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77385-77510-rebais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77385-77510-rebais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77385-77510-rebais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77386-77760-recloses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77386-77760-recloses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77386-77760-recloses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77386-77760-recloses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77387-77710-remauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77387-77710-remauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77387-77710-remauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77387-77710-remauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77388-77260-reuil_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77388-77260-reuil_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77388-77260-reuil_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77388-77260-reuil_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77389-77000-la_rochette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77389-77000-la_rochette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77389-77000-la_rochette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77389-77000-la_rochette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77390-77680-roissy_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77390-77680-roissy_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77390-77680-roissy_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77390-77680-roissy_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77391-77160-rouilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77391-77160-rouilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77391-77160-rouilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77391-77160-rouilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77392-77230-rouvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77392-77230-rouvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77392-77230-rouvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77392-77230-rouvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77393-77540-rozay_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77393-77540-rozay_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77393-77540-rozay_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77393-77540-rozay_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77394-77950-rubelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77394-77950-rubelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77394-77950-rubelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77394-77950-rubelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77395-77760-rumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77395-77760-rumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77395-77760-rumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77395-77760-rumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77396-77560-rupereux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77396-77560-rupereux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77396-77560-rupereux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77396-77560-rupereux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77397-77730-saacy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77397-77730-saacy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77397-77730-saacy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77397-77730-saacy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77398-77510-sablonnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77398-77510-sablonnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77398-77510-sablonnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77398-77510-sablonnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77400-77515-saint_augustin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77400-77515-saint_augustin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77400-77515-saint_augustin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77400-77515-saint_augustin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77401-77260-sainte_aulde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77401-77260-sainte_aulde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77401-77260-sainte_aulde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77401-77260-sainte_aulde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77402-77320-saint_barthelemy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77402-77320-saint_barthelemy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77402-77320-saint_barthelemy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77402-77320-saint_barthelemy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77403-77160-saint_brice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77403-77160-saint_brice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77403-77160-saint_brice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77403-77160-saint_brice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77404-77650-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77404-77650-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77404-77650-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77404-77650-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77405-77750-saint_cyr_sur_morin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77405-77750-saint_cyr_sur_morin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77405-77750-saint_cyr_sur_morin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77405-77750-saint_cyr_sur_morin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77406-77510-saint_denis_les_rebais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77406-77510-saint_denis_les_rebais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77406-77510-saint_denis_les_rebais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77406-77510-saint_denis_les_rebais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77407-77310-saint_fargeau_ponthierry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77407-77310-saint_fargeau_ponthierry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77407-77310-saint_fargeau_ponthierry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77407-77310-saint_fargeau_ponthierry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77408-77470-saint_fiacre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77408-77470-saint_fiacre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77408-77470-saint_fiacre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77408-77470-saint_fiacre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77409-77130-saint_germain_laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77409-77130-saint_germain_laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77409-77130-saint_germain_laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77409-77130-saint_germain_laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77410-77950-saint_germain_laxis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77410-77950-saint_germain_laxis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77410-77950-saint_germain_laxis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77410-77950-saint_germain_laxis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77411-77169-saint_germain_sous_doue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77411-77169-saint_germain_sous_doue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77411-77169-saint_germain_sous_doue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77411-77169-saint_germain_sous_doue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77412-77930-saint_germain_sur_ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77412-77930-saint_germain_sur_ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77412-77930-saint_germain_sur_ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77412-77930-saint_germain_sur_ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77413-77860-saint_germain_sur_morin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77413-77860-saint_germain_sur_morin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77413-77860-saint_germain_sur_morin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77413-77860-saint_germain_sur_morin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77414-77160-saint_hilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77414-77160-saint_hilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77414-77160-saint_hilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77414-77160-saint_hilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77415-77660-saint_jean_les_deux_jumeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77415-77660-saint_jean_les_deux_jumeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77415-77660-saint_jean_les_deux_jumeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77415-77660-saint_jean_les_deux_jumeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77416-77370-saint_just_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77416-77370-saint_just_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77416-77370-saint_just_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77416-77370-saint_just_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77417-77510-saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77417-77510-saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77417-77510-saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77417-77510-saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77418-77650-saint_loup_de_naud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77418-77650-saint_loup_de_naud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77418-77650-saint_loup_de_naud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77418-77650-saint_loup_de_naud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77419-77670-saint_mammes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77419-77670-saint_mammes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77419-77670-saint_mammes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77419-77670-saint_mammes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77420-77230-saint_mard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77420-77230-saint_mard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77420-77230-saint_mard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77420-77230-saint_mard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77421-77320-saint_mars_vieux_maisons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77421-77320-saint_mars_vieux_maisons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77421-77320-saint_mars_vieux_maisons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77421-77320-saint_mars_vieux_maisons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77423-77320-saint_martin_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77423-77320-saint_martin_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77423-77320-saint_martin_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77423-77320-saint_martin_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77424-77320-saint_martin_du_boschet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77424-77320-saint_martin_du_boschet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77424-77320-saint_martin_du_boschet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77424-77320-saint_martin_du_boschet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77425-77630-saint_martin_en_biere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77425-77630-saint_martin_en_biere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77425-77630-saint_martin_en_biere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77425-77630-saint_martin_en_biere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77426-77720-saint_mery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77426-77720-saint_mery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77426-77720-saint_mery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77426-77720-saint_mery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77427-77410-saint_mesmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77427-77410-saint_mesmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77427-77410-saint_mesmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77427-77410-saint_mesmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77428-77720-saint_ouen_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77428-77720-saint_ouen_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77428-77720-saint_ouen_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77428-77720-saint_ouen_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77429-77750-saint_ouen_sur_morin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77429-77750-saint_ouen_sur_morin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77429-77750-saint_ouen_sur_morin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77429-77750-saint_ouen_sur_morin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77430-77178-saint_pathus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77430-77178-saint_pathus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77430-77178-saint_pathus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77430-77178-saint_pathus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77431-77140-saint_pierre_les_nemours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77431-77140-saint_pierre_les_nemours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77431-77140-saint_pierre_les_nemours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77431-77140-saint_pierre_les_nemours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77432-77320-saint_remy_la_vanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77432-77320-saint_remy_la_vanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77432-77320-saint_remy_la_vanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77432-77320-saint_remy_la_vanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77433-77120-beautheil_saints/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77433-77120-beautheil_saints/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77433-77120-beautheil_saints/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77433-77120-beautheil_saints/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77434-77480-saint_sauveur_les_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77434-77480-saint_sauveur_les_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77434-77480-saint_sauveur_les_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77434-77480-saint_sauveur_les_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77435-77930-saint_sauveur_sur_ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77435-77930-saint_sauveur_sur_ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77435-77930-saint_sauveur_sur_ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77435-77930-saint_sauveur_sur_ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77436-77169-saint_simeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77436-77169-saint_simeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77436-77169-saint_simeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77436-77169-saint_simeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77437-77165-saint_soupplets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77437-77165-saint_soupplets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77437-77165-saint_soupplets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77437-77165-saint_soupplets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77438-77400-saint_thibault_des_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77438-77400-saint_thibault_des_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77438-77400-saint_thibault_des_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77438-77400-saint_thibault_des_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77439-77148-salins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77439-77148-salins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77439-77148-salins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77439-77148-salins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77440-77260-sammeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77440-77260-sammeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77440-77260-sammeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77440-77260-sammeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77441-77920-samois_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77441-77920-samois_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77441-77920-samois_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77441-77920-samois_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77442-77210-samoreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77442-77210-samoreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77442-77210-samoreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77442-77210-samoreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77443-77580-sancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77443-77580-sancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77443-77580-sancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77443-77580-sancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77444-77320-sancy_les_provins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77444-77320-sancy_les_provins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77444-77320-sancy_les_provins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77444-77320-sancy_les_provins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77445-77176-savigny_le_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77445-77176-savigny_le_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77445-77176-savigny_le_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77445-77176-savigny_le_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77446-77650-savins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77446-77650-savins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77446-77650-savins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77446-77650-savins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77447-77240-seine_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77447-77240-seine_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77447-77240-seine_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77447-77240-seine_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77448-77260-sept_sorts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77448-77260-sept_sorts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77448-77260-sept_sorts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77448-77260-sept_sorts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77449-77700-serris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77449-77700-serris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77449-77700-serris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77449-77700-serris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77450-77170-servon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77450-77170-servon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77450-77170-servon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77450-77170-servon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77451-77640-signy_signets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77451-77640-signy_signets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77451-77640-signy_signets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77451-77640-signy_signets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77452-77520-sigy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77452-77520-sigy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77452-77520-sigy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77452-77520-sigy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77453-77115-sivry_courtry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77453-77115-sivry_courtry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77453-77115-sivry_courtry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77453-77115-sivry_courtry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77454-77520-sognolles_en_montois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77454-77520-sognolles_en_montois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77454-77520-sognolles_en_montois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77454-77520-sognolles_en_montois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77455-77111-soignolles_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77455-77111-soignolles_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77455-77111-soignolles_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77455-77111-soignolles_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77456-77650-soisy_bouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77456-77650-soisy_bouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77456-77650-soisy_bouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77456-77650-soisy_bouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77457-77111-solers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77457-77111-solers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77457-77111-solers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77457-77111-solers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77458-77460-souppes_sur_loing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77458-77460-souppes_sur_loing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77458-77460-souppes_sur_loing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77458-77460-souppes_sur_loing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77459-77171-sourdun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77459-77171-sourdun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77459-77171-sourdun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77459-77171-sourdun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77460-77440-tancrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77460-77440-tancrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77460-77440-tancrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77460-77440-tancrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77461-77520-thenisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77461-77520-thenisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77461-77520-thenisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77461-77520-thenisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77462-77230-thieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77462-77230-thieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77462-77230-thieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77462-77230-thieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77463-77810-thomery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77463-77810-thomery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77463-77810-thomery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77463-77810-thomery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77464-77400-thorigny_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77464-77400-thorigny_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77464-77400-thorigny_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77464-77400-thorigny_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77465-77940-thoury_ferottes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77465-77940-thoury_ferottes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77465-77940-thoury_ferottes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77465-77940-thoury_ferottes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77466-77163-tigeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77466-77163-tigeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77466-77163-tigeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77466-77163-tigeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77467-77130-la_tombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77467-77130-la_tombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77467-77130-la_tombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77467-77130-la_tombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77468-77200-torcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77468-77200-torcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77468-77200-torcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77468-77200-torcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77469-77131-touquin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77469-77131-touquin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77469-77131-touquin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77469-77131-touquin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77470-77220-tournan_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77470-77220-tournan_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77470-77220-tournan_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77470-77220-tournan_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77471-77123-tousson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77471-77123-tousson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77471-77123-tousson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77471-77123-tousson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77472-77510-la_tretoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77472-77510-la_tretoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77472-77510-la_tretoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77472-77510-la_tretoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77473-77710-treuzy_levelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77473-77710-treuzy_levelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77473-77710-treuzy_levelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77473-77710-treuzy_levelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77474-77450-trilbardou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77474-77450-trilbardou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77474-77450-trilbardou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77474-77450-trilbardou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77475-77470-trilport/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77475-77470-trilport/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77475-77470-trilport/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77475-77470-trilport/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77476-77440-trocy_en_multien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77476-77440-trocy_en_multien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77476-77440-trocy_en_multien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77476-77440-trocy_en_multien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77477-77760-ury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77477-77760-ury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77477-77760-ury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77477-77760-ury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77478-77260-ussy_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77478-77260-ussy_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77478-77260-ussy_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77478-77260-ussy_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77479-77360-vaires_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77479-77360-vaires_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77479-77360-vaires_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77479-77360-vaires_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77480-77830-valence_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77480-77830-valence_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77480-77830-valence_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77480-77830-valence_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77481-77370-vanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77481-77370-vanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77481-77370-vanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77481-77370-vanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77482-77130-varennes_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77482-77130-varennes_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77482-77130-varennes_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77482-77130-varennes_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77483-77910-varreddes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77483-77910-varreddes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77483-77910-varreddes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77483-77910-varreddes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77484-77580-vaucourtois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77484-77580-vaucourtois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77484-77580-vaucourtois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77484-77580-vaucourtois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77485-77123-le_vaudoue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77485-77123-le_vaudoue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77485-77123-le_vaudoue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77485-77123-le_vaudoue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77486-77141-vaudoy_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77486-77141-vaudoy_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77486-77141-vaudoy_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77486-77141-vaudoy_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77487-77000-vaux_le_penil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77487-77000-vaux_le_penil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77487-77000-vaux_le_penil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77487-77000-vaux_le_penil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77489-77710-vaux_sur_lunain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77489-77710-vaux_sur_lunain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77489-77710-vaux_sur_lunain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77489-77710-vaux_sur_lunain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77490-77440-vendrest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77490-77440-vendrest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77490-77440-vendrest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77490-77440-vendrest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77492-77510-verdelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77492-77510-verdelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77492-77510-verdelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77492-77510-verdelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77493-77390-verneuil_l_etang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77493-77390-verneuil_l_etang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77493-77390-verneuil_l_etang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77493-77390-verneuil_l_etang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77494-77670-vernou_la_celle_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77494-77670-vernou_la_celle_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77494-77670-vernou_la_celle_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77494-77670-vernou_la_celle_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77495-77240-vert_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77495-77240-vert_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77495-77240-vert_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77495-77240-vert_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77496-77370-vieux_champagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77496-77370-vieux_champagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77496-77370-vieux_champagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77496-77370-vieux_champagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77498-77450-vignely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77498-77450-vignely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77498-77450-vignely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77498-77450-vignely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77500-77710-villebeon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77500-77710-villebeon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77500-77710-villebeon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77500-77710-villebeon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77501-77250-villecerf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77501-77250-villecerf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77501-77250-villecerf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77501-77250-villecerf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77504-77710-villemarechal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77504-77710-villemarechal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77504-77710-villemarechal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77504-77710-villemarechal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77505-77470-villemareuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77505-77470-villemareuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77505-77470-villemareuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77505-77470-villemareuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77506-77250-villemer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77506-77250-villemer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77506-77250-villemer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77506-77250-villemer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77507-77480-villenauxe_la_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77507-77480-villenauxe_la_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77507-77480-villenauxe_la_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77507-77480-villenauxe_la_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77508-77174-villeneuve_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77508-77174-villeneuve_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77508-77174-villeneuve_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77508-77174-villeneuve_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77509-77154-villeneuve_les_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77509-77154-villeneuve_les_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77509-77154-villeneuve_les_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77509-77154-villeneuve_les_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77510-77174-villeneuve_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77510-77174-villeneuve_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77510-77174-villeneuve_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77510-77174-villeneuve_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77511-77230-villeneuve_sous_dammartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77511-77230-villeneuve_sous_dammartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77511-77230-villeneuve_sous_dammartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77511-77230-villeneuve_sous_dammartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77512-77510-villeneuve_sur_bellot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77512-77510-villeneuve_sur_bellot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77512-77510-villeneuve_sur_bellot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77512-77510-villeneuve_sur_bellot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77513-77124-villenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77513-77124-villenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77513-77124-villenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77513-77124-villenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77514-77270-villeparisis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77514-77270-villeparisis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77514-77270-villeparisis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77514-77270-villeparisis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77515-77410-villeroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77515-77410-villeroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77515-77410-villeroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77515-77410-villeroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77516-77130-ville_saint_jacques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77516-77130-ville_saint_jacques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77516-77130-ville_saint_jacques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77516-77130-ville_saint_jacques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77517-77410-villevaude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77517-77410-villevaude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77517-77410-villevaude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77517-77410-villevaude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77518-77190-villiers_en_biere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77518-77190-villiers_en_biere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77518-77190-villiers_en_biere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77518-77190-villiers_en_biere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77519-77560-villiers_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77519-77560-villiers_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77519-77560-villiers_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77519-77560-villiers_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77520-77760-villiers_sous_grez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77520-77760-villiers_sous_grez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77520-77760-villiers_sous_grez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77520-77760-villiers_sous_grez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77521-77580-villiers_sur_morin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77521-77580-villiers_sur_morin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77521-77580-villiers_sur_morin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77521-77580-villiers_sur_morin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77522-77114-villiers_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77522-77114-villiers_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77522-77114-villiers_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77522-77114-villiers_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77523-77480-villuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77523-77480-villuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77523-77480-villuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77523-77480-villuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77524-77520-vimpelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77524-77520-vimpelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77524-77520-vimpelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77524-77520-vimpelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77525-77230-vinantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77525-77230-vinantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77525-77230-vinantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77525-77230-vinantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77526-77139-vincy_manoeuvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77526-77139-vincy_manoeuvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77526-77139-vincy_manoeuvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77526-77139-vincy_manoeuvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77527-77540-voinsles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77527-77540-voinsles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77527-77540-voinsles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77527-77540-voinsles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77528-77950-voisenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77528-77950-voisenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77528-77950-voisenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77528-77950-voisenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77529-77580-voulangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77529-77580-voulangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77529-77580-voulangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77529-77580-voulangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77530-77560-voulton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77530-77560-voulton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77530-77560-voulton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77530-77560-voulton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77531-77940-voulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77531-77940-voulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77531-77940-voulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77531-77940-voulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77532-77160-vulaines_les_provins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77532-77160-vulaines_les_provins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77532-77160-vulaines_les_provins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77532-77160-vulaines_les_provins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77533-77870-vulaines_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77533-77870-vulaines_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77533-77870-vulaines_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77533-77870-vulaines_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77534-77390-yebles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77534-77390-yebles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77534-77390-yebles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt77-seine_et_marne/commune77534-77390-yebles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-78.xml
+++ b/public/sitemaps/sitemap-78.xml
@@ -5,556 +5,1108 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78003-78660-ablis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78003-78660-ablis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78003-78660-ablis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78003-78660-ablis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78005-78260-acheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78005-78260-acheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78005-78260-acheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78005-78260-acheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78006-78113-adainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78006-78113-adainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78006-78113-adainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78006-78113-adainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78007-78240-aigremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78007-78240-aigremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78007-78240-aigremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78007-78240-aigremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78009-78660-allainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78009-78660-allainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78009-78660-allainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78009-78660-allainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78010-78580-les_alluets_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78010-78580-les_alluets_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78010-78580-les_alluets_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78010-78580-les_alluets_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78013-78770-andelu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78013-78770-andelu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78013-78770-andelu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78013-78770-andelu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78570-andresy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78570-andresy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78570-andresy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78570-andresy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78260-andresy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78260-andresy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78260-andresy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78260-andresy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78780-andresy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78780-andresy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78780-andresy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78015-78780-andresy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78020-78790-arnouville_les_mantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78020-78790-arnouville_les_mantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78020-78790-arnouville_les_mantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78020-78790-arnouville_les_mantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78029-78410-aubergenville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78029-78410-aubergenville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78029-78410-aubergenville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78029-78410-aubergenville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78030-78610-auffargis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78030-78610-auffargis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78030-78610-auffargis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78030-78610-auffargis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78031-78930-auffreville_brasseuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78031-78930-auffreville_brasseuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78031-78930-auffreville_brasseuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78031-78930-auffreville_brasseuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78033-78126-aulnay_sur_mauldre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78033-78126-aulnay_sur_mauldre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78033-78126-aulnay_sur_mauldre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78033-78126-aulnay_sur_mauldre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78034-78770-auteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78034-78770-auteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78034-78770-auteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78034-78770-auteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78036-78770-autouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78036-78770-autouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78036-78770-autouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78036-78770-autouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78043-78870-bailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78043-78870-bailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78043-78870-bailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78043-78870-bailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78048-78550-bazainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78048-78550-bazainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78048-78550-bazainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78048-78550-bazainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78049-78580-bazemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78049-78580-bazemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78049-78580-bazemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78049-78580-bazemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78050-78490-bazoches_sur_guyonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78050-78490-bazoches_sur_guyonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78050-78490-bazoches_sur_guyonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78050-78490-bazoches_sur_guyonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78053-78910-behoust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78053-78910-behoust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78053-78910-behoust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78053-78910-behoust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78057-78270-bennecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78057-78270-bennecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78057-78270-bennecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78057-78270-bennecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78062-78650-beynes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78062-78650-beynes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78062-78650-beynes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78062-78650-beynes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78068-78270-blaru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78068-78270-blaru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78068-78270-blaru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78068-78270-blaru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78070-78930-boinville_en_mantois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78070-78930-boinville_en_mantois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78070-78930-boinville_en_mantois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78070-78930-boinville_en_mantois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78071-78660-boinville_le_gaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78071-78660-boinville_le_gaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78071-78660-boinville_le_gaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78071-78660-boinville_le_gaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78072-78200-boinvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78072-78200-boinvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78072-78200-boinvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78072-78200-boinvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78073-78390-bois_d_arcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78073-78390-bois_d_arcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78073-78390-bois_d_arcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78073-78390-bois_d_arcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78076-78910-boissets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78076-78910-boissets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78076-78910-boissets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78076-78910-boissets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78077-78125-la_boissiere_ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78077-78125-la_boissiere_ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78077-78125-la_boissiere_ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78077-78125-la_boissiere_ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78082-78200-boissy_mauvoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78082-78200-boissy_mauvoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78082-78200-boissy_mauvoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78082-78200-boissy_mauvoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78084-78490-boissy_sans_avoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78084-78490-boissy_sans_avoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78084-78490-boissy_sans_avoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78084-78490-boissy_sans_avoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78087-78830-bonnelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78087-78830-bonnelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78087-78830-bonnelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78087-78830-bonnelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78089-78270-bonnieres_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78089-78270-bonnieres_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78089-78270-bonnieres_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78089-78270-bonnieres_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78090-78410-bouafle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78090-78410-bouafle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78090-78410-bouafle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78090-78410-bouafle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78090-78130-bouafle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78090-78130-bouafle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78090-78130-bouafle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78090-78130-bouafle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78092-78380-bougival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78092-78380-bougival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78092-78380-bougival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78092-78380-bougival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78096-78113-bourdonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78096-78113-bourdonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78096-78113-bourdonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78096-78113-bourdonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78104-78930-breuil_bois_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78104-78930-breuil_bois_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78104-78930-breuil_bois_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78104-78930-breuil_bois_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78107-78980-breval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78107-78980-breval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78107-78980-breval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78107-78980-breval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78108-78610-les_breviaires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78108-78610-les_breviaires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78108-78610-les_breviaires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78108-78610-les_breviaires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78113-78440-brueil_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78113-78440-brueil_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78113-78440-brueil_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78113-78440-brueil_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78117-78530-buc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78117-78530-buc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78117-78530-buc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78117-78530-buc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78118-78200-buchelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78118-78200-buchelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78118-78200-buchelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78118-78200-buchelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78120-78830-bullion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78120-78830-bullion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78120-78830-bullion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78120-78830-bullion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78123-78955-carrieres_sous_poissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78123-78955-carrieres_sous_poissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78123-78955-carrieres_sous_poissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78123-78955-carrieres_sous_poissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78123-78570-carrieres_sous_poissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78123-78570-carrieres_sous_poissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78123-78570-carrieres_sous_poissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78123-78570-carrieres_sous_poissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78124-78420-carrieres_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78124-78420-carrieres_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78124-78420-carrieres_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78124-78420-carrieres_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78125-78720-la_celle_les_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78125-78720-la_celle_les_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78125-78720-la_celle_les_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78125-78720-la_celle_les_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78126-78170-la_celle_saint_cloud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78126-78170-la_celle_saint_cloud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78126-78170-la_celle_saint_cloud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78126-78170-la_celle_saint_cloud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78128-78720-cernay_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78128-78720-cernay_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78128-78720-cernay_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78128-78720-cernay_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78133-78240-chambourcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78133-78240-chambourcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78133-78240-chambourcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78133-78240-chambourcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78138-78570-chanteloup_les_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78138-78570-chanteloup_les_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78138-78570-chanteloup_les_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78138-78570-chanteloup_les_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78140-78130-chapet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78140-78130-chapet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78140-78130-chapet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78140-78130-chapet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78143-78117-chateaufort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78143-78117-chateaufort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78143-78117-chateaufort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78143-78117-chateaufort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78146-78400-chatou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78146-78400-chatou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78146-78400-chatou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78146-78400-chatou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78146-78110-chatou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78146-78110-chatou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78146-78110-chatou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78146-78110-chatou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78147-78270-chaufour_les_bonnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78147-78270-chaufour_les_bonnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78147-78270-chaufour_les_bonnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78147-78270-chaufour_les_bonnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78152-78450-chavenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78152-78450-chavenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78152-78450-chavenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78152-78450-chavenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78158-78150-le_chesnay_rocquencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78158-78150-le_chesnay_rocquencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78158-78150-le_chesnay_rocquencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78158-78150-le_chesnay_rocquencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78160-78460-chevreuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78160-78460-chevreuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78160-78460-chevreuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78160-78460-chevreuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78162-78460-choisel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78162-78460-choisel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78162-78460-choisel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78162-78460-choisel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78163-78910-civry_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78163-78910-civry_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78163-78910-civry_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78163-78910-civry_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78164-78120-clairefontaine_en_yvelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78164-78120-clairefontaine_en_yvelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78164-78120-clairefontaine_en_yvelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78164-78120-clairefontaine_en_yvelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78165-78340-les_clayes_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78165-78340-les_clayes_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78165-78340-les_clayes_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78165-78340-les_clayes_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78168-78310-coignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78168-78310-coignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78168-78310-coignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78168-78310-coignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78171-78113-conde_sur_vesgre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78171-78113-conde_sur_vesgre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78171-78113-conde_sur_vesgre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78171-78113-conde_sur_vesgre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78172-78700-conflans_sainte_honorine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78172-78700-conflans_sainte_honorine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78172-78700-conflans_sainte_honorine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78172-78700-conflans_sainte_honorine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78185-78790-courgent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78185-78790-courgent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78185-78790-courgent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78185-78790-courgent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78188-78270-cravent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78188-78270-cravent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78188-78270-cravent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78188-78270-cravent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78189-78121-crespieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78189-78121-crespieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78189-78121-crespieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78189-78121-crespieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78190-78290-croissy_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78190-78290-croissy_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78190-78290-croissy_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78190-78290-croissy_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78192-78111-dammartin_en_serve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78192-78111-dammartin_en_serve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78192-78111-dammartin_en_serve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78192-78111-dammartin_en_serve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78193-78720-dampierre_en_yvelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78193-78720-dampierre_en_yvelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78193-78720-dampierre_en_yvelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78193-78720-dampierre_en_yvelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78194-78550-dannemarie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78194-78550-dannemarie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78194-78550-dannemarie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78194-78550-dannemarie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78196-78810-davron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78196-78810-davron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78196-78810-davron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78196-78810-davron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78202-78440-drocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78202-78440-drocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78202-78440-drocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78202-78440-drocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78206-78920-ecquevilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78206-78920-ecquevilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78206-78920-ecquevilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78206-78920-ecquevilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78208-78990-elancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78208-78990-elancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78208-78990-elancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78208-78990-elancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78209-78125-emance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78209-78125-emance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78209-78125-emance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78209-78125-emance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78217-78680-epone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78217-78680-epone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78217-78680-epone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78217-78680-epone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78220-78690-les_essarts_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78220-78690-les_essarts_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78220-78690-les_essarts_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78220-78690-les_essarts_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78224-78620-l_etang_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78224-78620-l_etang_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78224-78620-l_etang_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78224-78620-l_etang_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78227-78740-evecquemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78227-78740-evecquemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78227-78740-evecquemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78227-78740-evecquemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78230-78410-la_falaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78230-78410-la_falaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78230-78410-la_falaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78230-78410-la_falaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78231-78200-favrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78231-78200-favrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78231-78200-favrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78231-78200-favrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78233-78810-feucherolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78233-78810-feucherolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78233-78810-feucherolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78233-78810-feucherolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78234-78200-flacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78234-78200-flacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78234-78200-flacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78234-78200-flacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78236-78910-flexanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78236-78910-flexanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78236-78910-flexanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78236-78910-flexanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78237-78790-flins_neuve_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78237-78790-flins_neuve_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78237-78790-flins_neuve_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78237-78790-flins_neuve_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78238-78410-flins_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78238-78410-flins_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78238-78410-flins_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78238-78410-flins_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78239-78520-follainville_dennemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78239-78520-follainville_dennemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78239-78520-follainville_dennemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78239-78520-follainville_dennemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78242-78330-fontenay_le_fleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78242-78330-fontenay_le_fleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78242-78330-fontenay_le_fleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78242-78330-fontenay_le_fleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78245-78200-fontenay_mauvoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78245-78200-fontenay_mauvoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78245-78200-fontenay_mauvoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78245-78200-fontenay_mauvoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78246-78440-fontenay_saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78246-78440-fontenay_saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78246-78440-fontenay_saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78246-78440-fontenay_saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78255-78840-freneuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78255-78840-freneuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78255-78840-freneuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78255-78840-freneuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78261-78250-gaillon_sur_montcient/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78261-78250-gaillon_sur_montcient/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78261-78250-gaillon_sur_montcient/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78261-78250-gaillon_sur_montcient/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78262-78490-galluis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78262-78490-galluis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78262-78490-galluis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78262-78490-galluis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78263-78950-gambais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78263-78950-gambais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78263-78950-gambais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78263-78950-gambais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78264-78490-gambaiseuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78264-78490-gambaiseuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78264-78490-gambaiseuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78264-78490-gambaiseuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78265-78890-garancieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78265-78890-garancieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78265-78890-garancieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78265-78890-garancieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78267-78440-gargenville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78267-78440-gargenville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78267-78440-gargenville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78267-78440-gargenville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78269-78125-gazeran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78269-78125-gazeran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78269-78125-gazeran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78269-78125-gazeran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78276-78270-gommecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78276-78270-gommecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78276-78270-gommecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78276-78270-gommecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78278-78770-goupillieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78278-78770-goupillieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78278-78770-goupillieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78278-78770-goupillieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78281-78930-goussonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78281-78930-goussonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78281-78930-goussonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78281-78930-goussonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78283-78113-grandchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78283-78113-grandchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78283-78113-grandchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78283-78113-grandchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78285-78550-gressey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78285-78550-gressey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78285-78550-gressey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78285-78550-gressey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78289-78490-grosrouvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78289-78490-grosrouvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78289-78490-grosrouvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78289-78490-grosrouvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78290-78520-guernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78290-78520-guernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78290-78520-guernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78290-78520-guernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78291-78930-guerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78291-78930-guerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78291-78930-guerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78291-78930-guerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78296-78440-guitrancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78296-78440-guitrancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78296-78440-guitrancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78296-78440-guitrancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78297-78280-guyancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78297-78280-guyancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78297-78280-guyancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78297-78280-guyancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78299-78250-hardricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78299-78250-hardricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78299-78250-hardricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78299-78250-hardricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78300-78790-hargeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78300-78790-hargeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78300-78790-hargeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78300-78790-hargeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78302-78113-la_hauteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78302-78113-la_hauteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78302-78113-la_hauteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78302-78113-la_hauteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78305-78580-herbeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78305-78580-herbeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78305-78580-herbeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78305-78580-herbeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78307-78125-hermeray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78307-78125-hermeray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78307-78125-hermeray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78307-78125-hermeray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78310-78550-houdan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78310-78550-houdan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78310-78550-houdan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78310-78550-houdan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78311-78800-houilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78311-78800-houilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78311-78800-houilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78311-78800-houilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78314-78440-issou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78314-78440-issou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78314-78440-issou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78314-78440-issou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78317-78440-jambville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78317-78440-jambville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78317-78440-jambville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78317-78440-jambville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78320-78270-notre_dame_de_la_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78320-78270-notre_dame_de_la_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78320-78270-notre_dame_de_la_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78320-78270-notre_dame_de_la_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78321-78760-jouars_pontchartrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78321-78760-jouars_pontchartrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78321-78760-jouars_pontchartrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78321-78760-jouars_pontchartrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78322-78350-jouy_en_josas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78322-78350-jouy_en_josas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78322-78350-jouy_en_josas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78322-78350-jouy_en_josas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78324-78200-jouy_mauvoisin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78324-78200-jouy_mauvoisin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78324-78200-jouy_mauvoisin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78324-78200-jouy_mauvoisin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78325-78580-jumeauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78325-78580-jumeauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78325-78580-jumeauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78325-78580-jumeauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78327-78820-juziers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78327-78820-juziers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78327-78820-juziers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78327-78820-juziers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78329-78440-lainville_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78329-78440-lainville_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78329-78440-lainville_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78329-78440-lainville_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78334-78320-levis_saint_nom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78334-78320-levis_saint_nom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78334-78320-levis_saint_nom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78334-78320-levis_saint_nom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78334-78690-levis_saint_nom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78334-78690-levis_saint_nom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78334-78690-levis_saint_nom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78334-78690-levis_saint_nom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78335-78520-limay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78335-78520-limay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78335-78520-limay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78335-78520-limay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78337-78270-limetz_villez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78337-78270-limetz_villez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78337-78270-limetz_villez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78337-78270-limetz_villez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78343-78350-les_loges_en_josas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78343-78350-les_loges_en_josas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78343-78350-les_loges_en_josas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78343-78350-les_loges_en_josas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78344-78270-lommoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78344-78270-lommoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78344-78270-lommoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78344-78270-lommoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78346-78980-longnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78346-78980-longnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78346-78980-longnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78346-78980-longnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78349-78730-longvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78349-78730-longvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78349-78730-longvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78349-78730-longvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78350-78430-louveciennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78350-78430-louveciennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78350-78430-louveciennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78350-78430-louveciennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78354-78200-magnanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78354-78200-magnanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78354-78200-magnanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78354-78200-magnanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78356-78114-magny_les_hameaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78356-78114-magny_les_hameaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78356-78114-magny_les_hameaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78356-78114-magny_les_hameaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78358-78600-maisons_laffitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78358-78600-maisons_laffitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78358-78600-maisons_laffitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78358-78600-maisons_laffitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78361-78200-mantes_la_jolie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78361-78200-mantes_la_jolie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78361-78200-mantes_la_jolie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78361-78200-mantes_la_jolie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78362-78711-mantes_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78362-78711-mantes_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78362-78711-mantes_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78362-78711-mantes_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78364-78770-marcq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78364-78770-marcq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78364-78770-marcq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78364-78770-marcq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78366-78490-mareil_le_guyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78366-78490-mareil_le_guyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78366-78490-mareil_le_guyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78366-78490-mareil_le_guyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78367-78750-mareil_marly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78367-78750-mareil_marly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78367-78750-mareil_marly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78367-78750-mareil_marly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78368-78124-mareil_sur_mauldre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78368-78124-mareil_sur_mauldre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78368-78124-mareil_sur_mauldre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78368-78124-mareil_sur_mauldre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78372-78160-marly_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78372-78160-marly_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78372-78160-marly_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78372-78160-marly_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78380-78580-maule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78380-78580-maule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78380-78580-maule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78380-78580-maule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78381-78550-maulette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78381-78550-maulette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78381-78550-maulette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78381-78550-maulette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78382-78780-maurecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78382-78780-maurecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78382-78780-maurecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78382-78780-maurecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78383-78310-maurepas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78383-78310-maurepas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78383-78310-maurepas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78383-78310-maurepas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78384-78670-medan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78384-78670-medan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78384-78670-medan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78384-78670-medan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78385-78200-menerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78385-78200-menerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78385-78200-menerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78385-78200-menerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78389-78490-mere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78389-78490-mere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78389-78490-mere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78389-78490-mere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78391-78270-mericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78391-78270-mericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78391-78270-mericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78391-78270-mericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78396-78600-le_mesnil_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78396-78600-le_mesnil_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78396-78600-le_mesnil_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78396-78600-le_mesnil_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78397-78320-le_mesnil_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78397-78320-le_mesnil_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78397-78320-le_mesnil_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78397-78320-le_mesnil_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78398-78490-les_mesnuls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78398-78490-les_mesnuls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78398-78490-les_mesnuls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78398-78490-les_mesnuls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78401-78250-meulan_en_yvelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78401-78250-meulan_en_yvelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78401-78250-meulan_en_yvelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78401-78250-meulan_en_yvelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78402-78970-mezieres_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78402-78970-mezieres_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78402-78970-mezieres_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78402-78970-mezieres_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78403-78250-mezy_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78403-78250-mezy_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78403-78250-mezy_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78403-78250-mezy_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78404-78940-millemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78404-78940-millemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78404-78940-millemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78404-78940-millemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78406-78470-milon_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78406-78470-milon_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78406-78470-milon_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78406-78470-milon_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78407-78125-mittainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78407-78125-mittainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78407-78125-mittainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78407-78125-mittainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78410-78840-moisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78410-78840-moisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78410-78840-moisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78410-78840-moisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78413-78980-mondreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78413-78980-mondreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78413-78980-mondreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78413-78980-mondreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78415-78124-montainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78415-78124-montainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78415-78124-montainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78415-78124-montainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78416-78440-montalet_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78416-78440-montalet_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78416-78440-montalet_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78416-78440-montalet_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78417-78790-montchauvet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78417-78790-montchauvet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78417-78790-montchauvet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78417-78790-montchauvet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78418-78360-montesson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78418-78360-montesson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78418-78360-montesson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78418-78360-montesson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78420-78490-montfort_l_amaury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78420-78490-montfort_l_amaury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78420-78490-montfort_l_amaury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78420-78490-montfort_l_amaury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78423-78180-montigny_le_bretonneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78423-78180-montigny_le_bretonneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78423-78180-montigny_le_bretonneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78423-78180-montigny_le_bretonneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78431-78630-morainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78431-78630-morainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78431-78630-morainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78431-78630-morainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78437-78270-mousseaux_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78437-78270-mousseaux_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78437-78270-mousseaux_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78437-78270-mousseaux_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78439-78790-mulcent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78439-78790-mulcent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78439-78790-mulcent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78439-78790-mulcent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78440-78130-les_mureaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78440-78130-les_mureaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78440-78130-les_mureaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78440-78130-les_mureaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78442-78640-neauphle_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78442-78640-neauphle_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78442-78640-neauphle_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78442-78640-neauphle_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78443-78640-neauphle_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78443-78640-neauphle_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78443-78640-neauphle_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78443-78640-neauphle_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78444-78980-neauphlette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78444-78980-neauphlette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78444-78980-neauphlette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78444-78980-neauphlette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78451-78410-nezel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78451-78410-nezel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78451-78410-nezel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78451-78410-nezel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78455-78590-noisy_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78455-78590-noisy_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78455-78590-noisy_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78455-78590-noisy_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78460-78250-oinville_sur_montcient/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78460-78250-oinville_sur_montcient/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78460-78250-oinville_sur_montcient/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78460-78250-oinville_sur_montcient/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78464-78125-orcemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78464-78125-orcemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78464-78125-orcemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78464-78125-orcemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78465-78910-orgerus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78465-78910-orgerus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78465-78910-orgerus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78465-78910-orgerus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78466-78630-orgeval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78466-78630-orgeval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78466-78630-orgeval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78466-78630-orgeval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78470-78125-orphin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78470-78125-orphin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78470-78125-orphin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78470-78125-orphin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78472-78660-orsonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78472-78660-orsonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78472-78660-orsonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78472-78660-orsonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78474-78910-orvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78474-78910-orvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78474-78910-orvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78474-78910-orvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78475-78910-osmoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78475-78910-osmoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78475-78910-osmoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78475-78910-osmoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78478-78660-paray_douaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78478-78660-paray_douaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78478-78660-paray_douaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78478-78660-paray_douaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78481-78230-le_pecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78481-78230-le_pecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78481-78230-le_pecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78481-78230-le_pecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78484-78200-perdreauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78484-78200-perdreauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78484-78200-perdreauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78484-78200-perdreauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78486-78610-le_perray_en_yvelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78486-78610-le_perray_en_yvelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78486-78610-le_perray_en_yvelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78486-78610-le_perray_en_yvelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78490-78370-plaisir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78490-78370-plaisir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78490-78370-plaisir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78490-78370-plaisir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78497-78125-poigny_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78497-78125-poigny_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78497-78125-poigny_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78497-78125-poigny_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78498-78300-poissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78498-78300-poissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78498-78300-poissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78498-78300-poissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78499-78730-ponthevrard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78499-78730-ponthevrard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78499-78730-ponthevrard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78499-78730-ponthevrard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78501-78440-porcheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78501-78440-porcheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78501-78440-porcheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78501-78440-porcheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78502-78560-le_port_marly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78502-78560-le_port_marly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78502-78560-le_port_marly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78502-78560-le_port_marly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78502-78380-le_port_marly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78502-78380-le_port_marly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78502-78380-le_port_marly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78502-78380-le_port_marly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78505-78910-prunay_le_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78505-78910-prunay_le_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78505-78910-prunay_le_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78505-78910-prunay_le_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78506-78660-prunay_en_yvelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78506-78660-prunay_en_yvelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78506-78660-prunay_en_yvelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78506-78660-prunay_en_yvelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78513-78940-la_queue_les_yvelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78513-78940-la_queue_les_yvelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78513-78940-la_queue_les_yvelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78513-78940-la_queue_les_yvelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78516-78125-raizeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78516-78125-raizeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78516-78125-raizeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78516-78125-raizeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78517-78120-rambouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78517-78120-rambouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78517-78120-rambouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78517-78120-rambouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78518-78590-rennemoulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78518-78590-rennemoulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78518-78590-rennemoulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78518-78590-rennemoulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78520-78550-richebourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78520-78550-richebourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78520-78550-richebourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78520-78550-richebourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78522-78730-rochefort_en_yvelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78522-78730-rochefort_en_yvelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78522-78730-rochefort_en_yvelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78522-78730-rochefort_en_yvelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78528-78270-rolleboise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78528-78270-rolleboise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78528-78270-rolleboise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78528-78270-rolleboise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78530-78790-rosay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78530-78790-rosay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78530-78790-rosay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78530-78790-rosay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78531-78710-rosny_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78531-78710-rosny_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78531-78710-rosny_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78531-78710-rosny_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78536-78440-sailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78536-78440-sailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78536-78440-sailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78536-78440-sailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78537-78730-saint_arnoult_en_yvelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78537-78730-saint_arnoult_en_yvelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78537-78730-saint_arnoult_en_yvelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78537-78730-saint_arnoult_en_yvelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78545-78210-saint_cyr_l_ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78545-78210-saint_cyr_l_ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78545-78210-saint_cyr_l_ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78545-78210-saint_cyr_l_ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78548-78720-saint_forget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78548-78720-saint_forget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78548-78720-saint_forget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78548-78720-saint_forget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78550-78640-saint_germain_de_la_grange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78550-78640-saint_germain_de_la_grange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78550-78640-saint_germain_de_la_grange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78550-78640-saint_germain_de_la_grange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78100-saint_germain_en_laye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78100-saint_germain_en_laye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78100-saint_germain_en_laye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78100-saint_germain_en_laye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78260-saint_germain_en_laye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78260-saint_germain_en_laye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78260-saint_germain_en_laye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78260-saint_germain_en_laye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78600-saint_germain_en_laye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78600-saint_germain_en_laye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78600-saint_germain_en_laye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78600-saint_germain_en_laye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78700-saint_germain_en_laye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78700-saint_germain_en_laye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78700-saint_germain_en_laye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78700-saint_germain_en_laye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78300-saint_germain_en_laye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78300-saint_germain_en_laye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78300-saint_germain_en_laye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78300-saint_germain_en_laye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78240-saint_germain_en_laye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78240-saint_germain_en_laye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78240-saint_germain_en_laye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78240-saint_germain_en_laye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78112-saint_germain_en_laye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78112-saint_germain_en_laye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78112-saint_germain_en_laye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78551-78112-saint_germain_en_laye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78557-78125-saint_hilarion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78557-78125-saint_hilarion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78557-78125-saint_hilarion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78557-78125-saint_hilarion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78558-78980-saint_illiers_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78558-78980-saint_illiers_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78558-78980-saint_illiers_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78558-78980-saint_illiers_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78559-78980-saint_illiers_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78559-78980-saint_illiers_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78559-78980-saint_illiers_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78559-78980-saint_illiers_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78561-78470-saint_lambert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78561-78470-saint_lambert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78561-78470-saint_lambert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78561-78470-saint_lambert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78562-78610-saint_leger_en_yvelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78562-78610-saint_leger_en_yvelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78562-78610-saint_leger_en_yvelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78562-78610-saint_leger_en_yvelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78564-78660-saint_martin_de_brethencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78564-78660-saint_martin_de_brethencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78564-78660-saint_martin_de_brethencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78564-78660-saint_martin_de_brethencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78565-78790-saint_martin_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78565-78790-saint_martin_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78565-78790-saint_martin_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78565-78790-saint_martin_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78567-78520-saint_martin_la_garenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78567-78520-saint_martin_la_garenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78567-78520-saint_martin_la_garenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78567-78520-saint_martin_la_garenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78569-78730-sainte_mesme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78569-78730-sainte_mesme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78569-78730-sainte_mesme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78569-78730-sainte_mesme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78571-78860-saint_nom_la_breteche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78571-78860-saint_nom_la_breteche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78571-78860-saint_nom_la_breteche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78571-78860-saint_nom_la_breteche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78575-78470-saint_remy_les_chevreuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78575-78470-saint_remy_les_chevreuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78575-78470-saint_remy_les_chevreuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78575-78470-saint_remy_les_chevreuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78576-78690-saint_remy_l_honore/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78576-78690-saint_remy_l_honore/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78576-78690-saint_remy_l_honore/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78576-78690-saint_remy_l_honore/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78586-78500-sartrouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78586-78500-sartrouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78586-78500-sartrouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78586-78500-sartrouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78588-78650-saulx_marchais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78588-78650-saulx_marchais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78588-78650-saulx_marchais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78588-78650-saulx_marchais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78590-78720-senlisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78590-78720-senlisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78590-78720-senlisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78590-78720-senlisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78591-78790-septeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78591-78790-septeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78591-78790-septeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78591-78790-septeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78597-78200-soindres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78597-78200-soindres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78597-78200-soindres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78597-78200-soindres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78601-78120-sonchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78601-78120-sonchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78601-78120-sonchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78601-78120-sonchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78605-78910-tacoignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78605-78910-tacoignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78605-78910-tacoignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78605-78910-tacoignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78606-78113-le_tartre_gaudran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78606-78113-le_tartre_gaudran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78606-78113-le_tartre_gaudran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78606-78113-le_tartre_gaudran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78608-78980-le_tertre_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78608-78980-le_tertre_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78608-78980-le_tertre_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78608-78980-le_tertre_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78609-78250-tessancourt_sur_aubette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78609-78250-tessancourt_sur_aubette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78609-78250-tessancourt_sur_aubette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78609-78250-tessancourt_sur_aubette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78615-78850-thiverval_grignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78615-78850-thiverval_grignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78615-78850-thiverval_grignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78615-78850-thiverval_grignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78616-78770-thoiry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78616-78770-thoiry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78616-78770-thoiry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78616-78770-thoiry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78618-78790-tilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78618-78790-tilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78618-78790-tilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78618-78790-tilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78620-78117-toussus_le_noble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78620-78117-toussus_le_noble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78620-78117-toussus_le_noble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78620-78117-toussus_le_noble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78621-78190-trappes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78621-78190-trappes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78621-78190-trappes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78621-78190-trappes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78623-78490-le_tremblay_sur_mauldre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78623-78490-le_tremblay_sur_mauldre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78623-78490-le_tremblay_sur_mauldre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78623-78490-le_tremblay_sur_mauldre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78624-78510-triel_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78624-78510-triel_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78624-78510-triel_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78624-78510-triel_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78638-78740-vaux_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78638-78740-vaux_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78638-78740-vaux_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78638-78740-vaux_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78640-78140-velizy_villacoublay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78640-78140-velizy_villacoublay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78640-78140-velizy_villacoublay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78640-78140-velizy_villacoublay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78640-78129-velizy_villacoublay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78640-78129-velizy_villacoublay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78640-78129-velizy_villacoublay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78640-78129-velizy_villacoublay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78642-78480-verneuil_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78642-78480-verneuil_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78642-78480-verneuil_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78642-78480-verneuil_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78643-78540-vernouillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78643-78540-vernouillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78643-78540-vernouillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78643-78540-vernouillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78644-78320-la_verriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78644-78320-la_verriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78644-78320-la_verriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78644-78320-la_verriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78646-78000-versailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78646-78000-versailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78646-78000-versailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78646-78000-versailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78647-78930-vert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78647-78930-vert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78647-78930-vert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78647-78930-vert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78650-78110-le_vesinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78650-78110-le_vesinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78650-78110-le_vesinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78650-78110-le_vesinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78650-78400-le_vesinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78650-78400-le_vesinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78650-78400-le_vesinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78650-78400-le_vesinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78653-78490-vicq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78653-78490-vicq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78653-78490-vicq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78653-78490-vicq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78655-78125-vieille_eglise_en_yvelines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78655-78125-vieille_eglise_en_yvelines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78655-78125-vieille_eglise_en_yvelines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78655-78125-vieille_eglise_en_yvelines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78668-78270-la_villeneuve_en_chevrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78668-78270-la_villeneuve_en_chevrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78668-78270-la_villeneuve_en_chevrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78668-78270-la_villeneuve_en_chevrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78672-78670-villennes_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78672-78670-villennes_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78672-78670-villennes_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78672-78670-villennes_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78674-78450-villepreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78674-78450-villepreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78674-78450-villepreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78674-78450-villepreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78674-78590-villepreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78674-78590-villepreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78674-78590-villepreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78674-78590-villepreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78677-78930-villette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78677-78930-villette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78677-78930-villette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78677-78930-villette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78681-78770-villiers_le_mahieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78681-78770-villiers_le_mahieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78681-78770-villiers_le_mahieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78681-78770-villiers_le_mahieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78683-78640-villiers_saint_frederic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78683-78640-villiers_saint_frederic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78683-78640-villiers_saint_frederic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78683-78640-villiers_saint_frederic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78686-78220-viroflay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78686-78220-viroflay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78686-78220-viroflay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78686-78220-viroflay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78688-78960-voisins_le_bretonneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78688-78960-voisins_le_bretonneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78688-78960-voisins_le_bretonneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt78-yvelines/commune78688-78960-voisins_le_bretonneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-79.xml
+++ b/public/sitemaps/sitemap-79.xml
@@ -5,538 +5,1072 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79001-79240-l_absie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79001-79240-l_absie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79001-79240-l_absie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79001-79240-l_absie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79002-79200-adilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79002-79200-adilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79002-79200-adilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79002-79200-adilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79003-79230-aiffres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79003-79230-aiffres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79003-79230-aiffres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79003-79230-aiffres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79005-79600-airvault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79005-79600-airvault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79005-79600-airvault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79005-79600-airvault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79007-79130-allonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79007-79130-allonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79007-79130-allonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79007-79130-allonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79008-79350-amailloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79008-79350-amailloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79008-79350-amailloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79008-79350-amailloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79009-79210-amure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79009-79210-amure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79009-79210-amure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79009-79210-amure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79010-79210-arcais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79010-79210-arcais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79010-79210-arcais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79010-79210-arcais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79012-79160-ardin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79012-79160-ardin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79012-79160-ardin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79012-79160-ardin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79013-79150-argentonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79013-79150-argentonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79013-79150-argentonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79013-79150-argentonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79013-79300-argentonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79013-79300-argentonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79013-79300-argentonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79013-79300-argentonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79014-79290-loretz_d’argenton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79014-79290-loretz_d’argenton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79014-79290-loretz_d’argenton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79014-79290-loretz_d’argenton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79015-79170-asnieres_en_poitou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79015-79170-asnieres_en_poitou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79015-79170-asnieres_en_poitou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79015-79170-asnieres_en_poitou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79016-79600-assais_les_jumeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79016-79600-assais_les_jumeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79016-79600-assais_les_jumeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79016-79600-assais_les_jumeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79018-79110-aubigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79018-79110-aubigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79018-79110-aubigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79018-79110-aubigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79019-79390-aubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79019-79390-aubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79019-79390-aubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79019-79390-aubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79020-79400-auge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79020-79400-auge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79020-79400-auge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79020-79400-auge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79022-79600-availles_thouarsais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79022-79600-availles_thouarsais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79022-79600-availles_thouarsais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79022-79600-availles_thouarsais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79023-79800-avon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79023-79800-avon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79023-79800-avon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79023-79800-avon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79024-79400-azay_le_brule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79024-79400-azay_le_brule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79024-79400-azay_le_brule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79024-79400-azay_le_brule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79025-79130-azay_sur_thouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79025-79130-azay_sur_thouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79025-79130-azay_sur_thouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79025-79130-azay_sur_thouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79029-79420-beaulieu_sous_parthenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79029-79420-beaulieu_sous_parthenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79029-79420-beaulieu_sous_parthenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79029-79420-beaulieu_sous_parthenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79030-79370-beaussais_vitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79030-79370-beaussais_vitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79030-79370-beaussais_vitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79030-79370-beaussais_vitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79031-79360-beauvoir_sur_niort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79031-79360-beauvoir_sur_niort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79031-79360-beauvoir_sur_niort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79031-79360-beauvoir_sur_niort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79032-79160-beceleuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79032-79160-beceleuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79032-79160-beceleuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79032-79160-beceleuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79034-79000-bessines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79034-79000-bessines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79034-79000-bessines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79034-79000-bessines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79038-79300-boisme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79038-79300-boisme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79038-79300-boisme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79038-79300-boisme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79040-79310-la_boissiere_en_gatine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79040-79310-la_boissiere_en_gatine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79040-79310-la_boissiere_en_gatine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79040-79310-la_boissiere_en_gatine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79042-79800-bougon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79042-79800-bougon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79042-79800-bougon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79042-79800-bougon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79046-79210-le_bourdet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79046-79210-le_bourdet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79046-79210-le_bourdet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79046-79210-le_bourdet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79047-79600-boussais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79047-79600-boussais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79047-79600-boussais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79047-79600-boussais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79048-79260-la_creche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79048-79260-la_creche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79048-79260-la_creche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79048-79260-la_creche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79049-79300-bressuire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79049-79300-bressuire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79049-79300-bressuire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79049-79300-bressuire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79050-79140-bretignolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79050-79140-bretignolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79050-79140-bretignolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79050-79140-bretignolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79055-79170-brieuil_sur_chize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79055-79170-brieuil_sur_chize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79055-79170-brieuil_sur_chize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79055-79170-brieuil_sur_chize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79056-79290-brion_pres_thouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79056-79290-brion_pres_thouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79056-79290-brion_pres_thouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79056-79290-brion_pres_thouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79057-79170-brioux_sur_boutonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79057-79170-brioux_sur_boutonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79057-79170-brioux_sur_boutonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79057-79170-brioux_sur_boutonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79058-79230-brulain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79058-79230-brulain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79058-79230-brulain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79058-79230-brulain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79059-79240-le_busseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79059-79240-le_busseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79059-79240-le_busseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79059-79240-le_busseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79060-79190-caunay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79060-79190-caunay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79060-79190-caunay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79060-79190-caunay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79061-79370-celles_sur_belle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79061-79370-celles_sur_belle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79061-79370-celles_sur_belle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79061-79370-celles_sur_belle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79062-79140-cerizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79062-79140-cerizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79062-79140-cerizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79062-79140-cerizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79063-79290-val_en_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79063-79290-val_en_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79063-79290-val_en_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79063-79290-val_en_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79063-79150-val_en_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79063-79150-val_en_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79063-79150-val_en_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79063-79150-val_en_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79064-79500-fontivillie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79064-79500-fontivillie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79064-79500-fontivillie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79064-79500-fontivillie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79064-79110-fontivillie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79064-79110-fontivillie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79064-79110-fontivillie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79064-79110-fontivillie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79066-79220-champdeniers_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79066-79220-champdeniers_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79066-79220-champdeniers_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79066-79220-champdeniers_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79069-79320-chanteloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79069-79320-chanteloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79069-79320-chanteloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79069-79320-chanteloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79070-79220-la_chapelle_baton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79070-79220-la_chapelle_baton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79070-79220-la_chapelle_baton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79070-79220-la_chapelle_baton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79071-79200-la_chapelle_bertrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79071-79200-la_chapelle_bertrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79071-79200-la_chapelle_bertrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79071-79200-la_chapelle_bertrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79074-79190-la_chapelle_pouilloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79074-79190-la_chapelle_pouilloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79074-79190-la_chapelle_pouilloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79074-79190-la_chapelle_pouilloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79076-79430-la_chapelle_saint_laurent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79076-79430-la_chapelle_saint_laurent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79076-79430-la_chapelle_saint_laurent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79076-79430-la_chapelle_saint_laurent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79077-79160-beugnon_thireuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79077-79160-beugnon_thireuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79077-79160-beugnon_thireuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79077-79160-beugnon_thireuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79077-79130-beugnon_thireuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79077-79130-beugnon_thireuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79077-79130-beugnon_thireuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79077-79130-beugnon_thireuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79078-79360-plaine_d_argenson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79078-79360-plaine_d_argenson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79078-79360-plaine_d_argenson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79078-79360-plaine_d_argenson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79079-79700-mauleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79079-79700-mauleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79079-79700-mauleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79079-79700-mauleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79080-79200-chatillon_sur_thouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79080-79200-chatillon_sur_thouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79080-79200-chatillon_sur_thouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79080-79200-chatillon_sur_thouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79081-79180-chauray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79081-79180-chauray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79081-79180-chauray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79081-79180-chauray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79083-79110-chef_boutonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79083-79110-chef_boutonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79083-79110-chef_boutonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79083-79110-chef_boutonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79084-79120-chenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79084-79120-chenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79084-79120-chenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79084-79120-chenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79085-79170-cherigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79085-79170-cherigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79085-79170-cherigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79085-79170-cherigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79086-79410-cherveux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79086-79410-cherveux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79086-79410-cherveux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79086-79410-cherveux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79087-79120-chey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79087-79120-chey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79087-79120-chey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79087-79120-chey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79088-79350-chiche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79088-79350-chiche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79088-79350-chiche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79088-79350-chiche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79089-79600-le_chillou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79089-79600-le_chillou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79089-79600-le_chillou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79089-79600-le_chillou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79090-79170-chize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79090-79170-chize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79090-79170-chize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79090-79170-chize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79091-79140-cirieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79091-79140-cirieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79091-79140-cirieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79091-79140-cirieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79092-79420-clave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79092-79420-clave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79092-79420-clave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79092-79420-clave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79094-79350-clesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79094-79350-clesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79094-79350-clesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79094-79350-clesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79095-79190-clussais_la_pommeraie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79095-79190-clussais_la_pommeraie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79095-79190-clussais_la_pommeraie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79095-79190-clussais_la_pommeraie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79096-79140-combrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79096-79140-combrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79096-79140-combrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79096-79140-combrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79100-79510-coulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79100-79510-coulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79100-79510-coulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79100-79510-coulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79101-79160-coulonges_sur_l_autize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79101-79160-coulonges_sur_l_autize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79101-79160-coulonges_sur_l_autize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79101-79160-coulonges_sur_l_autize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79102-79330-coulonges_thouarsais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79102-79330-coulonges_thouarsais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79102-79330-coulonges_thouarsais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79102-79330-coulonges_thouarsais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79103-79440-courlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79103-79440-courlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79103-79440-courlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79103-79440-courlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79104-79220-cours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79104-79220-cours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79104-79220-cours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79104-79220-cours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79105-79340-les_chateliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79105-79340-les_chateliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79105-79340-les_chateliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79105-79340-les_chateliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79106-79110-couture_d_argenson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79106-79110-couture_d_argenson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79106-79110-couture_d_argenson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79106-79110-couture_d_argenson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79108-79390-doux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79108-79390-doux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79108-79390-doux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79108-79390-doux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79109-79410-echire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79109-79410-echire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79109-79410-echire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79109-79410-echire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79111-79170-ensigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79111-79170-ensigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79111-79170-ensigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79111-79170-ensigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79112-79270-epannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79112-79270-epannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79112-79270-epannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79112-79270-epannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79114-79400-exireuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79114-79400-exireuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79114-79400-exireuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79114-79400-exireuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79115-79800-exoudun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79115-79800-exoudun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79115-79800-exoudun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79115-79800-exoudun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79116-79350-faye_l_abbesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79116-79350-faye_l_abbesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79116-79350-faye_l_abbesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79116-79350-faye_l_abbesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79117-79160-faye_sur_ardin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79117-79160-faye_sur_ardin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79117-79160-faye_sur_ardin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79117-79160-faye_sur_ardin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79118-79450-fenery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79118-79450-fenery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79118-79450-fenery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79118-79450-fenery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79119-79160-fenioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79119-79160-fenioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79119-79160-fenioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79119-79160-fenioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79120-79390-la_ferriere_en_parthenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79120-79390-la_ferriere_en_parthenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79120-79390-la_ferriere_en_parthenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79120-79390-la_ferriere_en_parthenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79121-79340-fomperron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79121-79340-fomperron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79121-79340-fomperron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79121-79340-fomperron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79122-79110-fontenille_saint_martin_d_entraigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79122-79110-fontenille_saint_martin_d_entraigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79122-79110-fontenille_saint_martin_d_entraigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79122-79110-fontenille_saint_martin_d_entraigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79123-79380-la_foret_sur_sevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79123-79380-la_foret_sur_sevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79123-79380-la_foret_sur_sevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79123-79380-la_foret_sur_sevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79124-79340-les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79124-79340-les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79124-79340-les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79124-79340-les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79125-79230-fors/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79125-79230-fors/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79125-79230-fors/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79125-79230-fors/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79126-79360-les_fosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79126-79360-les_fosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79126-79360-les_fosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79126-79360-les_fosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79127-79360-la_foye_monjault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79127-79360-la_foye_monjault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79127-79360-la_foye_monjault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79127-79360-la_foye_monjault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79128-79260-francois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79128-79260-francois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79128-79260-francois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79128-79260-francois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79129-79370-fressines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79129-79370-fressines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79129-79370-fressines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79129-79370-fressines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79130-79270-frontenay_rohan_rohan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79130-79270-frontenay_rohan_rohan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79130-79270-frontenay_rohan_rohan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79130-79270-frontenay_rohan_rohan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79131-79330-geay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79131-79330-geay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79131-79330-geay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79131-79330-geay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79132-79150-genneton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79132-79150-genneton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79132-79150-genneton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79132-79150-genneton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79133-79220-germond_rouvre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79133-79220-germond_rouvre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79133-79220-germond_rouvre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79133-79220-germond_rouvre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79134-79330-glenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79134-79330-glenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79134-79330-glenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79134-79330-glenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79135-79200-gourge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79135-79200-gourge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79135-79200-gourge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79135-79200-gourge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79136-79110-alloinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79136-79110-alloinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79136-79110-alloinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79136-79110-alloinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79136-79190-alloinay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79136-79190-alloinay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79136-79190-alloinay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79136-79190-alloinay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79137-79360-granzay_gript/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79137-79360-granzay_gript/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79137-79360-granzay_gript/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79137-79360-granzay_gript/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79139-79220-les_groseillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79139-79220-les_groseillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79139-79220-les_groseillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79139-79220-les_groseillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79140-79110-valdelaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79140-79110-valdelaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79140-79110-valdelaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79140-79110-valdelaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79141-79600-irais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79141-79600-irais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79141-79600-irais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79141-79600-irais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79142-79170-juille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79142-79170-juille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79142-79170-juille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79142-79170-juille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79144-79230-juscorps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79144-79230-juscorps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79144-79230-juscorps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79144-79230-juscorps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79145-79200-lageon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79145-79200-lageon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79145-79200-lageon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79145-79200-lageon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79147-79240-largeasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79147-79240-largeasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79147-79240-largeasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79147-79240-largeasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79148-79120-lezay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79148-79120-lezay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79148-79120-lezay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79148-79120-lezay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79149-79390-lhoumois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79149-79390-lhoumois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79149-79390-lhoumois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79149-79390-lhoumois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79150-79190-limalonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79150-79190-limalonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79150-79190-limalonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79150-79190-limalonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79152-79190-lorigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79152-79190-lorigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79152-79190-lorigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79152-79190-lorigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79153-79110-loubigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79153-79110-loubigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79153-79110-loubigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79153-79110-loubigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79154-79110-loubille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79154-79110-loubille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79154-79110-loubille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79154-79110-loubille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79156-79600-louin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79156-79600-louin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79156-79600-louin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79156-79600-louin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79157-79100-louzy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79157-79100-louzy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79157-79100-louzy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79157-79100-louzy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79158-79170-luche_sur_brioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79158-79170-luche_sur_brioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79158-79170-luche_sur_brioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79158-79170-luche_sur_brioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79159-79330-luche_thouarsais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79159-79330-luche_thouarsais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79159-79330-luche_thouarsais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79159-79330-luche_thouarsais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79160-79170-lusseray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79160-79170-lusseray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79160-79170-lusseray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79160-79170-lusseray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79161-79100-luzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79161-79100-luzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79161-79100-luzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79161-79100-luzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79162-79460-magne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79162-79460-magne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79162-79460-magne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79162-79460-magne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79163-79190-maire_levescault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79163-79190-maire_levescault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79163-79190-maire_levescault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79163-79190-maire_levescault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79164-79500-maisonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79164-79500-maisonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79164-79500-maisonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79164-79500-maisonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79165-79600-maisontiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79165-79600-maisontiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79165-79600-maisontiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79165-79600-maisontiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79166-79360-marigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79166-79360-marigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79166-79360-marigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79166-79360-marigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79167-79600-marnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79167-79600-marnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79167-79600-marnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79167-79600-marnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79170-79210-mauze_sur_le_mignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79170-79210-mauze_sur_le_mignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79170-79210-mauze_sur_le_mignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79170-79210-mauze_sur_le_mignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79172-79310-mazieres_en_gatine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79172-79310-mazieres_en_gatine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79172-79310-mazieres_en_gatine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79172-79310-mazieres_en_gatine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79174-79500-melle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79174-79500-melle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79174-79500-melle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79174-79500-melle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79175-79190-melleran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79175-79190-melleran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79175-79190-melleran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79175-79190-melleran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79176-79340-menigoute/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79176-79340-menigoute/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79176-79340-menigoute/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79176-79340-menigoute/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79177-79120-messe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79177-79120-messe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79177-79120-messe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79177-79120-messe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79320-moncoutant_sur_sevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79320-moncoutant_sur_sevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79320-moncoutant_sur_sevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79320-moncoutant_sur_sevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79240-moncoutant_sur_sevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79240-moncoutant_sur_sevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79240-moncoutant_sur_sevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79240-moncoutant_sur_sevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79380-moncoutant_sur_sevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79380-moncoutant_sur_sevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79380-moncoutant_sur_sevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79179-79380-moncoutant_sur_sevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79180-79190-montalembert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79180-79190-montalembert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79180-79190-montalembert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79180-79190-montalembert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79183-79140-montravers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79183-79140-montravers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79183-79140-montravers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79183-79140-montravers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79184-79800-la_mothe_saint_heray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79184-79800-la_mothe_saint_heray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79184-79800-la_mothe_saint_heray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79184-79800-la_mothe_saint_heray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79185-79370-aigondigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79185-79370-aigondigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79185-79370-aigondigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79185-79370-aigondigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79189-79400-nanteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79189-79400-nanteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79189-79400-nanteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79189-79400-nanteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79190-79130-neuvy_bouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79190-79130-neuvy_bouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79190-79130-neuvy_bouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79190-79130-neuvy_bouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79191-79000-niort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79191-79000-niort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79191-79000-niort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79191-79000-niort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79195-79250-nueil_les_aubiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79195-79250-nueil_les_aubiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79195-79250-nueil_les_aubiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79195-79250-nueil_les_aubiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79196-79100-plaine_et_vallees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79196-79100-plaine_et_vallees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79196-79100-plaine_et_vallees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79196-79100-plaine_et_vallees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79196-79600-plaine_et_vallees/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79196-79600-plaine_et_vallees/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79196-79600-plaine_et_vallees/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79196-79600-plaine_et_vallees/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79197-79390-oroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79197-79390-oroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79197-79390-oroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79197-79390-oroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79198-79170-paizay_le_chapt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79198-79170-paizay_le_chapt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79198-79170-paizay_le_chapt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79198-79170-paizay_le_chapt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79200-79220-pamplie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79200-79220-pamplie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79200-79220-pamplie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79200-79220-pamplie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79201-79800-pamproux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79201-79800-pamproux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79201-79800-pamproux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79201-79800-pamproux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79202-79200-parthenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79202-79200-parthenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79202-79200-parthenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79202-79200-parthenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79203-79100-pas_de_jeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79203-79100-pas_de_jeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79203-79100-pas_de_jeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79203-79100-pas_de_jeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79204-79170-perigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79204-79170-perigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79204-79170-perigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79204-79170-perigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79205-79190-pers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79205-79190-pers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79205-79190-pers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79205-79190-pers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79207-79700-la_petite_boissiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79207-79700-la_petite_boissiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79207-79700-la_petite_boissiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79207-79700-la_petite_boissiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79208-79200-la_peyratte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79208-79200-la_peyratte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79208-79200-la_peyratte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79208-79200-la_peyratte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79209-79330-pierrefitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79209-79330-pierrefitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79209-79330-pierrefitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79209-79330-pierrefitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79210-79140-le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79210-79140-le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79210-79140-le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79210-79140-le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79212-79190-pliboux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79212-79190-pliboux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79212-79190-pliboux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79212-79190-pliboux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79213-79200-pompaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79213-79200-pompaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79213-79200-pompaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79213-79200-pompaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79215-79130-pougne_herisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79215-79130-pougne_herisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79215-79130-pougne_herisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79215-79130-pougne_herisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79216-79230-prahecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79216-79230-prahecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79216-79230-prahecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79216-79230-prahecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79217-79370-prailles_la_couarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79217-79370-prailles_la_couarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79217-79370-prailles_la_couarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79217-79370-prailles_la_couarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79217-79800-prailles_la_couarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79217-79800-prailles_la_couarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79217-79800-prailles_la_couarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79217-79800-prailles_la_couarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79218-79390-pressigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79218-79390-pressigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79218-79390-pressigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79218-79390-pressigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79220-79210-prin_deyrancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79220-79210-prin_deyrancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79220-79210-prin_deyrancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79220-79210-prin_deyrancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79223-79160-puihardy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79223-79160-puihardy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79223-79160-puihardy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79223-79160-puihardy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79225-79420-reffannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79225-79420-reffannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79225-79420-reffannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79225-79420-reffannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79226-79130-le_retail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79226-79130-le_retail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79226-79130-le_retail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79226-79130-le_retail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79229-79270-la_rochenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79229-79270-la_rochenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79229-79270-la_rochenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79229-79270-la_rochenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79230-79120-rom/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79230-79120-rom/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79230-79120-rom/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79230-79120-rom/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79231-79260-romans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79231-79260-romans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79231-79260-romans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79231-79260-romans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79235-79700-saint_amand_sur_sevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79235-79700-saint_amand_sur_sevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79235-79700-saint_amand_sur_sevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79235-79700-saint_amand_sur_sevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79236-79380-saint_andre_sur_sevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79236-79380-saint_andre_sur_sevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79236-79380-saint_andre_sur_sevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79236-79380-saint_andre_sur_sevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79238-79300-saint_aubin_du_plain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79238-79300-saint_aubin_du_plain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79238-79300-saint_aubin_du_plain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79238-79300-saint_aubin_du_plain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79239-79450-saint_aubin_le_cloud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79239-79450-saint_aubin_le_cloud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79239-79450-saint_aubin_le_cloud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79239-79450-saint_aubin_le_cloud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79241-79220-saint_christophe_sur_roc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79241-79220-saint_christophe_sur_roc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79241-79220-saint_christophe_sur_roc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79241-79220-saint_christophe_sur_roc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79242-79150-voulmentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79242-79150-voulmentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79242-79150-voulmentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79242-79150-voulmentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79243-79120-saint_coutant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79243-79120-saint_coutant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79243-79120-saint_coutant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79243-79120-saint_coutant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79244-79100-saint_cyr_la_lande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79244-79100-saint_cyr_la_lande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79244-79100-saint_cyr_la_lande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79244-79100-saint_cyr_la_lande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79246-79800-sainte_eanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79246-79800-sainte_eanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79246-79800-sainte_eanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79246-79800-sainte_eanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79249-79410-saint_gelais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79249-79410-saint_gelais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79249-79410-saint_gelais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79249-79410-saint_gelais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79250-79330-sainte_gemme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79250-79330-sainte_gemme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79250-79330-sainte_gemme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79250-79330-sainte_gemme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79251-79500-marcille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79251-79500-marcille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79251-79500-marcille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79251-79500-marcille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79252-79600-saint_generoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79252-79600-saint_generoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79252-79600-saint_generoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79252-79600-saint_generoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79253-79400-saint_georges_de_noisne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79253-79400-saint_georges_de_noisne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79253-79400-saint_georges_de_noisne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79253-79400-saint_georges_de_noisne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79254-79210-saint_georges_de_rex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79254-79210-saint_georges_de_rex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79254-79210-saint_georges_de_rex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79254-79210-saint_georges_de_rex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79255-79200-saint_germain_de_longue_chaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79255-79200-saint_germain_de_longue_chaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79255-79200-saint_germain_de_longue_chaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79255-79200-saint_germain_de_longue_chaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79256-79340-saint_germier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79256-79340-saint_germier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79256-79340-saint_germier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79256-79340-saint_germier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79257-79210-saint_hilaire_la_palud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79257-79210-saint_hilaire_la_palud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79257-79210-saint_hilaire_la_palud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79257-79210-saint_hilaire_la_palud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79258-79100-saint_jacques_de_thouars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79258-79100-saint_jacques_de_thouars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79258-79100-saint_jacques_de_thouars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79258-79100-saint_jacques_de_thouars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79259-79100-saint_jean_de_thouars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79259-79100-saint_jean_de_thouars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79259-79100-saint_jean_de_thouars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79259-79100-saint_jean_de_thouars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79263-79160-saint_laurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79263-79160-saint_laurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79263-79160-saint_laurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79263-79160-saint_laurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79265-79100-saint_leger_de_montbrun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79265-79100-saint_leger_de_montbrun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79265-79100-saint_leger_de_montbrun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79265-79100-saint_leger_de_montbrun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79267-79420-saint_lin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79267-79420-saint_lin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79267-79420-saint_lin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79267-79420-saint_lin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79268-79600-saint_loup_lamaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79268-79600-saint_loup_lamaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79268-79600-saint_loup_lamaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79268-79600-saint_loup_lamaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79269-79160-saint_maixent_de_beugne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79269-79160-saint_maixent_de_beugne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79269-79160-saint_maixent_de_beugne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79269-79160-saint_maixent_de_beugne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79270-79400-saint_maixent_l_ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79270-79400-saint_maixent_l_ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79270-79400-saint_maixent_l_ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79270-79400-saint_maixent_l_ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79271-79310-saint_marc_la_lande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79271-79310-saint_marc_la_lande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79271-79310-saint_marc_la_lande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79271-79310-saint_marc_la_lande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79273-79230-saint_martin_de_bernegoue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79273-79230-saint_martin_de_bernegoue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79273-79230-saint_martin_de_bernegoue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79273-79230-saint_martin_de_bernegoue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79274-79100-saint_martin_de_macon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79274-79100-saint_martin_de_macon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79274-79100-saint_martin_de_macon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79274-79100-saint_martin_de_macon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79276-79400-saint_martin_de_saint_maixent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79276-79400-saint_martin_de_saint_maixent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79276-79400-saint_martin_de_saint_maixent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79276-79400-saint_martin_de_saint_maixent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79277-79290-saint_martin_de_sanzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79277-79290-saint_martin_de_sanzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79277-79290-saint_martin_de_sanzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79277-79290-saint_martin_de_sanzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79278-79420-saint_martin_du_fouilloux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79278-79420-saint_martin_du_fouilloux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79278-79420-saint_martin_du_fouilloux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79278-79420-saint_martin_du_fouilloux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79280-79150-saint_maurice_etusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79280-79150-saint_maurice_etusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79280-79150-saint_maurice_etusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79280-79150-saint_maurice_etusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79281-79410-saint_maxire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79281-79410-saint_maxire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79281-79410-saint_maxire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79281-79410-saint_maxire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79283-79260-sainte_neomaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79283-79260-sainte_neomaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79283-79260-sainte_neomaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79283-79260-sainte_neomaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79284-79220-sainte_ouenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79284-79220-sainte_ouenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79284-79220-sainte_ouenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79284-79220-sainte_ouenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79285-79310-saint_pardoux_soutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79285-79310-saint_pardoux_soutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79285-79310-saint_pardoux_soutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79285-79310-saint_pardoux_soutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79286-79240-saint_paul_en_gatine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79286-79240-saint_paul_en_gatine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79286-79240-saint_paul_en_gatine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79286-79240-saint_paul_en_gatine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79289-79700-saint_pierre_des_echaubrognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79289-79700-saint_pierre_des_echaubrognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79289-79700-saint_pierre_des_echaubrognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79289-79700-saint_pierre_des_echaubrognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79290-79160-saint_pompain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79290-79160-saint_pompain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79290-79160-saint_pompain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79290-79160-saint_pompain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79293-79410-saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79293-79410-saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79293-79410-saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79293-79410-saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79294-79230-saint_romans_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79294-79230-saint_romans_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79294-79230-saint_romans_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79294-79230-saint_romans_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79295-79500-saint_romans_les_melle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79295-79500-saint_romans_les_melle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79295-79500-saint_romans_les_melle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79295-79500-saint_romans_les_melle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79297-79120-sainte_soline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79297-79120-sainte_soline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79297-79120-sainte_soline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79297-79120-sainte_soline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79298-79270-saint_symphorien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79298-79270-saint_symphorien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79298-79270-saint_symphorien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79298-79270-saint_symphorien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79299-79330-saint_varent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79299-79330-saint_varent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79299-79330-saint_varent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79299-79330-saint_varent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79300-79100-sainte_verge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79300-79100-sainte_verge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79300-79100-sainte_verge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79300-79100-sainte_verge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79301-79500-saint_vincent_la_chatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79301-79500-saint_vincent_la_chatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79301-79500-saint_vincent_la_chatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79301-79500-saint_vincent_la_chatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79302-79400-saivres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79302-79400-saivres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79302-79400-saivres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79302-79400-saivres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79303-79800-salles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79303-79800-salles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79303-79800-salles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79303-79800-salles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79304-79270-sansais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79304-79270-sansais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79304-79270-sansais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79304-79270-sansais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79306-79200-saurais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79306-79200-saurais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79306-79200-saurais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79306-79200-saurais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79307-79190-sauze_vaussais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79307-79190-sauze_vaussais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79307-79190-sauze_vaussais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79307-79190-sauze_vaussais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79308-79000-sciecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79308-79000-sciecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79308-79000-sciecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79308-79000-sciecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79309-79240-scille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79309-79240-scille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79309-79240-scille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79309-79240-scille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79310-79170-secondigne_sur_belle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79310-79170-secondigne_sur_belle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79310-79170-secondigne_sur_belle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79310-79170-secondigne_sur_belle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79311-79130-secondigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79311-79130-secondigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79311-79130-secondigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79311-79130-secondigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79312-79170-seligne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79312-79170-seligne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79312-79170-seligne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79312-79170-seligne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79313-79120-sepvret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79313-79120-sepvret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79313-79120-sepvret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79313-79120-sepvret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79316-79800-soudan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79316-79800-soudan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79316-79800-soudan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79316-79800-soudan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79319-79800-souvigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79319-79800-souvigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79319-79800-souvigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79319-79800-souvigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79320-79220-surin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79320-79220-surin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79320-79220-surin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79320-79220-surin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79322-79200-le_tallud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79322-79200-le_tallud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79322-79200-le_tallud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79322-79200-le_tallud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79326-79390-thenezay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79326-79390-thenezay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79326-79390-thenezay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79326-79390-thenezay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79329-79100-thouars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79329-79100-thouars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79329-79100-thouars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79329-79100-thouars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79331-79100-tourtenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79331-79100-tourtenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79331-79100-tourtenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79331-79100-tourtenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79332-79240-trayes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79332-79240-trayes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79332-79240-trayes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79332-79240-trayes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79334-79210-val_du_mignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79334-79210-val_du_mignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79334-79210-val_du_mignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79334-79210-val_du_mignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79334-79360-val_du_mignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79334-79360-val_du_mignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79334-79360-val_du_mignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79334-79360-val_du_mignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79335-79270-vallans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79335-79270-vallans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79335-79270-vallans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79335-79270-vallans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79336-79120-vancais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79336-79120-vancais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79336-79120-vancais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79336-79120-vancais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79337-79270-le_vanneau_irleau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79337-79270-le_vanneau_irleau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79337-79270-le_vanneau_irleau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79337-79270-le_vanneau_irleau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79338-79120-vanzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79338-79120-vanzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79338-79120-vanzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79338-79120-vanzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79339-79340-vasles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79339-79340-vasles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79339-79340-vasles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79339-79340-vasles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79340-79420-vausseroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79340-79420-vausseroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79340-79420-vausseroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79340-79420-vausseroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79341-79420-vautebis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79341-79420-vautebis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79341-79420-vautebis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79341-79420-vautebis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79342-79240-vernoux_en_gatine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79342-79240-vernoux_en_gatine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79342-79240-vernoux_en_gatine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79342-79240-vernoux_en_gatine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79343-79170-vernoux_sur_boutonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79343-79170-vernoux_sur_boutonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79343-79170-vernoux_sur_boutonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79343-79170-vernoux_sur_boutonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79345-79310-verruyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79345-79310-verruyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79345-79310-verruyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79345-79310-verruyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79346-79170-le_vert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79346-79170-le_vert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79346-79170-le_vert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79346-79170-le_vert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79347-79200-viennay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79347-79200-viennay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79347-79200-viennay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79347-79200-viennay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79348-79170-villefollet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79348-79170-villefollet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79348-79170-villefollet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79348-79170-villefollet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79349-79110-villemain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79349-79110-villemain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79349-79110-villemain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79349-79110-villemain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79350-79360-villiers_en_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79350-79360-villiers_en_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79350-79360-villiers_en_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79350-79360-villiers_en_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79351-79160-villiers_en_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79351-79160-villiers_en_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79351-79160-villiers_en_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79351-79160-villiers_en_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79352-79170-villiers_sur_chize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79352-79170-villiers_sur_chize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79352-79170-villiers_sur_chize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79352-79170-villiers_sur_chize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79354-79310-vouhe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79354-79310-vouhe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79354-79310-vouhe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79354-79310-vouhe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79355-79230-vouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79355-79230-vouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79355-79230-vouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79355-79230-vouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79357-79220-xaintray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79357-79220-xaintray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79357-79220-xaintray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt79-deux_sevres/commune79357-79220-xaintray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-80.xml
+++ b/public/sitemaps/sitemap-80.xml
@@ -5,1556 +5,3108 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80001-80100-abbeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80001-80100-abbeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80001-80100-abbeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80001-80100-abbeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80002-80320-ablaincourt_pressoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80002-80320-ablaincourt_pressoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80002-80320-ablaincourt_pressoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80002-80320-ablaincourt_pressoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80003-80560-acheux_en_amienois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80003-80560-acheux_en_amienois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80003-80560-acheux_en_amienois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80003-80560-acheux_en_amienois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80004-80210-acheux_en_vimeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80004-80210-acheux_en_vimeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80004-80210-acheux_en_vimeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80004-80210-acheux_en_vimeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80005-80370-agenville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80005-80370-agenville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80005-80370-agenville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80005-80370-agenville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80006-80150-agenvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80006-80150-agenvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80006-80150-agenvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80006-80150-agenvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80008-80210-aigneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80008-80210-aigneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80008-80210-aigneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80008-80210-aigneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80009-80690-ailly_le_haut_clocher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80009-80690-ailly_le_haut_clocher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80009-80690-ailly_le_haut_clocher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80009-80690-ailly_le_haut_clocher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80010-80250-ailly_sur_noye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80010-80250-ailly_sur_noye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80010-80250-ailly_sur_noye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80010-80250-ailly_sur_noye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80011-80470-ailly_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80011-80470-ailly_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80011-80470-ailly_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80011-80470-ailly_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80013-80270-airaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80013-80270-airaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80013-80270-airaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80013-80270-airaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80014-80240-aizecourt_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80014-80240-aizecourt_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80014-80240-aizecourt_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80014-80240-aizecourt_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80015-80200-aizecourt_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80015-80200-aizecourt_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80015-80200-aizecourt_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80015-80200-aizecourt_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80016-80300-albert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80016-80300-albert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80016-80300-albert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80016-80300-albert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80017-80200-allaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80017-80200-allaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80017-80200-allaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80017-80200-allaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80018-80130-allenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80018-80130-allenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80018-80130-allenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80018-80130-allenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80019-80270-allery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80019-80270-allery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80019-80270-allery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80019-80270-allery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80020-80260-allonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80020-80260-allonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80020-80260-allonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80020-80260-allonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80000-amiens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80000-amiens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80000-amiens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80000-amiens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80090-amiens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80090-amiens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80090-amiens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80090-amiens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80080-amiens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80080-amiens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80080-amiens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80021-80080-amiens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80022-80140-andainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80022-80140-andainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80022-80140-andainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80022-80140-andainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80023-80700-andechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80023-80700-andechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80023-80700-andechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80023-80700-andechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80024-80470-argoeuves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80024-80470-argoeuves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80024-80470-argoeuves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80024-80470-argoeuves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80025-80120-argoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80025-80120-argoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80025-80120-argoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80025-80120-argoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80026-80140-arguel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80026-80140-arguel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80026-80140-arguel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80026-80140-arguel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80027-80700-armancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80027-80700-armancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80027-80700-armancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80027-80700-armancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80028-80560-arqueves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80028-80560-arqueves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80028-80560-arqueves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80028-80560-arqueves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80029-80820-arrest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80029-80820-arrest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80029-80820-arrest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80029-80820-arrest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80030-80120-arry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80030-80120-arry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80030-80120-arry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80030-80120-arry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80031-80910-arvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80031-80910-arvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80031-80910-arvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80031-80910-arvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80032-80500-assainvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80032-80500-assainvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80032-80500-assainvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80032-80500-assainvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80033-80200-assevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80033-80200-assevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80033-80200-assevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80033-80200-assevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80034-80200-athies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80034-80200-athies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80034-80200-athies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80034-80200-athies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80035-80110-aubercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80035-80110-aubercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80035-80110-aubercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80035-80110-aubercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80036-80800-aubigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80036-80800-aubigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80036-80800-aubigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80036-80800-aubigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80037-80110-aubvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80037-80110-aubvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80037-80110-aubvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80037-80110-aubvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80038-80560-auchonvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80038-80560-auchonvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80038-80560-auchonvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80038-80560-auchonvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80039-80460-ault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80039-80460-ault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80039-80460-ault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80039-80460-ault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80040-80140-aumatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80040-80140-aumatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80040-80140-aumatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80040-80140-aumatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80041-80640-aumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80041-80640-aumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80041-80640-aumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80041-80640-aumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80042-80600-autheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80042-80600-autheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80042-80600-autheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80042-80600-autheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80043-80560-authie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80043-80560-authie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80043-80560-authie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80043-80560-authie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80044-80600-authieule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80044-80600-authieule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80044-80600-authieule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80044-80600-authieule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80045-80300-authuille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80045-80300-authuille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80045-80300-authuille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80045-80300-authuille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80046-80270-avelesges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80046-80270-avelesges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80046-80270-avelesges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80046-80270-avelesges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80047-80300-aveluy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80047-80300-aveluy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80047-80300-aveluy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80047-80300-aveluy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80048-80140-avesnes_chaussoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80048-80140-avesnes_chaussoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80048-80140-avesnes_chaussoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80048-80140-avesnes_chaussoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80049-80500-ayencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80049-80500-ayencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80049-80500-ayencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80049-80500-ayencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80050-80480-bacouel_sur_selle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80050-80480-bacouel_sur_selle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80050-80480-bacouel_sur_selle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80050-80480-bacouel_sur_selle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80051-80490-bailleul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80051-80490-bailleul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80051-80490-bailleul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80051-80490-bailleul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80052-80300-baizieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80052-80300-baizieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80052-80300-baizieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80052-80300-baizieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80053-80700-balatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80053-80700-balatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80053-80700-balatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80053-80700-balatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80054-80200-barleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80054-80200-barleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80054-80200-barleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80054-80200-barleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80055-80600-barly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80055-80600-barly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80055-80600-barly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80055-80600-barly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80056-80260-bavelincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80056-80260-bavelincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80056-80260-bavelincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80056-80260-bavelincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80057-80560-bayencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80057-80560-bayencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80057-80560-bayencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80057-80560-bayencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80058-80170-bayonvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80058-80170-bayonvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80058-80170-bayonvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80058-80170-bayonvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80059-80300-bazentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80059-80300-bazentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80059-80300-bazentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80059-80300-bazentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80060-80370-bealcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80060-80370-bealcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80060-80370-bealcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80060-80370-bealcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80061-80430-beaucamps_le_jeune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80061-80430-beaucamps_le_jeune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80061-80430-beaucamps_le_jeune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80061-80430-beaucamps_le_jeune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80062-80430-beaucamps_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80062-80430-beaucamps_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80062-80430-beaucamps_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80062-80430-beaucamps_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80063-80770-beauchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80063-80770-beauchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80063-80770-beauchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80063-80770-beauchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80064-80110-beaucourt_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80064-80110-beaucourt_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80064-80110-beaucourt_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80064-80110-beaucourt_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80065-80300-beaucourt_sur_l_ancre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80065-80300-beaucourt_sur_l_ancre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80065-80300-beaucourt_sur_l_ancre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80065-80300-beaucourt_sur_l_ancre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80066-80260-beaucourt_sur_l_hallue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80066-80260-beaucourt_sur_l_hallue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80066-80260-beaucourt_sur_l_hallue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80066-80260-beaucourt_sur_l_hallue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80067-80170-beaufort_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80067-80170-beaufort_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80067-80170-beaufort_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80067-80170-beaufort_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80068-80370-beaumetz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80068-80370-beaumetz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80068-80370-beaumetz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80068-80370-beaumetz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80069-80300-beaumont_hamel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80069-80300-beaumont_hamel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80069-80300-beaumont_hamel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80069-80300-beaumont_hamel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80070-80600-beauquesne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80070-80600-beauquesne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80070-80600-beauquesne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80070-80600-beauquesne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80071-80630-beauval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80071-80630-beauval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80071-80630-beauval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80071-80630-beauval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80073-80300-becordel_becourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80073-80300-becordel_becourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80073-80300-becordel_becourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80073-80300-becordel_becourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80074-80500-becquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80074-80500-becquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80074-80500-becquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80074-80500-becquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80076-80870-behen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80076-80870-behen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80076-80870-behen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80076-80870-behen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80077-80260-behencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80077-80260-behencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80077-80260-behencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80077-80260-behencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80078-80132-bellancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80078-80132-bellancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80078-80132-bellancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80078-80132-bellancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80079-80160-belleuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80079-80160-belleuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80079-80160-belleuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80079-80160-belleuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80080-80200-belloy_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80080-80200-belloy_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80080-80200-belloy_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80080-80200-belloy_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80081-80270-belloy_saint_leonard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80081-80270-belloy_saint_leonard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80081-80270-belloy_saint_leonard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80081-80270-belloy_saint_leonard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80082-80310-belloy_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80082-80310-belloy_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80082-80310-belloy_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80082-80310-belloy_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80083-80290-bergicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80083-80290-bergicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80083-80290-bergicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80083-80290-bergicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80084-80140-bermesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80084-80140-bermesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80084-80140-bermesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80084-80140-bermesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80085-80370-bernatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80085-80370-bernatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80085-80370-bernatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80085-80370-bernatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80086-80370-bernaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80086-80370-bernaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80086-80370-bernaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80086-80370-bernaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80087-80120-bernay_en_ponthieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80087-80120-bernay_en_ponthieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80087-80120-bernay_en_ponthieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80087-80120-bernay_en_ponthieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80088-80240-bernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80088-80240-bernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80088-80240-bernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80088-80240-bernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80089-80620-berneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80089-80620-berneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80089-80620-berneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80089-80620-berneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80090-80200-berny_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80090-80200-berny_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80090-80200-berny_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80090-80200-berny_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80092-80260-bertangles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80092-80260-bertangles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80092-80260-bertangles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80092-80260-bertangles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80093-80850-berteaucourt_les_dames/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80093-80850-berteaucourt_les_dames/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80093-80850-berteaucourt_les_dames/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80093-80850-berteaucourt_les_dames/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80094-80110-berteaucourt_les_thennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80094-80110-berteaucourt_les_thennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80094-80110-berteaucourt_les_thennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80094-80110-berteaucourt_les_thennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80095-80560-bertrancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80095-80560-bertrancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80095-80560-bertrancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80095-80560-bertrancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80096-80130-bethencourt_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80096-80130-bethencourt_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80096-80130-bethencourt_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80096-80130-bethencourt_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80097-80190-bethencourt_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80097-80190-bethencourt_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80097-80190-bethencourt_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80097-80190-bethencourt_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80098-80290-bettembos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80098-80290-bettembos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80098-80290-bettembos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80098-80290-bettembos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80099-80270-bettencourt_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80099-80270-bettencourt_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80099-80270-bettencourt_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80099-80270-bettencourt_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80100-80610-bettencourt_saint_ouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80100-80610-bettencourt_saint_ouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80100-80610-bettencourt_saint_ouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80100-80610-bettencourt_saint_ouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80101-80700-beuvraignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80101-80700-beuvraignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80101-80700-beuvraignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80101-80700-beuvraignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80102-80200-biaches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80102-80200-biaches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80102-80200-biaches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80102-80200-biaches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80103-80190-biarre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80103-80190-biarre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80103-80190-biarre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80103-80190-biarre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80104-80140-biencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80104-80140-biencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80104-80140-biencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80104-80140-biencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80105-80190-billancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80105-80190-billancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80105-80190-billancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80105-80190-billancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80106-80290-blangy_sous_poix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80106-80290-blangy_sous_poix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80106-80290-blangy_sous_poix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80106-80290-blangy_sous_poix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80107-80440-blangy_tronville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80107-80440-blangy_tronville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80107-80440-blangy_tronville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80107-80440-blangy_tronville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80108-80600-boisbergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80108-80600-boisbergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80108-80600-boisbergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80108-80600-boisbergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80109-80150-le_boisle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80109-80150-le_boisle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80109-80150-le_boisle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80109-80150-le_boisle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80110-80230-boismont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80110-80230-boismont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80110-80230-boismont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80110-80230-boismont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80112-80800-bonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80112-80800-bonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80112-80800-bonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80112-80800-bonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80113-80670-bonneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80113-80670-bonneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80113-80670-bonneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80113-80670-bonneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80114-80160-bosquel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80114-80160-bosquel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80114-80160-bosquel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80114-80160-bosquel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80115-80200-bouchavesnes_bergen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80115-80200-bouchavesnes_bergen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80115-80200-bouchavesnes_bergen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80115-80200-bouchavesnes_bergen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80116-80910-bouchoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80116-80910-bouchoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80116-80910-bouchoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80116-80910-bouchoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80117-80830-bouchon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80117-80830-bouchon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80117-80830-bouchon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80117-80830-bouchon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80118-80150-boufflers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80118-80150-boufflers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80118-80150-boufflers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80118-80150-boufflers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80119-80540-bougainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80119-80540-bougainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80119-80540-bougainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80119-80540-bougainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80120-80220-bouillancourt_en_sery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80120-80220-bouillancourt_en_sery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80120-80220-bouillancourt_en_sery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80120-80220-bouillancourt_en_sery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80121-80500-bouillancourt_la_bataille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80121-80500-bouillancourt_la_bataille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80121-80500-bouillancourt_la_bataille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80121-80500-bouillancourt_la_bataille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80122-80600-bouquemaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80122-80600-bouquemaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80122-80600-bouquemaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80122-80600-bouquemaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80123-80310-bourdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80123-80310-bourdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80123-80310-bourdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80123-80310-bourdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80124-80130-bourseville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80124-80130-bourseville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80124-80130-bourseville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80124-80130-bourseville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80125-80500-boussicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80125-80500-boussicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80125-80500-boussicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80125-80500-boussicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80126-80220-bouttencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80126-80220-bouttencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80126-80220-bouttencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80126-80220-bouttencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80127-80220-bouvaincourt_sur_bresle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80127-80220-bouvaincourt_sur_bresle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80127-80220-bouvaincourt_sur_bresle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80127-80220-bouvaincourt_sur_bresle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80128-80200-bouvincourt_en_vermandois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80128-80200-bouvincourt_en_vermandois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80128-80200-bouvincourt_en_vermandois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80128-80200-bouvincourt_en_vermandois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80129-80300-bouzincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80129-80300-bouzincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80129-80300-bouzincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80129-80300-bouzincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80130-80540-bovelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80130-80540-bovelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80130-80540-bovelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80130-80540-bovelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80131-80440-boves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80131-80440-boves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80131-80440-boves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80131-80440-boves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80132-80110-braches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80132-80110-braches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80132-80110-braches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80132-80110-braches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80133-80150-brailly_cornehotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80133-80150-brailly_cornehotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80133-80150-brailly_cornehotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80133-80150-brailly_cornehotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80134-80160-brassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80134-80160-brassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80134-80160-brassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80134-80160-brassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80135-80580-bray_les_mareuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80135-80580-bray_les_mareuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80135-80580-bray_les_mareuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80135-80580-bray_les_mareuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80136-80340-bray_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80136-80340-bray_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80136-80340-bray_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80136-80340-bray_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80137-80470-breilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80137-80470-breilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80137-80470-breilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80137-80470-breilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80138-80300-bresle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80138-80300-bresle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80138-80300-bresle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80138-80300-bresle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80139-80400-breuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80139-80400-breuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80139-80400-breuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80139-80400-breuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80140-80600-brevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80140-80600-brevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80140-80600-brevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80140-80600-brevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80141-80200-brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80141-80200-brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80141-80200-brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80141-80200-brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80142-80540-briquemesnil_floxicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80142-80540-briquemesnil_floxicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80142-80540-briquemesnil_floxicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80142-80540-briquemesnil_floxicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80143-80430-brocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80143-80430-brocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80143-80430-brocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80143-80430-brocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80144-80400-brouchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80144-80400-brouchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80144-80400-brouchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80144-80400-brouchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80145-80690-brucamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80145-80690-brucamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80145-80690-brucamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80145-80690-brucamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80146-80230-brutelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80146-80230-brutelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80146-80230-brutelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80146-80230-brutelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80147-80132-buigny_l_abbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80147-80132-buigny_l_abbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80147-80132-buigny_l_abbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80147-80132-buigny_l_abbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80148-80220-buigny_les_gamaches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80148-80220-buigny_les_gamaches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80148-80220-buigny_les_gamaches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80148-80220-buigny_les_gamaches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80149-80132-buigny_saint_maclou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80149-80132-buigny_saint_maclou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80149-80132-buigny_saint_maclou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80149-80132-buigny_saint_maclou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80150-80200-buire_courcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80150-80200-buire_courcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80150-80200-buire_courcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80150-80200-buire_courcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80151-80300-buire_sur_l_ancre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80151-80300-buire_sur_l_ancre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80151-80300-buire_sur_l_ancre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80151-80300-buire_sur_l_ancre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80152-80700-bus_la_mesiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80152-80700-bus_la_mesiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80152-80700-bus_la_mesiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80152-80700-bus_la_mesiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80153-80560-bus_les_artois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80153-80560-bus_les_artois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80153-80560-bus_les_artois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80153-80560-bus_les_artois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80154-80200-bussu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80154-80200-bussu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80154-80200-bussu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80154-80200-bussu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80155-80135-bussus_bussuel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80155-80135-bussus_bussuel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80155-80135-bussus_bussuel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80155-80135-bussus_bussuel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80156-80800-bussy_les_daours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80156-80800-bussy_les_daours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80156-80800-bussy_les_daours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80156-80800-bussy_les_daours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80157-80290-bussy_les_poix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80157-80290-bussy_les_poix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80157-80290-bussy_les_poix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80157-80290-bussy_les_poix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80158-80400-buverchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80158-80400-buverchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80158-80400-buverchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80158-80400-buverchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80159-80800-cachy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80159-80800-cachy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80159-80800-cachy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80159-80800-cachy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80160-80330-cagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80160-80330-cagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80160-80330-cagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80160-80330-cagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80161-80132-cahon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80161-80132-cahon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80161-80132-cahon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80161-80132-cahon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80162-80170-caix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80162-80170-caix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80162-80170-caix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80162-80170-caix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80163-80132-cambron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80163-80132-cambron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80163-80132-cambron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80163-80132-cambron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80164-80450-camon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80164-80450-camon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80164-80450-camon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80164-80450-camon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80165-80540-camps_en_amienois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80165-80540-camps_en_amienois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80165-80540-camps_en_amienois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80165-80540-camps_en_amienois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80166-80670-canaples/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80166-80670-canaples/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80166-80670-canaples/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80166-80670-canaples/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80167-80150-canchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80167-80150-canchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80167-80150-canchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80167-80150-canchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80168-80750-candas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80168-80750-candas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80168-80750-candas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80168-80750-candas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80169-80140-cannessieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80169-80140-cannessieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80169-80140-cannessieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80169-80140-cannessieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80170-80500-cantigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80170-80500-cantigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80170-80500-cantigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80170-80500-cantigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80171-80132-caours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80171-80132-caours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80171-80132-caours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80171-80132-caours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80172-80340-cappy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80172-80340-cappy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80172-80340-cappy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80172-80340-cappy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80173-80260-cardonnette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80173-80260-cardonnette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80173-80260-cardonnette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80173-80260-cardonnette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80174-80500-le_cardonnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80174-80500-le_cardonnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80174-80500-le_cardonnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80174-80500-le_cardonnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80176-80700-carrepuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80176-80700-carrepuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80176-80700-carrepuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80176-80700-carrepuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80177-80200-cartigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80177-80200-cartigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80177-80200-cartigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80177-80200-cartigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80179-80290-caulieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80179-80290-caulieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80179-80290-caulieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80179-80290-caulieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80180-80310-cavillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80180-80310-cavillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80180-80310-cavillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80180-80310-cavillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80181-80800-cayeux_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80181-80800-cayeux_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80181-80800-cayeux_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80181-80800-cayeux_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80182-80410-cayeux_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80182-80410-cayeux_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80182-80410-cayeux_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80182-80410-cayeux_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80183-80140-cerisy_buleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80183-80140-cerisy_buleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80183-80140-cerisy_buleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80183-80140-cerisy_buleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80184-80800-cerisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80184-80800-cerisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80184-80800-cerisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80184-80800-cerisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80185-80700-champien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80185-80700-champien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80185-80700-champien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80185-80700-champien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80186-80320-chaulnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80186-80320-chaulnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80186-80320-chaulnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80186-80320-chaulnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80187-80310-la_chaussee_tirancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80187-80310-la_chaussee_tirancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80187-80310-la_chaussee_tirancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80187-80310-la_chaussee_tirancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80188-80250-chaussoy_epagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80188-80250-chaussoy_epagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80188-80250-chaussoy_epagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80188-80250-chaussoy_epagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80189-80700-la_chavatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80189-80700-la_chavatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80189-80700-la_chavatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80189-80700-la_chavatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80190-80210-chepy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80190-80210-chepy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80190-80210-chepy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80190-80210-chepy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80191-80170-chilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80191-80170-chilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80191-80170-chilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80191-80170-chilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80192-80800-chipilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80192-80800-chipilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80192-80800-chipilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80192-80800-chipilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80193-80250-chirmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80193-80250-chirmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80193-80250-chirmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80193-80250-chirmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80194-80340-chuignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80194-80340-chuignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80194-80340-chuignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80194-80340-chuignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80195-80340-chuignolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80195-80340-chuignolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80195-80340-chuignolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80195-80340-chuignolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80196-80490-citerne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80196-80490-citerne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80196-80490-citerne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80196-80490-citerne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80197-80200-cizancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80197-80200-cizancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80197-80200-cizancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80197-80200-cizancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80198-80540-clairy_saulchoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80198-80540-clairy_saulchoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80198-80540-clairy_saulchoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80198-80540-clairy_saulchoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80199-80200-clery_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80199-80200-clery_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80199-80200-clery_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80199-80200-clery_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80200-80510-cocquerel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80200-80510-cocquerel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80200-80510-cocquerel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80200-80510-cocquerel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80201-80560-coigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80201-80560-coigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80201-80560-coigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80201-80560-coigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80202-80260-coisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80202-80260-coisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80202-80260-coisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80202-80260-coisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80203-80560-colincamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80203-80560-colincamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80203-80560-colincamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80203-80560-colincamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80204-80360-combles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80204-80360-combles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80204-80360-combles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80204-80360-combles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80205-80890-conde_folie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80205-80890-conde_folie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80205-80890-conde_folie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80205-80890-conde_folie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80206-80300-contalmaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80206-80300-contalmaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80206-80300-contalmaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80206-80300-contalmaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80207-80560-contay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80207-80560-contay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80207-80560-contay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80207-80560-contay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80208-80370-conteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80208-80370-conteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80208-80370-conteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80208-80370-conteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80210-80160-contre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80210-80160-contre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80210-80160-contre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80210-80160-contre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80211-80160-conty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80211-80160-conty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80211-80160-conty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80211-80160-conty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80212-80800-corbie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80212-80800-corbie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80212-80800-corbie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80212-80800-corbie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80213-80440-cottenchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80213-80440-cottenchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80213-80440-cottenchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80213-80440-cottenchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80214-80250-coullemelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80214-80250-coullemelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80214-80250-coullemelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80214-80250-coullemelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80215-80135-coulonvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80215-80135-coulonvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80215-80135-coulonvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80215-80135-coulonvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80216-80300-courcelette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80216-80300-courcelette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80216-80300-courcelette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80216-80300-courcelette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80217-80560-courcelles_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80217-80560-courcelles_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80217-80560-courcelles_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80217-80560-courcelles_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80218-80290-courcelles_sous_moyencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80218-80290-courcelles_sous_moyencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80218-80290-courcelles_sous_moyencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80218-80290-courcelles_sous_moyencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80219-80160-courcelles_sous_thoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80219-80160-courcelles_sous_thoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80219-80160-courcelles_sous_thoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80219-80160-courcelles_sous_thoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80220-80500-courtemanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80220-80500-courtemanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80220-80500-courtemanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80220-80500-courtemanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80221-80370-cramont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80221-80370-cramont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80221-80370-cramont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80221-80370-cramont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80222-80150-crecy_en_ponthieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80222-80150-crecy_en_ponthieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80222-80150-crecy_en_ponthieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80222-80150-crecy_en_ponthieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80223-80700-cremery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80223-80700-cremery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80223-80700-cremery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80223-80700-cremery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80224-80190-cressy_omencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80224-80190-cressy_omencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80224-80190-cressy_omencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80224-80190-cressy_omencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80225-80480-creuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80225-80480-creuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80225-80480-creuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80225-80480-creuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80226-80400-croix_moligneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80226-80400-croix_moligneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80226-80400-croix_moligneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80226-80400-croix_moligneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80227-80290-croixrault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80227-80290-croixrault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80227-80290-croixrault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80227-80290-croixrault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80228-80550-le_crotoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80228-80550-le_crotoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80228-80550-le_crotoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80228-80550-le_crotoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80229-80310-crouy_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80229-80310-crouy_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80229-80310-crouy_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80229-80310-crouy_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80230-80190-curchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80230-80190-curchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80230-80190-curchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80230-80190-curchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80231-80360-curlu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80231-80360-curlu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80231-80360-curlu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80231-80360-curlu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80232-80700-damery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80232-80700-damery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80232-80700-damery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80232-80700-damery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80233-80700-dancourt_popincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80233-80700-dancourt_popincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80233-80700-dancourt_popincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80233-80700-dancourt_popincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80234-80800-daours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80234-80800-daours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80234-80800-daours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80234-80800-daours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80235-80570-dargnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80235-80570-dargnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80235-80570-dargnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80235-80570-dargnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80236-80500-davenescourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80236-80500-davenescourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80236-80500-davenescourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80236-80500-davenescourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80237-80110-demuin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80237-80110-demuin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80237-80110-demuin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80237-80110-demuin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80238-80300-dernancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80238-80300-dernancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80238-80300-dernancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80238-80300-dernancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80239-80200-devise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80239-80200-devise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80239-80200-devise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80239-80200-devise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80240-80200-doingt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80240-80200-doingt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80240-80200-doingt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80240-80200-doingt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80241-80620-domart_en_ponthieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80241-80620-domart_en_ponthieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80241-80620-domart_en_ponthieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80241-80620-domart_en_ponthieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80242-80110-domart_sur_la_luce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80242-80110-domart_sur_la_luce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80242-80110-domart_sur_la_luce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80242-80110-domart_sur_la_luce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80243-80370-domesmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80243-80370-domesmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80243-80370-domesmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80243-80370-domesmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80244-80120-dominois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80244-80120-dominois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80244-80120-dominois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80244-80120-dominois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80245-80370-domleger_longvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80245-80370-domleger_longvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80245-80370-domleger_longvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80245-80370-domleger_longvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80246-80440-dommartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80246-80440-dommartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80246-80440-dommartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80246-80440-dommartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80247-80980-dompierre_becquincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80247-80980-dompierre_becquincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80247-80980-dompierre_becquincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80247-80980-dompierre_becquincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80248-80150-dompierre_sur_authie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80248-80150-dompierre_sur_authie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80248-80150-dompierre_sur_authie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80248-80150-dompierre_sur_authie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80249-80620-domqueur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80249-80620-domqueur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80249-80620-domqueur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80249-80620-domqueur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80250-80150-domvast/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80250-80150-domvast/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80250-80150-domvast/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80250-80150-domvast/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80251-80140-doudelainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80251-80140-doudelainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80251-80140-doudelainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80251-80140-doudelainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80252-80400-douilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80252-80400-douilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80252-80400-douilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80252-80400-douilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80253-80600-doullens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80253-80600-doullens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80253-80600-doullens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80253-80600-doullens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80256-80470-dreuil_les_amiens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80256-80470-dreuil_les_amiens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80256-80470-dreuil_les_amiens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80256-80470-dreuil_les_amiens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80258-80240-driencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80258-80240-driencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80258-80240-driencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80258-80240-driencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80259-80640-dromesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80259-80640-dromesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80259-80640-dromesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80259-80640-dromesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80260-80132-drucat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80260-80132-drucat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80260-80132-drucat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80260-80132-drucat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80261-80480-dury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80261-80480-dury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80261-80480-dury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80261-80480-dury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80262-80580-eaucourt_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80262-80580-eaucourt_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80262-80580-eaucourt_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80262-80580-eaucourt_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80263-80700-l_echelle_saint_aurin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80263-80700-l_echelle_saint_aurin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80263-80700-l_echelle_saint_aurin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80263-80700-l_echelle_saint_aurin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80264-80340-eclusier_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80264-80340-eclusier_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80264-80340-eclusier_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80264-80340-eclusier_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80265-80570-embreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80265-80570-embreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80265-80570-embreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80265-80570-embreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80266-80300-englebelmer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80266-80300-englebelmer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80266-80300-englebelmer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80266-80300-englebelmer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80267-80200-ennemain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80267-80200-ennemain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80267-80200-ennemain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80267-80200-ennemain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80268-80580-epagne_epagnette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80268-80580-epagne_epagnette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80268-80580-epagne_epagnette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80268-80580-epagne_epagnette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80269-80140-epaumesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80269-80140-epaumesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80269-80140-epaumesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80269-80140-epaumesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80270-80370-epecamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80270-80370-epecamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80270-80370-epecamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80270-80370-epecamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80271-80740-epehy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80271-80740-epehy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80271-80740-epehy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80271-80740-epehy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80272-80190-epenancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80272-80190-epenancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80272-80190-epenancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80272-80190-epenancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80273-80290-eplessier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80273-80290-eplessier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80273-80290-eplessier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80273-80290-eplessier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80274-80400-eppeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80274-80400-eppeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80274-80400-eppeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80274-80400-eppeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80275-80360-equancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80275-80360-equancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80275-80360-equancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80275-80360-equancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80276-80290-equennes_eramecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80276-80290-equennes_eramecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80276-80290-equennes_eramecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80276-80290-equennes_eramecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80278-80500-erches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80278-80500-erches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80278-80500-erches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80278-80500-erches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80279-80400-ercheu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80279-80400-ercheu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80279-80400-ercheu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80279-80400-ercheu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80280-80210-ercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80280-80210-ercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80280-80210-ercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80280-80210-ercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80281-80690-ergnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80281-80690-ergnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80281-80690-ergnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80281-80690-ergnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80282-80580-erondelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80282-80580-erondelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80282-80580-erondelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80282-80580-erondelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80283-80250-esclainvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80283-80250-esclainvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80283-80250-esclainvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80283-80250-esclainvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80284-80400-esmery_hallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80284-80400-esmery_hallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80284-80400-esmery_hallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80284-80400-esmery_hallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80285-80160-essertaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80285-80160-essertaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80285-80160-essertaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80285-80160-essertaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80287-80230-estreboeuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80287-80230-estreboeuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80287-80230-estreboeuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80287-80230-estreboeuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80288-80200-estrees_deniecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80288-80200-estrees_deniecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80288-80200-estrees_deniecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80288-80200-estrees_deniecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80290-80150-estrees_les_crecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80290-80150-estrees_les_crecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80290-80150-estrees_les_crecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80290-80150-estrees_les_crecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80291-80250-estrees_sur_noye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80291-80250-estrees_sur_noye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80291-80250-estrees_sur_noye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80291-80250-estrees_sur_noye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80292-80190-etalon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80292-80190-etalon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80292-80190-etalon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80292-80190-etalon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80293-80500-etelfay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80293-80500-etelfay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80293-80500-etelfay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80293-80500-etelfay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80294-80200-eterpigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80294-80200-eterpigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80294-80200-eterpigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80294-80200-eterpigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80295-80340-etinehem_mericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80295-80340-etinehem_mericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80295-80340-etinehem_mericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80295-80340-etinehem_mericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80296-80830-l_etoile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80296-80830-l_etoile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80296-80830-l_etoile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80296-80830-l_etoile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80297-80140-etrejust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80297-80140-etrejust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80297-80140-etrejust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80297-80140-etrejust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80298-80360-etricourt_manancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80298-80360-etricourt_manancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80298-80360-etricourt_manancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80298-80360-etricourt_manancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80299-80250-la_faloise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80299-80250-la_faloise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80299-80250-la_faloise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80299-80250-la_faloise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80300-80190-falvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80300-80190-falvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80300-80190-falvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80300-80190-falvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80301-80290-famechon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80301-80290-famechon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80301-80290-famechon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80301-80290-famechon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80302-80500-faverolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80302-80500-faverolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80302-80500-faverolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80302-80500-faverolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80303-80120-favieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80303-80120-favieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80303-80120-favieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80303-80120-favieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80304-80200-fay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80304-80200-fay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80304-80200-fay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80304-80200-fay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80305-80470-ferrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80305-80470-ferrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80305-80470-ferrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80305-80470-ferrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80306-80500-fescamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80306-80500-fescamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80306-80500-fescamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80306-80500-fescamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80307-80200-feuilleres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80307-80200-feuilleres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80307-80200-feuilleres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80307-80200-feuilleres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80308-80210-feuquieres_en_vimeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80308-80210-feuquieres_en_vimeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80308-80210-feuquieres_en_vimeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80308-80210-feuquieres_en_vimeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80310-80750-fienvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80310-80750-fienvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80310-80750-fienvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80310-80750-fienvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80311-80500-fignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80311-80500-fignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80311-80500-fignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80311-80500-fignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80312-80360-fins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80312-80360-fins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80312-80360-fins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80312-80360-fins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80313-80200-flaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80313-80200-flaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80313-80200-flaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80313-80200-flaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80314-80360-flers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80314-80360-flers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80314-80360-flers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80314-80360-flers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80315-80160-flers_sur_noye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80315-80160-flers_sur_noye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80315-80160-flers_sur_noye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80315-80160-flers_sur_noye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80316-80260-flesselles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80316-80260-flesselles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80316-80260-flesselles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80316-80260-flesselles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80317-80160-fleury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80317-80160-fleury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80317-80160-fleury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80317-80160-fleury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80318-80420-flixecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80318-80420-flixecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80318-80420-flixecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80318-80420-flixecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80319-80540-fluy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80319-80540-fluy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80319-80540-fluy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80319-80540-fluy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80320-80170-folies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80320-80170-folies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80320-80170-folies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80320-80170-folies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80321-80250-folleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80321-80250-folleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80321-80250-folleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80321-80250-folleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80322-80700-fonches_fonchette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80322-80700-fonches_fonchette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80322-80700-fonches_fonchette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80322-80700-fonches_fonchette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80324-80140-fontaine_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80324-80140-fontaine_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80324-80140-fontaine_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80324-80140-fontaine_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80325-80340-fontaine_les_cappy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80325-80340-fontaine_les_cappy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80325-80340-fontaine_les_cappy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80325-80340-fontaine_les_cappy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80326-80500-fontaine_sous_montdidier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80326-80500-fontaine_sous_montdidier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80326-80500-fontaine_sous_montdidier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80326-80500-fontaine_sous_montdidier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80327-80150-fontaine_sur_maye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80327-80150-fontaine_sur_maye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80327-80150-fontaine_sur_maye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80327-80150-fontaine_sur_maye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80328-80510-fontaine_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80328-80510-fontaine_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80328-80510-fontaine_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80328-80510-fontaine_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80329-80560-forceville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80329-80560-forceville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80329-80560-forceville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80329-80560-forceville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80330-80140-forceville_en_vimeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80330-80140-forceville_en_vimeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80330-80140-forceville_en_vimeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80330-80140-forceville_en_vimeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80331-80150-forest_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80331-80150-forest_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80331-80150-forest_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80331-80150-forest_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80332-80120-forest_montiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80332-80120-forest_montiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80332-80120-forest_montiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80332-80120-forest_montiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80333-80120-fort_mahon_plage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80333-80120-fort_mahon_plage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80333-80120-fort_mahon_plage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80333-80120-fort_mahon_plage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80334-80160-fossemanant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80334-80160-fossemanant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80334-80160-fossemanant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80334-80160-fossemanant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80335-80340-foucaucourt_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80335-80340-foucaucourt_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80335-80340-foucaucourt_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80335-80340-foucaucourt_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80336-80140-foucaucourt_hors_nesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80336-80140-foucaucourt_hors_nesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80336-80140-foucaucourt_hors_nesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80336-80140-foucaucourt_hors_nesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80337-80440-fouencamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80337-80440-fouencamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80337-80440-fouencamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80337-80440-fouencamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80338-80800-fouilloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80338-80800-fouilloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80338-80800-fouilloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80338-80800-fouilloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80339-80170-fouquescourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80339-80170-fouquescourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80339-80170-fouquescourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80339-80170-fouquescourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80340-80290-fourcigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80340-80290-fourcigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80340-80290-fourcigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80340-80290-fourcigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80341-80310-fourdrinoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80341-80310-fourdrinoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80341-80310-fourdrinoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80341-80310-fourdrinoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80342-80131-framerville_rainecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80342-80131-framerville_rainecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80342-80131-framerville_rainecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80342-80131-framerville_rainecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80343-80140-framicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80343-80140-framicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80343-80140-framicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80343-80140-framicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80344-80690-francieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80344-80690-francieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80344-80690-francieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80344-80690-francieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80345-80210-franleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80345-80210-franleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80345-80210-franleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80345-80210-franleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80346-80620-franqueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80346-80620-franqueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80346-80620-franqueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80346-80620-franqueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80347-80700-fransart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80347-80700-fransart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80347-80700-fransart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80347-80700-fransart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80348-80620-fransu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80348-80620-fransu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80348-80620-fransu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80348-80620-fransu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80349-80160-fransures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80349-80160-fransures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80349-80160-fransures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80349-80160-fransures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80350-80800-franvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80350-80800-franvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80350-80800-franvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80350-80800-franvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80351-80260-frechencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80351-80260-frechencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80351-80260-frechencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80351-80260-frechencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80352-80160-fremontiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80352-80160-fremontiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80352-80160-fremontiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80352-80160-fremontiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80353-80320-fresnes_mazancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80353-80320-fresnes_mazancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80353-80320-fresnes_mazancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80353-80320-fresnes_mazancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80354-80140-fresnes_tilloloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80354-80140-fresnes_tilloloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80354-80140-fresnes_tilloloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80354-80140-fresnes_tilloloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80355-80140-fresneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80355-80140-fresneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80355-80140-fresneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80355-80140-fresneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80356-80140-fresnoy_andainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80356-80140-fresnoy_andainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80356-80140-fresnoy_andainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80356-80140-fresnoy_andainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80357-80290-fresnoy_au_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80357-80290-fresnoy_au_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80357-80290-fresnoy_au_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80357-80290-fresnoy_au_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80358-80110-fresnoy_en_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80358-80110-fresnoy_en_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80358-80110-fresnoy_en_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80358-80110-fresnoy_en_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80359-80700-fresnoy_les_roye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80359-80700-fresnoy_les_roye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80359-80700-fresnoy_les_roye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80359-80700-fresnoy_les_roye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80360-80390-fressenneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80360-80390-fressenneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80360-80390-fressenneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80360-80390-fressenneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80361-80140-frettecuisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80361-80140-frettecuisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80361-80140-frettecuisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80361-80140-frettecuisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80362-80220-frettemeule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80362-80220-frettemeule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80362-80220-frettemeule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80362-80220-frettemeule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80364-80460-friaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80364-80460-friaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80364-80460-friaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80364-80460-friaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80365-80290-fricamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80365-80290-fricamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80365-80290-fricamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80365-80290-fricamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80366-80300-fricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80366-80300-fricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80366-80300-fricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80366-80300-fricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80367-80340-frise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80367-80340-frise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80367-80340-frise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80367-80340-frise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80368-80130-friville_escarbotin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80368-80130-friville_escarbotin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80368-80130-friville_escarbotin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80368-80130-friville_escarbotin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80369-80370-frohen_sur_authie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80369-80370-frohen_sur_authie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80369-80370-frohen_sur_authie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80369-80370-frohen_sur_authie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80371-80150-froyelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80371-80150-froyelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80371-80150-froyelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80371-80150-froyelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80372-80490-frucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80372-80490-frucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80372-80490-frucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80372-80490-frucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80373-80220-gamaches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80373-80220-gamaches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80373-80220-gamaches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80373-80220-gamaches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80374-80150-gapennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80374-80150-gapennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80374-80150-gapennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80374-80150-gapennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80375-80290-gauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80375-80290-gauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80375-80290-gauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80375-80290-gauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80376-80800-gentelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80376-80800-gentelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80376-80800-gentelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80376-80800-gentelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80377-80600-gezaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80377-80600-gezaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80377-80600-gezaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80377-80600-gezaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80378-80360-ginchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80378-80360-ginchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80378-80360-ginchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80378-80360-ginchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80379-80440-glisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80379-80440-glisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80379-80440-glisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80379-80440-glisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80380-80690-gorenflos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80380-80690-gorenflos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80380-80690-gorenflos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80380-80690-gorenflos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80381-80370-gorges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80381-80370-gorges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80381-80370-gorges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80381-80370-gorges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80383-80700-goyencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80383-80700-goyencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80383-80700-goyencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80383-80700-goyencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80384-80300-grandcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80384-80300-grandcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80384-80300-grandcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80384-80300-grandcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80385-80132-grand_laviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80385-80132-grand_laviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80385-80132-grand_laviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80385-80132-grand_laviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80386-80500-gratibus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80386-80500-gratibus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80386-80500-gratibus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80386-80500-gratibus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80387-80680-grattepanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80387-80680-grattepanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80387-80680-grattepanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80387-80680-grattepanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80388-80140-grebault_mesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80388-80140-grebault_mesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80388-80140-grebault_mesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80388-80140-grebault_mesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80390-80250-grivesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80390-80250-grivesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80390-80250-grivesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80390-80250-grivesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80391-80700-grivillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80391-80700-grivillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80391-80700-grivillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80391-80700-grivillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80392-80600-grouches_luchuel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80392-80600-grouches_luchuel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80392-80600-grouches_luchuel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80392-80600-grouches_luchuel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80393-80700-gruny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80393-80700-gruny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80393-80700-gruny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80393-80700-gruny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80395-80500-guerbigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80395-80500-guerbigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80395-80500-guerbigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80395-80500-guerbigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80396-80150-gueschart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80396-80150-gueschart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80396-80150-gueschart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80396-80150-gueschart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80397-80360-gueudecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80397-80360-gueudecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80397-80360-gueudecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80397-80360-gueudecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80399-80540-guignemicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80399-80540-guignemicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80399-80540-guignemicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80399-80540-guignemicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80400-80170-guillaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80400-80170-guillaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80400-80170-guillaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80400-80170-guillaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80401-80360-guillemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80401-80360-guillemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80401-80360-guillemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80401-80360-guillemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80402-80290-guizancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80402-80290-guizancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80402-80290-guizancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80402-80290-guizancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80403-80250-guyencourt_sur_noye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80403-80250-guyencourt_sur_noye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80403-80250-guyencourt_sur_noye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80403-80250-guyencourt_sur_noye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80404-80240-guyencourt_saulcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80404-80240-guyencourt_saulcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80404-80240-guyencourt_saulcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80404-80240-guyencourt_saulcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80405-80440-hailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80405-80440-hailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80405-80440-hailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80405-80440-hailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80406-80490-hallencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80406-80490-hallencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80406-80490-hallencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80406-80490-hallencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80407-80250-hallivillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80407-80250-hallivillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80407-80250-hallivillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80407-80250-hallivillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80408-80670-halloy_les_pernois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80408-80670-halloy_les_pernois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80408-80670-halloy_les_pernois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80408-80670-halloy_les_pernois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80409-80320-hallu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80409-80320-hallu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80409-80320-hallu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80409-80320-hallu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80410-80400-ham/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80410-80400-ham/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80410-80400-ham/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80410-80400-ham/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80411-80800-le_hamel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80411-80800-le_hamel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80411-80800-le_hamel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80411-80800-le_hamel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80412-80800-hamelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80412-80800-hamelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80412-80800-hamelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80412-80800-hamelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80413-80240-hancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80413-80240-hancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80413-80240-hancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80413-80240-hancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80414-80110-hangard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80414-80110-hangard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80414-80110-hangard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80414-80110-hangard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80415-80134-hangest_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80415-80134-hangest_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80415-80134-hangest_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80415-80134-hangest_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80416-80310-hangest_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80416-80310-hangest_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80416-80310-hangest_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80416-80310-hangest_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80417-80131-harbonnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80417-80131-harbonnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80417-80131-harbonnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80417-80131-harbonnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80418-80360-hardecourt_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80418-80360-hardecourt_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80418-80360-hardecourt_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80418-80360-hardecourt_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80420-80560-harponville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80420-80560-harponville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80420-80560-harponville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80420-80560-harponville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80421-80700-hattencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80421-80700-hattencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80421-80700-hattencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80421-80700-hattencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80422-80132-hautvillers_ouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80422-80132-hautvillers_ouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80422-80132-hautvillers_ouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80422-80132-hautvillers_ouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80423-80670-havernas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80423-80670-havernas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80423-80670-havernas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80423-80670-havernas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80424-80680-hebecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80424-80680-hebecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80424-80680-hebecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80424-80680-hebecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80425-80560-hedauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80425-80560-hedauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80425-80560-hedauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80425-80560-hedauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80426-80800-heilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80426-80800-heilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80426-80800-heilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80426-80800-heilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80427-80600-hem_hardinval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80427-80600-hem_hardinval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80427-80600-hem_hardinval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80427-80600-hem_hardinval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80428-80360-hem_monacu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80428-80360-hem_monacu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80428-80360-hem_monacu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80428-80360-hem_monacu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80429-80300-henencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80429-80300-henencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80429-80300-henencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80429-80300-henencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80430-80200-herbecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80430-80200-herbecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80430-80200-herbecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80430-80200-herbecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80431-80260-herissart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80431-80260-herissart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80431-80260-herissart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80431-80260-herissart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80432-80340-herleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80432-80340-herleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80432-80340-herleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80432-80340-herleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80433-80190-herly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80433-80190-herly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80433-80190-herly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80433-80190-herly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80434-80240-hervilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80434-80240-hervilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80434-80240-hervilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80434-80240-hervilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80435-80240-hesbecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80435-80240-hesbecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80435-80240-hesbecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80435-80240-hesbecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80436-80290-hescamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80436-80290-hescamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80436-80290-hescamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80436-80290-hescamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80437-80270-heucourt_croquoison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80437-80270-heucourt_croquoison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80437-80270-heucourt_croquoison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80437-80270-heucourt_croquoison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80438-80122-heudicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80438-80122-heudicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80438-80122-heudicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80438-80122-heudicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80439-80370-heuzecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80439-80370-heuzecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80439-80370-heuzecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80439-80370-heuzecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80440-80370-hiermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80440-80370-hiermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80440-80370-hiermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80440-80370-hiermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80442-80400-hombleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80442-80400-hombleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80442-80400-hombleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80442-80400-hombleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80443-80640-hornoy_le_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80443-80640-hornoy_le_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80443-80640-hornoy_le_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80443-80640-hornoy_le_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80444-80132-huchenneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80444-80132-huchenneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80444-80132-huchenneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80444-80132-huchenneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80445-80600-humbercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80445-80600-humbercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80445-80600-humbercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80445-80600-humbercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80446-80140-huppy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80446-80140-huppy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80446-80140-huppy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80446-80140-huppy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80449-80800-ignaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80449-80800-ignaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80449-80800-ignaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80449-80800-ignaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80450-80430-inval_boiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80450-80430-inval_boiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80450-80430-inval_boiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80450-80430-inval_boiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80451-80300-irles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80451-80300-irles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80451-80300-irles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80451-80300-irles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80452-80250-jumel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80452-80250-jumel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80452-80250-jumel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80452-80250-jumel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80453-80500-laboissiere_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80453-80500-laboissiere_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80453-80500-laboissiere_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80453-80500-laboissiere_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80455-80290-lachapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80455-80290-lachapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80455-80290-lachapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80455-80290-lachapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80456-80430-lafresguimont_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80456-80430-lafresguimont_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80456-80430-lafresguimont_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80456-80430-lafresguimont_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80458-80800-lahoussoye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80458-80800-lahoussoye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80458-80800-lahoussoye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80458-80800-lahoussoye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80459-80270-laleu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80459-80270-laleu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80459-80270-laleu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80459-80270-laleu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80460-80290-lamaronde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80460-80290-lamaronde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80460-80290-lamaronde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80460-80290-lamaronde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80461-80450-lamotte_brebiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80461-80450-lamotte_brebiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80461-80450-lamotte_brebiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80461-80450-lamotte_brebiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80462-80150-lamotte_buleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80462-80150-lamotte_buleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80462-80150-lamotte_buleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80462-80150-lamotte_buleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80463-80800-lamotte_warfusee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80463-80800-lamotte_warfusee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80463-80800-lamotte_warfusee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80463-80800-lamotte_warfusee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80464-80230-lancheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80464-80230-lancheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80464-80230-lancheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80464-80230-lancheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80465-80190-languevoisin_quiquery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80465-80190-languevoisin_quiquery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80465-80190-languevoisin_quiquery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80465-80190-languevoisin_quiquery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80466-80620-lanches_saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80466-80620-lanches_saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80466-80620-lanches_saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80466-80620-lanches_saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80467-80700-laucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80467-80700-laucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80467-80700-laucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80467-80700-laucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80468-80300-lavieville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80468-80300-lavieville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80468-80300-lavieville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80468-80300-lavieville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80469-80250-lawarde_mauger_l_hortoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80469-80250-lawarde_mauger_l_hortoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80469-80250-lawarde_mauger_l_hortoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80469-80250-lawarde_mauger_l_hortoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80470-80560-lealvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80470-80560-lealvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80470-80560-lealvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80470-80560-lealvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80472-80360-lesboeufs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80472-80360-lesboeufs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80472-80360-lesboeufs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80472-80360-lesboeufs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80473-80700-liancourt_fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80473-80700-liancourt_fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80473-80700-liancourt_fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80473-80700-liancourt_fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80474-80320-licourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80474-80320-licourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80474-80320-licourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80474-80320-licourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80475-80240-lieramont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80475-80240-lieramont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80475-80240-lieramont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80475-80240-lieramont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80476-80580-liercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80476-80580-liercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80476-80580-liercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80476-80580-liercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80477-80150-ligescourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80477-80150-ligescourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80477-80150-ligescourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80477-80150-ligescourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80478-80500-lignieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80478-80500-lignieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80478-80500-lignieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80478-80500-lignieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80479-80290-lignieres_chatelain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80479-80290-lignieres_chatelain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80479-80290-lignieres_chatelain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80479-80290-lignieres_chatelain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80480-80140-lignieres_en_vimeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80480-80140-lignieres_en_vimeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80480-80140-lignieres_en_vimeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80480-80140-lignieres_en_vimeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80481-80320-lihons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80481-80320-lihons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80481-80320-lihons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80481-80320-lihons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80482-80490-limeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80482-80490-limeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80482-80490-limeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80482-80490-limeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80484-80430-liomer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80484-80430-liomer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80484-80430-liomer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80484-80430-liomer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80485-80160-o_de_selle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80485-80160-o_de_selle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80485-80160-o_de_selle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80485-80160-o_de_selle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80486-80510-long/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80486-80510-long/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80486-80510-long/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80486-80510-long/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80487-80240-longavesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80487-80240-longavesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80487-80240-longavesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80487-80240-longavesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80488-80510-longpre_les_corps_saints/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80488-80510-longpre_les_corps_saints/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80488-80510-longpre_les_corps_saints/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80488-80510-longpre_les_corps_saints/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80489-80330-longueau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80489-80330-longueau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80489-80330-longueau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80489-80330-longueau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80490-80360-longueval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80490-80360-longueval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80490-80360-longueval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80490-80360-longueval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80491-80600-longuevillette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80491-80600-longuevillette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80491-80600-longuevillette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80491-80600-longuevillette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80493-80560-louvencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80493-80560-louvencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80493-80560-louvencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80493-80560-louvencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80494-80250-louvrechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80494-80250-louvrechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80494-80250-louvrechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80494-80250-louvrechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80495-80600-lucheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80495-80600-lucheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80495-80600-lucheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80495-80600-lucheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80496-80150-machiel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80496-80150-machiel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80496-80150-machiel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80496-80150-machiel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80497-80150-machy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80497-80150-machy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80497-80150-machy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80497-80150-machy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80498-80560-mailly_maillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80498-80560-mailly_maillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80498-80560-mailly_maillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80498-80560-mailly_maillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80499-80110-mailly_raineval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80499-80110-mailly_raineval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80499-80110-mailly_raineval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80499-80110-mailly_raineval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80500-80220-maisnieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80500-80220-maisnieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80500-80220-maisnieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80500-80220-maisnieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80501-80150-maison_ponthieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80501-80150-maison_ponthieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80501-80150-maison_ponthieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80501-80150-maison_ponthieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80502-80135-maison_roland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80502-80135-maison_roland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80502-80135-maison_roland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80502-80135-maison_roland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80503-80370-maizicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80503-80370-maizicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80503-80370-maizicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80503-80370-maizicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80504-80250-malpart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80504-80250-malpart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80504-80250-malpart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80504-80250-malpart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80505-80300-carnoy_mametz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80505-80300-carnoy_mametz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80505-80300-carnoy_mametz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80505-80300-carnoy_mametz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80507-80800-marcelcave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80507-80800-marcelcave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80507-80800-marcelcave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80507-80800-marcelcave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80508-80700-marche_allouarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80508-80700-marche_allouarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80508-80700-marche_allouarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80508-80700-marche_allouarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80509-80200-marchelepot_misery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80509-80200-marchelepot_misery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80509-80200-marchelepot_misery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80509-80200-marchelepot_misery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80509-80320-marchelepot_misery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80509-80320-marchelepot_misery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80509-80320-marchelepot_misery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80509-80320-marchelepot_misery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80511-80500-marestmontiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80511-80500-marestmontiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80511-80500-marestmontiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80511-80500-marestmontiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80512-80132-mareuil_caubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80512-80132-mareuil_caubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80512-80132-mareuil_caubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80512-80132-mareuil_caubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80513-80360-maricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80513-80360-maricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80513-80360-maricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80513-80360-maricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80514-80560-marieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80514-80560-marieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80514-80560-marieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80514-80560-marieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80515-80290-marlers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80515-80290-marlers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80515-80290-marlers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80515-80290-marlers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80516-80240-marquaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80516-80240-marquaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80516-80240-marquaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80516-80240-marquaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80517-80700-marquivillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80517-80700-marquivillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80517-80700-marquivillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80517-80700-marquivillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80518-80140-martainneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80518-80140-martainneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80518-80140-martainneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80518-80140-martainneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80519-80400-matigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80519-80400-matigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80519-80400-matigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80519-80400-matigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80520-80170-maucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80520-80170-maucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80520-80170-maucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80520-80170-maucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80521-80360-maurepas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80521-80360-maurepas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80521-80360-maurepas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80521-80360-maurepas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80522-80430-le_mazis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80522-80430-le_mazis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80522-80430-le_mazis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80522-80430-le_mazis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80523-80300-meaulte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80523-80300-meaulte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80523-80300-meaulte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80523-80300-meaulte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80524-80170-meharicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80524-80170-meharicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80524-80170-meharicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80524-80170-meharicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80525-80290-meigneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80525-80290-meigneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80525-80290-meigneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80525-80290-meigneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80526-80370-le_meillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80526-80370-le_meillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80526-80370-le_meillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80526-80370-le_meillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80527-80520-meneslies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80527-80520-meneslies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80527-80520-meneslies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80527-80520-meneslies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80528-80290-mereaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80528-80290-mereaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80528-80290-mereaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80528-80290-mereaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80529-80490-merelessart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80529-80490-merelessart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80529-80490-merelessart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80529-80490-merelessart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80530-80800-mericourt_l_abbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80530-80800-mericourt_l_abbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80530-80800-mericourt_l_abbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80530-80800-mericourt_l_abbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80531-80640-mericourt_en_vimeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80531-80640-mericourt_en_vimeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80531-80640-mericourt_en_vimeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80531-80640-mericourt_en_vimeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80533-80350-mers_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80533-80350-mers_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80533-80350-mers_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80533-80350-mers_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80535-80310-le_mesge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80535-80310-le_mesge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80535-80310-le_mesge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80535-80310-le_mesge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80536-80200-mesnil_bruntel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80536-80200-mesnil_bruntel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80536-80200-mesnil_bruntel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80536-80200-mesnil_bruntel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80537-80620-mesnil_domqueur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80537-80620-mesnil_domqueur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80537-80620-mesnil_domqueur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80537-80620-mesnil_domqueur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80538-80360-mesnil_en_arrouaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80538-80360-mesnil_en_arrouaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80538-80360-mesnil_en_arrouaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80538-80360-mesnil_en_arrouaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80540-80300-mesnil_martinsart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80540-80300-mesnil_martinsart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80540-80300-mesnil_martinsart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80540-80300-mesnil_martinsart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80541-80500-mesnil_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80541-80500-mesnil_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80541-80500-mesnil_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80541-80500-mesnil_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80542-80190-mesnil_saint_nicaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80542-80190-mesnil_saint_nicaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80542-80190-mesnil_saint_nicaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80542-80190-mesnil_saint_nicaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80543-80270-metigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80543-80270-metigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80543-80270-metigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80543-80270-metigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80544-80600-mezerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80544-80600-mezerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80544-80600-mezerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80544-80600-mezerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80545-80110-mezieres_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80545-80110-mezieres_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80545-80110-mezieres_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80545-80110-mezieres_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80546-80132-miannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80546-80132-miannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80546-80132-miannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80546-80132-miannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80547-80300-millencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80547-80300-millencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80547-80300-millencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80547-80300-millencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80548-80135-millencourt_en_ponthieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80548-80135-millencourt_en_ponthieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80548-80135-millencourt_en_ponthieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80548-80135-millencourt_en_ponthieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80549-80300-miraumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80549-80300-miraumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80549-80300-miraumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80549-80300-miraumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80550-80260-mirvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80550-80260-mirvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80550-80260-mirvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80550-80260-mirvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80552-80200-moislains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80552-80200-moislains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80552-80200-moislains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80552-80200-moislains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80553-80260-molliens_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80553-80260-molliens_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80553-80260-molliens_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80553-80260-molliens_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80554-80540-molliens_dreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80554-80540-molliens_dreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80554-80540-molliens_dreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80554-80540-molliens_dreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80555-80200-monchy_lagache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80555-80200-monchy_lagache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80555-80200-monchy_lagache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80555-80200-monchy_lagache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80556-80210-mons_boubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80556-80210-mons_boubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80556-80210-mons_boubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80556-80210-mons_boubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80557-80200-estrees_mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80557-80200-estrees_mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80557-80200-estrees_mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80557-80200-estrees_mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80558-80160-monsures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80558-80160-monsures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80558-80160-monsures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80558-80160-monsures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80559-80540-montagne_fayel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80559-80540-montagne_fayel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80559-80540-montagne_fayel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80559-80540-montagne_fayel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80560-80300-montauban_de_picardie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80560-80300-montauban_de_picardie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80560-80300-montauban_de_picardie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80560-80300-montauban_de_picardie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80561-80500-montdidier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80561-80500-montdidier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80561-80500-montdidier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80561-80500-montdidier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80562-80260-montigny_sur_l_hallue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80562-80260-montigny_sur_l_hallue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80562-80260-montigny_sur_l_hallue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80562-80260-montigny_sur_l_hallue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80563-80370-montigny_les_jongleurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80563-80370-montigny_les_jongleurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80563-80370-montigny_les_jongleurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80563-80370-montigny_les_jongleurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80565-80260-montonvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80565-80260-montonvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80565-80260-montonvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80565-80260-montonvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80566-80670-fieffes_montrelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80566-80670-fieffes_montrelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80566-80670-fieffes_montrelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80566-80670-fieffes_montrelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80568-80190-morchain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80568-80190-morchain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80568-80190-morchain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80568-80190-morchain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80569-80340-morcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80569-80340-morcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80569-80340-morcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80569-80340-morcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80570-80110-moreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80570-80110-moreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80570-80110-moreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80570-80110-moreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80571-80110-morisel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80571-80110-morisel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80571-80110-morisel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80571-80110-morisel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80572-80300-morlancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80572-80300-morlancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80572-80300-morlancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80572-80300-morlancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80573-80290-morvillers_saint_saturnin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80573-80290-morvillers_saint_saturnin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80573-80290-morvillers_saint_saturnin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80573-80290-morvillers_saint_saturnin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80574-80690-mouflers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80574-80690-mouflers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80574-80690-mouflers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80574-80690-mouflers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80575-80140-mouflieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80575-80140-mouflieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80575-80140-mouflieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80575-80140-mouflieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80576-80400-moyencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80576-80400-moyencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80576-80400-moyencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80576-80400-moyencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80577-80290-moyencourt_les_poix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80577-80290-moyencourt_les_poix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80577-80290-moyencourt_les_poix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80577-80290-moyencourt_les_poix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80578-80870-moyenneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80578-80870-moyenneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80578-80870-moyenneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80578-80870-moyenneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80579-80400-muille_villette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80579-80400-muille_villette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80579-80400-muille_villette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80579-80400-muille_villette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80580-80120-nampont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80580-80120-nampont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80580-80120-nampont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80580-80120-nampont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80582-80290-namps_maisnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80582-80290-namps_maisnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80582-80290-namps_maisnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80582-80290-namps_maisnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80583-80160-nampty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80583-80160-nampty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80583-80160-nampty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80583-80160-nampty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80584-80260-naours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80584-80260-naours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80584-80260-naours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80584-80260-naours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80585-80190-nesle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80585-80190-nesle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80585-80190-nesle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80585-80190-nesle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80586-80140-nesle_l_hopital/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80586-80140-nesle_l_hopital/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80586-80140-nesle_l_hopital/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80586-80140-nesle_l_hopital/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80587-80140-neslette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80587-80140-neslette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80587-80140-neslette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80587-80140-neslette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80588-80132-neufmoulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80588-80132-neufmoulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80588-80132-neufmoulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80588-80132-neufmoulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80589-80150-neuilly_le_dien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80589-80150-neuilly_le_dien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80589-80150-neuilly_le_dien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80589-80150-neuilly_le_dien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80590-80132-neuilly_l_hopital/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80590-80132-neuilly_l_hopital/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80590-80132-neuilly_l_hopital/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80590-80132-neuilly_l_hopital/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80591-80140-neuville_au_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80591-80140-neuville_au_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80591-80140-neuville_au_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80591-80140-neuville_au_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80592-80430-neuville_coppegueule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80592-80430-neuville_coppegueule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80592-80430-neuville_coppegueule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80592-80430-neuville_coppegueule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80593-80340-la_neuville_les_bray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80593-80340-la_neuville_les_bray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80593-80340-la_neuville_les_bray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80593-80340-la_neuville_les_bray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80595-80110-la_neuville_sire_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80595-80110-la_neuville_sire_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80595-80110-la_neuville_sire_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80595-80110-la_neuville_sire_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80596-80600-neuvillette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80596-80600-neuvillette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80596-80600-neuvillette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80596-80600-neuvillette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80597-80390-nibas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80597-80390-nibas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80597-80390-nibas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80597-80390-nibas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80598-80860-nouvion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80598-80860-nouvion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80598-80860-nouvion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80598-80860-nouvion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80599-80150-noyelles_en_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80599-80150-noyelles_en_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80599-80150-noyelles_en_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80599-80150-noyelles_en_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80600-80860-noyelles_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80600-80860-noyelles_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80600-80860-noyelles_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80600-80860-noyelles_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80601-80240-nurlu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80601-80240-nurlu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80601-80240-nurlu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80601-80240-nurlu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80602-80600-occoches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80602-80600-occoches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80602-80600-occoches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80602-80600-occoches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80603-80210-ochancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80603-80210-ochancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80603-80210-ochancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80603-80210-ochancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80604-80290-offignies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80604-80290-offignies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80604-80290-offignies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80604-80290-offignies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80605-80400-offoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80605-80400-offoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80605-80400-offoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80605-80400-offoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80606-80140-oisemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80606-80140-oisemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80606-80140-oisemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80606-80140-oisemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80607-80540-oissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80607-80540-oissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80607-80540-oissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80607-80540-oissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80609-80135-oneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80609-80135-oneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80609-80135-oneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80609-80135-oneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80611-80160-oresmaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80611-80160-oresmaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80611-80160-oresmaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80611-80160-oresmaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80613-80460-oust_marest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80613-80460-oust_marest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80613-80460-oust_marest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80613-80460-oust_marest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80614-80600-outrebois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80614-80600-outrebois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80614-80600-outrebois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80614-80600-outrebois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80615-80300-ovillers_la_boisselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80615-80300-ovillers_la_boisselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80615-80300-ovillers_la_boisselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80615-80300-ovillers_la_boisselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80616-80190-pargny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80616-80190-pargny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80616-80190-pargny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80616-80190-pargny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80617-80700-parvillers_le_quesnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80617-80700-parvillers_le_quesnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80617-80700-parvillers_le_quesnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80617-80700-parvillers_le_quesnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80618-80230-pende/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80618-80230-pende/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80618-80230-pende/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80618-80230-pende/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80619-80670-pernois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80619-80670-pernois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80619-80670-pernois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80619-80670-pernois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80620-80200-peronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80620-80200-peronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80620-80200-peronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80620-80200-peronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80621-80320-hypercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80621-80320-hypercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80621-80320-hypercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80621-80320-hypercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80622-80310-picquigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80622-80310-picquigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80622-80310-picquigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80622-80310-picquigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80623-80500-piennes_onvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80623-80500-piennes_onvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80623-80500-piennes_onvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80623-80500-piennes_onvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80624-80260-pierregot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80624-80260-pierregot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80624-80260-pierregot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80624-80260-pierregot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80625-80500-trois_rivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80625-80500-trois_rivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80625-80500-trois_rivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80625-80500-trois_rivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80626-80540-pissy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80626-80540-pissy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80626-80540-pissy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80626-80540-pissy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80627-80160-plachy_buyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80627-80160-plachy_buyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80627-80160-plachy_buyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80627-80160-plachy_buyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80628-80110-le_plessier_rozainvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80628-80110-le_plessier_rozainvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80628-80110-le_plessier_rozainvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80628-80110-le_plessier_rozainvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80629-80240-poeuilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80629-80240-poeuilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80629-80240-poeuilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80629-80240-poeuilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80630-80290-poix_de_picardie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80630-80290-poix_de_picardie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80630-80290-poix_de_picardie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80630-80290-poix_de_picardie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80631-80150-ponches_estruval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80631-80150-ponches_estruval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80631-80150-ponches_estruval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80631-80150-ponches_estruval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80632-80480-pont_de_metz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80632-80480-pont_de_metz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80632-80480-pont_de_metz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80632-80480-pont_de_metz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80633-80860-ponthoile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80633-80860-ponthoile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80633-80860-ponthoile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80633-80860-ponthoile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80634-80115-pont_noyelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80634-80115-pont_noyelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80634-80115-pont_noyelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80634-80115-pont_noyelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80635-80580-pont_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80635-80580-pont_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80635-80580-pont_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80635-80580-pont_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80637-80132-port_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80637-80132-port_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80637-80132-port_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80637-80132-port_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80638-80190-potte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80638-80190-potte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80638-80190-potte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80638-80190-potte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80639-80260-poulainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80639-80260-poulainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80639-80260-poulainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80639-80260-poulainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80640-80300-pozieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80640-80300-pozieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80640-80300-pozieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80640-80300-pozieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80642-80370-prouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80642-80370-prouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80642-80370-prouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80642-80370-prouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80643-80160-prouzel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80643-80160-prouzel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80643-80160-prouzel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80643-80160-prouzel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80644-80340-proyart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80644-80340-proyart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80644-80340-proyart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80644-80340-proyart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80645-80560-puchevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80645-80560-puchevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80645-80560-puchevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80645-80560-puchevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80646-80320-punchy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80646-80320-punchy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80646-80320-punchy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80646-80320-punchy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80647-80320-puzeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80647-80320-puzeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80647-80320-puzeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80647-80320-puzeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80648-80300-pys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80648-80300-pys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80648-80300-pys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80648-80300-pys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80649-80120-quend/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80649-80120-quend/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80649-80120-quend/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80649-80120-quend/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80650-80115-querrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80650-80115-querrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80650-80115-querrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80650-80115-querrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80651-80430-le_quesne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80651-80430-le_quesne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80651-80430-le_quesne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80651-80430-le_quesne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80652-80118-le_quesnel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80652-80118-le_quesnel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80652-80118-le_quesnel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80652-80118-le_quesnel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80654-80132-quesnoy_le_montant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80654-80132-quesnoy_le_montant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80654-80132-quesnoy_le_montant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80654-80132-quesnoy_le_montant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80655-80270-quesnoy_sur_airaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80655-80270-quesnoy_sur_airaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80655-80270-quesnoy_sur_airaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80655-80270-quesnoy_sur_airaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80656-80710-quevauvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80656-80710-quevauvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80656-80710-quevauvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80656-80710-quevauvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80657-80250-quiry_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80657-80250-quiry_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80657-80250-quiry_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80657-80250-quiry_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80658-80400-quivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80658-80400-quivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80658-80400-quivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80658-80400-quivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80659-80600-raincheval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80659-80600-raincheval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80659-80600-raincheval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80659-80600-raincheval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80661-80260-rainneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80661-80260-rainneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80661-80260-rainneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80661-80260-rainneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80662-80140-ramburelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80662-80140-ramburelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80662-80140-ramburelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80662-80140-ramburelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80663-80140-rambures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80663-80140-rambures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80663-80140-rambures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80663-80140-rambures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80664-80360-rancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80664-80360-rancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80664-80360-rancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80664-80360-rancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80665-80120-regniere_ecluse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80665-80120-regniere_ecluse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80665-80120-regniere_ecluse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80665-80120-regniere_ecluse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80666-80600-remaisnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80666-80600-remaisnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80666-80600-remaisnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80666-80600-remaisnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80667-80500-remaugies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80667-80500-remaugies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80667-80500-remaugies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80667-80500-remaugies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80668-80250-remiencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80668-80250-remiencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80668-80250-remiencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80668-80250-remiencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80669-80700-rethonvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80669-80700-rethonvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80669-80700-rethonvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80669-80700-rethonvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80670-80540-revelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80670-80540-revelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80670-80540-revelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80670-80540-revelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80671-80620-ribeaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80671-80620-ribeaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80671-80620-ribeaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80671-80620-ribeaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80672-80800-ribemont_sur_ancre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80672-80800-ribemont_sur_ancre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80672-80800-ribemont_sur_ancre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80672-80800-ribemont_sur_ancre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80673-80310-riencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80673-80310-riencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80673-80310-riencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80673-80310-riencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80674-80136-rivery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80674-80136-rivery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80674-80136-rivery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80674-80136-rivery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80675-80160-rogy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80675-80160-rogy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80675-80160-rogy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80675-80160-rogy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80676-80700-roiglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80676-80700-roiglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80676-80700-roiglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80676-80700-roiglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80677-80240-roisel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80677-80240-roisel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80677-80240-roisel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80677-80240-roisel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80678-80500-rollot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80678-80500-rollot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80678-80500-rollot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80678-80500-rollot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80679-80740-ronssoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80679-80740-ronssoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80679-80740-ronssoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80679-80740-ronssoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80680-80170-rosieres_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80680-80170-rosieres_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80680-80170-rosieres_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80680-80170-rosieres_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80681-80250-rouvrel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80681-80250-rouvrel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80681-80250-rouvrel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80681-80250-rouvrel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80682-80170-rouvroy_en_santerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80682-80170-rouvroy_en_santerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80682-80170-rouvroy_en_santerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80682-80170-rouvroy_en_santerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80683-80190-rouy_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80683-80190-rouy_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80683-80190-rouy_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80683-80190-rouy_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80684-80190-rouy_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80684-80190-rouy_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80684-80190-rouy_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80684-80190-rouy_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80685-80700-roye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80685-80700-roye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80685-80700-roye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80685-80700-roye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80686-80260-rubempre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80686-80260-rubempre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80686-80260-rubempre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80686-80260-rubempre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80687-80500-rubescourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80687-80500-rubescourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80687-80500-rubescourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80687-80500-rubescourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80688-80120-rue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80688-80120-rue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80688-80120-rue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80688-80120-rue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80690-80680-rumigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80690-80680-rumigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80690-80680-rumigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80690-80680-rumigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80691-80230-saigneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80691-80230-saigneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80691-80230-saigneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80691-80230-saigneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80692-80970-sailly_flibeaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80692-80970-sailly_flibeaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80692-80970-sailly_flibeaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80692-80970-sailly_flibeaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80693-80800-sailly_laurette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80693-80800-sailly_laurette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80693-80800-sailly_laurette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80693-80800-sailly_laurette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80694-80800-sailly_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80694-80800-sailly_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80694-80800-sailly_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80694-80800-sailly_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80695-80360-sailly_saillisel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80695-80360-sailly_saillisel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80695-80360-sailly_saillisel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80695-80360-sailly_saillisel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80696-80680-sains_en_amienois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80696-80680-sains_en_amienois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80696-80680-sains_en_amienois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80696-80680-sains_en_amienois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80697-80370-saint_acheul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80697-80370-saint_acheul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80697-80370-saint_acheul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80697-80370-saint_acheul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80698-80540-saint_aubin_montenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80698-80540-saint_aubin_montenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80698-80540-saint_aubin_montenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80698-80540-saint_aubin_montenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80699-80430-saint_aubin_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80699-80430-saint_aubin_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80699-80430-saint_aubin_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80699-80430-saint_aubin_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80700-80960-saint_blimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80700-80960-saint_blimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80700-80960-saint_blimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80700-80960-saint_blimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80701-80200-saint_christ_briost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80701-80200-saint_christ_briost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80701-80200-saint_christ_briost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80701-80200-saint_christ_briost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80702-80680-saint_fuscien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80702-80680-saint_fuscien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80702-80680-saint_fuscien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80702-80680-saint_fuscien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80703-80430-saint_germain_sur_bresle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80703-80430-saint_germain_sur_bresle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80703-80430-saint_germain_sur_bresle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80703-80430-saint_germain_sur_bresle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80704-80260-saint_gratien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80704-80260-saint_gratien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80704-80260-saint_gratien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80704-80260-saint_gratien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80705-80560-saint_leger_les_authie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80705-80560-saint_leger_les_authie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80705-80560-saint_leger_les_authie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80705-80560-saint_leger_les_authie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80706-80780-saint_leger_les_domart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80706-80780-saint_leger_les_domart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80706-80780-saint_leger_les_domart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80706-80780-saint_leger_les_domart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80707-80140-saint_leger_sur_bresle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80707-80140-saint_leger_sur_bresle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80707-80140-saint_leger_sur_bresle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80707-80140-saint_leger_sur_bresle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80708-80700-saint_mard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80708-80700-saint_mard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80708-80700-saint_mard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80708-80700-saint_mard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80709-80140-saint_maulvis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80709-80140-saint_maulvis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80709-80140-saint_maulvis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80709-80140-saint_maulvis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80710-80140-saint_maxent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80710-80140-saint_maxent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80710-80140-saint_maxent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80710-80140-saint_maxent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80711-80610-saint_ouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80711-80610-saint_ouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80711-80610-saint_ouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80711-80610-saint_ouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80713-80120-saint_quentin_en_tourmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80713-80120-saint_quentin_en_tourmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80713-80120-saint_quentin_en_tourmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80713-80120-saint_quentin_en_tourmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80714-80880-saint_quentin_la_motte_croix_au_bailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80714-80880-saint_quentin_la_motte_croix_au_bailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80714-80880-saint_quentin_la_motte_croix_au_bailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80714-80880-saint_quentin_la_motte_croix_au_bailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80716-80135-saint_riquier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80716-80135-saint_riquier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80716-80135-saint_riquier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80716-80135-saint_riquier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80717-80160-saint_sauflieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80717-80160-saint_sauflieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80717-80160-saint_sauflieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80717-80160-saint_sauflieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80718-80470-saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80718-80470-saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80718-80470-saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80718-80470-saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80719-80290-sainte_segree/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80719-80290-sainte_segree/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80719-80290-sainte_segree/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80719-80290-sainte_segree/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80721-80230-saint_valery_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80721-80230-saint_valery_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80721-80230-saint_valery_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80721-80230-saint_valery_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80722-80310-saint_vaast_en_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80722-80310-saint_vaast_en_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80722-80310-saint_vaast_en_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80722-80310-saint_vaast_en_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80723-80540-saisseval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80723-80540-saisseval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80723-80540-saisseval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80723-80540-saisseval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80724-80480-saleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80724-80480-saleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80724-80480-saleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80724-80480-saleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80725-80480-salouel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80725-80480-salouel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80725-80480-salouel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80725-80480-salouel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80726-80400-sancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80726-80400-sancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80726-80400-sancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80726-80400-sancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80728-80290-saulchoy_sous_poix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80728-80290-saulchoy_sous_poix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80728-80290-saulchoy_sous_poix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80728-80290-saulchoy_sous_poix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80729-80110-sauvillers_mongival/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80729-80110-sauvillers_mongival/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80729-80110-sauvillers_mongival/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80729-80110-sauvillers_mongival/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80730-80470-saveuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80730-80470-saveuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80730-80470-saveuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80730-80470-saveuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80732-80140-senarpont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80732-80140-senarpont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80732-80140-senarpont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80732-80140-senarpont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80733-80300-senlis_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80733-80300-senlis_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80733-80300-senlis_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80733-80300-senlis_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80734-80160-sentelie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80734-80160-sentelie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80734-80160-sentelie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80734-80160-sentelie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80735-80540-seux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80735-80540-seux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80735-80540-seux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80735-80540-seux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80736-80490-sorel_en_vimeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80736-80490-sorel_en_vimeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80736-80490-sorel_en_vimeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80736-80490-sorel_en_vimeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80737-80240-sorel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80737-80240-sorel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80737-80240-sorel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80737-80240-sorel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80738-80310-soues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80738-80310-soues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80738-80310-soues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80738-80310-soues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80740-80250-sourdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80740-80250-sourdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80740-80250-sourdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80740-80250-sourdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80741-80200-soyecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80741-80200-soyecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80741-80200-soyecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80741-80200-soyecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80742-80620-surcamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80742-80620-surcamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80742-80620-surcamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80742-80620-surcamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80743-80340-suzanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80743-80340-suzanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80743-80340-suzanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80743-80340-suzanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80744-80270-tailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80744-80270-tailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80744-80270-tailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80744-80270-tailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80746-80260-talmas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80746-80260-talmas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80746-80260-talmas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80746-80260-talmas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80747-80240-templeux_la_fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80747-80240-templeux_la_fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80747-80240-templeux_la_fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80747-80240-templeux_la_fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80748-80240-templeux_le_guerard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80748-80240-templeux_le_guerard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80748-80240-templeux_le_guerard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80748-80240-templeux_le_guerard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80749-80600-terramesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80749-80600-terramesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80749-80600-terramesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80749-80600-terramesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80750-80200-tertry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80750-80200-tertry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80750-80200-tertry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80750-80200-tertry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80751-80110-thennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80751-80110-thennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80751-80110-thennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80751-80110-thennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80752-80440-thezy_glimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80752-80440-thezy_glimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80752-80440-thezy_glimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80752-80440-thezy_glimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80753-80300-thiepval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80753-80300-thiepval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80753-80300-thiepval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80753-80300-thiepval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80754-80640-thieulloy_l_abbaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80754-80640-thieulloy_l_abbaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80754-80640-thieulloy_l_abbaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80754-80640-thieulloy_l_abbaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80755-80290-thieulloy_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80755-80290-thieulloy_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80755-80290-thieulloy_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80755-80290-thieulloy_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80756-62760-thievres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80756-62760-thievres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80756-62760-thievres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80756-62760-thievres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80757-80160-thoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80757-80160-thoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80757-80160-thoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80757-80160-thoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80758-80250-thory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80758-80250-thory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80758-80250-thory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80758-80250-thory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80759-80700-tilloloy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80759-80700-tilloloy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80759-80700-tilloloy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80759-80700-tilloloy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80760-80220-tilloy_floriville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80760-80220-tilloy_floriville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80760-80220-tilloy_floriville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80760-80220-tilloy_floriville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80762-80240-tincourt_boucly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80762-80240-tincourt_boucly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80762-80240-tincourt_boucly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80762-80240-tincourt_boucly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80763-80132-le_titre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80763-80132-le_titre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80763-80132-le_titre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80763-80132-le_titre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80764-80870-toeufles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80764-80870-toeufles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80764-80870-toeufles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80764-80870-toeufles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80765-80210-tours_en_vimeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80765-80210-tours_en_vimeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80765-80210-tours_en_vimeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80765-80210-tours_en_vimeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80766-80560-toutencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80766-80560-toutencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80766-80560-toutencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80766-80560-toutencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80767-80140-le_translay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80767-80140-le_translay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80767-80140-le_translay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80767-80140-le_translay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80769-80300-treux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80769-80300-treux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80769-80300-treux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80769-80300-treux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80770-80130-tully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80770-80130-tully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80770-80130-tully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80770-80130-tully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80771-80400-ugny_l_equipee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80771-80400-ugny_l_equipee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80771-80400-ugny_l_equipee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80771-80400-ugny_l_equipee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80773-80560-vadencourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80773-80560-vadencourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80773-80560-vadencourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80773-80560-vadencourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80774-80800-vaire_sous_corbie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80774-80800-vaire_sous_corbie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80774-80800-vaire_sous_corbie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80774-80800-vaire_sous_corbie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80775-80210-valines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80775-80210-valines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80775-80210-valines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80775-80210-valines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80776-80560-varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80776-80560-varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80776-80560-varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80776-80560-varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80777-80560-vauchelles_les_authie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80777-80560-vauchelles_les_authie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80777-80560-vauchelles_les_authie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80777-80560-vauchelles_les_authie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80778-80620-vauchelles_les_domart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80778-80620-vauchelles_les_domart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80778-80620-vauchelles_les_domart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80778-80620-vauchelles_les_domart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80779-80132-vauchelles_les_quesnoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80779-80132-vauchelles_les_quesnoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80779-80132-vauchelles_les_quesnoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80779-80132-vauchelles_les_quesnoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80780-80230-vaudricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80780-80230-vaudricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80780-80230-vaudricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80780-80230-vaudricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80781-80131-vauvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80781-80131-vauvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80781-80131-vauvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80781-80131-vauvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80782-80260-vaux_en_amienois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80782-80260-vaux_en_amienois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80782-80260-vaux_en_amienois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80782-80260-vaux_en_amienois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80783-80140-vaux_marquenneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80783-80140-vaux_marquenneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80783-80140-vaux_marquenneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80783-80140-vaux_marquenneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80784-80800-vaux_sur_somme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80784-80800-vaux_sur_somme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80784-80800-vaux_sur_somme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80784-80800-vaux_sur_somme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80785-80800-vecquemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80785-80800-vecquemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80785-80800-vecquemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80785-80800-vecquemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80786-80160-velennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80786-80160-velennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80786-80160-velennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80786-80160-velennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80787-80120-vercourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80787-80120-vercourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80787-80120-vercourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80787-80120-vercourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80788-80270-vergies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80788-80270-vergies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80788-80270-vergies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80788-80270-vergies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80789-80320-vermandovillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80789-80320-vermandovillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80789-80320-vermandovillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80789-80320-vermandovillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80790-80700-verpillieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80790-80700-verpillieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80790-80700-verpillieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80790-80700-verpillieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80791-80480-vers_sur_selle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80791-80480-vers_sur_selle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80791-80480-vers_sur_selle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80791-80480-vers_sur_selle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80792-80260-la_vicogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80792-80260-la_vicogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80792-80260-la_vicogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80792-80260-la_vicogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80793-80650-vignacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80793-80650-vignacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80793-80650-vignacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80793-80650-vignacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80794-80190-villecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80794-80190-villecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80794-80190-villecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80794-80190-villecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80795-80420-ville_le_marclet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80795-80420-ville_le_marclet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80795-80420-ville_le_marclet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80795-80420-ville_le_marclet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80796-80140-villeroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80796-80140-villeroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80796-80140-villeroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80796-80140-villeroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80797-80110-villers_aux_erables/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80797-80110-villers_aux_erables/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80797-80110-villers_aux_erables/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80797-80110-villers_aux_erables/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80798-80260-villers_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80798-80260-villers_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80798-80260-villers_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80798-80260-villers_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80799-80800-villers_bretonneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80799-80800-villers_bretonneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80799-80800-villers_bretonneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80799-80800-villers_bretonneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80800-80140-villers_campsart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80800-80140-villers_campsart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80800-80140-villers_campsart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80800-80140-villers_campsart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80801-80200-villers_carbonnel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80801-80200-villers_carbonnel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80801-80200-villers_carbonnel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80801-80200-villers_carbonnel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80802-80240-villers_faucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80802-80240-villers_faucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80802-80240-villers_faucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80802-80240-villers_faucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80803-80700-villers_les_roye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80803-80700-villers_les_roye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80803-80700-villers_les_roye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80803-80700-villers_les_roye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80804-80690-villers_sous_ailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80804-80690-villers_sous_ailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80804-80690-villers_sous_ailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80804-80690-villers_sous_ailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80805-80500-villers_tournelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80805-80500-villers_tournelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80805-80500-villers_tournelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80805-80500-villers_tournelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80806-80120-villers_sur_authie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80806-80120-villers_sur_authie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80806-80120-villers_sur_authie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80806-80120-villers_sur_authie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80807-80300-ville_sur_ancre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80807-80300-ville_sur_ancre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80807-80300-ville_sur_ancre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80807-80300-ville_sur_ancre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80808-80150-vironchaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80808-80150-vironchaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80808-80150-vironchaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80808-80150-vironchaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80809-80140-vismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80809-80140-vismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80809-80140-vismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80809-80140-vismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80810-80150-vitz_sur_authie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80810-80150-vitz_sur_authie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80810-80150-vitz_sur_authie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80810-80150-vitz_sur_authie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80811-80400-voyennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80811-80400-voyennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80811-80400-voyennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80811-80400-voyennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80812-80240-vraignes_en_vermandois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80812-80240-vraignes_en_vermandois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80812-80240-vraignes_en_vermandois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80812-80240-vraignes_en_vermandois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80813-80640-vraignes_les_hornoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80813-80640-vraignes_les_hornoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80813-80640-vraignes_les_hornoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80813-80640-vraignes_les_hornoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80814-80170-vrely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80814-80170-vrely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80814-80170-vrely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80814-80170-vrely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80815-80120-vron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80815-80120-vron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80815-80120-vron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80815-80120-vron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80819-80670-wargnies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80819-80670-wargnies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80819-80670-wargnies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80819-80670-wargnies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80820-80300-warloy_baillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80820-80300-warloy_baillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80820-80300-warloy_baillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80820-80300-warloy_baillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80821-80270-warlus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80821-80270-warlus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80821-80270-warlus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80821-80270-warlus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80822-80500-warsy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80822-80500-warsy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80822-80500-warsy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80822-80500-warsy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80823-80170-warvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80823-80170-warvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80823-80170-warvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80823-80170-warvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80824-80170-wiencourt_l_equipee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80824-80170-wiencourt_l_equipee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80824-80170-wiencourt_l_equipee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80824-80170-wiencourt_l_equipee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80825-80270-wiry_au_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80825-80270-wiry_au_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80825-80270-wiry_au_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80825-80270-wiry_au_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80826-80460-woignarue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80826-80460-woignarue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80826-80460-woignarue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80826-80460-woignarue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80827-80520-woincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80827-80520-woincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80827-80520-woincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80827-80520-woincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80828-80140-woirel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80828-80140-woirel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80828-80140-woirel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80828-80140-woirel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80829-80190-y/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80829-80190-y/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80829-80190-y/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80829-80190-y/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80830-80135-yaucourt_bussus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80830-80135-yaucourt_bussus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80830-80135-yaucourt_bussus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80830-80135-yaucourt_bussus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80832-80150-yvrench/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80832-80150-yvrench/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80832-80150-yvrench/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80832-80150-yvrench/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80833-80150-yvrencheux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80833-80150-yvrencheux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80833-80150-yvrencheux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80833-80150-yvrencheux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80834-80520-yzengremer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80834-80520-yzengremer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80834-80520-yzengremer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80834-80520-yzengremer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80835-80310-yzeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80835-80310-yzeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80835-80310-yzeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80835-80310-yzeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80836-80132-yonval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80836-80132-yonval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80836-80132-yonval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt80-somme/commune80836-80132-yonval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-81.xml
+++ b/public/sitemaps/sitemap-81.xml
@@ -5,658 +5,1312 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81001-81470-aguts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81001-81470-aguts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81001-81470-aguts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81001-81470-aguts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81002-81200-aiguefonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81002-81200-aiguefonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81002-81200-aiguefonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81002-81200-aiguefonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81003-81250-alban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81003-81250-alban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81003-81250-alban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81003-81250-alban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81004-81000-albi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81004-81000-albi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81004-81000-albi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81004-81000-albi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81005-81240-albine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81005-81240-albine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81005-81240-albine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81005-81240-albine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81006-81470-algans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81006-81470-algans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81006-81470-algans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81006-81470-algans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81007-81140-alos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81007-81140-alos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81007-81140-alos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81007-81140-alos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81008-81190-almayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81008-81190-almayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81008-81190-almayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81008-81190-almayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81009-81170-amarens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81009-81170-amarens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81009-81170-amarens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81009-81170-amarens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81010-81430-ambialet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81010-81430-ambialet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81010-81430-ambialet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81010-81430-ambialet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81011-81500-ambres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81011-81500-ambres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81011-81500-ambres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81011-81500-ambres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81012-81140-andillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81012-81140-andillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81012-81140-andillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81012-81140-andillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81013-81350-andouque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81013-81350-andouque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81013-81350-andouque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81013-81350-andouque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81014-81260-angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81014-81260-angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81014-81260-angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81014-81260-angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81015-81700-appelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81015-81700-appelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81015-81700-appelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81015-81700-appelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81016-81110-arfons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81016-81110-arfons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81016-81110-arfons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81016-81110-arfons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81017-81360-arifat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81017-81360-arifat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81017-81360-arifat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81017-81360-arifat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81018-81160-arthes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81018-81160-arthes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81018-81160-arthes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81018-81160-arthes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81019-81340-assac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81019-81340-assac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81019-81340-assac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81019-81340-assac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81020-81600-aussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81020-81600-aussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81020-81600-aussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81020-81600-aussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81021-81200-aussillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81021-81200-aussillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81021-81200-aussillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81021-81200-aussillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81022-81500-bannieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81022-81500-bannieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81022-81500-bannieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81022-81500-bannieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81023-81320-barre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81023-81320-barre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81023-81320-barre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81023-81320-barre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81024-81630-beauvais_sur_tescou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81024-81630-beauvais_sur_tescou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81024-81630-beauvais_sur_tescou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81024-81630-beauvais_sur_tescou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81025-81500-belcastel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81025-81500-belcastel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81025-81500-belcastel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81025-81500-belcastel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81026-81430-bellegarde_marsal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81026-81430-bellegarde_marsal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81026-81430-bellegarde_marsal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81026-81430-bellegarde_marsal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81027-81540-belleserre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81027-81540-belleserre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81027-81540-belleserre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81027-81540-belleserre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81028-81260-berlats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81028-81260-berlats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81028-81260-berlats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81028-81260-berlats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81029-81150-bernac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81029-81150-bernac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81029-81150-bernac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81029-81150-bernac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81030-81700-bertre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81030-81700-bertre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81030-81700-bertre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81030-81700-bertre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81031-81260-le_bez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81031-81260-le_bez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81031-81260-le_bez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81031-81260-le_bez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81032-81700-blan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81032-81700-blan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81032-81700-blan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81032-81700-blan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81033-81400-blaye_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81033-81400-blaye_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81033-81400-blaye_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81033-81400-blaye_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81034-81490-boissezon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81034-81490-boissezon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81034-81490-boissezon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81034-81490-boissezon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81034-81100-boissezon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81034-81100-boissezon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81034-81100-boissezon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81034-81100-boissezon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81035-81170-bournazel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81035-81170-bournazel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81035-81170-bournazel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81035-81170-bournazel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81036-81660-bout_du_pont_de_larn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81036-81660-bout_du_pont_de_larn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81036-81660-bout_du_pont_de_larn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81036-81660-bout_du_pont_de_larn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81036-81200-bout_du_pont_de_larn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81036-81200-bout_du_pont_de_larn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81036-81200-bout_du_pont_de_larn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81036-81200-bout_du_pont_de_larn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81037-81260-brassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81037-81260-brassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81037-81260-brassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81037-81260-brassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81038-81600-brens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81038-81600-brens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81038-81600-brens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81038-81600-brens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81039-81390-briatexte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81039-81390-briatexte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81039-81390-briatexte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81039-81390-briatexte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81040-81440-brousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81040-81440-brousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81040-81440-brousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81040-81440-brousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81041-81600-broze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81041-81600-broze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81041-81600-broze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81041-81600-broze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81042-81100-burlats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81042-81100-burlats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81042-81100-burlats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81042-81100-burlats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81043-81300-busque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81043-81300-busque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81043-81300-busque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81043-81300-busque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81044-81500-cabanes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81044-81500-cabanes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81044-81500-cabanes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81044-81500-cabanes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81045-81170-les_cabannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81045-81170-les_cabannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81045-81170-les_cabannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81045-81170-les_cabannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81046-81600-cadalen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81046-81600-cadalen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81046-81600-cadalen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81046-81600-cadalen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81047-81340-cadix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81047-81340-cadix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81047-81340-cadix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81047-81340-cadix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81048-81130-cagnac_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81048-81130-cagnac_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81048-81130-cagnac_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81048-81130-cagnac_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81048-81400-cagnac_les_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81048-81400-cagnac_les_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81048-81400-cagnac_les_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81048-81400-cagnac_les_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81049-81540-cahuzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81049-81540-cahuzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81049-81540-cahuzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81049-81540-cahuzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81050-81470-cambon_les_lavaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81050-81470-cambon_les_lavaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81050-81470-cambon_les_lavaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81050-81470-cambon_les_lavaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81051-81140-cahuzac_sur_vere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81051-81140-cahuzac_sur_vere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81051-81140-cahuzac_sur_vere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81051-81140-cahuzac_sur_vere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81052-81990-cambon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81052-81990-cambon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81052-81990-cambon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81052-81990-cambon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81053-81260-cambounes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81053-81260-cambounes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81053-81260-cambounes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81053-81260-cambounes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81054-81580-cambounet_sur_le_sor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81054-81580-cambounet_sur_le_sor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81054-81580-cambounet_sur_le_sor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81054-81580-cambounet_sur_le_sor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81055-81540-les_cammazes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81055-81540-les_cammazes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81055-81540-les_cammazes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81055-81540-les_cammazes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81056-81140-campagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81056-81140-campagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81056-81140-campagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81056-81140-campagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81058-81570-carbes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81058-81570-carbes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81058-81570-carbes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81058-81570-carbes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81059-81990-carlus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81059-81990-carlus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81059-81990-carlus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81059-81990-carlus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81060-81400-carmaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81060-81400-carmaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81060-81400-carmaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81060-81400-carmaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81061-81150-castanet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81061-81150-castanet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81061-81150-castanet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81061-81150-castanet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81062-81260-fontrieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81062-81260-fontrieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81062-81260-fontrieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81062-81260-fontrieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81063-81150-castelnau_de_levis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81063-81150-castelnau_de_levis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81063-81150-castelnau_de_levis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81063-81150-castelnau_de_levis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81064-81140-castelnau_de_montmiral/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81064-81140-castelnau_de_montmiral/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81064-81140-castelnau_de_montmiral/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81064-81140-castelnau_de_montmiral/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81065-81100-castres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81065-81100-castres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81065-81100-castres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81065-81100-castres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81066-81200-caucalieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81066-81200-caucalieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81066-81200-caucalieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81066-81200-caucalieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81067-81150-cestayrols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81067-81150-cestayrols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81067-81150-cestayrols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81067-81150-cestayrols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81068-81640-combefa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81068-81640-combefa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81068-81640-combefa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81068-81640-combefa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81069-81170-cordes_sur_ciel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81069-81170-cordes_sur_ciel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81069-81170-cordes_sur_ciel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81069-81170-cordes_sur_ciel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81070-81800-coufouleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81070-81800-coufouleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81070-81800-coufouleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81070-81800-coufouleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81071-81340-courris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81071-81340-courris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81071-81340-courris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81071-81340-courris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81072-81350-crespin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81072-81350-crespin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81072-81350-crespin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81072-81350-crespin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81073-81350-crespinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81073-81350-crespinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81073-81350-crespinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81073-81350-crespinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81074-81990-cunac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81074-81990-cunac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81074-81990-cunac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81074-81990-cunac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81075-81570-cuq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81075-81570-cuq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81075-81570-cuq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81075-81570-cuq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81076-81470-cuq_toulza/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81076-81470-cuq_toulza/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81076-81470-cuq_toulza/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81076-81470-cuq_toulza/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81077-81250-curvalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81077-81250-curvalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81077-81250-curvalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81077-81250-curvalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81078-81220-damiatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81078-81220-damiatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81078-81220-damiatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81078-81220-damiatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81079-81120-denat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81079-81120-denat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81079-81120-denat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81079-81120-denat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81080-81170-donnazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81080-81170-donnazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81080-81170-donnazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81080-81170-donnazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81081-81110-dourgne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81081-81110-dourgne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81081-81110-dourgne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81081-81110-dourgne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81082-81340-le_dourn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81082-81340-le_dourn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81082-81340-le_dourn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81082-81340-le_dourn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81083-81540-durfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81083-81540-durfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81083-81540-durfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81083-81540-durfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81084-81290-escoussens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81084-81290-escoussens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81084-81290-escoussens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81084-81290-escoussens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81085-81530-escroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81085-81530-escroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81085-81530-escroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81085-81530-escroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81086-81260-esperausses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81086-81260-esperausses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81086-81260-esperausses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81086-81260-esperausses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81087-81150-fayssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81087-81150-fayssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81087-81150-fayssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81087-81150-fayssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81088-81120-fauch/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81088-81120-fauch/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81088-81120-fauch/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81088-81120-fauch/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81089-81340-faussergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81089-81340-faussergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81089-81340-faussergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81089-81340-faussergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81090-81600-fenols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81090-81600-fenols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81090-81600-fenols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81090-81600-fenols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81092-81500-fiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81092-81500-fiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81092-81500-fiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81092-81500-fiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81093-81150-florentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81093-81150-florentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81093-81150-florentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81093-81150-florentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81094-81340-fraissines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81094-81340-fraissines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81094-81340-fraissines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81094-81340-fraissines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81095-81170-frausseilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81095-81170-frausseilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81095-81170-frausseilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81095-81170-frausseilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81096-81430-le_fraysse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81096-81430-le_fraysse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81096-81430-le_fraysse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81096-81430-le_fraysse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81097-81990-frejairolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81097-81990-frejairolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81097-81990-frejairolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81097-81990-frejairolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81098-81570-frejeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81098-81570-frejeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81098-81570-frejeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81098-81570-frejeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81099-81600-gaillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81099-81600-gaillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81099-81600-gaillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81099-81600-gaillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81100-81700-garrevaques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81100-81700-garrevaques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81100-81700-garrevaques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81100-81700-garrevaques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81101-81450-le_garric/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81101-81450-le_garric/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81101-81450-le_garric/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81101-81450-le_garric/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81101-81400-le_garric/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81101-81400-le_garric/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81101-81400-le_garric/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81101-81400-le_garric/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81102-81500-garrigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81102-81500-garrigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81102-81500-garrigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81102-81500-garrigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81103-81530-gijounet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81103-81530-gijounet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81103-81530-gijounet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81103-81530-gijounet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81103-81230-gijounet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81103-81230-gijounet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81103-81230-gijounet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81103-81230-gijounet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81104-81500-giroussens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81104-81500-giroussens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81104-81500-giroussens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81104-81500-giroussens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81105-81300-graulhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81105-81300-graulhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81105-81300-graulhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81105-81300-graulhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81106-81800-grazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81106-81800-grazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81106-81800-grazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81106-81800-grazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81108-81170-itzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81108-81170-itzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81108-81170-itzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81108-81170-itzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81109-81440-jonquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81109-81440-jonquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81109-81440-jonquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81109-81440-jonquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81110-81190-jouqueviel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81110-81190-jouqueviel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81110-81190-jouqueviel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81110-81190-jouqueviel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81111-81170-labarthe_bleys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81111-81170-labarthe_bleys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81111-81170-labarthe_bleys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81111-81170-labarthe_bleys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81112-81150-labastide_de_levis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81112-81150-labastide_de_levis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81112-81150-labastide_de_levis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81112-81150-labastide_de_levis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81114-81400-labastide_gabausse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81114-81400-labastide_gabausse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81114-81400-labastide_gabausse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81114-81400-labastide_gabausse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81115-81270-labastide_rouairoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81115-81270-labastide_rouairoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81115-81270-labastide_rouairoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81115-81270-labastide_rouairoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81116-81500-labastide_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81116-81500-labastide_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81116-81500-labastide_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81116-81500-labastide_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81117-81300-labessiere_candeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81117-81300-labessiere_candeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81117-81300-labessiere_candeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81117-81300-labessiere_candeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81118-81100-laboulbene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81118-81100-laboulbene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81118-81100-laboulbene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81118-81100-laboulbene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81119-81120-laboutarie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81119-81120-laboutarie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81119-81120-laboutarie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81119-81120-laboutarie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81120-81290-labruguiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81120-81290-labruguiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81120-81290-labruguiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81120-81290-labruguiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81121-81240-lacabarede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81121-81240-lacabarede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81121-81240-lacabarede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81121-81240-lacabarede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81122-81340-lacapelle_pinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81122-81340-lacapelle_pinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81122-81340-lacapelle_pinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81122-81340-lacapelle_pinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81123-81170-lacapelle_segalar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81123-81170-lacapelle_segalar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81123-81170-lacapelle_segalar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81123-81170-lacapelle_segalar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81124-81230-lacaune/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81124-81230-lacaune/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81124-81230-lacaune/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81124-81230-lacaune/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81125-81330-lacaze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81125-81330-lacaze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81125-81330-lacaze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81125-81330-lacaze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81126-81500-lacougotte_cadoul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81126-81500-lacougotte_cadoul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81126-81500-lacougotte_cadoul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81126-81500-lacougotte_cadoul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81127-81470-lacroisille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81127-81470-lacroisille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81127-81470-lacroisille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81127-81470-lacroisille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81128-81210-lacrouzette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81128-81210-lacrouzette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81128-81210-lacrouzette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81128-81210-lacrouzette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81129-81110-lagardiolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81129-81110-lagardiolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81129-81110-lagardiolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81129-81110-lagardiolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81130-81090-lagarrigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81130-81090-lagarrigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81130-81090-lagarrigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81130-81090-lagarrigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81130-81290-lagarrigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81130-81290-lagarrigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81130-81290-lagarrigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81130-81290-lagarrigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81131-81150-lagrave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81131-81150-lagrave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81131-81150-lagrave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81131-81150-lagrave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81132-81220-guitalens_l_albarede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81132-81220-guitalens_l_albarede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81132-81220-guitalens_l_albarede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81132-81220-guitalens_l_albarede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81133-81120-lamillarie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81133-81120-lamillarie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81133-81120-lamillarie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81133-81120-lamillarie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81134-81260-lamontelarie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81134-81260-lamontelarie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81134-81260-lamontelarie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81134-81260-lamontelarie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81135-81640-laparrouquial/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81135-81640-laparrouquial/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81135-81640-laparrouquial/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81135-81640-laparrouquial/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81136-81140-larroque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81136-81140-larroque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81136-81140-larroque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81136-81140-larroque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81137-81260-lasfaillades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81137-81260-lasfaillades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81137-81260-lasfaillades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81137-81260-lasfaillades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81138-81300-lasgraisses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81138-81300-lasgraisses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81138-81300-lasgraisses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81138-81300-lasgraisses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81139-81440-lautrec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81139-81440-lautrec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81139-81440-lautrec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81139-81440-lautrec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81140-81500-lavaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81140-81500-lavaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81140-81500-lavaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81140-81500-lavaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81141-81340-ledas_et_penthies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81141-81340-ledas_et_penthies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81141-81340-ledas_et_penthies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81141-81340-ledas_et_penthies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81142-81700-lempaut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81142-81700-lempaut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81142-81700-lempaut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81142-81700-lempaut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81143-81110-lescout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81143-81110-lescout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81143-81110-lescout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81143-81110-lescout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81144-81380-lescure_d_albigeois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81144-81380-lescure_d_albigeois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81144-81380-lescure_d_albigeois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81144-81380-lescure_d_albigeois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81144-81000-lescure_d_albigeois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81144-81000-lescure_d_albigeois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81144-81000-lescure_d_albigeois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81144-81000-lescure_d_albigeois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81145-81310-lisle_sur_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81145-81310-lisle_sur_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81145-81310-lisle_sur_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81145-81310-lisle_sur_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81145-81800-lisle_sur_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81145-81800-lisle_sur_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81145-81800-lisle_sur_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81145-81800-lisle_sur_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81146-81170-livers_cazelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81146-81170-livers_cazelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81146-81170-livers_cazelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81146-81170-livers_cazelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81147-81120-lombers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81147-81120-lombers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81147-81120-lombers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81147-81120-lombers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81148-81170-loubers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81148-81170-loubers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81148-81170-loubers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81148-81170-loubers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81149-81800-loupiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81149-81800-loupiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81149-81800-loupiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81149-81800-loupiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81150-81500-lugan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81150-81500-lugan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81150-81500-lugan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81150-81500-lugan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81151-81220-magrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81151-81220-magrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81151-81220-magrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81151-81220-magrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81152-81130-mailhoc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81152-81130-mailhoc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81152-81130-mailhoc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81152-81130-mailhoc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81154-81170-marnaves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81154-81170-marnaves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81154-81170-marnaves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81154-81170-marnaves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81156-81150-marssac_sur_tarn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81156-81150-marssac_sur_tarn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81156-81150-marssac_sur_tarn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81156-81150-marssac_sur_tarn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81157-81500-marzens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81157-81500-marzens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81157-81500-marzens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81157-81500-marzens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81158-81530-le_masnau_massuguies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81158-81530-le_masnau_massuguies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81158-81530-le_masnau_massuguies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81158-81530-le_masnau_massuguies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81159-81500-massac_seran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81159-81500-massac_seran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81159-81500-massac_seran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81159-81500-massac_seran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81160-81110-massaguel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81160-81110-massaguel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81160-81110-massaguel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81160-81110-massaguel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81161-81250-massals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81161-81250-massals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81161-81250-massals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81161-81250-massals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81162-81470-maurens_scopont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81162-81470-maurens_scopont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81162-81470-maurens_scopont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81162-81470-maurens_scopont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81163-81200-mazamet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81163-81200-mazamet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81163-81200-mazamet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81163-81200-mazamet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81164-81800-mezens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81164-81800-mezens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81164-81800-mezens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81164-81800-mezens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81165-81170-milhars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81165-81170-milhars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81165-81170-milhars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81165-81170-milhars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81166-81130-milhavet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81166-81130-milhavet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81166-81130-milhavet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81166-81130-milhavet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81167-81250-miolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81167-81250-miolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81167-81250-miolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81167-81250-miolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81168-81190-mirandol_bourgnounac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81168-81190-mirandol_bourgnounac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81168-81190-mirandol_bourgnounac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81168-81190-mirandol_bourgnounac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81169-81300-missecle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81169-81300-missecle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81169-81300-missecle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81169-81300-missecle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81170-81640-monesties/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81170-81640-monesties/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81170-81640-monesties/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81170-81640-monesties/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81171-81600-montans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81171-81600-montans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81171-81600-montans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81171-81600-montans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81172-81190-montauriol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81172-81190-montauriol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81172-81190-montauriol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81172-81190-montauriol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81173-81500-montcabrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81173-81500-montcabrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81173-81500-montcabrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81173-81500-montcabrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81174-81440-montdragon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81174-81440-montdragon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81174-81440-montdragon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81174-81440-montdragon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81175-81630-montdurausse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81175-81630-montdurausse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81175-81630-montdurausse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81175-81630-montdurausse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81176-81140-montels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81176-81140-montels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81176-81140-montels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81176-81140-montels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81177-81210-montfa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81177-81210-montfa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81177-81210-montfa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81177-81210-montfa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81178-81630-montgaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81178-81630-montgaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81178-81630-montgaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81178-81630-montgaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81179-81470-montgey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81179-81470-montgey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81179-81470-montgey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81179-81470-montgey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81180-81190-montirat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81180-81190-montirat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81180-81190-montirat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81180-81190-montirat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81181-81440-montpinier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81181-81440-montpinier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81181-81440-montpinier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81181-81440-montpinier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81182-81360-montredon_labessonnie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81182-81360-montredon_labessonnie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81182-81360-montredon_labessonnie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81182-81360-montredon_labessonnie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81183-81120-mont_roc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81183-81120-mont_roc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81183-81120-mont_roc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81183-81120-mont_roc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81184-81170-montrosier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81184-81170-montrosier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81184-81170-montrosier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81184-81170-montrosier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81185-81630-montvalen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81185-81630-montvalen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81185-81630-montvalen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81185-81630-montvalen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81186-81190-moulares/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81186-81190-moulares/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81186-81190-moulares/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81186-81190-moulares/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81187-81300-moulayres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81187-81300-moulayres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81187-81300-moulayres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81187-81300-moulayres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81188-81320-moulin_mage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81188-81320-moulin_mage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81188-81320-moulin_mage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81188-81320-moulin_mage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81189-81470-mouzens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81189-81470-mouzens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81189-81470-mouzens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81189-81470-mouzens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81190-81430-mouzieys_teulet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81190-81430-mouzieys_teulet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81190-81430-mouzieys_teulet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81190-81430-mouzieys_teulet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81191-81170-mouzieys_panens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81191-81170-mouzieys_panens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81191-81170-mouzieys_panens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81191-81170-mouzieys_panens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81192-81320-murat_sur_vebre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81192-81320-murat_sur_vebre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81192-81320-murat_sur_vebre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81192-81320-murat_sur_vebre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81193-81320-nages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81193-81320-nages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81193-81320-nages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81193-81320-nages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81195-81710-naves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81195-81710-naves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81195-81710-naves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81195-81710-naves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81196-81490-noailhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81196-81490-noailhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81196-81490-noailhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81196-81490-noailhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81197-81170-noailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81197-81170-noailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81197-81170-noailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81197-81170-noailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81198-81120-orban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81198-81120-orban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81198-81120-orban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81198-81120-orban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81199-81340-padies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81199-81340-padies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81199-81340-padies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81199-81340-padies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81200-81700-palleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81200-81700-palleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81200-81700-palleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81200-81700-palleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81201-81190-pampelonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81201-81190-pampelonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81201-81190-pampelonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81201-81190-pampelonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81202-81310-parisot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81202-81310-parisot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81202-81310-parisot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81202-81310-parisot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81202-81800-parisot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81202-81800-parisot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81202-81800-parisot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81202-81800-parisot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81203-81250-paulinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81203-81250-paulinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81203-81250-paulinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81203-81250-paulinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81204-81660-payrin_augmontel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81204-81660-payrin_augmontel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81204-81660-payrin_augmontel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81204-81660-payrin_augmontel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81205-81470-pechaudier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81205-81470-pechaudier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81205-81470-pechaudier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81205-81470-pechaudier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81206-81140-penne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81206-81140-penne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81206-81140-penne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81206-81140-penne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81207-81440-peyregoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81207-81440-peyregoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81207-81440-peyregoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81207-81440-peyregoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81208-81310-peyrole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81208-81310-peyrole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81208-81310-peyrole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81208-81310-peyrole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81209-81660-pont_de_larn/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81209-81660-pont_de_larn/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81209-81660-pont_de_larn/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81209-81660-pont_de_larn/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81210-81700-poudis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81210-81700-poudis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81210-81700-poudis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81210-81700-poudis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81211-81120-poulan_pouzols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81211-81120-poulan_pouzols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81211-81120-poulan_pouzols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81211-81120-poulan_pouzols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81212-81220-prades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81212-81220-prades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81212-81220-prades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81212-81220-prades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81213-81500-pratviel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81213-81500-pratviel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81213-81500-pratviel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81213-81500-pratviel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81214-81470-puechoursi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81214-81470-puechoursi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81214-81470-puechoursi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81214-81470-puechoursi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81215-81390-puybegon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81215-81390-puybegon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81215-81390-puybegon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81215-81390-puybegon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81216-81440-puycalvel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81216-81440-puycalvel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81216-81440-puycalvel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81216-81440-puycalvel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81217-81140-puycelsi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81217-81140-puycelsi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81217-81140-puycelsi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81217-81140-puycelsi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81218-81990-puygouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81218-81990-puygouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81218-81990-puygouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81218-81990-puygouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81218-81120-puygouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81218-81120-puygouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81218-81120-puygouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81218-81120-puygouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81219-81700-puylaurens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81219-81700-puylaurens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81219-81700-puylaurens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81219-81700-puylaurens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81220-81800-rabastens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81220-81800-rabastens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81220-81800-rabastens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81220-81800-rabastens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81221-81330-rayssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81221-81330-rayssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81221-81330-rayssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81221-81330-rayssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81222-81120-realmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81222-81120-realmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81222-81120-realmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81222-81120-realmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81223-81240-le_rialet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81223-81240-le_rialet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81223-81240-le_rialet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81223-81240-le_rialet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81224-81170-le_riols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81224-81170-le_riols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81224-81170-le_riols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81224-81170-le_riols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81225-81600-rivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81225-81600-rivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81225-81600-rivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81225-81600-rivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81227-81210-roquecourbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81227-81210-roquecourbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81227-81210-roquecourbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81227-81210-roquecourbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81228-81800-roquemaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81228-81800-roquemaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81228-81800-roquemaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81228-81800-roquemaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81229-81470-roquevidal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81229-81470-roquevidal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81229-81470-roquevidal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81229-81470-roquevidal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81230-81400-rosieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81230-81400-rosieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81230-81400-rosieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81230-81400-rosieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81231-81240-rouairoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81231-81240-rouairoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81231-81240-rouairoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81231-81240-rouairoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81231-81200-rouairoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81231-81200-rouairoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81231-81200-rouairoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81231-81200-rouairoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81232-81150-rouffiac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81232-81150-rouffiac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81232-81150-rouffiac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81232-81150-rouffiac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81233-81120-terre_de_bancalie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81233-81120-terre_de_bancalie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81233-81120-terre_de_bancalie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81233-81120-terre_de_bancalie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81234-81140-roussayrolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81234-81140-roussayrolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81234-81140-roussayrolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81234-81140-roussayrolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81235-81290-saint_affrique_les_montagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81235-81290-saint_affrique_les_montagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81235-81290-saint_affrique_les_montagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81235-81290-saint_affrique_les_montagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81236-81500-saint_agnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81236-81500-saint_agnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81236-81500-saint_agnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81236-81500-saint_agnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81237-81110-saint_amancet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81237-81110-saint_amancet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81237-81110-saint_amancet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81237-81110-saint_amancet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81238-81240-saint_amans_soult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81238-81240-saint_amans_soult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81238-81240-saint_amans_soult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81238-81240-saint_amans_soult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81239-81240-saint_amans_valtoret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81239-81240-saint_amans_valtoret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81239-81240-saint_amans_valtoret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81239-81240-saint_amans_valtoret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81240-81250-saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81240-81250-saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81240-81250-saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81240-81250-saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81242-81110-saint_avit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81242-81110-saint_avit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81242-81110-saint_avit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81242-81110-saint_avit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81243-81140-saint_beauzile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81243-81140-saint_beauzile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81243-81140-saint_beauzile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81243-81140-saint_beauzile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81244-81400-saint_benoit_de_carmaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81244-81400-saint_benoit_de_carmaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81244-81400-saint_benoit_de_carmaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81244-81400-saint_benoit_de_carmaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81245-81190-saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81245-81190-saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81245-81190-saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81245-81190-saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81246-81140-sainte_cecile_du_cayrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81246-81140-sainte_cecile_du_cayrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81246-81140-sainte_cecile_du_cayrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81246-81140-sainte_cecile_du_cayrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81247-81340-saint_cirgue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81247-81340-saint_cirgue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81247-81340-saint_cirgue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81247-81340-saint_cirgue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81248-81390-saint_gauzens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81248-81390-saint_gauzens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81248-81390-saint_gauzens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81248-81390-saint_gauzens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81249-81190-sainte_gemme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81249-81190-sainte_gemme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81249-81190-sainte_gemme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81249-81190-sainte_gemme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81250-81440-saint_genest_de_contest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81250-81440-saint_genest_de_contest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81250-81440-saint_genest_de_contest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81250-81440-saint_genest_de_contest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81251-81700-saint_germain_des_pres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81251-81700-saint_germain_des_pres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81251-81700-saint_germain_des_pres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81251-81700-saint_germain_des_pres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81252-81210-saint_germier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81252-81210-saint_germier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81252-81210-saint_germier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81252-81210-saint_germier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81253-81350-saint_gregoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81253-81350-saint_gregoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81253-81350-saint_gregoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81253-81350-saint_gregoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81254-81350-saint_jean_de_marcel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81254-81350-saint_jean_de_marcel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81254-81350-saint_jean_de_marcel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81254-81350-saint_jean_de_marcel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81255-81500-saint_jean_de_rives/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81255-81500-saint_jean_de_rives/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81255-81500-saint_jean_de_rives/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81255-81500-saint_jean_de_rives/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81256-81210-saint_jean_de_vals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81256-81210-saint_jean_de_vals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81256-81210-saint_jean_de_vals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81256-81210-saint_jean_de_vals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81257-81160-saint_juery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81257-81160-saint_juery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81257-81160-saint_juery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81257-81160-saint_juery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81258-81440-saint_julien_du_puy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81258-81440-saint_julien_du_puy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81258-81440-saint_julien_du_puy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81258-81440-saint_julien_du_puy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81259-81340-saint_julien_gaulene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81259-81340-saint_julien_gaulene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81259-81340-saint_julien_gaulene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81259-81340-saint_julien_gaulene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81261-81500-saint_lieux_les_lavaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81261-81500-saint_lieux_les_lavaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81261-81500-saint_lieux_les_lavaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81261-81500-saint_lieux_les_lavaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81262-81170-saint_marcel_campes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81262-81170-saint_marcel_campes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81262-81170-saint_marcel_campes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81262-81170-saint_marcel_campes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81263-81170-saint_martin_laguepie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81263-81170-saint_martin_laguepie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81263-81170-saint_martin_laguepie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81263-81170-saint_martin_laguepie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81264-81340-saint_michel_labadie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81264-81340-saint_michel_labadie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81264-81340-saint_michel_labadie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81264-81340-saint_michel_labadie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81265-81140-saint_michel_de_vax/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81265-81140-saint_michel_de_vax/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81265-81140-saint_michel_de_vax/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81265-81140-saint_michel_de_vax/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81266-81220-saint_paul_cap_de_joux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81266-81220-saint_paul_cap_de_joux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81266-81220-saint_paul_cap_de_joux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81266-81220-saint_paul_cap_de_joux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81267-81330-saint_pierre_de_trivisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81267-81330-saint_pierre_de_trivisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81267-81330-saint_pierre_de_trivisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81267-81330-saint_pierre_de_trivisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81268-81530-saint_salvi_de_carcaves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81268-81530-saint_salvi_de_carcaves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81268-81530-saint_salvi_de_carcaves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81268-81530-saint_salvi_de_carcaves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81269-81490-saint_salvy_de_la_balme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81269-81490-saint_salvy_de_la_balme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81269-81490-saint_salvy_de_la_balme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81269-81490-saint_salvy_de_la_balme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81270-81700-saint_sernin_les_lavaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81270-81700-saint_sernin_les_lavaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81270-81700-saint_sernin_les_lavaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81270-81700-saint_sernin_les_lavaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81271-81370-saint_sulpice_la_pointe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81271-81370-saint_sulpice_la_pointe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81271-81370-saint_sulpice_la_pointe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81271-81370-saint_sulpice_la_pointe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81272-81630-saint_urcisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81272-81630-saint_urcisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81272-81630-saint_urcisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81272-81630-saint_urcisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81273-81710-saix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81273-81710-saix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81273-81710-saix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81273-81710-saix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81274-81990-salies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81274-81990-salies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81274-81990-salies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81274-81990-salies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81275-81640-salles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81275-81640-salles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81275-81640-salles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81275-81640-salles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81276-81630-salvagnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81276-81630-salvagnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81276-81630-salvagnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81276-81630-salvagnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81277-81350-saussenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81277-81350-saussenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81277-81350-saussenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81277-81350-saussenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81278-81240-sauveterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81278-81240-sauveterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81278-81240-sauveterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81278-81240-sauveterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81279-81630-la_sauziere_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81279-81630-la_sauziere_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81279-81630-la_sauziere_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81279-81630-la_sauziere_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81280-81640-le_segur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81280-81640-le_segur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81280-81640-le_segur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81280-81640-le_segur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81281-81570-semalens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81281-81570-semalens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81281-81570-semalens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81281-81570-semalens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81282-81530-senaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81282-81530-senaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81282-81530-senaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81282-81530-senaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81283-81600-senouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81283-81600-senouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81283-81600-senouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81283-81600-senouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81284-81990-le_sequestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81284-81990-le_sequestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81284-81990-le_sequestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81284-81990-le_sequestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81285-81350-serenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81285-81350-serenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81285-81350-serenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81285-81350-serenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81285-81000-serenac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81285-81000-serenac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81285-81000-serenac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81285-81000-serenac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81286-81220-servies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81286-81220-servies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81286-81220-servies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81286-81220-servies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81287-81120-sieurac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81287-81120-sieurac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81287-81120-sieurac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81287-81120-sieurac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81288-81540-soreze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81288-81540-soreze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81288-81540-soreze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81288-81540-soreze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81289-81580-soual/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81289-81580-soual/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81289-81580-soual/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81289-81580-soual/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81290-81170-souel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81290-81170-souel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81290-81170-souel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81290-81170-souel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81291-81130-taix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81291-81130-taix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81291-81130-taix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81291-81130-taix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81292-81190-tanus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81292-81190-tanus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81292-81190-tanus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81292-81190-tanus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81293-81630-tauriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81293-81630-tauriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81293-81630-tauriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81293-81630-tauriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81294-81600-tecou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81294-81600-tecou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81294-81600-tecou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81294-81600-tecou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81295-81120-teillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81295-81120-teillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81295-81120-teillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81295-81120-teillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81297-81150-terssac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81297-81150-terssac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81297-81150-terssac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81297-81150-terssac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81298-81500-teulat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81298-81500-teulat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81298-81500-teulat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81298-81500-teulat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81299-81220-teyssode/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81299-81220-teyssode/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81299-81220-teyssode/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81299-81220-teyssode/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81300-81170-tonnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81300-81170-tonnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81300-81170-tonnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81300-81170-tonnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81302-81190-treban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81302-81190-treban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81302-81190-treban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81302-81190-treban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81303-81340-trebas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81303-81340-trebas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81303-81340-trebas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81303-81340-trebas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81304-81190-trevien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81304-81190-trevien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81304-81190-trevien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81304-81190-trevien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81305-81330-vabre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81305-81330-vabre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81305-81330-vabre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81305-81330-vabre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81306-81350-valderies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81306-81350-valderies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81306-81350-valderies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81306-81350-valderies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81307-81090-valdurenque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81307-81090-valdurenque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81307-81090-valdurenque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81307-81090-valdurenque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81308-81340-valence_d_albigeois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81308-81340-valence_d_albigeois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81308-81340-valence_d_albigeois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81308-81340-valence_d_albigeois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81309-81140-vaour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81309-81140-vaour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81309-81140-vaour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81309-81140-vaour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81310-81500-veilhes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81310-81500-veilhes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81310-81500-veilhes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81310-81500-veilhes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81311-81440-venes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81311-81440-venes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81311-81440-venes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81311-81440-venes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81312-81110-verdalle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81312-81110-verdalle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81312-81110-verdalle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81312-81110-verdalle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81313-81140-le_verdier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81313-81140-le_verdier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81313-81140-le_verdier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81313-81140-le_verdier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81314-81530-viane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81314-81530-viane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81314-81530-viane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81314-81530-viane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81315-81570-vielmur_sur_agout/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81315-81570-vielmur_sur_agout/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81315-81570-vielmur_sur_agout/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81315-81570-vielmur_sur_agout/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81316-81140-vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81316-81140-vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81316-81140-vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81316-81140-vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81317-81430-villefranche_d_albigeois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81317-81430-villefranche_d_albigeois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81317-81430-villefranche_d_albigeois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81317-81430-villefranche_d_albigeois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81318-81500-villeneuve_les_lavaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81318-81500-villeneuve_les_lavaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81318-81500-villeneuve_les_lavaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81318-81500-villeneuve_les_lavaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81319-81130-villeneuve_sur_vere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81319-81130-villeneuve_sur_vere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81319-81130-villeneuve_sur_vere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81319-81130-villeneuve_sur_vere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81320-81170-vindrac_alayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81320-81170-vindrac_alayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81320-81170-vindrac_alayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81320-81170-vindrac_alayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81321-81240-le_vintrou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81321-81240-le_vintrou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81321-81240-le_vintrou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81321-81240-le_vintrou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81322-81640-virac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81322-81640-virac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81322-81640-virac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81322-81640-virac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81323-81220-viterbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81323-81220-viterbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81323-81220-viterbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81323-81220-viterbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81324-81500-viviers_les_lavaur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81324-81500-viviers_les_lavaur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81324-81500-viviers_les_lavaur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81324-81500-viviers_les_lavaur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81325-81290-viviers_les_montagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81325-81290-viviers_les_montagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81325-81290-viviers_les_montagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81325-81290-viviers_les_montagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81326-81150-sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81326-81150-sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81326-81150-sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt81-tarn/commune81326-81150-sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-82.xml
+++ b/public/sitemaps/sitemap-82.xml
@@ -5,396 +5,788 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82001-82290-albefeuille_lagarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82001-82290-albefeuille_lagarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82001-82290-albefeuille_lagarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82001-82290-albefeuille_lagarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82002-82350-albias/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82002-82350-albias/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82002-82350-albias/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82002-82350-albias/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82003-82210-angeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82003-82210-angeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82003-82210-angeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82003-82210-angeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82004-82120-asques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82004-82120-asques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82004-82120-asques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82004-82120-asques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82005-82600-aucamville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82005-82600-aucamville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82005-82600-aucamville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82005-82600-aucamville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82006-82500-auterive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82006-82500-auterive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82006-82500-auterive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82006-82500-auterive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82007-82220-auty/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82007-82220-auty/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82007-82220-auty/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82007-82220-auty/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82008-82340-auvillar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82008-82340-auvillar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82008-82340-auvillar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82008-82340-auvillar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82009-82120-balignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82009-82120-balignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82009-82120-balignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82009-82120-balignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82010-82340-bardigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82010-82340-bardigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82010-82340-bardigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82010-82340-bardigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82011-82290-barry_d_islemade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82011-82290-barry_d_islemade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82011-82290-barry_d_islemade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82011-82290-barry_d_islemade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82012-82100-les_barthes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82012-82100-les_barthes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82012-82100-les_barthes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82012-82100-les_barthes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82013-82500-beaumont_de_lomagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82013-82500-beaumont_de_lomagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82013-82500-beaumont_de_lomagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82013-82500-beaumont_de_lomagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82014-82600-beaupuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82014-82600-beaupuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82014-82600-beaupuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82014-82600-beaupuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82015-82500-belbeze_en_lomagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82015-82500-belbeze_en_lomagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82015-82500-belbeze_en_lomagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82015-82500-belbeze_en_lomagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82016-82150-belveze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82016-82150-belveze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82016-82150-belveze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82016-82150-belveze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82017-82170-bessens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82017-82170-bessens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82017-82170-bessens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82017-82170-bessens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82018-82800-bioule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82018-82800-bioule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82018-82800-bioule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82018-82800-bioule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82019-82200-boudou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82019-82200-boudou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82019-82200-boudou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82019-82200-boudou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82020-82600-bouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82020-82600-bouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82020-82600-bouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82020-82600-bouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82021-82110-bouloc_en_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82021-82110-bouloc_en_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82021-82110-bouloc_en_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82021-82110-bouloc_en_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82022-82190-bourg_de_visa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82022-82190-bourg_de_visa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82022-82190-bourg_de_visa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82022-82190-bourg_de_visa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82023-82700-bourret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82023-82700-bourret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82023-82700-bourret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82023-82700-bourret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82024-82190-brassac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82024-82190-brassac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82024-82190-brassac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82024-82190-brassac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82025-82710-bressols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82025-82710-bressols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82025-82710-bressols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82025-82710-bressols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82026-82800-bruniquel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82026-82800-bruniquel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82026-82800-bruniquel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82026-82800-bruniquel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82027-82370-campsas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82027-82370-campsas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82027-82370-campsas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82027-82370-campsas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82028-82170-canals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82028-82170-canals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82028-82170-canals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82028-82170-canals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82029-82160-castanet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82029-82160-castanet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82029-82160-castanet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82029-82160-castanet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82030-82100-castelferrus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82030-82100-castelferrus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82030-82100-castelferrus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82030-82100-castelferrus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82031-82210-castelmayran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82031-82210-castelmayran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82031-82210-castelmayran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82031-82210-castelmayran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82032-82400-castelsagrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82032-82400-castelsagrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82032-82400-castelsagrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82032-82400-castelsagrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82033-82100-castelsarrasin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82033-82100-castelsarrasin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82033-82100-castelsarrasin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82033-82100-castelsarrasin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82034-82120-castera_bouzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82034-82120-castera_bouzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82034-82120-castera_bouzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82034-82120-castera_bouzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82035-82210-caumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82035-82210-caumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82035-82210-caumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82035-82210-caumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82036-82500-le_cause/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82036-82500-le_cause/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82036-82500-le_cause/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82036-82500-le_cause/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82037-82300-caussade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82037-82300-caussade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82037-82300-caussade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82037-82300-caussade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82038-82160-caylus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82038-82160-caylus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82038-82160-caylus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82038-82160-caylus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82039-82440-cayrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82039-82440-cayrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82039-82440-cayrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82039-82440-cayrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82040-82240-cayriech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82040-82240-cayriech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82040-82240-cayriech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82040-82240-cayriech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82041-82140-cazals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82041-82140-cazals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82041-82140-cazals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82041-82140-cazals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82042-82110-cazes_mondenard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82042-82110-cazes_mondenard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82042-82110-cazes_mondenard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82042-82110-cazes_mondenard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82043-82600-comberouger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82043-82600-comberouger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82043-82600-comberouger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82043-82600-comberouger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82044-82370-corbarieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82044-82370-corbarieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82044-82370-corbarieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82044-82370-corbarieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82045-82700-cordes_tolosannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82045-82700-cordes_tolosannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82045-82700-cordes_tolosannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82045-82700-cordes_tolosannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82046-82210-coutures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82046-82210-coutures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82046-82210-coutures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82046-82210-coutures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82047-82500-cumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82047-82500-cumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82047-82500-cumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82047-82500-cumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82048-82170-dieupentale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82048-82170-dieupentale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82048-82170-dieupentale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82048-82170-dieupentale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82049-82340-donzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82049-82340-donzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82049-82340-donzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82049-82340-donzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82050-82340-dunes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82050-82340-dunes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82050-82340-dunes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82050-82340-dunes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82051-82390-durfort_lacapelette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82051-82390-durfort_lacapelette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82051-82390-durfort_lacapelette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82051-82390-durfort_lacapelette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82052-82700-escatalens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82052-82700-escatalens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82052-82700-escatalens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82052-82700-escatalens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82053-82500-escazeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82053-82500-escazeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82053-82500-escazeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82053-82500-escazeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82054-82400-espalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82054-82400-espalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82054-82400-espalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82054-82400-espalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82055-82500-esparsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82055-82500-esparsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82055-82500-esparsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82055-82500-esparsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82056-82160-espinas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82056-82160-espinas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82056-82160-espinas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82056-82160-espinas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82057-82170-fabas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82057-82170-fabas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82057-82170-fabas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82057-82170-fabas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82058-82210-fajolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82058-82210-fajolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82058-82210-fajolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82058-82210-fajolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82059-82500-faudoas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82059-82500-faudoas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82059-82500-faudoas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82059-82500-faudoas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82060-82190-fauroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82060-82190-fauroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82060-82190-fauroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82060-82190-fauroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82061-82140-feneyrols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82061-82140-feneyrols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82061-82140-feneyrols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82061-82140-feneyrols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82062-82700-finhan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82062-82700-finhan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82062-82700-finhan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82062-82700-finhan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82063-82100-garganvillar/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82063-82100-garganvillar/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82063-82100-garganvillar/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82063-82100-garganvillar/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82064-82500-garies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82064-82500-garies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82064-82500-garies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82064-82500-garies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82065-82400-gasques/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82065-82400-gasques/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82065-82400-gasques/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82065-82400-gasques/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82066-82230-genebrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82066-82230-genebrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82066-82230-genebrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82066-82230-genebrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82067-82120-gensac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82067-82120-gensac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82067-82120-gensac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82067-82120-gensac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82068-82500-gimat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82068-82500-gimat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82068-82500-gimat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82068-82500-gimat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82069-82330-ginals/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82069-82330-ginals/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82069-82330-ginals/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82069-82330-ginals/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82070-82500-glatens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82070-82500-glatens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82070-82500-glatens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82070-82500-glatens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82071-82500-goas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82071-82500-goas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82071-82500-goas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82071-82500-goas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82072-82400-golfech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82072-82400-golfech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82072-82400-golfech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82072-82400-golfech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82073-82400-goudourville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82073-82400-goudourville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82073-82400-goudourville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82073-82400-goudourville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82074-82120-gramont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82074-82120-gramont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82074-82120-gramont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82074-82120-gramont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82075-82170-grisolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82075-82170-grisolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82075-82170-grisolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82075-82170-grisolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82076-82130-l_honor_de_cos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82076-82130-l_honor_de_cos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82076-82130-l_honor_de_cos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82076-82130-l_honor_de_cos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82077-82220-labarthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82077-82220-labarthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82077-82220-labarthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82077-82220-labarthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82078-82240-labastide_de_penne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82078-82240-labastide_de_penne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82078-82240-labastide_de_penne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82078-82240-labastide_de_penne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82079-82370-labastide_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82079-82370-labastide_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82079-82370-labastide_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82079-82370-labastide_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82080-82100-labastide_du_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82080-82100-labastide_du_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82080-82100-labastide_du_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82080-82100-labastide_du_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82081-82100-labourgade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82081-82100-labourgade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82081-82100-labourgade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82081-82100-labourgade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82082-82160-lacapelle_livron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82082-82160-lacapelle_livron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82082-82160-lacapelle_livron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82082-82160-lacapelle_livron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82083-82120-lachapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82083-82120-lachapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82083-82120-lachapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82083-82120-lachapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82084-82190-lacour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82084-82190-lacour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82084-82190-lacour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82084-82190-lacour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82085-82290-lacourt_saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82085-82290-lacourt_saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82085-82290-lacourt_saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82085-82290-lacourt_saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82086-82100-lafitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82086-82100-lafitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82086-82100-lafitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82086-82100-lafitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82087-82130-lafrancaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82087-82130-lafrancaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82087-82130-lafrancaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82087-82130-lafrancaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82088-82250-laguepie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82088-82250-laguepie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82088-82250-laguepie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82088-82250-laguepie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82089-82360-lamagistere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82089-82360-lamagistere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82089-82360-lamagistere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82089-82360-lamagistere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82090-82130-lamothe_capdeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82090-82130-lamothe_capdeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82090-82130-lamothe_capdeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82090-82130-lamothe_capdeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82091-82500-lamothe_cumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82091-82500-lamothe_cumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82091-82500-lamothe_cumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82091-82500-lamothe_cumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82092-82240-lapenche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82092-82240-lapenche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82092-82240-lapenche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82092-82240-lapenche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82093-82500-larrazet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82093-82500-larrazet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82093-82500-larrazet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82093-82500-larrazet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82094-82110-lauzerte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82094-82110-lauzerte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82094-82110-lauzerte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82094-82110-lauzerte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82095-82240-lavaurette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82095-82240-lavaurette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82095-82240-lavaurette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82095-82240-lavaurette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82096-82290-la_ville_dieu_du_temple/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82096-82290-la_ville_dieu_du_temple/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82096-82290-la_ville_dieu_du_temple/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82096-82290-la_ville_dieu_du_temple/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82097-82120-lavit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82097-82120-lavit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82097-82120-lavit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82097-82120-lavit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82098-82230-leojac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82098-82230-leojac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82098-82230-leojac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82098-82230-leojac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82099-82200-lizac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82099-82200-lizac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82099-82200-lizac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82099-82200-lizac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82100-82160-loze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82100-82160-loze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82100-82160-loze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82100-82160-loze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82101-82200-malause/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82101-82200-malause/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82101-82200-malause/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82101-82200-malause/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82102-82120-mansonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82102-82120-mansonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82102-82120-mansonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82102-82120-mansonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82103-82500-marignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82103-82500-marignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82103-82500-marignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82103-82500-marignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82104-82120-marsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82104-82120-marsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82104-82120-marsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82104-82120-marsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82105-82600-mas_grenier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82105-82600-mas_grenier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82105-82600-mas_grenier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82105-82600-mas_grenier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82106-82500-maubec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82106-82500-maubec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82106-82500-maubec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82106-82500-maubec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82107-82120-maumusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82107-82120-maumusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82107-82120-maumusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82107-82120-maumusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82108-82290-meauzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82108-82290-meauzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82108-82290-meauzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82108-82290-meauzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82109-82210-merles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82109-82210-merles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82109-82210-merles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82109-82210-merles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82110-82440-mirabel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82110-82440-mirabel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82110-82440-mirabel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82110-82440-mirabel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82111-82190-miramont_de_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82111-82190-miramont_de_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82111-82190-miramont_de_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82111-82190-miramont_de_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82112-82200-moissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82112-82200-moissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82112-82200-moissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82112-82200-moissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82113-82220-molieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82113-82220-molieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82113-82220-molieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82113-82220-molieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82114-82170-monbequi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82114-82170-monbequi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82114-82170-monbequi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82114-82170-monbequi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82115-82230-monclar_de_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82115-82230-monclar_de_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82115-82230-monclar_de_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82115-82230-monclar_de_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82116-82110-montagudet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82116-82110-montagudet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82116-82110-montagudet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82116-82110-montagudet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82117-82150-montaigu_de_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82117-82150-montaigu_de_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82117-82150-montaigu_de_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82117-82150-montaigu_de_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82118-82100-montain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82118-82100-montain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82118-82100-montain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82118-82100-montain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82119-82270-montalzat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82119-82270-montalzat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82119-82270-montalzat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82119-82270-montalzat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82120-82130-montastruc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82120-82130-montastruc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82120-82130-montastruc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82120-82130-montastruc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82121-82000-montauban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82121-82000-montauban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82121-82000-montauban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82121-82000-montauban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82122-82110-montbarla/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82122-82110-montbarla/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82122-82110-montbarla/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82122-82110-montbarla/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82123-82700-montbartier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82123-82700-montbartier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82123-82700-montbartier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82123-82700-montbartier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82124-82290-montbeton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82124-82290-montbeton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82124-82290-montbeton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82124-82290-montbeton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82125-82700-montech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82125-82700-montech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82125-82700-montech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82125-82700-montech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82126-82300-monteils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82126-82300-monteils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82126-82300-monteils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82126-82300-monteils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82127-82200-montesquieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82127-82200-montesquieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82127-82200-montesquieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82127-82200-montesquieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82128-82270-montfermier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82128-82270-montfermier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82128-82270-montfermier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82128-82270-montfermier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82129-82120-montgaillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82129-82120-montgaillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82129-82120-montgaillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82129-82120-montgaillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82130-82400-montjoi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82130-82400-montjoi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82130-82400-montjoi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82130-82400-montjoi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82131-82270-montpezat_de_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82131-82270-montpezat_de_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82131-82270-montpezat_de_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82131-82270-montpezat_de_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82132-82800-montricoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82132-82800-montricoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82132-82800-montricoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82132-82800-montricoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82133-82160-mouillac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82133-82160-mouillac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82133-82160-mouillac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82133-82160-mouillac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82134-82800-negrepelisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82134-82800-negrepelisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82134-82800-negrepelisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82134-82800-negrepelisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82135-82370-nohic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82135-82370-nohic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82135-82370-nohic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82135-82370-nohic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82136-82370-orgueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82136-82370-orgueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82136-82370-orgueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82136-82370-orgueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82137-82160-parisot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82137-82160-parisot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82137-82160-parisot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82137-82160-parisot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82138-82400-perville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82138-82400-perville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82138-82400-perville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82138-82400-perville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82139-82340-le_pin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82139-82340-le_pin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82139-82340-le_pin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82139-82340-le_pin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82140-82130-piquecos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82140-82130-piquecos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82140-82130-piquecos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82140-82130-piquecos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82141-82400-pommevic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82141-82400-pommevic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82141-82400-pommevic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82141-82400-pommevic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82142-82170-pompignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82142-82170-pompignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82142-82170-pompignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82142-82170-pompignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82143-82120-poupas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82143-82120-poupas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82143-82120-poupas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82143-82120-poupas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82144-82220-puycornet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82144-82220-puycornet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82144-82220-puycornet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82144-82220-puycornet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82145-82800-puygaillard_de_quercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82145-82800-puygaillard_de_quercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82145-82800-puygaillard_de_quercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82145-82800-puygaillard_de_quercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82146-82120-puygaillard_de_lomagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82146-82120-puygaillard_de_lomagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82146-82120-puygaillard_de_lomagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82146-82120-puygaillard_de_lomagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82147-82160-puylagarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82147-82160-puylagarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82147-82160-puylagarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82147-82160-puylagarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82148-82240-puylaroque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82148-82240-puylaroque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82148-82240-puylaroque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82148-82240-puylaroque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82149-82440-realville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82149-82440-realville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82149-82440-realville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82149-82440-realville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82150-82370-reynies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82150-82370-reynies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82150-82370-reynies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82150-82370-reynies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82151-82150-roquecor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82151-82150-roquecor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82151-82150-roquecor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82151-82150-roquecor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82152-82100-saint_aignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82152-82100-saint_aignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82152-82100-saint_aignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82152-82100-saint_aignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82153-82150-saint_amans_du_pech/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82153-82150-saint_amans_du_pech/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82153-82150-saint_amans_du_pech/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82153-82150-saint_amans_du_pech/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82154-82110-saint_amans_de_pellagal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82154-82110-saint_amans_de_pellagal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82154-82110-saint_amans_de_pellagal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82154-82110-saint_amans_de_pellagal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82155-82140-saint_antonin_noble_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82155-82140-saint_antonin_noble_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82155-82140-saint_antonin_noble_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82155-82140-saint_antonin_noble_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82156-82210-saint_arroumex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82156-82210-saint_arroumex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82156-82210-saint_arroumex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82156-82210-saint_arroumex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82157-82150-saint_beauzeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82157-82150-saint_beauzeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82157-82150-saint_beauzeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82157-82150-saint_beauzeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82158-82340-saint_cirice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82158-82340-saint_cirice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82158-82340-saint_cirice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82158-82340-saint_cirice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82159-82300-saint_cirq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82159-82300-saint_cirq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82159-82300-saint_cirq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82159-82300-saint_cirq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82160-82400-saint_clair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82160-82400-saint_clair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82160-82400-saint_clair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82160-82400-saint_clair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82161-82410-saint_etienne_de_tulmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82161-82410-saint_etienne_de_tulmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82161-82410-saint_etienne_de_tulmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82161-82410-saint_etienne_de_tulmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82162-82240-saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82162-82240-saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82162-82240-saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82162-82240-saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82163-82120-saint_jean_du_bouzet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82163-82120-saint_jean_du_bouzet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82163-82120-saint_jean_du_bouzet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82163-82120-saint_jean_du_bouzet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82164-82110-sainte_juliette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82164-82110-sainte_juliette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82164-82110-sainte_juliette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82164-82110-sainte_juliette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82165-82340-saint_loup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82165-82340-saint_loup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82165-82340-saint_loup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82165-82340-saint_loup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82166-82340-saint_michel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82166-82340-saint_michel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82166-82340-saint_michel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82166-82340-saint_michel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82167-82370-saint_nauphary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82167-82370-saint_nauphary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82167-82370-saint_nauphary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82167-82370-saint_nauphary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82168-82190-saint_nazaire_de_valentane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82168-82190-saint_nazaire_de_valentane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82168-82190-saint_nazaire_de_valentane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82168-82190-saint_nazaire_de_valentane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82169-82210-saint_nicolas_de_la_grave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82169-82210-saint_nicolas_de_la_grave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82169-82210-saint_nicolas_de_la_grave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82169-82210-saint_nicolas_de_la_grave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82170-82400-saint_paul_d_espis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82170-82400-saint_paul_d_espis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82170-82400-saint_paul_d_espis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82170-82400-saint_paul_d_espis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82171-82700-saint_porquier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82171-82700-saint_porquier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82171-82700-saint_porquier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82171-82700-saint_porquier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82172-82160-saint_projet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82172-82160-saint_projet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82172-82160-saint_projet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82172-82160-saint_projet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82173-82600-saint_sardos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82173-82600-saint_sardos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82173-82600-saint_sardos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82173-82600-saint_sardos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82174-82300-saint_vincent_d_autejac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82174-82300-saint_vincent_d_autejac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82174-82300-saint_vincent_d_autejac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82174-82300-saint_vincent_d_autejac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82175-82400-saint_vincent_lespinasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82175-82400-saint_vincent_lespinasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82175-82400-saint_vincent_lespinasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82175-82400-saint_vincent_lespinasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82176-82230-la_salvetat_belmontet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82176-82230-la_salvetat_belmontet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82176-82230-la_salvetat_belmontet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82176-82230-la_salvetat_belmontet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82177-82110-sauveterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82177-82110-sauveterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82177-82110-sauveterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82177-82110-sauveterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82178-82600-savenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82178-82600-savenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82178-82600-savenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82178-82600-savenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82179-82240-septfonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82179-82240-septfonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82179-82240-septfonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82179-82240-septfonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82180-82500-serignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82180-82500-serignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82180-82500-serignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82180-82500-serignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82181-82340-sistels/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82181-82340-sistels/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82181-82340-sistels/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82181-82340-sistels/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82182-82190-touffailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82182-82190-touffailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82182-82190-touffailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82182-82190-touffailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82183-82110-trejouls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82183-82110-trejouls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82183-82110-trejouls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82183-82110-trejouls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82184-82800-vaissac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82184-82800-vaissac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82184-82800-vaissac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82184-82800-vaissac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82185-82150-valeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82185-82150-valeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82185-82150-valeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82185-82150-valeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82186-82400-valence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82186-82400-valence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82186-82400-valence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82186-82400-valence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82187-82330-varen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82187-82330-varen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82187-82330-varen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82187-82330-varen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82188-82370-varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82188-82370-varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82188-82370-varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82188-82370-varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82189-82220-vazerac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82189-82220-vazerac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82189-82220-vazerac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82189-82220-vazerac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82190-82600-verdun_sur_garonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82190-82600-verdun_sur_garonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82190-82600-verdun_sur_garonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82190-82600-verdun_sur_garonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82191-82330-verfeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82191-82330-verfeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82191-82330-verfeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82191-82330-verfeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82192-82230-verlhac_tescou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82192-82230-verlhac_tescou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82192-82230-verlhac_tescou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82192-82230-verlhac_tescou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82193-82500-vigueron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82193-82500-vigueron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82193-82500-vigueron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82193-82500-vigueron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82194-82370-villebrumier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82194-82370-villebrumier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82194-82370-villebrumier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82194-82370-villebrumier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82195-82130-villemade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82195-82130-villemade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82195-82130-villemade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt82-tarn_et_garonne/commune82195-82130-villemade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-83.xml
+++ b/public/sitemaps/sitemap-83.xml
@@ -5,330 +5,656 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83001-83600-les_adrets_de_l_esterel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83001-83600-les_adrets_de_l_esterel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83001-83600-les_adrets_de_l_esterel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83001-83600-les_adrets_de_l_esterel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83002-83630-aiguines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83002-83630-aiguines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83002-83630-aiguines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83002-83630-aiguines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83003-83111-ampus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83003-83111-ampus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83003-83111-ampus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83003-83111-ampus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83004-83460-les_arcs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83004-83460-les_arcs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83004-83460-les_arcs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83004-83460-les_arcs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83005-83630-artignosc_sur_verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83005-83630-artignosc_sur_verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83005-83630-artignosc_sur_verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83005-83630-artignosc_sur_verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83006-83560-artigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83006-83560-artigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83006-83560-artigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83006-83560-artigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83007-83630-aups/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83007-83630-aups/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83007-83630-aups/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83007-83630-aups/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83008-83600-bagnols_en_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83008-83600-bagnols_en_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83008-83600-bagnols_en_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83008-83600-bagnols_en_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83009-83150-bandol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83009-83150-bandol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83009-83150-bandol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83009-83150-bandol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83010-83840-bargeme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83010-83840-bargeme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83010-83840-bargeme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83010-83840-bargeme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83011-83830-bargemon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83011-83830-bargemon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83011-83830-bargemon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83011-83830-bargemon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83012-83670-barjols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83012-83670-barjols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83012-83670-barjols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83012-83670-barjols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83013-83840-la_bastide/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83013-83840-la_bastide/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83013-83840-la_bastide/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83013-83840-la_bastide/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83014-83630-baudinard_sur_verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83014-83630-baudinard_sur_verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83014-83630-baudinard_sur_verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83014-83630-baudinard_sur_verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83015-83630-bauduen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83015-83630-bauduen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83015-83630-bauduen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83015-83630-bauduen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83016-83330-le_beausset/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83016-83330-le_beausset/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83016-83330-le_beausset/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83016-83330-le_beausset/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83017-83210-belgentier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83017-83210-belgentier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83017-83210-belgentier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83017-83210-belgentier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83018-83890-besse_sur_issole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83018-83890-besse_sur_issole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83018-83890-besse_sur_issole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83018-83890-besse_sur_issole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83019-83230-bormes_les_mimosas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83019-83230-bormes_les_mimosas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83019-83230-bormes_les_mimosas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83019-83230-bormes_les_mimosas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83020-83840-le_bourguet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83020-83840-le_bourguet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83020-83840-le_bourguet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83020-83840-le_bourguet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83021-83149-bras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83021-83149-bras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83021-83149-bras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83021-83149-bras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83022-83840-brenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83022-83840-brenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83022-83840-brenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83022-83840-brenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83023-83170-brignoles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83023-83170-brignoles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83023-83170-brignoles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83023-83170-brignoles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83025-83119-brue_auriac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83025-83119-brue_auriac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83025-83119-brue_auriac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83025-83119-brue_auriac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83026-83340-cabasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83026-83340-cabasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83026-83340-cabasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83026-83340-cabasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83027-83740-la_cadiere_d_azur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83027-83740-la_cadiere_d_azur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83027-83740-la_cadiere_d_azur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83027-83740-la_cadiere_d_azur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83028-83830-callas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83028-83830-callas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83028-83830-callas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83028-83830-callas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83029-83440-callian/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83029-83440-callian/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83029-83440-callian/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83029-83440-callian/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83030-83170-camps_la_source/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83030-83170-camps_la_source/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83030-83170-camps_la_source/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83030-83170-camps_la_source/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83031-83340-le_cannet_des_maures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83031-83340-le_cannet_des_maures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83031-83340-le_cannet_des_maures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83031-83340-le_cannet_des_maures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83032-83570-carces/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83032-83570-carces/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83032-83570-carces/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83032-83570-carces/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83033-83660-carnoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83033-83660-carnoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83033-83660-carnoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83033-83660-carnoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83034-83320-carqueiranne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83034-83320-carqueiranne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83034-83320-carqueiranne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83034-83320-carqueiranne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83035-83330-le_castellet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83035-83330-le_castellet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83035-83330-le_castellet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83035-83330-le_castellet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83036-83240-cavalaire_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83036-83240-cavalaire_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83036-83240-cavalaire_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83036-83240-cavalaire_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83037-83170-la_celle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83037-83170-la_celle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83037-83170-la_celle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83037-83170-la_celle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83038-83300-chateaudouble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83038-83300-chateaudouble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83038-83300-chateaudouble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83038-83300-chateaudouble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83039-83670-chateauvert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83039-83670-chateauvert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83039-83670-chateauvert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83039-83670-chateauvert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83040-83840-chateauvieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83040-83840-chateauvieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83040-83840-chateauvieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83040-83840-chateauvieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83041-83830-claviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83041-83830-claviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83041-83830-claviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83041-83830-claviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83042-83310-cogolin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83042-83310-cogolin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83042-83310-cogolin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83042-83310-cogolin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83043-83610-collobrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83043-83610-collobrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83043-83610-collobrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83043-83610-collobrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83044-83840-comps_sur_artuby/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83044-83840-comps_sur_artuby/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83044-83840-comps_sur_artuby/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83044-83840-comps_sur_artuby/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83045-83570-correns/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83045-83570-correns/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83045-83570-correns/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83045-83570-correns/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83046-83570-cotignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83046-83570-cotignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83046-83570-cotignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83046-83570-cotignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83047-83260-la_crau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83047-83260-la_crau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83047-83260-la_crau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83047-83260-la_crau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83048-83420-la_croix_valmer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83048-83420-la_croix_valmer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83048-83420-la_croix_valmer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83048-83420-la_croix_valmer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83049-83390-cuers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83049-83390-cuers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83049-83390-cuers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83049-83390-cuers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83050-83300-draguignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83050-83300-draguignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83050-83300-draguignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83050-83300-draguignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83051-83570-entrecasteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83051-83570-entrecasteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83051-83570-entrecasteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83051-83570-entrecasteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83052-83560-esparron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83052-83560-esparron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83052-83560-esparron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83052-83560-esparron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83053-83330-evenos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83053-83330-evenos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83053-83330-evenos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83053-83330-evenos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83054-83210-la_farlede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83054-83210-la_farlede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83054-83210-la_farlede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83054-83210-la_farlede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83055-83440-fayence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83055-83440-fayence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83055-83440-fayence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83055-83440-fayence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83056-83830-figanieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83056-83830-figanieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83056-83830-figanieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83056-83830-figanieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83057-83340-flassans_sur_issole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83057-83340-flassans_sur_issole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83057-83340-flassans_sur_issole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83057-83340-flassans_sur_issole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83058-83780-flayosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83058-83780-flayosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83058-83780-flayosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83058-83780-flayosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83058-83510-flayosc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83058-83510-flayosc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83058-83510-flayosc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83058-83510-flayosc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83059-83136-forcalqueiret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83059-83136-forcalqueiret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83059-83136-forcalqueiret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83059-83136-forcalqueiret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83060-83670-fox_amphoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83060-83670-fox_amphoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83060-83670-fox_amphoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83060-83670-fox_amphoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83061-83600-frejus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83061-83600-frejus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83061-83600-frejus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83061-83600-frejus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83061-83370-frejus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83061-83370-frejus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83061-83370-frejus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83061-83370-frejus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83062-83130-la_garde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83062-83130-la_garde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83062-83130-la_garde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83062-83130-la_garde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83063-83680-la_garde_freinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83063-83680-la_garde_freinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83063-83680-la_garde_freinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83063-83680-la_garde_freinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83064-83136-gareoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83064-83136-gareoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83064-83136-gareoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83064-83136-gareoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83065-83580-gassin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83065-83580-gassin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83065-83580-gassin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83065-83580-gassin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83066-83560-ginasservis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83066-83560-ginasservis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83066-83560-ginasservis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83066-83560-ginasservis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83067-83590-gonfaron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83067-83590-gonfaron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83067-83590-gonfaron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83067-83590-gonfaron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83068-83310-grimaud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83068-83310-grimaud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83068-83310-grimaud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83068-83310-grimaud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83069-83400-hyeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83069-83400-hyeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83069-83400-hyeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83069-83400-hyeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83070-83980-le_lavandou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83070-83980-le_lavandou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83070-83980-le_lavandou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83070-83980-le_lavandou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83071-83250-la_londe_les_maures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83071-83250-la_londe_les_maures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83071-83250-la_londe_les_maures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83071-83250-la_londe_les_maures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83072-83510-lorgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83072-83510-lorgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83072-83510-lorgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83072-83510-lorgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83073-83340-le_luc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83073-83340-le_luc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83073-83340-le_luc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83073-83340-le_luc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83074-83840-la_martre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83074-83840-la_martre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83074-83840-la_martre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83074-83840-la_martre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83075-83340-les_mayons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83075-83340-les_mayons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83075-83340-les_mayons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83075-83340-les_mayons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83076-83136-mazaugues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83076-83136-mazaugues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83076-83136-mazaugues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83076-83136-mazaugues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83077-83136-meounes_les_montrieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83077-83136-meounes_les_montrieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83077-83136-meounes_les_montrieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83077-83136-meounes_les_montrieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83078-83630-moissac_bellevue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83078-83630-moissac_bellevue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83078-83630-moissac_bellevue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83078-83630-moissac_bellevue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83079-83310-la_mole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83079-83310-la_mole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83079-83310-la_mole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83079-83310-la_mole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83080-83440-mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83080-83440-mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83080-83440-mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83080-83440-mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83081-83440-montauroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83081-83440-montauroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83081-83440-montauroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83081-83440-montauroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83082-83131-montferrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83082-83131-montferrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83082-83131-montferrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83082-83131-montferrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83082-83998-montferrat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83082-83998-montferrat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83082-83998-montferrat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83082-83998-montferrat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83083-83570-montfort_sur_argens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83083-83570-montfort_sur_argens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83083-83570-montfort_sur_argens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83083-83570-montfort_sur_argens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83084-83670-montmeyan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83084-83670-montmeyan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83084-83670-montmeyan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83084-83670-montmeyan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83085-83920-la_motte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83085-83920-la_motte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83085-83920-la_motte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83085-83920-la_motte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83086-83490-le_muy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83086-83490-le_muy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83086-83490-le_muy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83086-83490-le_muy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83087-83860-nans_les_pins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83087-83860-nans_les_pins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83087-83860-nans_les_pins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83087-83860-nans_les_pins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83088-83136-neoules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83088-83136-neoules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83088-83136-neoules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83088-83136-neoules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83089-83470-ollieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83089-83470-ollieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83089-83470-ollieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83089-83470-ollieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83090-83190-ollioules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83090-83190-ollioules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83090-83190-ollioules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83090-83190-ollioules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83091-83390-pierrefeu_du_var/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83091-83390-pierrefeu_du_var/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83091-83390-pierrefeu_du_var/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83091-83390-pierrefeu_du_var/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83092-83790-pignans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83092-83790-pignans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83092-83790-pignans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83092-83790-pignans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83093-83640-plan_d_aups_sainte_baume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83093-83640-plan_d_aups_sainte_baume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83093-83640-plan_d_aups_sainte_baume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83093-83640-plan_d_aups_sainte_baume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83094-83120-le_plan_de_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83094-83120-le_plan_de_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83094-83120-le_plan_de_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83094-83120-le_plan_de_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83095-83670-ponteves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83095-83670-ponteves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83095-83670-ponteves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83095-83670-ponteves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83096-83470-pourcieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83096-83470-pourcieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83096-83470-pourcieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83096-83470-pourcieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83097-83910-pourrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83097-83910-pourrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83097-83910-pourrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83097-83910-pourrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83098-83220-le_pradet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83098-83220-le_pradet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83098-83220-le_pradet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83098-83220-le_pradet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83099-83480-puget_sur_argens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83099-83480-puget_sur_argens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83099-83480-puget_sur_argens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83099-83480-puget_sur_argens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83100-83390-puget_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83100-83390-puget_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83100-83390-puget_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83100-83390-puget_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83101-83350-ramatuelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83101-83350-ramatuelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83101-83350-ramatuelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83101-83350-ramatuelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83102-83630-regusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83102-83630-regusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83102-83630-regusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83102-83630-regusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83103-83200-le_revest_les_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83103-83200-le_revest_les_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83103-83200-le_revest_les_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83103-83200-le_revest_les_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83104-83560-rians/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83104-83560-rians/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83104-83560-rians/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83104-83560-rians/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83105-13780-riboux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83105-13780-riboux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83105-13780-riboux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83105-13780-riboux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83106-83136-rocbaron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83106-83136-rocbaron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83106-83136-rocbaron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83106-83136-rocbaron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83520-roquebrune_sur_argens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83520-roquebrune_sur_argens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83520-roquebrune_sur_argens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83520-roquebrune_sur_argens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83380-roquebrune_sur_argens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83380-roquebrune_sur_argens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83380-roquebrune_sur_argens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83380-roquebrune_sur_argens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83370-roquebrune_sur_argens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83370-roquebrune_sur_argens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83370-roquebrune_sur_argens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83107-83370-roquebrune_sur_argens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83108-83136-la_roquebrussanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83108-83136-la_roquebrussanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83108-83136-la_roquebrussanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83108-83136-la_roquebrussanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83109-83840-la_roque_esclapon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83109-83840-la_roque_esclapon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83109-83840-la_roque_esclapon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83109-83840-la_roque_esclapon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83110-83170-rougiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83110-83170-rougiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83110-83170-rougiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83110-83170-rougiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83111-83136-sainte_anastasie_sur_issole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83111-83136-sainte_anastasie_sur_issole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83111-83136-sainte_anastasie_sur_issole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83111-83136-sainte_anastasie_sur_issole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83112-83270-saint_cyr_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83112-83270-saint_cyr_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83112-83270-saint_cyr_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83112-83270-saint_cyr_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83113-83560-saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83113-83560-saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83113-83560-saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83113-83560-saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83114-83560-saint_martin_de_pallieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83114-83560-saint_martin_de_pallieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83114-83560-saint_martin_de_pallieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83114-83560-saint_martin_de_pallieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83115-83120-sainte_maxime/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83115-83120-sainte_maxime/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83115-83120-sainte_maxime/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83115-83120-sainte_maxime/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83116-83470-saint_maximin_la_sainte_baume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83116-83470-saint_maximin_la_sainte_baume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83116-83470-saint_maximin_la_sainte_baume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83116-83470-saint_maximin_la_sainte_baume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83117-83440-saint_paul_en_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83117-83440-saint_paul_en_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83117-83440-saint_paul_en_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83117-83440-saint_paul_en_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83118-83700-saint_raphael/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83118-83700-saint_raphael/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83118-83700-saint_raphael/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83118-83700-saint_raphael/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83118-83530-saint_raphael/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83118-83530-saint_raphael/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83118-83530-saint_raphael/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83118-83530-saint_raphael/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83119-83990-saint_tropez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83119-83990-saint_tropez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83119-83990-saint_tropez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83119-83990-saint_tropez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83120-83640-saint_zacharie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83120-83640-saint_zacharie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83120-83640-saint_zacharie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83120-83640-saint_zacharie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83121-83690-salernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83121-83690-salernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83121-83690-salernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83121-83690-salernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83122-83630-les_salles_sur_verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83122-83630-les_salles_sur_verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83122-83630-les_salles_sur_verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83122-83630-les_salles_sur_verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83123-83110-sanary_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83123-83110-sanary_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83123-83110-sanary_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83123-83110-sanary_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83124-83440-seillans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83124-83440-seillans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83124-83440-seillans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83124-83440-seillans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83125-83470-seillons_source_d_argens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83125-83470-seillons_source_d_argens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83125-83470-seillons_source_d_argens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83125-83470-seillons_source_d_argens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83126-83500-la_seyne_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83126-83500-la_seyne_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83126-83500-la_seyne_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83126-83500-la_seyne_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83127-83870-signes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83127-83870-signes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83127-83870-signes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83127-83870-signes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83128-83690-sillans_la_cascade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83128-83690-sillans_la_cascade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83128-83690-sillans_la_cascade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83128-83690-sillans_la_cascade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83129-83140-six_fours_les_plages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83129-83140-six_fours_les_plages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83129-83140-six_fours_les_plages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83129-83140-six_fours_les_plages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83130-83210-sollies_pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83130-83210-sollies_pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83130-83210-sollies_pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83130-83210-sollies_pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83131-83210-sollies_toucas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83131-83210-sollies_toucas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83131-83210-sollies_toucas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83131-83210-sollies_toucas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83132-83210-sollies_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83132-83210-sollies_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83132-83210-sollies_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83132-83210-sollies_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83133-83440-tanneron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83133-83440-tanneron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83133-83440-tanneron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83133-83440-tanneron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83134-83460-taradeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83134-83460-taradeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83134-83460-taradeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83134-83460-taradeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83135-83670-tavernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83135-83670-tavernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83135-83670-tavernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83135-83670-tavernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83136-83340-le_thoronet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83136-83340-le_thoronet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83136-83340-le_thoronet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83136-83340-le_thoronet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83000-toulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83000-toulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83000-toulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83000-toulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83100-toulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83100-toulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83100-toulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83100-toulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83200-toulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83200-toulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83200-toulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83200-toulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83800-toulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83800-toulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83800-toulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83137-83800-toulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83138-83440-tourrettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83138-83440-tourrettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83138-83440-tourrettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83138-83440-tourrettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83139-83690-tourtour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83139-83690-tourtour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83139-83690-tourtour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83139-83690-tourtour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83140-83170-tourves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83140-83170-tourves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83140-83170-tourves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83140-83170-tourves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83141-83720-trans_en_provence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83141-83720-trans_en_provence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83141-83720-trans_en_provence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83141-83720-trans_en_provence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83142-83840-trigance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83142-83840-trigance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83142-83840-trigance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83142-83840-trigance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83143-83143-le_val/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83143-83143-le_val/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83143-83143-le_val/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83143-83143-le_val/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83144-83160-la_valette_du_var/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83144-83160-la_valette_du_var/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83144-83160-la_valette_du_var/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83144-83160-la_valette_du_var/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83145-83670-varages/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83145-83670-varages/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83145-83670-varages/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83145-83670-varages/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83146-83560-la_verdiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83146-83560-la_verdiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83146-83560-la_verdiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83146-83560-la_verdiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83147-83630-verignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83147-83630-verignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83147-83630-verignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83147-83630-verignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83148-83550-vidauban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83148-83550-vidauban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83148-83550-vidauban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83148-83550-vidauban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83149-83690-villecroze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83149-83690-villecroze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83149-83690-villecroze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83149-83690-villecroze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83150-83560-vinon_sur_verdon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83150-83560-vinon_sur_verdon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83150-83560-vinon_sur_verdon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83150-83560-vinon_sur_verdon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83151-83170-vins_sur_caramy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83151-83170-vins_sur_caramy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83151-83170-vins_sur_caramy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83151-83170-vins_sur_caramy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83152-83820-rayol_canadel_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83152-83820-rayol_canadel_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83152-83820-rayol_canadel_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83152-83820-rayol_canadel_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83153-83430-saint_mandrier_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83153-83430-saint_mandrier_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83153-83430-saint_mandrier_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83153-83430-saint_mandrier_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83154-83510-saint_antonin_du_var/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83154-83510-saint_antonin_du_var/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83154-83510-saint_antonin_du_var/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt83-var/commune83154-83510-saint_antonin_du_var/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-84.xml
+++ b/public/sitemaps/sitemap-84.xml
@@ -5,310 +5,616 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84001-84210-althen_des_paluds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84001-84210-althen_des_paluds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84001-84210-althen_des_paluds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84001-84210-althen_des_paluds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84002-84240-ansouis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84002-84240-ansouis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84002-84240-ansouis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84002-84240-ansouis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84003-84400-apt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84003-84400-apt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84003-84400-apt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84003-84400-apt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84004-84810-aubignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84004-84810-aubignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84004-84810-aubignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84004-84810-aubignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84005-84390-aurel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84005-84390-aurel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84005-84390-aurel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84005-84390-aurel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84006-84400-auribeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84006-84400-auribeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84006-84400-auribeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84006-84400-auribeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84007-84140-avignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84007-84140-avignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84007-84140-avignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84007-84140-avignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84007-84000-avignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84007-84000-avignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84007-84000-avignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84007-84000-avignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84008-84330-le_barroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84008-84330-le_barroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84008-84330-le_barroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84008-84330-le_barroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84009-84240-la_bastide_des_jourdans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84009-84240-la_bastide_des_jourdans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84009-84240-la_bastide_des_jourdans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84009-84240-la_bastide_des_jourdans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84010-84120-la_bastidonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84010-84120-la_bastidonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84010-84120-la_bastidonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84010-84120-la_bastidonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84011-84210-le_beaucet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84011-84210-le_beaucet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84011-84210-le_beaucet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84011-84210-le_beaucet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84012-84190-beaumes_de_venise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84012-84190-beaumes_de_venise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84012-84190-beaumes_de_venise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84012-84190-beaumes_de_venise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84013-84220-beaumettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84013-84220-beaumettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84013-84220-beaumettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84013-84220-beaumettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84014-84120-beaumont_de_pertuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84014-84120-beaumont_de_pertuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84014-84120-beaumont_de_pertuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84014-84120-beaumont_de_pertuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84015-84340-beaumont_du_ventoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84015-84340-beaumont_du_ventoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84015-84340-beaumont_du_ventoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84015-84340-beaumont_du_ventoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84016-84370-bedarrides/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84016-84370-bedarrides/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84016-84370-bedarrides/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84016-84370-bedarrides/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84017-84410-bedoin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84017-84410-bedoin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84017-84410-bedoin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84017-84410-bedoin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84018-84570-blauvac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84018-84570-blauvac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84018-84570-blauvac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84018-84570-blauvac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84019-84500-bollene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84019-84500-bollene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84019-84500-bollene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84019-84500-bollene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84020-84480-bonnieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84020-84480-bonnieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84020-84480-bonnieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84020-84480-bonnieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84021-84390-brantes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84021-84390-brantes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84021-84390-brantes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84021-84390-brantes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84022-84110-buisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84022-84110-buisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84022-84110-buisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84022-84110-buisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84023-84480-buoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84023-84480-buoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84023-84480-buoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84023-84480-buoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84024-84240-cabrieres_d_aigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84024-84240-cabrieres_d_aigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84024-84240-cabrieres_d_aigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84024-84240-cabrieres_d_aigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84025-84220-cabrieres_d_avignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84025-84220-cabrieres_d_avignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84025-84220-cabrieres_d_avignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84025-84220-cabrieres_d_avignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84026-84160-cadenet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84026-84160-cadenet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84026-84160-cadenet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84026-84160-cadenet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84027-84860-caderousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84027-84860-caderousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84027-84860-caderousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84027-84860-caderousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84028-84290-cairanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84028-84290-cairanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84028-84290-cairanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84028-84290-cairanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84029-84850-camaret_sur_aigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84029-84850-camaret_sur_aigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84029-84850-camaret_sur_aigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84029-84850-camaret_sur_aigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84030-84330-caromb/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84030-84330-caromb/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84030-84330-caromb/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84030-84330-caromb/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84031-84200-carpentras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84031-84200-carpentras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84031-84200-carpentras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84031-84200-carpentras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84032-84750-caseneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84032-84750-caseneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84032-84750-caseneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84032-84750-caseneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84033-84400-castellet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84033-84400-castellet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84033-84400-castellet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84033-84400-castellet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84034-84510-caumont_sur_durance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84034-84510-caumont_sur_durance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84034-84510-caumont_sur_durance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84034-84510-caumont_sur_durance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84035-84300-cavaillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84035-84300-cavaillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84035-84300-cavaillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84035-84300-cavaillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84036-84470-chateauneuf_de_gadagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84036-84470-chateauneuf_de_gadagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84036-84470-chateauneuf_de_gadagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84036-84470-chateauneuf_de_gadagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84037-84230-chateauneuf_du_pape/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84037-84230-chateauneuf_du_pape/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84037-84230-chateauneuf_du_pape/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84037-84230-chateauneuf_du_pape/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84038-84460-cheval_blanc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84038-84460-cheval_blanc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84038-84460-cheval_blanc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84038-84460-cheval_blanc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84039-84350-courthezon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84039-84350-courthezon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84039-84350-courthezon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84039-84350-courthezon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84040-84110-crestet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84040-84110-crestet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84040-84110-crestet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84040-84110-crestet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84041-84410-crillon_le_brave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84041-84410-crillon_le_brave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84041-84410-crillon_le_brave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84041-84410-crillon_le_brave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84042-84160-cucuron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84042-84160-cucuron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84042-84160-cucuron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84042-84160-cucuron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84043-84320-entraigues_sur_la_sorgue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84043-84320-entraigues_sur_la_sorgue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84043-84320-entraigues_sur_la_sorgue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84043-84320-entraigues_sur_la_sorgue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84044-84340-entrechaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84044-84340-entrechaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84044-84340-entrechaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84044-84340-entrechaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84045-84110-faucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84045-84110-faucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84045-84110-faucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84045-84110-faucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84046-84410-flassan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84046-84410-flassan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84046-84410-flassan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84046-84410-flassan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84047-84400-gargas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84047-84400-gargas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84047-84400-gargas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84047-84400-gargas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84048-84400-gignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84048-84400-gignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84048-84400-gignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84048-84400-gignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84049-84190-gigondas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84049-84190-gigondas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84049-84190-gigondas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84049-84190-gigondas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84050-84220-gordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84050-84220-gordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84050-84220-gordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84050-84220-gordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84051-84220-goult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84051-84220-goult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84051-84220-goult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84051-84220-goult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84052-84240-grambois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84052-84240-grambois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84052-84240-grambois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84052-84240-grambois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84053-84600-grillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84053-84600-grillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84053-84600-grillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84053-84600-grillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84054-84800-l_isle_sur_la_sorgue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84054-84800-l_isle_sur_la_sorgue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84054-84800-l_isle_sur_la_sorgue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84054-84800-l_isle_sur_la_sorgue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84055-84450-jonquerettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84055-84450-jonquerettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84055-84450-jonquerettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84055-84450-jonquerettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84056-84150-jonquieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84056-84150-jonquieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84056-84150-jonquieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84056-84150-jonquieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84057-84220-joucas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84057-84220-joucas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84057-84220-joucas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84057-84220-joucas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84058-84480-lacoste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84058-84480-lacoste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84058-84480-lacoste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84058-84480-lacoste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84059-84190-lafare/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84059-84190-lafare/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84059-84190-lafare/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84059-84190-lafare/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84060-84400-lagarde_d_apt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84060-84400-lagarde_d_apt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84060-84400-lagarde_d_apt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84060-84400-lagarde_d_apt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84061-84290-lagarde_pareol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84061-84290-lagarde_pareol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84061-84290-lagarde_pareol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84061-84290-lagarde_pareol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84062-84800-lagnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84062-84800-lagnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84062-84800-lagnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84062-84800-lagnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84063-84840-lamotte_du_rhone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84063-84840-lamotte_du_rhone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84063-84840-lamotte_du_rhone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84063-84840-lamotte_du_rhone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84064-84840-lapalud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84064-84840-lapalud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84064-84840-lapalud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84064-84840-lapalud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84065-84360-lauris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84065-84360-lauris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84065-84360-lauris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84065-84360-lauris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84066-84220-lioux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84066-84220-lioux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84066-84220-lioux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84066-84220-lioux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84067-84870-loriol_du_comtat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84067-84870-loriol_du_comtat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84067-84870-loriol_du_comtat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84067-84870-loriol_du_comtat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84068-84160-lourmarin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84068-84160-lourmarin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84068-84160-lourmarin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84068-84160-lourmarin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84069-84340-malaucene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84069-84340-malaucene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84069-84340-malaucene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84069-84340-malaucene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84070-84570-malemort_du_comtat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84070-84570-malemort_du_comtat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84070-84570-malemort_du_comtat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84070-84570-malemort_du_comtat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84071-84660-maubec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84071-84660-maubec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84071-84660-maubec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84071-84660-maubec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84072-84380-mazan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84072-84380-mazan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84072-84380-mazan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84072-84380-mazan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84073-84560-menerbes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84073-84560-menerbes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84073-84560-menerbes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84073-84560-menerbes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84074-84360-merindol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84074-84360-merindol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84074-84360-merindol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84074-84360-merindol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84075-84570-methamis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84075-84570-methamis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84075-84570-methamis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84075-84570-methamis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84076-84120-mirabeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84076-84120-mirabeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84076-84120-mirabeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84076-84120-mirabeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84077-84330-modene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84077-84330-modene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84077-84330-modene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84077-84330-modene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84078-84430-mondragon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84078-84430-mondragon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84078-84430-mondragon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84078-84430-mondragon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84079-84390-monieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84079-84390-monieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84079-84390-monieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84079-84390-monieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84080-84170-monteux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84080-84170-monteux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84080-84170-monteux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84080-84170-monteux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84081-84310-morieres_les_avignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84081-84310-morieres_les_avignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84081-84310-morieres_les_avignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84081-84310-morieres_les_avignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84082-84570-mormoiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84082-84570-mormoiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84082-84570-mormoiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84082-84570-mormoiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84083-84550-mornas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84083-84550-mornas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84083-84550-mornas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84083-84550-mornas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84084-84240-la_motte_d_aigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84084-84240-la_motte_d_aigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84084-84240-la_motte_d_aigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84084-84240-la_motte_d_aigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84085-84220-murs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84085-84220-murs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84085-84220-murs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84085-84220-murs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84086-84580-oppede/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84086-84580-oppede/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84086-84580-oppede/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84086-84580-oppede/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84087-84100-orange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84087-84100-orange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84087-84100-orange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84087-84100-orange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84088-84210-pernes_les_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84088-84210-pernes_les_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84088-84210-pernes_les_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84088-84210-pernes_les_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84089-84120-pertuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84089-84120-pertuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84089-84120-pertuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84089-84120-pertuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84090-84240-peypin_d_aigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84090-84240-peypin_d_aigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84090-84240-peypin_d_aigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84090-84240-peypin_d_aigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84091-84420-piolenc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84091-84420-piolenc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84091-84420-piolenc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84091-84420-piolenc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84092-84130-le_pontet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84092-84130-le_pontet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84092-84130-le_pontet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84092-84130-le_pontet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84093-84360-puget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84093-84360-puget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84093-84360-puget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84093-84360-puget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84094-84110-puymeras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84094-84110-puymeras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84094-84110-puymeras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84094-84110-puymeras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84095-84160-puyvert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84095-84160-puyvert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84095-84160-puyvert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84095-84160-puyvert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84096-84110-rasteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84096-84110-rasteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84096-84110-rasteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84096-84110-rasteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84097-84600-richerenches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84097-84600-richerenches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84097-84600-richerenches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84097-84600-richerenches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84098-84110-roaix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84098-84110-roaix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84098-84110-roaix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84098-84110-roaix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84099-84440-robion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84099-84440-robion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84099-84440-robion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84099-84440-robion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84100-84190-la_roque_alric/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84100-84190-la_roque_alric/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84100-84190-la_roque_alric/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84100-84190-la_roque_alric/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84101-84210-la_roque_sur_pernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84101-84210-la_roque_sur_pernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84101-84210-la_roque_sur_pernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84101-84210-la_roque_sur_pernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84102-84220-roussillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84102-84220-roussillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84102-84220-roussillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84102-84220-roussillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84103-84400-rustrel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84103-84400-rustrel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84103-84400-rustrel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84103-84400-rustrel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84104-84110-sablet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84104-84110-sablet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84104-84110-sablet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84104-84110-sablet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84105-84400-saignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84105-84400-saignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84105-84400-saignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84105-84400-saignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84106-84290-sainte_cecile_les_vignes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84106-84290-sainte_cecile_les_vignes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84106-84290-sainte_cecile_les_vignes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84106-84290-sainte_cecile_les_vignes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84107-84390-saint_christol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84107-84390-saint_christol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84107-84390-saint_christol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84107-84390-saint_christol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84108-84210-saint_didier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84108-84210-saint_didier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84108-84210-saint_didier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84108-84210-saint_didier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84109-84330-saint_hippolyte_le_graveyron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84109-84330-saint_hippolyte_le_graveyron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84109-84330-saint_hippolyte_le_graveyron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84109-84330-saint_hippolyte_le_graveyron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84110-84390-saint_leger_du_ventoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84110-84390-saint_leger_du_ventoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84110-84390-saint_leger_du_ventoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84110-84390-saint_leger_du_ventoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84111-84110-saint_marcellin_les_vaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84111-84110-saint_marcellin_les_vaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84111-84110-saint_marcellin_les_vaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84111-84110-saint_marcellin_les_vaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84112-84750-saint_martin_de_castillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84112-84750-saint_martin_de_castillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84112-84750-saint_martin_de_castillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84112-84750-saint_martin_de_castillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84113-84760-saint_martin_de_la_brasque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84113-84760-saint_martin_de_la_brasque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84113-84760-saint_martin_de_la_brasque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84113-84760-saint_martin_de_la_brasque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84114-84220-saint_pantaleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84114-84220-saint_pantaleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84114-84220-saint_pantaleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84114-84220-saint_pantaleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84115-84330-saint_pierre_de_vassols/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84115-84330-saint_pierre_de_vassols/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84115-84330-saint_pierre_de_vassols/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84115-84330-saint_pierre_de_vassols/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84116-84110-saint_romain_en_viennois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84116-84110-saint_romain_en_viennois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84116-84110-saint_romain_en_viennois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84116-84110-saint_romain_en_viennois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84117-84290-saint_roman_de_malegarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84117-84290-saint_roman_de_malegarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84117-84290-saint_roman_de_malegarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84117-84290-saint_roman_de_malegarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84118-84490-saint_saturnin_les_apt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84118-84490-saint_saturnin_les_apt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84118-84490-saint_saturnin_les_apt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84118-84490-saint_saturnin_les_apt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84119-84450-saint_saturnin_les_avignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84119-84450-saint_saturnin_les_avignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84119-84450-saint_saturnin_les_avignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84119-84450-saint_saturnin_les_avignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84120-84390-saint_trinit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84120-84390-saint_trinit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84120-84390-saint_trinit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84120-84390-saint_trinit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84121-84240-sannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84121-84240-sannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84121-84240-sannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84121-84240-sannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84122-84260-sarrians/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84122-84260-sarrians/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84122-84260-sarrians/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84122-84260-sarrians/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84123-84390-sault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84123-84390-sault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84123-84390-sault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84123-84390-sault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84124-84800-saumane_de_vaucluse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84124-84800-saumane_de_vaucluse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84124-84800-saumane_de_vaucluse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84124-84800-saumane_de_vaucluse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84125-84390-savoillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84125-84390-savoillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84125-84390-savoillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84125-84390-savoillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84126-84110-seguret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84126-84110-seguret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84126-84110-seguret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84126-84110-seguret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84127-84830-serignan_du_comtat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84127-84830-serignan_du_comtat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84127-84830-serignan_du_comtat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84127-84830-serignan_du_comtat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84128-84400-sivergues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84128-84400-sivergues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84128-84400-sivergues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84128-84400-sivergues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84129-84700-sorgues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84129-84700-sorgues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84129-84700-sorgues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84129-84700-sorgues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84130-84190-suzette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84130-84190-suzette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84130-84190-suzette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84130-84190-suzette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84131-84300-taillades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84131-84300-taillades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84131-84300-taillades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84131-84300-taillades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84132-84250-le_thor/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84132-84250-le_thor/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84132-84250-le_thor/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84132-84250-le_thor/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84133-84240-la_tour_d_aigues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84133-84240-la_tour_d_aigues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84133-84240-la_tour_d_aigues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84133-84240-la_tour_d_aigues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84134-84850-travaillan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84134-84850-travaillan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84134-84850-travaillan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84134-84850-travaillan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84135-84100-uchaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84135-84100-uchaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84135-84100-uchaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84135-84100-uchaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84136-84190-vacqueyras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84136-84190-vacqueyras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84136-84190-vacqueyras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84136-84190-vacqueyras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84137-84110-vaison_la_romaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84137-84110-vaison_la_romaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84137-84110-vaison_la_romaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84137-84110-vaison_la_romaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84138-84600-valreas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84138-84600-valreas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84138-84600-valreas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84138-84600-valreas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84139-84800-fontaine_de_vaucluse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84139-84800-fontaine_de_vaucluse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84139-84800-fontaine_de_vaucluse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84139-84800-fontaine_de_vaucluse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84140-84160-vaugines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84140-84160-vaugines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84140-84160-vaugines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84140-84160-vaugines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84141-84270-vedene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84141-84270-vedene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84141-84270-vedene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84141-84270-vedene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84142-84740-velleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84142-84740-velleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84142-84740-velleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84142-84740-velleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84143-84210-venasque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84143-84210-venasque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84143-84210-venasque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84143-84210-venasque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84144-84750-viens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84144-84750-viens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84144-84750-viens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84144-84750-viens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84145-84400-villars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84145-84400-villars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84145-84400-villars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84145-84400-villars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84146-84110-villedieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84146-84110-villedieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84146-84110-villedieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84146-84110-villedieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84147-84530-villelaure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84147-84530-villelaure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84147-84530-villelaure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84147-84530-villelaure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84148-84570-villes_sur_auzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84148-84570-villes_sur_auzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84148-84570-villes_sur_auzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84148-84570-villes_sur_auzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84149-84150-violes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84149-84150-violes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84149-84150-violes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84149-84150-violes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84150-84820-visan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84150-84820-visan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84150-84820-visan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84150-84820-visan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84151-84240-vitrolles_en_luberon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84151-84240-vitrolles_en_luberon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84151-84240-vitrolles_en_luberon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt84-vaucluse/commune84151-84240-vitrolles_en_luberon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-85.xml
+++ b/public/sitemaps/sitemap-85.xml
@@ -5,530 +5,1056 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85001-85460-l_aiguillon_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85001-85460-l_aiguillon_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85001-85460-l_aiguillon_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85001-85460-l_aiguillon_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85002-85220-l_aiguillon_sur_vie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85002-85220-l_aiguillon_sur_vie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85002-85220-l_aiguillon_sur_vie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85002-85220-l_aiguillon_sur_vie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85003-85190-aizenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85003-85190-aizenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85003-85190-aizenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85003-85190-aizenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85004-85750-angles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85004-85750-angles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85004-85750-angles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85004-85750-angles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85005-85120-antigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85005-85120-antigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85005-85120-antigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85005-85120-antigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85006-85220-apremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85006-85220-apremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85006-85220-apremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85006-85220-apremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85008-85430-aubigny_les_clouzeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85008-85430-aubigny_les_clouzeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85008-85430-aubigny_les_clouzeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85008-85430-aubigny_les_clouzeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85009-85200-auchay_sur_vendee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85009-85200-auchay_sur_vendee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85009-85200-auchay_sur_vendee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85009-85200-auchay_sur_vendee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85010-85440-avrille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85010-85440-avrille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85010-85440-avrille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85010-85440-avrille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85011-85630-barbatre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85011-85630-barbatre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85011-85630-barbatre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85011-85630-barbatre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85012-85550-la_barre_de_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85012-85550-la_barre_de_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85012-85550-la_barre_de_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85012-85550-la_barre_de_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85013-85130-bazoges_en_paillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85013-85130-bazoges_en_paillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85013-85130-bazoges_en_paillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85013-85130-bazoges_en_paillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85014-85390-bazoges_en_pareds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85014-85390-bazoges_en_pareds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85014-85390-bazoges_en_pareds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85014-85390-bazoges_en_pareds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85015-85170-beaufou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85015-85170-beaufou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85015-85170-beaufou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85015-85170-beaufou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85016-85190-beaulieu_sous_la_roche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85016-85190-beaulieu_sous_la_roche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85016-85190-beaulieu_sous_la_roche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85016-85190-beaulieu_sous_la_roche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85017-85500-beaurepaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85017-85500-beaurepaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85017-85500-beaurepaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85017-85500-beaurepaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85018-85230-beauvoir_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85018-85230-beauvoir_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85018-85230-beauvoir_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85018-85230-beauvoir_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85019-85170-bellevigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85019-85170-bellevigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85019-85170-bellevigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85019-85170-bellevigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85020-85490-benet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85020-85490-benet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85020-85490-benet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85020-85490-benet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85021-85610-la_bernardiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85021-85610-la_bernardiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85021-85610-la_bernardiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85021-85610-la_bernardiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85022-85560-le_bernard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85022-85560-le_bernard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85022-85560-le_bernard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85022-85560-le_bernard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85023-85320-bessay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85023-85320-bessay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85023-85320-bessay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85023-85320-bessay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85024-85710-bois_de_cene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85024-85710-bois_de_cene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85024-85710-bois_de_cene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85024-85710-bois_de_cene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85025-85600-la_boissiere_de_montaigu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85025-85600-la_boissiere_de_montaigu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85025-85600-la_boissiere_de_montaigu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85025-85600-la_boissiere_de_montaigu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85026-85430-la_boissiere_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85026-85430-la_boissiere_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85026-85430-la_boissiere_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85026-85430-la_boissiere_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85028-85420-bouille_courdault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85028-85420-bouille_courdault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85028-85420-bouille_courdault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85028-85420-bouille_courdault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85029-85230-bouin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85029-85230-bouin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85029-85230-bouin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85029-85230-bouin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85031-85510-le_boupere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85031-85510-le_boupere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85031-85510-le_boupere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85031-85510-le_boupere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85033-85200-bourneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85033-85200-bourneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85033-85200-bourneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85033-85200-bourneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85034-85480-bournezeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85034-85480-bournezeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85034-85480-bournezeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85034-85480-bournezeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85035-85470-bretignolles_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85035-85470-bretignolles_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85035-85470-bretignolles_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85035-85470-bretignolles_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85036-85320-la_bretonniere_la_claye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85036-85320-la_bretonniere_la_claye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85036-85320-la_bretonniere_la_claye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85036-85320-la_bretonniere_la_claye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85037-85120-breuil_barret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85037-85120-breuil_barret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85037-85120-breuil_barret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85037-85120-breuil_barret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85038-85260-les_brouzils/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85038-85260-les_brouzils/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85038-85260-les_brouzils/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85038-85260-les_brouzils/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85039-85530-la_bruffiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85039-85530-la_bruffiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85039-85530-la_bruffiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85039-85530-la_bruffiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85040-85410-la_caillere_saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85040-85410-la_caillere_saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85040-85410-la_caillere_saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85040-85410-la_caillere_saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85041-85410-cezais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85041-85410-cezais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85041-85410-cezais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85041-85410-cezais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85042-85450-chaille_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85042-85450-chaille_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85042-85450-chaille_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85042-85450-chaille_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85045-85220-la_chaize_giraud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85045-85220-la_chaize_giraud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85045-85220-la_chaize_giraud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85045-85220-la_chaize_giraud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85046-85310-la_chaize_le_vicomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85046-85310-la_chaize_le_vicomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85046-85310-la_chaize_le_vicomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85046-85310-la_chaize_le_vicomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85047-85300-challans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85047-85300-challans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85047-85300-challans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85047-85300-challans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85049-85450-champagne_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85049-85450-champagne_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85049-85450-champagne_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85049-85450-champagne_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85050-85540-le_champ_saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85050-85540-le_champ_saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85050-85540-le_champ_saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85050-85540-le_champ_saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85051-85110-chantonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85051-85110-chantonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85051-85110-chantonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85051-85110-chantonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85053-85120-la_chapelle_aux_lys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85053-85120-la_chapelle_aux_lys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85053-85120-la_chapelle_aux_lys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85053-85120-la_chapelle_aux_lys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85054-85220-la_chapelle_hermier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85054-85220-la_chapelle_hermier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85054-85220-la_chapelle_hermier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85054-85220-la_chapelle_hermier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85055-85670-la_chapelle_palluau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85055-85670-la_chapelle_palluau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85055-85670-la_chapelle_palluau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85055-85670-la_chapelle_palluau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85056-85210-la_chapelle_themer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85056-85210-la_chapelle_themer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85056-85210-la_chapelle_themer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85056-85210-la_chapelle_themer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85058-85400-chasnais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85058-85400-chasnais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85058-85400-chasnais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85058-85400-chasnais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85059-85120-la_chataigneraie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85059-85120-la_chataigneraie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85059-85120-la_chataigneraie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85059-85120-la_chataigneraie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85061-85320-chateau_guibert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85061-85320-chateau_guibert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85061-85320-chateau_guibert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85061-85320-chateau_guibert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85062-85710-chateauneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85062-85710-chateauneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85062-85710-chateauneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85062-85710-chateauneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85064-85140-chauche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85064-85140-chauche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85064-85140-chauche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85064-85140-chauche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85065-85250-chavagnes_en_paillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85065-85250-chavagnes_en_paillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85065-85250-chavagnes_en_paillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85065-85250-chavagnes_en_paillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85066-85390-chavagnes_les_redoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85066-85390-chavagnes_les_redoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85066-85390-chavagnes_les_redoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85066-85390-chavagnes_les_redoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85067-85390-cheffois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85067-85390-cheffois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85067-85390-cheffois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85067-85390-cheffois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85070-85220-coex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85070-85220-coex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85070-85220-coex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85070-85220-coex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85071-85220-commequiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85071-85220-commequiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85071-85220-commequiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85071-85220-commequiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85072-85260-la_copechagniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85072-85260-la_copechagniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85072-85260-la_copechagniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85072-85260-la_copechagniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85073-85320-corpe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85073-85320-corpe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85073-85320-corpe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85073-85320-corpe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85074-85320-la_couture/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85074-85320-la_couture/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85074-85320-la_couture/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85074-85320-la_couture/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85076-85610-cugand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85076-85610-cugand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85076-85610-cugand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85076-85610-cugand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85077-85540-curzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85077-85540-curzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85077-85540-curzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85077-85540-curzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85078-85420-damvix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85078-85420-damvix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85078-85420-damvix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85078-85420-damvix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85080-85200-doix_les_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85080-85200-doix_les_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85080-85200-doix_les_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85080-85200-doix_les_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85081-85170-dompierre_sur_yon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85081-85170-dompierre_sur_yon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85081-85170-dompierre_sur_yon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85081-85170-dompierre_sur_yon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85082-85590-les_epesses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85082-85590-les_epesses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85082-85590-les_epesses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85082-85590-les_epesses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85083-85740-l_epine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85083-85740-l_epine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85083-85740-l_epine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85083-85740-l_epine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85084-85140-essarts_en_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85084-85140-essarts_en_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85084-85140-essarts_en_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85084-85140-essarts_en_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85086-85670-falleron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85086-85670-falleron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85086-85670-falleron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85086-85670-falleron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85087-85240-faymoreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85087-85240-faymoreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85087-85240-faymoreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85087-85240-faymoreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85088-85800-le_fenouiller/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85088-85800-le_fenouiller/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85088-85800-le_fenouiller/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85088-85800-le_fenouiller/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85089-85280-la_ferriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85089-85280-la_ferriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85089-85280-la_ferriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85089-85280-la_ferriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85090-85700-sevremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85090-85700-sevremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85090-85700-sevremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85090-85700-sevremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85092-85200-fontenay_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85092-85200-fontenay_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85092-85200-fontenay_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85092-85200-fontenay_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85093-85480-fougere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85093-85480-fougere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85093-85480-fougere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85093-85480-fougere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85094-85240-foussais_payre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85094-85240-foussais_payre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85094-85240-foussais_payre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85094-85240-foussais_payre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85095-85300-froidfond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85095-85300-froidfond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85095-85300-froidfond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85095-85300-froidfond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85096-85710-la_garnache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85096-85710-la_garnache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85096-85710-la_garnache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85096-85710-la_garnache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85097-85130-la_gaubretiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85097-85130-la_gaubretiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85097-85130-la_gaubretiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85097-85130-la_gaubretiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85098-85190-la_genetouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85098-85190-la_genetouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85098-85190-la_genetouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85098-85190-la_genetouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85099-85150-le_girouard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85099-85150-le_girouard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85099-85150-le_girouard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85099-85150-le_girouard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85100-85800-givrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85100-85800-givrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85100-85800-givrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85100-85800-givrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85101-85540-le_givre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85101-85540-le_givre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85101-85540-le_givre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85101-85540-le_givre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85102-85670-grand_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85102-85670-grand_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85102-85670-grand_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85102-85670-grand_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85103-85440-grosbreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85103-85440-grosbreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85103-85440-grosbreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85103-85440-grosbreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85104-85580-grues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85104-85580-grues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85104-85580-grues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85104-85580-grues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85105-85770-le_gue_de_velluire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85105-85770-le_gue_de_velluire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85105-85770-le_gue_de_velluire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85105-85770-le_gue_de_velluire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85106-85680-la_gueriniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85106-85680-la_gueriniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85106-85680-la_gueriniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85106-85680-la_gueriniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85108-85260-l_herbergement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85108-85260-l_herbergement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85108-85260-l_herbergement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85108-85260-l_herbergement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85109-85500-les_herbiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85109-85500-les_herbiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85109-85500-les_herbiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85109-85500-les_herbiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85110-85570-l_hermenault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85110-85570-l_hermenault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85110-85570-l_hermenault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85110-85570-l_hermenault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85111-85770-l_ile_d_elle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85111-85770-l_ile_d_elle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85111-85770-l_ile_d_elle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85111-85770-l_ile_d_elle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85112-85340-l_ile_d_olonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85112-85340-l_ile_d_olonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85112-85340-l_ile_d_olonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85112-85340-l_ile_d_olonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85113-85350-l_ile_d_yeu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85113-85350-l_ile_d_yeu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85113-85350-l_ile_d_yeu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85113-85350-l_ile_d_yeu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85114-85520-jard_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85114-85520-jard_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85114-85520-jard_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85114-85520-jard_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85115-85110-la_jaudonniere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85115-85110-la_jaudonniere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85115-85110-la_jaudonniere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85115-85110-la_jaudonniere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85116-85540-la_jonchere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85116-85540-la_jonchere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85116-85540-la_jonchere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85116-85540-la_jonchere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85117-85400-lairoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85117-85400-lairoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85117-85400-lairoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85117-85400-lairoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85118-85150-landeronde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85118-85150-landeronde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85118-85150-landeronde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85118-85150-landeronde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85119-85130-les_landes_genusson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85119-85130-les_landes_genusson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85119-85130-les_landes_genusson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85119-85130-les_landes_genusson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85120-85220-landevieille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85120-85220-landevieille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85120-85220-landevieille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85120-85220-landevieille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85121-85370-le_langon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85121-85370-le_langon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85121-85370-le_langon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85121-85370-le_langon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85123-85420-liez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85123-85420-liez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85123-85420-liez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85123-85420-liez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85125-85120-loge_fougereuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85125-85120-loge_fougereuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85125-85120-loge_fougereuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85125-85120-loge_fougereuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85126-85200-longeves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85126-85200-longeves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85126-85200-longeves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85126-85200-longeves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85127-85560-longeville_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85127-85560-longeville_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85127-85560-longeville_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85127-85560-longeville_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85128-85400-lucon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85128-85400-lucon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85128-85400-lucon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85128-85400-lucon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85129-85170-les_lucs_sur_boulogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85129-85170-les_lucs_sur_boulogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85129-85170-les_lucs_sur_boulogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85129-85170-les_lucs_sur_boulogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85130-85190-mache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85130-85190-mache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85130-85190-mache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85130-85190-mache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85131-85400-les_magnils_reigniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85131-85400-les_magnils_reigniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85131-85400-les_magnils_reigniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85131-85400-les_magnils_reigniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85132-85420-maille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85132-85420-maille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85132-85420-maille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85132-85420-maille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85133-85420-maillezais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85133-85420-maillezais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85133-85420-maillezais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85133-85420-maillezais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85134-85590-mallievre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85134-85590-mallievre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85134-85590-mallievre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85134-85590-mallievre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85135-85320-mareuil_sur_lay_dissais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85135-85320-mareuil_sur_lay_dissais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85135-85320-mareuil_sur_lay_dissais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85135-85320-mareuil_sur_lay_dissais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85136-85240-marillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85136-85240-marillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85136-85240-marillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85136-85240-marillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85137-85570-marsais_sainte_radegonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85137-85570-marsais_sainte_radegonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85137-85570-marsais_sainte_radegonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85137-85570-marsais_sainte_radegonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85138-85150-martinet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85138-85150-martinet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85138-85150-martinet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85138-85150-martinet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85139-85420-le_mazeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85139-85420-le_mazeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85139-85420-le_mazeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85139-85420-le_mazeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85140-85700-la_meilleraie_tillay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85140-85700-la_meilleraie_tillay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85140-85700-la_meilleraie_tillay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85140-85700-la_meilleraie_tillay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85141-85700-menomblet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85141-85700-menomblet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85141-85700-menomblet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85141-85700-menomblet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85142-85140-la_merlatiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85142-85140-la_merlatiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85142-85140-la_merlatiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85142-85140-la_merlatiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85143-85200-mervent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85143-85200-mervent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85143-85200-mervent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85143-85200-mervent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85144-85500-mesnard_la_barotiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85144-85500-mesnard_la_barotiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85144-85500-mesnard_la_barotiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85144-85500-mesnard_la_barotiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85145-85110-monsireigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85145-85110-monsireigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85145-85110-monsireigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85145-85110-monsireigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85146-85600-montaigu_vendee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85146-85600-montaigu_vendee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85146-85600-montaigu_vendee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85146-85600-montaigu_vendee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85147-85700-montournais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85147-85700-montournais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85147-85700-montournais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85147-85700-montournais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85148-85200-montreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85148-85200-montreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85148-85200-montreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85148-85200-montreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85149-85450-moreilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85149-85450-moreilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85149-85450-moreilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85149-85450-moreilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85151-85290-mortagne_sur_sevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85151-85290-mortagne_sur_sevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85151-85290-mortagne_sur_sevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85151-85290-mortagne_sur_sevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85152-85150-les_achards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85152-85150-les_achards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85152-85150-les_achards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85152-85150-les_achards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85153-85640-mouchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85153-85640-mouchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85153-85640-mouchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85153-85640-mouchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85154-85390-mouilleron_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85154-85390-mouilleron_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85154-85390-mouilleron_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85154-85390-mouilleron_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85155-85000-mouilleron_le_captif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85155-85000-mouilleron_le_captif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85155-85000-mouilleron_le_captif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85155-85000-mouilleron_le_captif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85156-85540-moutiers_les_mauxfaits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85156-85540-moutiers_les_mauxfaits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85156-85540-moutiers_les_mauxfaits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85156-85540-moutiers_les_mauxfaits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85157-85320-moutiers_sur_le_lay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85157-85320-moutiers_sur_le_lay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85157-85320-moutiers_sur_le_lay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85157-85320-moutiers_sur_le_lay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85158-85370-mouzeuil_saint_martin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85158-85370-mouzeuil_saint_martin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85158-85370-mouzeuil_saint_martin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85158-85370-mouzeuil_saint_martin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85159-85370-nalliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85159-85370-nalliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85159-85370-nalliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85159-85370-nalliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85160-85310-nesmy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85160-85310-nesmy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85160-85310-nesmy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85160-85310-nesmy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85161-85430-nieul_le_dolent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85161-85430-nieul_le_dolent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85161-85430-nieul_le_dolent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85161-85430-nieul_le_dolent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85162-85240-rives_d’autise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85162-85240-rives_d’autise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85162-85240-rives_d’autise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85162-85240-rives_d’autise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85162-85420-rives_d’autise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85162-85420-rives_d’autise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85162-85420-rives_d’autise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85162-85420-rives_d’autise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85163-85330-noirmoutier_en_l_ile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85163-85330-noirmoutier_en_l_ile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85163-85330-noirmoutier_en_l_ile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85163-85330-noirmoutier_en_l_ile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85164-85690-notre_dame_de_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85164-85690-notre_dame_de_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85164-85690-notre_dame_de_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85164-85690-notre_dame_de_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85167-85200-l_orbrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85167-85200-l_orbrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85167-85200-l_orbrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85167-85200-l_orbrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85169-85670-palluau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85169-85670-palluau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85169-85670-palluau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85169-85670-palluau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85171-85320-peault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85171-85320-peault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85171-85320-peault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85171-85320-peault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85172-85300-le_perrier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85172-85300-le_perrier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85172-85300-le_perrier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85172-85300-le_perrier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85174-85570-petosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85174-85570-petosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85174-85570-petosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85174-85570-petosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85175-85320-les_pineaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85175-85320-les_pineaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85175-85320-les_pineaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85175-85320-les_pineaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85176-85200-pissotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85176-85200-pissotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85176-85200-pissotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85176-85200-pissotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85177-85770-les_velluire_sur_vendee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85177-85770-les_velluire_sur_vendee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85177-85770-les_velluire_sur_vendee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85177-85770-les_velluire_sur_vendee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85178-85170-le_poire_sur_vie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85178-85170-le_poire_sur_vie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85178-85170-le_poire_sur_vie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85178-85170-le_poire_sur_vie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85179-85440-poiroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85179-85440-poiroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85179-85440-poiroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85179-85440-poiroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85181-85570-pouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85181-85570-pouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85181-85570-pouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85181-85570-pouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85182-85700-pouzauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85182-85700-pouzauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85182-85700-pouzauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85182-85700-pouzauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85184-85240-puy_de_serre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85184-85240-puy_de_serre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85184-85240-puy_de_serre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85184-85240-puy_de_serre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85185-85450-puyravault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85185-85450-puyravault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85185-85450-puyravault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85185-85450-puyravault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85186-85250-la_rabateliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85186-85250-la_rabateliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85186-85250-la_rabateliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85186-85250-la_rabateliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85187-85700-reaumur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85187-85700-reaumur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85187-85700-reaumur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85187-85700-reaumur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85188-85210-la_reorthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85188-85210-la_reorthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85188-85210-la_reorthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85188-85210-la_reorthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85189-85270-notre_dame_de_riez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85189-85270-notre_dame_de_riez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85189-85270-notre_dame_de_riez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85189-85270-notre_dame_de_riez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85190-85620-rocheserviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85190-85620-rocheserviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85190-85620-rocheserviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85190-85620-rocheserviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85191-85000-la_roche_sur_yon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85191-85000-la_roche_sur_yon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85191-85000-la_roche_sur_yon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85191-85000-la_roche_sur_yon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85192-85510-rochetrejoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85192-85510-rochetrejoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85192-85510-rochetrejoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85192-85510-rochetrejoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85193-85320-rosnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85193-85320-rosnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85193-85320-rosnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85193-85320-rosnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85100-les_sables_d_olonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85100-les_sables_d_olonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85100-les_sables_d_olonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85100-les_sables_d_olonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85180-les_sables_d_olonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85180-les_sables_d_olonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85180-les_sables_d_olonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85180-les_sables_d_olonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85340-les_sables_d_olonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85340-les_sables_d_olonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85340-les_sables_d_olonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85194-85340-les_sables_d_olonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85196-85250-saint_andre_goule_d_oie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85196-85250-saint_andre_goule_d_oie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85196-85250-saint_andre_goule_d_oie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85196-85250-saint_andre_goule_d_oie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85197-85260-montreverd/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85197-85260-montreverd/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85197-85260-montreverd/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85197-85260-montreverd/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85198-85130-saint_aubin_des_ormeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85198-85130-saint_aubin_des_ormeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85198-85130-saint_aubin_des_ormeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85198-85130-saint_aubin_des_ormeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85199-85210-saint_aubin_la_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85199-85210-saint_aubin_la_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85199-85210-saint_aubin_la_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85199-85210-saint_aubin_la_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85200-85540-saint_avaugourd_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85200-85540-saint_avaugourd_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85200-85540-saint_avaugourd_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85200-85540-saint_avaugourd_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85201-85540-saint_benoist_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85201-85540-saint_benoist_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85201-85540-saint_benoist_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85201-85540-saint_benoist_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85202-85110-sainte_cecile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85202-85110-sainte_cecile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85202-85110-sainte_cecile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85202-85110-sainte_cecile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85204-85670-saint_christophe_du_ligneron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85204-85670-saint_christophe_du_ligneron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85204-85670-saint_christophe_du_ligneron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85204-85670-saint_christophe_du_ligneron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85205-85410-saint_cyr_des_gats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85205-85410-saint_cyr_des_gats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85205-85410-saint_cyr_des_gats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85205-85410-saint_cyr_des_gats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85206-85540-saint_cyr_en_talmondais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85206-85540-saint_cyr_en_talmondais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85206-85540-saint_cyr_en_talmondais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85206-85540-saint_cyr_en_talmondais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85207-85580-saint_denis_du_payre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85207-85580-saint_denis_du_payre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85207-85580-saint_denis_du_payre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85207-85580-saint_denis_du_payre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85208-85170-saint_denis_la_chevasse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85208-85170-saint_denis_la_chevasse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85208-85170-saint_denis_la_chevasse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85208-85170-saint_denis_la_chevasse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85209-85210-saint_etienne_de_brillouet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85209-85210-saint_etienne_de_brillouet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85209-85210-saint_etienne_de_brillouet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85209-85210-saint_etienne_de_brillouet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85210-85670-saint_etienne_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85210-85670-saint_etienne_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85210-85670-saint_etienne_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85210-85670-saint_etienne_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85211-85150-sainte_flaive_des_loups/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85211-85150-sainte_flaive_des_loups/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85211-85150-sainte_flaive_des_loups/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85211-85150-sainte_flaive_des_loups/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85213-85310-rives_de_l_yon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85213-85310-rives_de_l_yon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85213-85310-rives_de_l_yon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85213-85310-rives_de_l_yon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85214-85150-sainte_foy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85214-85150-sainte_foy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85214-85150-sainte_foy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85214-85150-sainte_foy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85215-85250-saint_fulgent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85215-85250-saint_fulgent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85215-85250-saint_fulgent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85215-85250-saint_fulgent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85216-85400-sainte_gemme_la_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85216-85400-sainte_gemme_la_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85216-85400-sainte_gemme_la_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85216-85400-sainte_gemme_la_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85218-85150-saint_georges_de_pointindoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85218-85150-saint_georges_de_pointindoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85218-85150-saint_georges_de_pointindoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85218-85150-saint_georges_de_pointindoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85220-85110-saint_germain_de_princay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85220-85110-saint_germain_de_princay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85220-85110-saint_germain_de_princay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85220-85110-saint_germain_de_princay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85221-85230-saint_gervais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85221-85230-saint_gervais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85221-85230-saint_gervais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85221-85230-saint_gervais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85222-85800-saint_gilles_croix_de_vie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85222-85800-saint_gilles_croix_de_vie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85222-85800-saint_gilles_croix_de_vie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85222-85800-saint_gilles_croix_de_vie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85223-85210-sainte_hermine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85223-85210-sainte_hermine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85223-85210-sainte_hermine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85223-85210-sainte_hermine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85226-85270-saint_hilaire_de_riez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85226-85270-saint_hilaire_de_riez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85226-85270-saint_hilaire_de_riez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85226-85270-saint_hilaire_de_riez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85227-85240-saint_hilaire_des_loges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85227-85240-saint_hilaire_des_loges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85227-85240-saint_hilaire_des_loges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85227-85240-saint_hilaire_des_loges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85229-85120-saint_hilaire_de_voust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85229-85120-saint_hilaire_de_voust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85229-85120-saint_hilaire_de_voust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85229-85120-saint_hilaire_de_voust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85231-85440-saint_hilaire_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85231-85440-saint_hilaire_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85231-85440-saint_hilaire_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85231-85440-saint_hilaire_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85232-85480-saint_hilaire_le_vouhis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85232-85480-saint_hilaire_le_vouhis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85232-85480-saint_hilaire_le_vouhis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85232-85480-saint_hilaire_le_vouhis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85233-85210-saint_jean_de_beugne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85233-85210-saint_jean_de_beugne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85233-85210-saint_jean_de_beugne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85233-85210-saint_jean_de_beugne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85234-85160-saint_jean_de_monts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85234-85160-saint_jean_de_monts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85234-85160-saint_jean_de_monts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85234-85160-saint_jean_de_monts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85235-85210-saint_juire_champgillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85235-85210-saint_juire_champgillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85235-85210-saint_juire_champgillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85235-85210-saint_juire_champgillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85236-85150-saint_julien_des_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85236-85150-saint_julien_des_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85236-85150-saint_julien_des_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85236-85150-saint_julien_des_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85237-85410-saint_laurent_de_la_salle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85237-85410-saint_laurent_de_la_salle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85237-85410-saint_laurent_de_la_salle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85237-85410-saint_laurent_de_la_salle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85238-85290-saint_laurent_sur_sevre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85238-85290-saint_laurent_sur_sevre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85238-85290-saint_laurent_sur_sevre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85238-85290-saint_laurent_sur_sevre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85239-85220-saint_maixent_sur_vie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85239-85220-saint_maixent_sur_vie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85239-85220-saint_maixent_sur_vie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85239-85220-saint_maixent_sur_vie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85240-85590-saint_malo_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85240-85590-saint_malo_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85240-85590-saint_malo_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85240-85590-saint_malo_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85242-85590-saint_mars_la_reorthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85242-85590-saint_mars_la_reorthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85242-85590-saint_mars_la_reorthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85242-85590-saint_mars_la_reorthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85243-85470-brem_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85243-85470-brem_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85243-85470-brem_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85243-85470-brem_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85244-85200-saint_martin_de_fraigneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85244-85200-saint_martin_de_fraigneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85244-85200-saint_martin_de_fraigneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85244-85200-saint_martin_de_fraigneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85245-85570-saint_martin_des_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85245-85570-saint_martin_des_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85245-85570-saint_martin_des_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85245-85570-saint_martin_des_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85246-85140-saint_martin_des_noyers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85246-85140-saint_martin_des_noyers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85246-85140-saint_martin_des_noyers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85246-85140-saint_martin_des_noyers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85247-85130-saint_martin_des_tilleuls/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85247-85130-saint_martin_des_tilleuls/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85247-85130-saint_martin_des_tilleuls/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85247-85130-saint_martin_des_tilleuls/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85248-85210-saint_martin_lars_en_sainte_hermine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85248-85210-saint_martin_lars_en_sainte_hermine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85248-85210-saint_martin_lars_en_sainte_hermine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85248-85210-saint_martin_lars_en_sainte_hermine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85250-85150-saint_mathurin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85250-85150-saint_mathurin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85250-85150-saint_mathurin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85250-85150-saint_mathurin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85251-85120-saint_maurice_des_noues/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85251-85120-saint_maurice_des_noues/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85251-85120-saint_maurice_des_noues/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85251-85120-saint_maurice_des_noues/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85252-85390-saint_maurice_le_girard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85252-85390-saint_maurice_le_girard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85252-85390-saint_maurice_le_girard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85252-85390-saint_maurice_le_girard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85254-85700-saint_mesmin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85254-85700-saint_mesmin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85254-85700-saint_mesmin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85254-85700-saint_mesmin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85255-85580-saint_michel_en_l_herm/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85255-85580-saint_michel_en_l_herm/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85255-85580-saint_michel_en_l_herm/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85255-85580-saint_michel_en_l_herm/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85256-85200-saint_michel_le_cloucq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85256-85200-saint_michel_le_cloucq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85256-85200-saint_michel_le_cloucq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85256-85200-saint_michel_le_cloucq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85259-85500-saint_paul_en_pareds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85259-85500-saint_paul_en_pareds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85259-85500-saint_paul_en_pareds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85259-85500-saint_paul_en_pareds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85260-85670-saint_paul_mont_penit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85260-85670-saint_paul_mont_penit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85260-85670-saint_paul_mont_penit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85260-85670-saint_paul_mont_penit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85261-85320-sainte_pexine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85261-85320-sainte_pexine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85261-85320-sainte_pexine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85261-85320-sainte_pexine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85262-85660-saint_philbert_de_bouaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85262-85660-saint_philbert_de_bouaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85262-85660-saint_philbert_de_bouaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85262-85660-saint_philbert_de_bouaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85264-85120-saint_pierre_du_chemin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85264-85120-saint_pierre_du_chemin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85264-85120-saint_pierre_du_chemin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85264-85120-saint_pierre_du_chemin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85265-85420-saint_pierre_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85265-85420-saint_pierre_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85265-85420-saint_pierre_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85265-85420-saint_pierre_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85266-85110-saint_prouant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85266-85110-saint_prouant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85266-85110-saint_prouant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85266-85110-saint_prouant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85267-85450-sainte_radegonde_des_noyers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85267-85450-sainte_radegonde_des_noyers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85267-85450-sainte_radegonde_des_noyers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85267-85450-sainte_radegonde_des_noyers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85268-85220-saint_reverend/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85268-85220-saint_reverend/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85268-85220-saint_reverend/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85268-85220-saint_reverend/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85269-85420-saint_sigismond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85269-85420-saint_sigismond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85269-85420-saint_sigismond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85269-85420-saint_sigismond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85271-85410-saint_sulpice_en_pareds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85271-85410-saint_sulpice_en_pareds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85271-85410-saint_sulpice_en_pareds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85271-85410-saint_sulpice_en_pareds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85273-85230-saint_urbain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85273-85230-saint_urbain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85273-85230-saint_urbain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85273-85230-saint_urbain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85274-85570-saint_valerien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85274-85570-saint_valerien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85274-85570-saint_valerien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85274-85570-saint_valerien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85276-85110-saint_vincent_sterlanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85276-85110-saint_vincent_sterlanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85276-85110-saint_vincent_sterlanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85276-85110-saint_vincent_sterlanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85277-85540-saint_vincent_sur_graon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85277-85540-saint_vincent_sur_graon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85277-85540-saint_vincent_sur_graon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85277-85540-saint_vincent_sur_graon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85278-85520-saint_vincent_sur_jard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85278-85520-saint_vincent_sur_jard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85278-85520-saint_vincent_sur_jard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85278-85520-saint_vincent_sur_jard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85280-85300-sallertaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85280-85300-sallertaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85280-85300-sallertaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85280-85300-sallertaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85281-85200-serigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85281-85200-serigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85281-85200-serigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85281-85200-serigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85282-85110-sigournais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85282-85110-sigournais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85282-85110-sigournais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85282-85110-sigournais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85284-85300-soullans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85284-85300-soullans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85284-85300-soullans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85284-85300-soullans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85285-85310-le_tablier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85285-85310-le_tablier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85285-85310-le_tablier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85285-85310-le_tablier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85286-85450-la_taillee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85286-85450-la_taillee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85286-85450-la_taillee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85286-85450-la_taillee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85287-85390-tallud_sainte_gemme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85287-85390-tallud_sainte_gemme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85287-85390-tallud_sainte_gemme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85287-85390-tallud_sainte_gemme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85288-85440-talmont_saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85288-85440-talmont_saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85288-85440-talmont_saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85288-85440-talmont_saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85289-85120-la_tardiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85289-85120-la_tardiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85289-85120-la_tardiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85289-85120-la_tardiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85290-85210-thire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85290-85210-thire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85290-85210-thire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85290-85210-thire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85291-85480-thorigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85291-85480-thorigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85291-85480-thorigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85291-85480-thorigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85292-85410-thouarsais_bouildroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85292-85410-thouarsais_bouildroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85292-85410-thouarsais_bouildroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85292-85410-thouarsais_bouildroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85293-85130-tiffauges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85293-85130-tiffauges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85293-85130-tiffauges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85293-85130-tiffauges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85294-85360-la_tranche_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85294-85360-la_tranche_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85294-85360-la_tranche_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85294-85360-la_tranche_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85295-85600-treize_septiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85295-85600-treize_septiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85295-85600-treize_septiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85295-85600-treize_septiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85296-85590-treize_vents/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85296-85590-treize_vents/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85296-85590-treize_vents/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85296-85590-treize_vents/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85297-85580-triaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85297-85580-triaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85297-85580-triaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85297-85580-triaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85298-85150-vaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85298-85150-vaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85298-85150-vaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85298-85150-vaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85300-85190-venansault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85300-85190-venansault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85300-85190-venansault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85300-85190-venansault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85301-85250-vendrennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85301-85250-vendrennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85301-85250-vendrennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85301-85250-vendrennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85302-85130-chanverrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85302-85130-chanverrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85302-85130-chanverrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85302-85130-chanverrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85302-85500-chanverrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85302-85500-chanverrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85302-85500-chanverrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85302-85500-chanverrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85303-85770-vix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85303-85770-vix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85303-85770-vix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85303-85770-vix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85304-85450-vouille_les_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85304-85450-vouille_les_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85304-85450-vouille_les_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85304-85450-vouille_les_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85305-85120-vouvant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85305-85120-vouvant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85305-85120-vouvant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85305-85120-vouvant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85306-85240-xanton_chassenon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85306-85240-xanton_chassenon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85306-85240-xanton_chassenon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85306-85240-xanton_chassenon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85307-85460-la_faute_sur_mer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85307-85460-la_faute_sur_mer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85307-85460-la_faute_sur_mer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt85-vendee/commune85307-85460-la_faute_sur_mer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-86.xml
+++ b/public/sitemaps/sitemap-86.xml
@@ -5,558 +5,1112 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86001-86430-adriers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86001-86430-adriers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86001-86430-adriers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86001-86430-adriers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86002-86110-amberre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86002-86110-amberre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86002-86110-amberre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86002-86110-amberre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86003-86700-anche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86003-86700-anche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86003-86700-anche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86003-86700-anche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86004-86260-angles_sur_l_anglin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86004-86260-angles_sur_l_anglin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86004-86260-angles_sur_l_anglin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86004-86260-angles_sur_l_anglin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86005-86330-angliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86005-86330-angliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86005-86330-angliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86005-86330-angliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86006-86310-antigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86006-86310-antigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86006-86310-antigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86006-86310-antigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86007-86100-antran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86007-86100-antran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86007-86100-antran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86007-86100-antran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86008-86200-arcay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86008-86200-arcay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86008-86200-arcay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86008-86200-arcay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86009-86210-archigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86009-86210-archigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86009-86210-archigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86009-86210-archigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86010-86340-aslonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86010-86340-aslonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86010-86340-aslonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86010-86340-aslonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86011-86430-asnieres_sur_blour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86011-86430-asnieres_sur_blour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86011-86430-asnieres_sur_blour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86011-86430-asnieres_sur_blour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86012-86250-asnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86012-86250-asnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86012-86250-asnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86012-86250-asnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86013-86330-aulnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86013-86330-aulnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86013-86330-aulnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86013-86330-aulnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86014-86530-availles_en_chatellerault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86014-86530-availles_en_chatellerault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86014-86530-availles_en_chatellerault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86014-86530-availles_en_chatellerault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86015-86460-availles_limouzine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86015-86460-availles_limouzine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86015-86460-availles_limouzine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86015-86460-availles_limouzine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86016-86170-avanton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86016-86170-avanton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86016-86170-avanton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86016-86170-avanton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86017-86190-ayron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86017-86190-ayron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86017-86190-ayron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86017-86190-ayron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86018-86200-basses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86018-86200-basses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86018-86200-basses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86018-86200-basses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86019-86490-beaumont_saint_cyr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86019-86490-beaumont_saint_cyr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86019-86490-beaumont_saint_cyr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86019-86490-beaumont_saint_cyr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86019-86130-beaumont_saint_cyr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86019-86130-beaumont_saint_cyr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86019-86130-beaumont_saint_cyr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86019-86130-beaumont_saint_cyr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86020-86210-bellefonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86020-86210-bellefonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86020-86210-bellefonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86020-86210-bellefonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86022-86120-berrie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86022-86120-berrie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86022-86120-berrie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86022-86120-berrie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86023-86420-berthegon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86023-86420-berthegon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86023-86420-berthegon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86023-86420-berthegon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86024-86190-beruges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86024-86190-beruges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86024-86190-beruges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86024-86190-beruges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86025-86310-bethines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86025-86310-bethines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86025-86310-bethines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86025-86310-bethines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86026-86120-beuxes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86026-86120-beuxes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86026-86120-beuxes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86026-86120-beuxes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86027-86580-biard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86027-86580-biard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86027-86580-biard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86027-86580-biard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86028-86800-bignoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86028-86800-bignoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86028-86800-bignoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86028-86800-bignoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86029-86400-blanzay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86029-86400-blanzay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86029-86400-blanzay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86029-86400-blanzay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86031-86300-bonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86031-86300-bonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86031-86300-bonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86031-86300-bonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86032-86210-bonneuil_matours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86032-86210-bonneuil_matours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86032-86210-bonneuil_matours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86032-86210-bonneuil_matours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86034-86410-bouresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86034-86410-bouresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86034-86410-bouresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86034-86410-bouresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86035-86390-bourg_archambault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86035-86390-bourg_archambault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86035-86390-bourg_archambault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86035-86390-bourg_archambault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86036-86120-bournand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86036-86120-bournand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86036-86120-bournand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86036-86120-bournand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86037-86290-brigueil_le_chantre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86037-86290-brigueil_le_chantre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86037-86290-brigueil_le_chantre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86037-86290-brigueil_le_chantre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86038-86160-brion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86038-86160-brion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86038-86160-brion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86038-86160-brion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86039-86510-brux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86039-86510-brux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86039-86510-brux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86039-86510-brux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86040-86310-la_bussiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86040-86310-la_bussiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86040-86310-la_bussiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86040-86310-la_bussiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86041-86180-buxerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86041-86180-buxerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86041-86180-buxerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86041-86180-buxerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86042-37160-buxeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86042-37160-buxeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86042-37160-buxeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86042-37160-buxeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86044-86200-ceaux_en_loudun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86044-86200-ceaux_en_loudun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86044-86200-ceaux_en_loudun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86044-86200-ceaux_en_loudun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86045-86600-celle_levescault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86045-86600-celle_levescault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86045-86600-celle_levescault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86045-86600-celle_levescault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86046-86530-cenon_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86046-86530-cenon_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86046-86530-cenon_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86046-86530-cenon_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86047-86140-cernay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86047-86140-cernay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86047-86140-cernay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86047-86140-cernay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86048-86380-chabournay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86048-86380-chabournay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86048-86380-chabournay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86048-86380-chabournay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86049-86200-chalais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86049-86200-chalais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86049-86200-chalais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86049-86200-chalais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86050-86190-chalandray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86050-86190-chalandray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86050-86190-chalandray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86050-86190-chalandray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86051-86510-champagne_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86051-86510-champagne_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86051-86510-champagne_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86051-86510-champagne_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86052-86160-champagne_saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86052-86160-champagne_saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86052-86160-champagne_saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86052-86160-champagne_saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86053-86170-champigny_en_rochereau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86053-86170-champigny_en_rochereau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86053-86170-champigny_en_rochereau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86053-86170-champigny_en_rochereau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86054-86400-champniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86054-86400-champniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86054-86400-champniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86054-86400-champniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86055-86250-la_chapelle_baton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86055-86250-la_chapelle_baton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86055-86250-la_chapelle_baton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86055-86250-la_chapelle_baton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86058-86210-la_chapelle_mouliere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86058-86210-la_chapelle_mouliere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86058-86210-la_chapelle_mouliere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86058-86210-la_chapelle_mouliere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86059-86300-chapelle_viviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86059-86300-chapelle_viviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86059-86300-chapelle_viviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86059-86300-chapelle_viviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86061-86250-charroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86061-86250-charroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86061-86250-charroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86061-86250-charroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86062-86360-chasseneuil_du_poitou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86062-86360-chasseneuil_du_poitou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86062-86360-chasseneuil_du_poitou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86062-86360-chasseneuil_du_poitou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86063-86250-chatain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86063-86250-chatain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86063-86250-chatain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86063-86250-chatain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86064-86350-chateau_garnier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86064-86350-chateau_garnier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86064-86350-chateau_garnier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86064-86350-chateau_garnier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86065-86370-chateau_larcher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86065-86370-chateau_larcher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86065-86370-chateau_larcher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86065-86370-chateau_larcher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86066-86100-chatellerault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86066-86100-chatellerault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86066-86100-chatellerault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86066-86100-chatellerault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86068-86510-chaunay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86068-86510-chaunay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86068-86510-chaunay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86068-86510-chaunay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86069-86330-la_chaussee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86069-86330-la_chaussee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86069-86330-la_chaussee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86069-86330-la_chaussee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86070-86300-chauvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86070-86300-chauvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86070-86300-chauvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86070-86300-chauvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86072-86450-chenevelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86072-86450-chenevelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86072-86450-chenevelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86072-86450-chenevelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86073-86170-cherves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86073-86170-cherves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86073-86170-cherves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86073-86170-cherves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86074-86190-chire_en_montreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86074-86190-chire_en_montreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86074-86190-chire_en_montreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86074-86190-chire_en_montreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86075-86110-chouppes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86075-86110-chouppes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86075-86110-chouppes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86075-86110-chouppes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86076-86170-cisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86076-86170-cisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86076-86170-cisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86076-86170-cisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86077-86320-civaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86077-86320-civaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86077-86320-civaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86077-86320-civaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86078-86400-civray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86078-86400-civray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86078-86400-civray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86078-86400-civray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86079-86200-la_roche_rigault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86079-86200-la_roche_rigault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86079-86200-la_roche_rigault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86079-86200-la_roche_rigault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86080-86600-cloue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86080-86600-cloue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86080-86600-cloue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86080-86600-cloue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86081-86490-colombiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86081-86490-colombiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86081-86490-colombiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86081-86490-colombiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86082-86700-valence_en_poitou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86082-86700-valence_en_poitou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86082-86700-valence_en_poitou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86082-86700-valence_en_poitou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86083-86600-coulombiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86083-86600-coulombiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86083-86600-coulombiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86083-86600-coulombiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86084-86290-coulonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86084-86290-coulonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86084-86290-coulonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86084-86290-coulonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86110-coussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86110-coussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86110-coussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86110-coussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86420-coussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86420-coussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86420-coussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86420-coussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86140-coussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86140-coussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86140-coussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86085-86140-coussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86086-86270-coussay_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86086-86270-coussay_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86086-86270-coussay_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86086-86270-coussay_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86087-86110-craon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86087-86110-craon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86087-86110-craon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86087-86110-craon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86088-86240-croutelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86088-86240-croutelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86088-86240-croutelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86088-86240-croutelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86089-86110-cuhon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86089-86110-cuhon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86089-86110-cuhon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86089-86110-cuhon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86090-86120-curcay_sur_dive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86090-86120-curcay_sur_dive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86090-86120-curcay_sur_dive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86090-86120-curcay_sur_dive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86091-86600-curzay_sur_vonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86091-86600-curzay_sur_vonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86091-86600-curzay_sur_vonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86091-86600-curzay_sur_vonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86092-86220-dange_saint_romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86092-86220-dange_saint_romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86092-86220-dange_saint_romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86092-86220-dange_saint_romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86093-86420-derce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86093-86420-derce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86093-86420-derce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86093-86420-derce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86094-86410-dienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86094-86410-dienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86094-86410-dienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86094-86410-dienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86095-86130-dissay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86095-86130-dissay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86095-86130-dissay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86095-86130-dissay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86096-86140-doussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86096-86140-doussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86096-86140-doussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86096-86140-doussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86097-86160-la_ferriere_airoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86097-86160-la_ferriere_airoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86097-86160-la_ferriere_airoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86097-86160-la_ferriere_airoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86098-86300-fleix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86098-86300-fleix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86098-86300-fleix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86098-86300-fleix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86099-86340-fleure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86099-86340-fleure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86099-86340-fleure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86099-86340-fleure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86100-86240-fontaine_le_comte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86100-86240-fontaine_le_comte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86100-86240-fontaine_le_comte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86100-86240-fontaine_le_comte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86102-86190-frozes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86102-86190-frozes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86102-86190-frozes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86102-86190-frozes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86103-86160-gencay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86103-86160-gencay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86103-86160-gencay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86103-86160-gencay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86104-86250-genouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86104-86250-genouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86104-86250-genouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86104-86250-genouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86105-86340-gizay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86105-86340-gizay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86105-86340-gizay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86105-86340-gizay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86106-86200-glenouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86106-86200-glenouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86106-86200-glenouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86106-86200-glenouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86107-86320-gouex/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86107-86320-gouex/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86107-86320-gouex/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86107-86320-gouex/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86108-86330-la_grimaudiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86108-86330-la_grimaudiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86108-86330-la_grimaudiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86108-86330-la_grimaudiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86108-86110-la_grimaudiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86108-86110-la_grimaudiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86108-86110-la_grimaudiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86108-86110-la_grimaudiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86109-86420-guesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86109-86420-guesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86109-86420-guesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86109-86420-guesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86110-86310-haims/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86110-86310-haims/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86110-86310-haims/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86110-86310-haims/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86111-86220-ingrandes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86111-86220-ingrandes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86111-86220-ingrandes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86111-86220-ingrandes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86112-86150-l_isle_jourdain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86112-86150-l_isle_jourdain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86112-86150-l_isle_jourdain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86112-86150-l_isle_jourdain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86113-86240-iteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86113-86240-iteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86113-86240-iteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86113-86240-iteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86114-86800-jardres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86114-86800-jardres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86114-86800-jardres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86114-86800-jardres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86115-86130-jaunay_marigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86115-86130-jaunay_marigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86115-86130-jaunay_marigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86115-86130-jaunay_marigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86115-86380-jaunay_marigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86115-86380-jaunay_marigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86115-86380-jaunay_marigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86115-86380-jaunay_marigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86116-86600-jazeneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86116-86600-jazeneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86116-86600-jazeneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86116-86600-jazeneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86117-86500-jouhet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86117-86500-jouhet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86117-86500-jouhet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86117-86500-jouhet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86118-86290-journet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86118-86290-journet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86118-86290-journet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86118-86290-journet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86119-86350-jousse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86119-86350-jousse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86119-86350-jousse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86119-86350-jousse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86120-86390-lathus_saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86120-86390-lathus_saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86120-86390-lathus_saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86120-86390-lathus_saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86121-86190-latille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86121-86190-latille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86121-86190-latille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86121-86190-latille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86122-86300-lauthiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86122-86300-lauthiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86122-86300-lauthiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86122-86300-lauthiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86123-86470-boivre_la_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86123-86470-boivre_la_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86123-86470-boivre_la_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86123-86470-boivre_la_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86124-86800-lavoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86124-86800-lavoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86124-86800-lavoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86124-86800-lavoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86125-86450-leigne_les_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86125-86450-leigne_les_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86125-86450-leigne_les_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86125-86450-leigne_les_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86126-86300-leignes_sur_fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86126-86300-leignes_sur_fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86126-86300-leignes_sur_fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86126-86300-leignes_sur_fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86127-86230-leigne_sur_usseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86127-86230-leigne_sur_usseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86127-86230-leigne_sur_usseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86127-86230-leigne_sur_usseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86128-86140-lencloitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86128-86140-lencloitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86128-86140-lencloitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86128-86140-lencloitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86129-86270-lesigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86129-86270-lesigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86129-86270-lesigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86129-86270-lesigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86130-86220-leugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86130-86220-leugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86130-86220-leugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86130-86220-leugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86131-86410-lhommaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86131-86410-lhommaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86131-86410-lhommaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86131-86410-lhommaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86132-86290-liglet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86132-86290-liglet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86132-86290-liglet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86132-86290-liglet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86133-86240-liguge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86133-86240-liguge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86133-86240-liguge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86133-86240-liguge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86134-86400-linazay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86134-86400-linazay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86134-86400-linazay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86134-86400-linazay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86135-86800-liniers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86135-86800-liniers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86135-86800-liniers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86135-86800-liniers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86136-86400-lizant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86136-86400-lizant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86136-86400-lizant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86136-86400-lizant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86137-86200-loudun/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86137-86200-loudun/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86137-86200-loudun/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86137-86200-loudun/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86138-86430-luchapt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86138-86430-luchapt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86138-86430-luchapt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86138-86430-luchapt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86139-86600-lusignan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86139-86600-lusignan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86139-86600-lusignan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86139-86600-lusignan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86140-86320-lussac_les_chateaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86140-86320-lussac_les_chateaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86140-86320-lussac_les_chateaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86140-86320-lussac_les_chateaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86141-86160-magne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86141-86160-magne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86141-86160-magne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86141-86160-magne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86142-86190-maille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86142-86190-maille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86142-86190-maille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86142-86190-maille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86143-86270-maire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86143-86270-maire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86143-86270-maire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86143-86270-maire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86144-86170-maisonneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86144-86170-maisonneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86144-86170-maisonneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86144-86170-maisonneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86145-86370-marcay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86145-86370-marcay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86145-86370-marcay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86145-86370-marcay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86147-86370-marigny_chemereau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86147-86370-marigny_chemereau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86147-86370-marigny_chemereau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86147-86370-marigny_chemereau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86148-86160-marnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86148-86160-marnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86148-86160-marnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86148-86160-marnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86149-86330-martaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86149-86330-martaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86149-86330-martaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86149-86330-martaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86150-86170-massognes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86150-86170-massognes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86150-86170-massognes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86150-86170-massognes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86151-86200-maulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86151-86200-maulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86151-86200-maulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86151-86200-maulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86152-86460-mauprevoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86152-86460-mauprevoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86152-86460-mauprevoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86152-86460-mauprevoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86153-86320-mazerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86153-86320-mazerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86153-86320-mazerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86153-86320-mazerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86154-86110-mazeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86154-86110-mazeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86154-86110-mazeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86154-86110-mazeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86156-86200-messeme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86156-86200-messeme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86156-86200-messeme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86156-86200-messeme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86157-86550-mignaloux_beauvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86157-86550-mignaloux_beauvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86157-86550-mignaloux_beauvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86157-86550-mignaloux_beauvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86158-86440-migne_auxances/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86158-86440-migne_auxances/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86158-86440-migne_auxances/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86158-86440-migne_auxances/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86159-86150-millac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86159-86150-millac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86159-86150-millac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86159-86150-millac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86160-86110-mirebeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86160-86110-mirebeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86160-86110-mirebeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86160-86110-mirebeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86161-86330-moncontour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86161-86330-moncontour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86161-86330-moncontour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86161-86330-moncontour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86162-86230-mondion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86162-86230-mondion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86162-86230-mondion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86162-86230-mondion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86163-86360-montamise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86163-86360-montamise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86163-86360-montamise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86163-86360-montamise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86164-86210-monthoiron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86164-86210-monthoiron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86164-86210-monthoiron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86164-86210-monthoiron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86165-86500-montmorillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86165-86500-montmorillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86165-86500-montmorillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86165-86500-montmorillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86167-86420-monts_sur_guesnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86167-86420-monts_sur_guesnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86167-86420-monts_sur_guesnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86167-86420-monts_sur_guesnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86169-86120-morton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86169-86120-morton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86169-86120-morton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86169-86120-morton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86170-86500-moulismes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86170-86500-moulismes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86170-86500-moulismes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86170-86500-moulismes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86171-86150-moussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86171-86150-moussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86171-86150-moussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86171-86150-moussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86172-86430-mouterre_sur_blourde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86172-86430-mouterre_sur_blourde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86172-86430-mouterre_sur_blourde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86172-86430-mouterre_sur_blourde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86173-86200-mouterre_silly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86173-86200-mouterre_silly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86173-86200-mouterre_silly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86173-86200-mouterre_silly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86174-86530-naintre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86174-86530-naintre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86174-86530-naintre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86174-86530-naintre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86175-86310-nalliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86175-86310-nalliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86175-86310-nalliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86175-86310-nalliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86176-86150-nerignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86176-86150-nerignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86176-86150-nerignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86176-86150-nerignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86177-86170-neuville_de_poitou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86177-86170-neuville_de_poitou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86177-86170-neuville_de_poitou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86177-86170-neuville_de_poitou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86178-86340-nieuil_l_espoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86178-86340-nieuil_l_espoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86178-86340-nieuil_l_espoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86178-86340-nieuil_l_espoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86180-86340-nouaille_maupertuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86180-86340-nouaille_maupertuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86180-86340-nouaille_maupertuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86180-86340-nouaille_maupertuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86181-86200-nueil_sous_faye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86181-86200-nueil_sous_faye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86181-86200-nueil_sous_faye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86181-86200-nueil_sous_faye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86182-86230-orches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86182-86230-orches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86182-86230-orches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86182-86230-orches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86183-86220-les_ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86183-86220-les_ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86183-86220-les_ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86183-86220-les_ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86184-86380-ouzilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86184-86380-ouzilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86184-86380-ouzilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86184-86380-ouzilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86186-86220-oyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86186-86220-oyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86186-86220-oyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86186-86220-oyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86187-86300-paizay_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86187-86300-paizay_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86187-86300-paizay_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86187-86300-paizay_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86189-86350-payroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86189-86350-payroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86189-86350-payroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86189-86350-payroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86190-86320-persac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86190-86320-persac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86190-86320-persac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86190-86320-persac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86191-86500-pindray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86191-86500-pindray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86191-86500-pindray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86191-86500-pindray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86192-86500-plaisance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86192-86500-plaisance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86192-86500-plaisance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86192-86500-plaisance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86193-86450-pleumartin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86193-86450-pleumartin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86193-86450-pleumartin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86193-86450-pleumartin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86194-86000-poitiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86194-86000-poitiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86194-86000-poitiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86194-86000-poitiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86195-86220-port_de_piles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86195-86220-port_de_piles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86195-86220-port_de_piles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86195-86220-port_de_piles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86196-86120-pouancay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86196-86120-pouancay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86196-86120-pouancay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86196-86120-pouancay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86197-86200-pouant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86197-86200-pouant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86197-86200-pouant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86197-86200-pouant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86197-37120-pouant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86197-37120-pouant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86197-37120-pouant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86197-37120-pouant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86198-86800-pouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86198-86800-pouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86198-86800-pouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86198-86800-pouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86200-86460-pressac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86200-86460-pressac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86200-86460-pressac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86200-86460-pressac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86201-86420-princay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86201-86420-princay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86201-86420-princay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86201-86420-princay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86202-86260-la_puye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86202-86260-la_puye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86202-86260-la_puye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86202-86260-la_puye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86203-86150-queaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86203-86150-queaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86203-86150-queaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86203-86150-queaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86204-86190-quincay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86204-86190-quincay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86204-86190-quincay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86204-86190-quincay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86205-86200-ranton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86205-86200-ranton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86205-86200-ranton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86205-86200-ranton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86206-86120-raslay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86206-86120-raslay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86206-86120-raslay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86206-86120-raslay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86207-86270-la_roche_posay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86207-86270-la_roche_posay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86207-86270-la_roche_posay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86207-86270-la_roche_posay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86209-86340-roches_premarie_andille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86209-86340-roches_premarie_andille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86209-86340-roches_premarie_andille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86209-86340-roches_premarie_andille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86210-86120-roiffe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86210-86120-roiffe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86210-86120-roiffe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86210-86120-roiffe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86211-86700-romagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86211-86700-romagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86211-86700-romagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86211-86700-romagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86211-86400-romagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86211-86400-romagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86211-86400-romagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86211-86400-romagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86213-86480-rouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86213-86480-rouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86213-86480-rouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86213-86480-rouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86214-86280-saint_benoit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86214-86280-saint_benoit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86214-86280-saint_benoit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86214-86280-saint_benoit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86217-86230-saint_christophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86217-86230-saint_christophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86217-86230-saint_christophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86217-86230-saint_christophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86218-86330-saint_clair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86218-86330-saint_clair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86218-86330-saint_clair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86218-86330-saint_clair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86220-86400-saint_gaudent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86220-86400-saint_gaudent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86220-86400-saint_gaudent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86220-86400-saint_gaudent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86221-86140-saint_genest_d_ambiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86221-86140-saint_genest_d_ambiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86221-86140-saint_genest_d_ambiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86221-86140-saint_genest_d_ambiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86222-86130-saint_georges_les_baillargeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86222-86130-saint_georges_les_baillargeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86222-86130-saint_georges_les_baillargeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86222-86130-saint_georges_les_baillargeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86223-86310-saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86223-86310-saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86223-86310-saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86223-86310-saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86224-86230-saint_gervais_les_trois_clochers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86224-86230-saint_gervais_les_trois_clochers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86224-86230-saint_gervais_les_trois_clochers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86224-86230-saint_gervais_les_trois_clochers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86225-86330-saint_jean_de_sauves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86225-86330-saint_jean_de_sauves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86225-86330-saint_jean_de_sauves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86225-86330-saint_jean_de_sauves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86225-86110-saint_jean_de_sauves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86225-86110-saint_jean_de_sauves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86225-86110-saint_jean_de_sauves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86225-86110-saint_jean_de_sauves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86226-86800-saint_julien_l_ars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86226-86800-saint_julien_l_ars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86226-86800-saint_julien_l_ars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86226-86800-saint_julien_l_ars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86227-86200-saint_laon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86227-86200-saint_laon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86227-86200-saint_laon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86227-86200-saint_laon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86228-86410-saint_laurent_de_jourdes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86228-86410-saint_laurent_de_jourdes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86228-86410-saint_laurent_de_jourdes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86228-86410-saint_laurent_de_jourdes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86229-86120-saint_leger_de_montbrillais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86229-86120-saint_leger_de_montbrillais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86229-86120-saint_leger_de_montbrillais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86229-86120-saint_leger_de_montbrillais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86230-86290-saint_leomer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86230-86290-saint_leomer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86230-86290-saint_leomer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86230-86290-saint_leomer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86231-86400-saint_macoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86231-86400-saint_macoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86231-86400-saint_macoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86231-86400-saint_macoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86233-86300-valdivienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86233-86300-valdivienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86233-86300-valdivienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86233-86300-valdivienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86234-86350-saint_martin_l_ars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86234-86350-saint_martin_l_ars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86234-86350-saint_martin_l_ars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86234-86350-saint_martin_l_ars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86235-86160-saint_maurice_la_clouere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86235-86160-saint_maurice_la_clouere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86235-86160-saint_maurice_la_clouere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86235-86160-saint_maurice_la_clouere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86236-86260-saint_pierre_de_maille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86236-86260-saint_pierre_de_maille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86236-86260-saint_pierre_de_maille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86236-86260-saint_pierre_de_maille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86237-86400-saint_pierre_d_exideuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86237-86400-saint_pierre_d_exideuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86237-86400-saint_pierre_d_exideuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86237-86400-saint_pierre_d_exideuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86239-86300-sainte_radegonde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86239-86300-sainte_radegonde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86239-86300-sainte_radegonde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86239-86300-sainte_radegonde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86241-86220-saint_remy_sur_creuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86241-86220-saint_remy_sur_creuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86241-86220-saint_remy_sur_creuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86241-86220-saint_remy_sur_creuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86242-86250-saint_romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86242-86250-saint_romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86242-86250-saint_romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86242-86250-saint_romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86244-86600-saint_sauvant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86244-86600-saint_sauvant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86244-86600-saint_sauvant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86244-86600-saint_sauvant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86245-86100-senille_saint_sauveur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86245-86100-senille_saint_sauveur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86245-86100-senille_saint_sauveur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86245-86100-senille_saint_sauveur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86246-86310-saint_savin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86246-86310-saint_savin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86246-86310-saint_savin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86246-86310-saint_savin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86247-86400-saint_saviol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86247-86400-saint_saviol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86247-86400-saint_saviol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86247-86400-saint_saviol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86248-86350-saint_secondin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86248-86350-saint_secondin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86248-86350-saint_secondin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86248-86350-saint_secondin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86249-86420-saires/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86249-86420-saires/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86249-86420-saires/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86249-86420-saires/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86250-86120-saix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86250-86120-saix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86250-86120-saix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86250-86120-saix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86252-86200-sammarcolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86252-86200-sammarcolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86252-86200-sammarcolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86252-86200-sammarcolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86253-86600-sanxay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86253-86600-sanxay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86253-86600-sanxay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86253-86600-sanxay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86254-86500-saulge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86254-86500-saulge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86254-86500-saulge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86254-86500-saulge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86255-86400-savigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86255-86400-savigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86255-86400-savigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86255-86400-savigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86256-86800-savigny_levescault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86256-86800-savigny_levescault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86256-86800-savigny_levescault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86256-86800-savigny_levescault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86257-86140-savigny_sous_faye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86257-86140-savigny_sous_faye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86257-86140-savigny_sous_faye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86257-86140-savigny_sous_faye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86258-86140-scorbe_clairvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86258-86140-scorbe_clairvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86258-86140-scorbe_clairvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86258-86140-scorbe_clairvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86260-86230-serigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86260-86230-serigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86260-86230-serigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86260-86230-serigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86261-86800-sevres_anxaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86261-86800-sevres_anxaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86261-86800-sevres_anxaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86261-86800-sevres_anxaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86262-86320-sillars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86262-86320-sillars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86262-86320-sillars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86262-86320-sillars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86263-86240-smarves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86263-86240-smarves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86263-86240-smarves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86263-86240-smarves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86264-86160-sommieres_du_clain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86264-86160-sommieres_du_clain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86264-86160-sommieres_du_clain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86264-86160-sommieres_du_clain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86265-86230-sossais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86265-86230-sossais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86265-86230-sossais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86265-86230-sossais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86266-86250-surin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86266-86250-surin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86266-86250-surin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86266-86250-surin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86268-86800-terce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86268-86800-terce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86268-86800-terce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86268-86800-terce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86269-86120-ternay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86269-86120-ternay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86269-86120-ternay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86269-86120-ternay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86270-86290-thollet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86270-86290-thollet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86270-86290-thollet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86270-86290-thollet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86271-86110-thurageau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86271-86110-thurageau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86271-86110-thurageau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86271-86110-thurageau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86272-86540-thure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86272-86540-thure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86272-86540-thure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86272-86540-thure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86273-86290-la_trimouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86273-86290-la_trimouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86273-86290-la_trimouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86273-86290-la_trimouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86274-86120-les_trois_moutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86274-86120-les_trois_moutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86274-86120-les_trois_moutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86274-86120-les_trois_moutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86275-86230-usseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86275-86230-usseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86275-86230-usseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86275-86230-usseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86276-86350-usson_du_poitou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86276-86350-usson_du_poitou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86276-86350-usson_du_poitou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86276-86350-usson_du_poitou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86279-86220-vaux_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86279-86220-vaux_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86279-86220-vaux_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86279-86220-vaux_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86280-86230-velleches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86280-86230-velleches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86280-86230-velleches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86280-86230-velleches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86380-saint_martin_la_pallu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86380-saint_martin_la_pallu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86380-saint_martin_la_pallu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86380-saint_martin_la_pallu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86170-saint_martin_la_pallu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86170-saint_martin_la_pallu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86170-saint_martin_la_pallu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86170-saint_martin_la_pallu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86110-saint_martin_la_pallu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86110-saint_martin_la_pallu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86110-saint_martin_la_pallu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86281-86110-saint_martin_la_pallu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86284-86340-vernon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86284-86340-vernon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86284-86340-vernon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86284-86340-vernon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86285-86410-verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86285-86410-verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86285-86410-verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86285-86410-verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86286-86420-verrue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86286-86420-verrue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86286-86420-verrue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86286-86420-verrue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86287-86120-vezieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86287-86120-vezieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86287-86120-vezieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86287-86120-vezieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86288-86260-vicq_sur_gartempe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86288-86260-vicq_sur_gartempe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86288-86260-vicq_sur_gartempe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86288-86260-vicq_sur_gartempe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86289-86150-le_vigeant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86289-86150-le_vigeant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86289-86150-le_vigeant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86289-86150-le_vigeant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86290-86340-la_villedieu_du_clain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86290-86340-la_villedieu_du_clain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86290-86340-la_villedieu_du_clain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86290-86340-la_villedieu_du_clain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86291-86310-villemort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86291-86310-villemort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86291-86310-villemort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86291-86310-villemort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86292-86190-villiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86292-86190-villiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86292-86190-villiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86292-86190-villiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86293-86370-vivonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86293-86370-vivonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86293-86370-vivonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86293-86370-vivonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86294-86190-vouille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86294-86190-vouille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86294-86190-vouille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86294-86190-vouille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86295-86400-vouleme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86295-86400-vouleme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86295-86400-vouleme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86295-86400-vouleme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86296-86700-voulon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86296-86700-voulon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86296-86700-voulon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86296-86700-voulon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86297-86580-vouneuil_sous_biard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86297-86580-vouneuil_sous_biard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86297-86580-vouneuil_sous_biard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86297-86580-vouneuil_sous_biard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86298-86210-vouneuil_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86298-86210-vouneuil_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86298-86210-vouneuil_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86298-86210-vouneuil_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86299-86170-vouzailles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86299-86170-vouzailles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86299-86170-vouzailles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86299-86170-vouzailles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86300-86170-yversay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86300-86170-yversay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86300-86170-yversay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt86-vienne/commune86300-86170-yversay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-87.xml
+++ b/public/sitemaps/sitemap-87.xml
@@ -5,404 +5,804 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87001-87700-aixe_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87001-87700-aixe_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87001-87700-aixe_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87001-87700-aixe_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87002-87240-ambazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87002-87240-ambazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87002-87240-ambazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87002-87240-ambazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87003-87160-arnac_la_poste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87003-87160-arnac_la_poste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87003-87160-arnac_la_poste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87003-87160-arnac_la_poste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87004-87120-augne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87004-87120-augne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87004-87120-augne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87004-87120-augne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87005-87220-aureil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87005-87220-aureil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87005-87220-aureil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87005-87220-aureil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87006-87360-azat_le_ris/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87006-87360-azat_le_ris/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87006-87360-azat_le_ris/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87006-87360-azat_le_ris/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87007-87290-balledent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87007-87290-balledent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87007-87290-balledent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87007-87290-balledent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87008-87210-la_bazeuge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87008-87210-la_bazeuge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87008-87210-la_bazeuge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87008-87210-la_bazeuge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87009-87120-beaumont_du_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87009-87120-beaumont_du_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87009-87120-beaumont_du_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87009-87120-beaumont_du_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87011-87300-bellac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87011-87300-bellac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87011-87300-bellac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87011-87300-bellac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87012-87300-berneuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87012-87300-berneuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87012-87300-berneuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87012-87300-berneuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87013-87370-bersac_sur_rivalier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87013-87370-bersac_sur_rivalier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87013-87370-bersac_sur_rivalier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87013-87370-bersac_sur_rivalier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87014-87250-bessines_sur_gartempe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87014-87250-bessines_sur_gartempe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87014-87250-bessines_sur_gartempe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87014-87250-bessines_sur_gartempe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87015-87700-beynac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87015-87700-beynac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87015-87700-beynac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87015-87700-beynac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87016-87340-les_billanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87016-87340-les_billanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87016-87340-les_billanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87016-87340-les_billanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87017-87300-blanzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87017-87300-blanzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87017-87300-blanzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87017-87300-blanzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87018-87300-blond/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87018-87300-blond/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87018-87300-blond/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87018-87300-blond/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87019-87220-boisseuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87019-87220-boisseuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87019-87220-boisseuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87019-87220-boisseuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87020-87270-bonnac_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87020-87270-bonnac_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87020-87270-bonnac_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87020-87270-bonnac_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87021-87110-bosmie_l_aiguille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87021-87110-bosmie_l_aiguille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87021-87110-bosmie_l_aiguille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87021-87110-bosmie_l_aiguille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87022-87300-breuilaufa/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87022-87300-breuilaufa/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87022-87300-breuilaufa/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87022-87300-breuilaufa/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87023-87140-le_buis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87023-87140-le_buis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87023-87140-le_buis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87023-87140-le_buis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87024-87460-bujaleuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87024-87460-bujaleuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87024-87460-bujaleuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87024-87460-bujaleuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87025-87800-burgnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87025-87800-burgnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87025-87800-burgnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87025-87800-burgnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87027-87230-bussiere_galant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87027-87230-bussiere_galant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87027-87230-bussiere_galant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87027-87230-bussiere_galant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87028-87320-val_d’oire_et_gartempe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87028-87320-val_d’oire_et_gartempe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87028-87320-val_d’oire_et_gartempe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87028-87320-val_d’oire_et_gartempe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87028-87330-val_d’oire_et_gartempe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87028-87330-val_d’oire_et_gartempe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87028-87330-val_d’oire_et_gartempe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87028-87330-val_d’oire_et_gartempe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87029-87230-les_cars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87029-87230-les_cars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87029-87230-les_cars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87029-87230-les_cars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87030-87200-chaillac_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87030-87200-chaillac_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87030-87200-chaillac_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87030-87200-chaillac_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87031-87500-le_chalard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87031-87500-le_chalard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87031-87500-le_chalard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87031-87500-le_chalard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87032-87230-chalus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87032-87230-chalus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87032-87230-chalus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87032-87230-chalus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87033-87140-chamboret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87033-87140-chamboret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87033-87140-chamboret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87033-87140-chamboret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87034-87150-champagnac_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87034-87150-champagnac_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87034-87150-champagnac_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87034-87150-champagnac_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87035-87400-champnetery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87035-87400-champnetery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87035-87400-champnetery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87035-87400-champnetery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87036-87230-champsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87036-87230-champsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87036-87230-champsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87036-87230-champsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87037-87440-la_chapelle_montbrandeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87037-87440-la_chapelle_montbrandeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87037-87440-la_chapelle_montbrandeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87037-87440-la_chapelle_montbrandeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87038-87270-chaptelat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87038-87270-chaptelat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87038-87270-chaptelat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87038-87270-chaptelat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87039-87380-chateau_chervix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87039-87380-chateau_chervix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87039-87380-chateau_chervix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87039-87380-chateau_chervix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87040-87130-chateauneuf_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87040-87130-chateauneuf_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87040-87130-chateauneuf_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87040-87130-chateauneuf_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87041-87290-chateauponsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87041-87290-chateauponsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87041-87290-chateauponsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87041-87290-chateauponsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87042-87400-le_chatenet_en_dognon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87042-87400-le_chatenet_en_dognon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87042-87400-le_chatenet_en_dognon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87042-87400-le_chatenet_en_dognon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87043-87460-cheissoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87043-87460-cheissoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87043-87460-cheissoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87043-87460-cheissoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87044-87600-cheronnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87044-87600-cheronnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87044-87600-cheronnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87044-87600-cheronnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87045-87520-cieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87045-87520-cieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87045-87520-cieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87045-87520-cieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87046-87310-cognac_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87046-87310-cognac_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87046-87310-cognac_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87046-87310-cognac_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87047-87140-compreignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87047-87140-compreignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87047-87140-compreignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87047-87140-compreignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87048-87920-condat_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87048-87920-condat_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87048-87920-condat_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87048-87920-condat_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87049-87500-coussac_bonneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87049-87500-coussac_bonneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87049-87500-coussac_bonneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87049-87500-coussac_bonneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87050-87270-couzeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87050-87270-couzeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87050-87270-couzeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87050-87270-couzeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87051-87130-la_croisille_sur_briance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87051-87130-la_croisille_sur_briance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87051-87130-la_croisille_sur_briance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87051-87130-la_croisille_sur_briance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87052-87210-la_croix_sur_gartempe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87052-87210-la_croix_sur_gartempe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87052-87210-la_croix_sur_gartempe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87052-87210-la_croix_sur_gartempe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87053-87160-cromac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87053-87160-cromac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87053-87160-cromac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87053-87160-cromac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87054-87150-cussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87054-87150-cussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87054-87150-cussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87054-87150-cussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87056-87210-dinsac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87056-87210-dinsac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87056-87210-dinsac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87056-87210-dinsac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87057-87190-dompierre_les_eglises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87057-87190-dompierre_les_eglises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87057-87190-dompierre_les_eglises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87057-87190-dompierre_les_eglises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87058-87120-domps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87058-87120-domps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87058-87120-domps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87058-87120-domps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87059-87210-le_dorat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87059-87210-le_dorat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87059-87210-le_dorat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87059-87210-le_dorat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87060-87230-dournazac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87060-87230-dournazac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87060-87230-dournazac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87060-87230-dournazac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87061-87190-droux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87061-87190-droux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87061-87190-droux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87061-87190-droux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87062-87400-eybouleuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87062-87400-eybouleuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87062-87400-eybouleuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87062-87400-eybouleuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87063-87220-eyjeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87063-87220-eyjeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87063-87220-eyjeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87063-87220-eyjeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87064-87120-eymoutiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87064-87120-eymoutiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87064-87120-eymoutiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87064-87120-eymoutiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87065-87220-feytiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87065-87220-feytiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87065-87220-feytiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87065-87220-feytiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87066-87230-flavignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87066-87230-flavignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87066-87230-flavignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87066-87230-flavignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87067-87250-folles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87067-87250-folles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87067-87250-folles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87067-87250-folles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87068-87250-fromental/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87068-87250-fromental/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87068-87250-fromental/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87068-87250-fromental/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87069-87330-gajoubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87069-87330-gajoubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87069-87330-gajoubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87069-87330-gajoubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87070-87400-la_geneytouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87070-87400-la_geneytouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87070-87400-la_geneytouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87070-87400-la_geneytouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87071-87500-glandon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87071-87500-glandon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87071-87500-glandon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87071-87500-glandon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87072-87380-glanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87072-87380-glanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87072-87380-glanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87072-87380-glanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87073-87310-gorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87073-87310-gorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87073-87310-gorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87073-87310-gorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87074-87160-les_grands_chezeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87074-87160-les_grands_chezeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87074-87160-les_grands_chezeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87074-87160-les_grands_chezeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87075-87170-isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87075-87170-isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87075-87170-isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87075-87170-isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87076-87370-jabreilles_les_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87076-87370-jabreilles_les_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87076-87370-jabreilles_les_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87076-87370-jabreilles_les_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87077-87800-janailhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87077-87800-janailhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87077-87800-janailhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87077-87800-janailhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87078-87520-javerdat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87078-87520-javerdat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87078-87520-javerdat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87078-87520-javerdat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87079-87340-la_jonchere_saint_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87079-87340-la_jonchere_saint_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87079-87340-la_jonchere_saint_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87079-87340-la_jonchere_saint_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87080-87890-jouac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87080-87890-jouac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87080-87890-jouac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87080-87890-jouac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87081-87800-jourgnac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87081-87800-jourgnac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87081-87800-jourgnac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87081-87800-jourgnac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87082-87500-ladignac_le_long/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87082-87500-ladignac_le_long/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87082-87500-ladignac_le_long/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87082-87500-ladignac_le_long/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87083-87370-lauriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87083-87370-lauriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87083-87370-lauriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87083-87370-lauriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87084-87230-lavignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87084-87230-lavignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87084-87230-lavignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87084-87230-lavignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87100-limoges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87100-limoges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87100-limoges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87100-limoges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87000-limoges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87000-limoges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87000-limoges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87000-limoges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87280-limoges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87280-limoges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87280-limoges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87085-87280-limoges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87086-87130-linards/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87086-87130-linards/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87086-87130-linards/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87086-87130-linards/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87087-87360-lussac_les_eglises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87087-87360-lussac_les_eglises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87087-87360-lussac_les_eglises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87087-87360-lussac_les_eglises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87088-87380-magnac_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87088-87380-magnac_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87088-87380-magnac_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87088-87380-magnac_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87089-87190-magnac_laval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87089-87190-magnac_laval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87089-87190-magnac_laval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87089-87190-magnac_laval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87090-87160-mailhac_sur_benaize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87090-87160-mailhac_sur_benaize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87090-87160-mailhac_sur_benaize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87090-87160-mailhac_sur_benaize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87091-87440-maisonnais_sur_tardoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87091-87440-maisonnais_sur_tardoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87091-87440-maisonnais_sur_tardoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87091-87440-maisonnais_sur_tardoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87092-87440-marval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87092-87440-marval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87092-87440-marval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87092-87440-marval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87093-87130-masleon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87093-87130-masleon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87093-87130-masleon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87093-87130-masleon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87094-87800-meilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87094-87800-meilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87094-87800-meilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87094-87800-meilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87095-87380-meuzac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87095-87380-meuzac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87095-87380-meuzac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87095-87380-meuzac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87096-87800-la_meyze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87096-87800-la_meyze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87096-87800-la_meyze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87096-87800-la_meyze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87097-87330-val_d_issoire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87097-87330-val_d_issoire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87097-87330-val_d_issoire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87097-87330-val_d_issoire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87099-87400-moissannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87099-87400-moissannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87099-87400-moissannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87099-87400-moissannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87100-87330-montrol_senard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87100-87330-montrol_senard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87100-87330-montrol_senard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87100-87330-montrol_senard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87101-87330-mortemart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87101-87330-mortemart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87101-87330-mortemart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87101-87330-mortemart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87103-87140-nantiat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87103-87140-nantiat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87103-87140-nantiat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87103-87140-nantiat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87104-87120-nedde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87104-87120-nedde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87104-87120-nedde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87104-87120-nedde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87105-87130-neuvic_entier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87105-87130-neuvic_entier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87105-87130-neuvic_entier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87105-87130-neuvic_entier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87106-87800-nexon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87106-87800-nexon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87106-87800-nexon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87106-87800-nexon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87107-87510-nieul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87107-87510-nieul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87107-87510-nieul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87107-87510-nieul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87108-87330-nouic/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87108-87330-nouic/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87108-87330-nouic/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87108-87330-nouic/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87109-87210-oradour_saint_genest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87109-87210-oradour_saint_genest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87109-87210-oradour_saint_genest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87109-87210-oradour_saint_genest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87110-87520-oradour_sur_glane/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87110-87520-oradour_sur_glane/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87110-87520-oradour_sur_glane/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87110-87520-oradour_sur_glane/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87111-87150-oradour_sur_vayres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87111-87150-oradour_sur_vayres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87111-87150-oradour_sur_vayres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87111-87150-oradour_sur_vayres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87112-87230-pageas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87112-87230-pageas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87112-87230-pageas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87112-87230-pageas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87113-87410-le_palais_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87113-87410-le_palais_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87113-87410-le_palais_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87113-87410-le_palais_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87114-87350-panazol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87114-87350-panazol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87114-87350-panazol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87114-87350-panazol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87115-87440-pensol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87115-87440-pensol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87115-87440-pensol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87115-87440-pensol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87116-87300-peyrat_de_bellac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87116-87300-peyrat_de_bellac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87116-87300-peyrat_de_bellac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87116-87300-peyrat_de_bellac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87117-87470-peyrat_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87117-87470-peyrat_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87117-87470-peyrat_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87117-87470-peyrat_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87118-87510-peyrilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87118-87510-peyrilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87118-87510-peyrilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87118-87510-peyrilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87119-87260-pierre_buffiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87119-87260-pierre_buffiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87119-87260-pierre_buffiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87119-87260-pierre_buffiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87120-87380-la_porcherie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87120-87380-la_porcherie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87120-87380-la_porcherie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87120-87380-la_porcherie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87121-87290-rancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87121-87290-rancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87121-87290-rancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87121-87290-rancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87122-87640-razes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87122-87640-razes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87122-87640-razes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87122-87640-razes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87123-87120-rempnat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87123-87120-rempnat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87123-87120-rempnat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87123-87120-rempnat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87124-87800-rilhac_lastours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87124-87800-rilhac_lastours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87124-87800-rilhac_lastours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87124-87800-rilhac_lastours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87125-87570-rilhac_rancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87125-87570-rilhac_rancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87125-87570-rilhac_rancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87125-87570-rilhac_rancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87126-87600-rochechouart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87126-87600-rochechouart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87126-87600-rochechouart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87126-87600-rochechouart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87127-87800-la_roche_l_abeille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87127-87800-la_roche_l_abeille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87127-87800-la_roche_l_abeille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87127-87800-la_roche_l_abeille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87128-87140-saint_pardoux_le_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87128-87140-saint_pardoux_le_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87128-87140-saint_pardoux_le_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87128-87140-saint_pardoux_le_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87128-87250-saint_pardoux_le_lac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87128-87250-saint_pardoux_le_lac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87128-87250-saint_pardoux_le_lac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87128-87250-saint_pardoux_le_lac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87129-87400-royeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87129-87400-royeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87129-87400-royeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87129-87400-royeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87130-87130-roziers_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87130-87130-roziers_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87130-87130-roziers_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87130-87130-roziers_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87131-87720-saillat_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87131-87720-saillat_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87131-87720-saillat_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87131-87720-saillat_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87132-87120-saint_amand_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87132-87120-saint_amand_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87132-87120-saint_amand_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87132-87120-saint_amand_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87133-87290-saint_amand_magnazeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87133-87290-saint_amand_magnazeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87133-87290-saint_amand_magnazeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87133-87290-saint_amand_magnazeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87134-87120-sainte_anne_saint_priest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87134-87120-sainte_anne_saint_priest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87134-87120-sainte_anne_saint_priest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87134-87120-sainte_anne_saint_priest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87135-87310-saint_auvent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87135-87310-saint_auvent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87135-87310-saint_auvent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87135-87310-saint_auvent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87137-87150-saint_bazile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87137-87150-saint_bazile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87137-87150-saint_bazile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87137-87150-saint_bazile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87138-87260-saint_bonnet_briance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87138-87260-saint_bonnet_briance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87138-87260-saint_bonnet_briance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87138-87260-saint_bonnet_briance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87139-87300-saint_bonnet_de_bellac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87139-87300-saint_bonnet_de_bellac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87139-87300-saint_bonnet_de_bellac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87139-87300-saint_bonnet_de_bellac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87140-87200-saint_brice_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87140-87200-saint_brice_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87140-87200-saint_brice_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87140-87200-saint_brice_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87141-87310-saint_cyr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87141-87310-saint_cyr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87141-87310-saint_cyr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87141-87310-saint_cyr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87142-87400-saint_denis_des_murs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87142-87400-saint_denis_des_murs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87142-87400-saint_denis_des_murs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87142-87400-saint_denis_des_murs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87143-87510-saint_gence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87143-87510-saint_gence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87143-87510-saint_gence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87143-87510-saint_gence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87144-87260-saint_genest_sur_roselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87144-87260-saint_genest_sur_roselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87144-87260-saint_genest_sur_roselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87144-87260-saint_genest_sur_roselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87145-87160-saint_georges_les_landes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87145-87160-saint_georges_les_landes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87145-87160-saint_georges_les_landes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87145-87160-saint_georges_les_landes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87146-87380-saint_germain_les_belles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87146-87380-saint_germain_les_belles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87146-87380-saint_germain_les_belles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87146-87380-saint_germain_les_belles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87147-87130-saint_gilles_les_forets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87147-87130-saint_gilles_les_forets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87147-87130-saint_gilles_les_forets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87147-87130-saint_gilles_les_forets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87148-87260-saint_hilaire_bonneval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87148-87260-saint_hilaire_bonneval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87148-87260-saint_hilaire_bonneval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87148-87260-saint_hilaire_bonneval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87149-87190-saint_hilaire_la_treille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87149-87190-saint_hilaire_la_treille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87149-87190-saint_hilaire_la_treille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87149-87190-saint_hilaire_la_treille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87150-87800-saint_hilaire_les_places/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87150-87800-saint_hilaire_les_places/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87150-87800-saint_hilaire_les_places/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87150-87800-saint_hilaire_les_places/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87151-87260-saint_jean_ligoure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87151-87260-saint_jean_ligoure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87151-87260-saint_jean_ligoure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87151-87260-saint_jean_ligoure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87152-87510-saint_jouvent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87152-87510-saint_jouvent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87152-87510-saint_jouvent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87152-87510-saint_jouvent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87153-87460-saint_julien_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87153-87460-saint_julien_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87153-87460-saint_julien_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87153-87460-saint_julien_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87154-87200-saint_junien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87154-87200-saint_junien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87154-87200-saint_junien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87154-87200-saint_junien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87155-87300-saint_junien_les_combes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87155-87300-saint_junien_les_combes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87155-87300-saint_junien_les_combes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87155-87300-saint_junien_les_combes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87156-87590-saint_just_le_martel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87156-87590-saint_just_le_martel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87156-87590-saint_just_le_martel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87156-87590-saint_just_le_martel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87157-87240-saint_laurent_les_eglises/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87157-87240-saint_laurent_les_eglises/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87157-87240-saint_laurent_les_eglises/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87157-87240-saint_laurent_les_eglises/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87158-87310-saint_laurent_sur_gorre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87158-87310-saint_laurent_sur_gorre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87158-87310-saint_laurent_sur_gorre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87158-87310-saint_laurent_sur_gorre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87159-87340-saint_leger_la_montagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87159-87340-saint_leger_la_montagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87159-87340-saint_leger_la_montagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87159-87340-saint_leger_la_montagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87160-87190-saint_leger_magnazeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87160-87190-saint_leger_magnazeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87160-87190-saint_leger_magnazeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87160-87190-saint_leger_magnazeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87161-87400-saint_leonard_de_noblat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87161-87400-saint_leonard_de_noblat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87161-87400-saint_leonard_de_noblat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87161-87400-saint_leonard_de_noblat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87162-87420-sainte_marie_de_vaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87162-87420-sainte_marie_de_vaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87162-87420-sainte_marie_de_vaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87162-87420-sainte_marie_de_vaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87163-87330-saint_martial_sur_isop/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87163-87330-saint_martial_sur_isop/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87163-87330-saint_martial_sur_isop/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87163-87330-saint_martial_sur_isop/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87164-87200-saint_martin_de_jussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87164-87200-saint_martin_de_jussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87164-87200-saint_martin_de_jussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87164-87200-saint_martin_de_jussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87165-87360-saint_martin_le_mault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87165-87360-saint_martin_le_mault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87165-87360-saint_martin_le_mault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87165-87360-saint_martin_le_mault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87166-87700-saint_martin_le_vieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87166-87700-saint_martin_le_vieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87166-87700-saint_martin_le_vieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87166-87700-saint_martin_le_vieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87167-87400-saint_martin_terressus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87167-87400-saint_martin_terressus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87167-87400-saint_martin_terressus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87167-87400-saint_martin_terressus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87168-87440-saint_mathieu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87168-87440-saint_mathieu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87168-87440-saint_mathieu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87168-87440-saint_mathieu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87169-87800-saint_maurice_les_brousses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87169-87800-saint_maurice_les_brousses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87169-87800-saint_maurice_les_brousses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87169-87800-saint_maurice_les_brousses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87170-87130-saint_meard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87170-87130-saint_meard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87170-87130-saint_meard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87170-87130-saint_meard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87172-87300-saint_ouen_sur_gartempe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87172-87300-saint_ouen_sur_gartempe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87172-87300-saint_ouen_sur_gartempe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87172-87300-saint_ouen_sur_gartempe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87174-87260-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87174-87260-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87174-87260-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87174-87260-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87176-87800-saint_priest_ligoure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87176-87800-saint_priest_ligoure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87176-87800-saint_priest_ligoure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87176-87800-saint_priest_ligoure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87177-87700-saint_priest_sous_aixe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87177-87700-saint_priest_sous_aixe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87177-87700-saint_priest_sous_aixe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87177-87700-saint_priest_sous_aixe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87178-87480-saint_priest_taurion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87178-87480-saint_priest_taurion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87178-87480-saint_priest_taurion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87178-87480-saint_priest_taurion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87179-87210-saint_sornin_la_marche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87179-87210-saint_sornin_la_marche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87179-87210-saint_sornin_la_marche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87179-87210-saint_sornin_la_marche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87180-87290-saint_sornin_leulac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87180-87290-saint_sornin_leulac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87180-87290-saint_sornin_leulac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87180-87290-saint_sornin_leulac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87181-87370-saint_sulpice_lauriere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87181-87370-saint_sulpice_lauriere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87181-87370-saint_sulpice_lauriere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87181-87370-saint_sulpice_lauriere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87182-87160-saint_sulpice_les_feuilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87182-87160-saint_sulpice_les_feuilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87182-87160-saint_sulpice_les_feuilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87182-87160-saint_sulpice_les_feuilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87183-87240-saint_sylvestre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87183-87240-saint_sylvestre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87183-87240-saint_sylvestre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87183-87240-saint_sylvestre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87185-87420-saint_victurnien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87185-87420-saint_victurnien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87185-87420-saint_victurnien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87185-87420-saint_victurnien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87186-87380-saint_vitte_sur_briance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87186-87380-saint_vitte_sur_briance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87186-87380-saint_vitte_sur_briance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87186-87380-saint_vitte_sur_briance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87187-87500-saint_yrieix_la_perche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87187-87500-saint_yrieix_la_perche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87187-87500-saint_yrieix_la_perche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87187-87500-saint_yrieix_la_perche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87188-87700-saint_yrieix_sous_aixe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87188-87700-saint_yrieix_sous_aixe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87188-87700-saint_yrieix_sous_aixe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87188-87700-saint_yrieix_sous_aixe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87189-87440-les_salles_lavauguyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87189-87440-les_salles_lavauguyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87189-87440-les_salles_lavauguyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87189-87440-les_salles_lavauguyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87190-87400-sauviat_sur_vige/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87190-87400-sauviat_sur_vige/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87190-87400-sauviat_sur_vige/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87190-87400-sauviat_sur_vige/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87191-87620-sereilhac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87191-87620-sereilhac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87191-87620-sereilhac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87191-87620-sereilhac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87192-87110-solignac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87192-87110-solignac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87192-87110-solignac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87192-87110-solignac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87193-87130-surdoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87193-87130-surdoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87193-87130-surdoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87193-87130-surdoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87194-87130-sussac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87194-87130-sussac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87194-87130-sussac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87194-87130-sussac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87195-87360-tersannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87195-87360-tersannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87195-87360-tersannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87195-87360-tersannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87197-87140-thouron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87197-87140-thouron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87197-87140-thouron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87197-87140-thouron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87198-87140-vaulry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87198-87140-vaulry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87198-87140-vaulry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87198-87140-vaulry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87199-87600-vayres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87199-87600-vayres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87199-87600-vayres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87199-87600-vayres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87200-87360-verneuil_moustiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87200-87360-verneuil_moustiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87200-87360-verneuil_moustiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87200-87360-verneuil_moustiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87201-87430-verneuil_sur_vienne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87201-87430-verneuil_sur_vienne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87201-87430-verneuil_sur_vienne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87201-87430-verneuil_sur_vienne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87202-87520-veyrac/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87202-87520-veyrac/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87202-87520-veyrac/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87202-87520-veyrac/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87203-87260-vicq_sur_breuilh/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87203-87260-vicq_sur_breuilh/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87203-87260-vicq_sur_breuilh/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87203-87260-vicq_sur_breuilh/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87204-87600-videix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87204-87600-videix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87204-87600-videix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87204-87600-videix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87205-87110-le_vigen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87205-87110-le_vigen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87205-87110-le_vigen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87205-87110-le_vigen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87206-87190-villefavard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87206-87190-villefavard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87206-87190-villefavard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt87-haute_vienne/commune87206-87190-villefavard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-88.xml
+++ b/public/sitemaps/sitemap-88.xml
@@ -5,1022 +5,2040 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88001-88270-les_ableuvenettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88001-88270-les_ableuvenettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88001-88270-les_ableuvenettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88001-88270-les_ableuvenettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88002-88500-aheville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88002-88500-aheville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88002-88500-aheville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88002-88500-aheville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88003-88140-aingeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88003-88140-aingeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88003-88140-aingeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88003-88140-aingeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88004-88320-ainvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88004-88320-ainvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88004-88320-ainvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88004-88320-ainvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88005-88110-allarmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88005-88110-allarmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88005-88110-allarmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88005-88110-allarmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88006-88500-ambacourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88006-88500-ambacourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88006-88500-ambacourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88006-88500-ambacourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88007-88410-ameuvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88007-88410-ameuvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88007-88410-ameuvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88007-88410-ameuvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88008-88700-anglemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88008-88700-anglemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88008-88700-anglemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88008-88700-anglemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88009-88650-anould/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88009-88650-anould/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88009-88650-anould/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88009-88650-anould/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88010-88170-aouze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88010-88170-aouze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88010-88170-aouze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88010-88170-aouze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88011-88380-arches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88011-88380-arches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88011-88380-arches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88011-88380-arches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88012-88380-archettes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88012-88380-archettes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88012-88380-archettes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88012-88380-archettes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88013-88170-aroffe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88013-88170-aroffe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88013-88170-aroffe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88013-88170-aroffe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88014-88430-arrentes_de_corcieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88014-88430-arrentes_de_corcieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88014-88430-arrentes_de_corcieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88014-88430-arrentes_de_corcieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88015-88300-attigneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88015-88300-attigneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88015-88300-attigneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88015-88300-attigneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88016-88260-attigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88016-88260-attigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88016-88260-attigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88016-88260-attigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88017-88300-aulnois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88017-88300-aulnois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88017-88300-aulnois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88017-88300-aulnois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88019-88300-autigny_la_tour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88019-88300-autigny_la_tour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88019-88300-autigny_la_tour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88019-88300-autigny_la_tour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88020-88300-autreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88020-88300-autreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88020-88300-autreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88020-88300-autreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88021-88700-autrey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88021-88700-autrey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88021-88700-autrey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88021-88700-autrey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88022-88140-auzainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88022-88140-auzainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88022-88140-auzainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88022-88140-auzainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88023-88500-avillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88023-88500-avillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88023-88500-avillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88023-88500-avillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88024-88130-avrainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88024-88130-avrainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88024-88130-avrainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88024-88130-avrainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88025-88630-avranville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88025-88630-avranville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88025-88630-avranville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88025-88630-avranville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88026-88600-aydoilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88026-88600-aydoilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88026-88600-aydoilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88026-88600-aydoilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88027-88330-badmenil_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88027-88330-badmenil_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88027-88330-badmenil_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88027-88330-badmenil_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88028-88460-la_baffe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88028-88460-la_baffe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88028-88460-la_baffe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88028-88460-la_baffe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88029-88240-la_voge_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88029-88240-la_voge_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88029-88240-la_voge_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88029-88240-la_voge_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88030-88270-bainville_aux_saules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88030-88270-bainville_aux_saules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88030-88270-bainville_aux_saules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88030-88270-bainville_aux_saules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88031-88170-balleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88031-88170-balleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88031-88170-balleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88031-88170-balleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88032-88520-ban_de_laveline/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88032-88520-ban_de_laveline/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88032-88520-ban_de_laveline/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88032-88520-ban_de_laveline/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88033-88210-ban_de_sapt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88033-88210-ban_de_sapt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88033-88210-ban_de_sapt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88033-88210-ban_de_sapt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88035-88640-barbey_seroux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88035-88640-barbey_seroux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88035-88640-barbey_seroux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88035-88640-barbey_seroux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88036-88300-barville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88036-88300-barville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88036-88300-barville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88036-88300-barville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88037-88120-basse_sur_le_rupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88037-88120-basse_sur_le_rupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88037-88120-basse_sur_le_rupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88037-88120-basse_sur_le_rupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88038-88130-battexey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88038-88130-battexey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88038-88130-battexey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88038-88130-battexey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88039-88500-baudricourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88039-88500-baudricourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88039-88500-baudricourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88039-88500-baudricourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88040-88150-bayecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88040-88150-bayecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88040-88150-bayecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88040-88150-bayecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88041-88270-bazegney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88041-88270-bazegney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88041-88270-bazegney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88041-88270-bazegney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88042-88700-bazien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88042-88700-bazien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88042-88700-bazien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88042-88700-bazien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88043-88500-bazoilles_et_menil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88043-88500-bazoilles_et_menil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88043-88500-bazoilles_et_menil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88043-88500-bazoilles_et_menil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88044-88300-bazoilles_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88044-88300-bazoilles_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88044-88300-bazoilles_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88044-88300-bazoilles_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88045-88300-beaufremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88045-88300-beaufremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88045-88300-beaufremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88045-88300-beaufremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88046-88600-beaumenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88046-88600-beaumenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88046-88600-beaumenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88046-88600-beaumenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88047-88270-begnecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88047-88270-begnecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88047-88270-begnecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88047-88270-begnecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88048-88370-bellefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88048-88370-bellefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88048-88370-bellefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88048-88370-bellefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88049-88260-belmont_les_darney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88049-88260-belmont_les_darney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88049-88260-belmont_les_darney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88049-88260-belmont_les_darney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88050-88600-belmont_sur_buttant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88050-88600-belmont_sur_buttant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88050-88600-belmont_sur_buttant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88050-88600-belmont_sur_buttant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88051-88800-belmont_sur_vair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88051-88800-belmont_sur_vair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88051-88800-belmont_sur_vair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88051-88800-belmont_sur_vair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88052-88260-belrupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88052-88260-belrupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88052-88260-belrupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88052-88260-belrupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88053-88210-belval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88053-88210-belval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88053-88210-belval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88053-88210-belval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88054-88520-bertrimoutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88054-88520-bertrimoutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88054-88520-bertrimoutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88054-88520-bertrimoutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88055-88450-bettegney_saint_brice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88055-88450-bettegney_saint_brice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88055-88450-bettegney_saint_brice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88055-88450-bettegney_saint_brice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88056-88500-bettoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88056-88500-bettoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88056-88500-bettoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88056-88500-bettoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88057-88490-le_beulay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88057-88490-le_beulay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88057-88490-le_beulay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88057-88490-le_beulay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88058-88170-biecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88058-88170-biecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88058-88170-biecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88058-88170-biecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88059-88430-biffontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88059-88430-biffontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88059-88430-biffontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88059-88430-biffontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88060-88500-blemerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88060-88500-blemerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88060-88500-blemerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88060-88500-blemerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88061-88410-bleurville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88061-88410-bleurville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88061-88410-bleurville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88061-88410-bleurville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88062-88320-blevaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88062-88320-blevaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88062-88320-blevaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88062-88320-blevaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88063-88270-bocquegney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88063-88270-bocquegney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88063-88270-bocquegney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88063-88270-bocquegney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88064-88600-bois_de_champ/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88064-88600-bois_de_champ/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88064-88600-bois_de_champ/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88064-88600-bois_de_champ/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88065-88260-bonvillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88065-88260-bonvillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88065-88260-bonvillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88065-88260-bonvillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88066-88500-boulaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88066-88500-boulaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88066-88500-boulaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88066-88500-boulaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88068-88470-la_bourgonce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88068-88470-la_bourgonce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88068-88470-la_bourgonce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88068-88470-la_bourgonce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88069-88270-bouxieres_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88069-88270-bouxieres_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88069-88270-bouxieres_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88069-88270-bouxieres_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88070-88130-bouxurulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88070-88130-bouxurulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88070-88130-bouxurulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88070-88130-bouxurulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88071-88270-bouzemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88071-88270-bouzemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88071-88270-bouzemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88071-88270-bouzemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88073-88130-brantigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88073-88130-brantigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88073-88130-brantigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88073-88130-brantigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88074-88350-brechainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88074-88350-brechainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88074-88350-brechainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88074-88350-brechainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88075-88250-la_bresse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88075-88250-la_bresse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88075-88250-la_bresse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88075-88250-la_bresse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88076-88600-brouvelieures/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88076-88600-brouvelieures/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88076-88600-brouvelieures/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88076-88600-brouvelieures/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88077-88700-bru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88077-88700-bru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88077-88700-bru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88077-88700-bru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88078-88600-bruyeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88078-88600-bruyeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88078-88600-bruyeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88078-88600-bruyeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88079-88140-bulgneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88079-88140-bulgneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88079-88140-bulgneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88079-88140-bulgneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88080-88700-bult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88080-88700-bult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88080-88700-bult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88080-88700-bult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88081-88540-bussang/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88081-88540-bussang/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88081-88540-bussang/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88081-88540-bussang/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88082-88110-celles_sur_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88082-88110-celles_sur_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88082-88110-celles_sur_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88082-88110-celles_sur_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88083-88300-certilleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88083-88300-certilleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88083-88300-certilleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88083-88300-certilleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88084-88130-chamagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88084-88130-chamagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88084-88130-chamagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88084-88130-chamagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88085-88640-champdray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88085-88640-champdray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88085-88640-champdray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88085-88640-champdray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88086-88600-champ_le_duc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88086-88600-champ_le_duc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88086-88600-champ_le_duc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88086-88600-champ_le_duc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88087-88000-chantraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88087-88000-chantraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88087-88000-chantraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88087-88000-chantraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88088-88240-la_chapelle_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88088-88240-la_chapelle_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88088-88240-la_chapelle_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88088-88240-la_chapelle_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88089-88600-la_chapelle_devant_bruyeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88089-88600-la_chapelle_devant_bruyeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88089-88600-la_chapelle_devant_bruyeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88089-88600-la_chapelle_devant_bruyeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88090-88130-charmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88090-88130-charmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88090-88130-charmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88090-88130-charmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88091-88460-charmois_devant_bruyeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88091-88460-charmois_devant_bruyeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88091-88460-charmois_devant_bruyeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88091-88460-charmois_devant_bruyeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88092-88270-charmois_l_orgueilleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88092-88270-charmois_l_orgueilleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88092-88270-charmois_l_orgueilleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88092-88270-charmois_l_orgueilleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88093-88210-chatas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88093-88210-chatas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88093-88210-chatas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88093-88210-chatas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88094-88330-chatel_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88094-88330-chatel_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88094-88330-chatel_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88094-88330-chatel_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88095-88170-chatenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88095-88170-chatenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88095-88170-chatenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88095-88170-chatenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88096-88410-chatillon_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88096-88410-chatillon_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88096-88410-chatillon_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88096-88410-chatillon_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88097-88500-chauffecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88097-88500-chauffecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88097-88500-chauffecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88097-88500-chauffecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88098-88390-chaumousey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88098-88390-chaumousey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88098-88390-chaumousey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88098-88390-chaumousey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88099-88150-chavelot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88099-88150-chavelot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88099-88150-chavelot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88099-88150-chavelot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88100-88500-chef_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88100-88500-chef_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88100-88500-chef_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88100-88500-chef_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88101-88460-chenimenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88101-88460-chenimenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88101-88460-chenimenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88101-88460-chenimenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88102-88630-chermisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88102-88630-chermisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88102-88630-chermisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88102-88630-chermisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88103-88270-circourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88103-88270-circourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88103-88270-circourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88103-88270-circourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88104-88300-circourt_sur_mouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88104-88300-circourt_sur_mouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88104-88300-circourt_sur_mouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88104-88300-circourt_sur_mouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88105-88410-claudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88105-88410-claudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88105-88410-claudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88105-88410-claudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88106-88230-ban_sur_meurthe_clefcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88106-88230-ban_sur_meurthe_clefcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88106-88230-ban_sur_meurthe_clefcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88106-88230-ban_sur_meurthe_clefcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88107-88630-clerey_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88107-88630-clerey_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88107-88630-clerey_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88107-88630-clerey_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88108-88240-le_clerjus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88108-88240-le_clerjus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88108-88240-le_clerjus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88108-88240-le_clerjus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88109-88120-cleurie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88109-88120-cleurie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88109-88120-cleurie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88109-88120-cleurie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88110-88700-clezentaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88110-88700-clezentaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88110-88700-clezentaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88110-88700-clezentaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88111-88100-coinches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88111-88100-coinches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88111-88100-coinches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88111-88100-coinches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88113-88490-combrimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88113-88490-combrimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88113-88490-combrimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88113-88490-combrimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88114-88140-contrexeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88114-88140-contrexeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88114-88140-contrexeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88114-88140-contrexeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88115-88430-corcieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88115-88430-corcieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88115-88430-corcieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88115-88430-corcieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88116-88310-cornimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88116-88310-cornimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88116-88310-cornimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88116-88310-cornimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88117-88170-courcelles_sous_chatenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88117-88170-courcelles_sous_chatenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88117-88170-courcelles_sous_chatenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88117-88170-courcelles_sous_chatenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88118-88630-coussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88118-88630-coussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88118-88630-coussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88118-88630-coussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88119-88140-crainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88119-88140-crainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88119-88140-crainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88119-88140-crainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88120-88520-la_croix_aux_mines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88120-88520-la_croix_aux_mines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88120-88520-la_croix_aux_mines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88120-88520-la_croix_aux_mines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88121-88330-damas_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88121-88330-damas_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88121-88330-damas_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88121-88330-damas_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88122-88270-damas_et_bettegney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88122-88270-damas_et_bettegney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88122-88270-damas_et_bettegney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88122-88270-damas_et_bettegney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88123-88320-damblain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88123-88320-damblain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88123-88320-damblain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88123-88320-damblain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88124-88260-darney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88124-88260-darney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88124-88260-darney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88124-88260-darney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88125-88170-darney_aux_chenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88125-88170-darney_aux_chenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88125-88170-darney_aux_chenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88125-88170-darney_aux_chenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88126-88390-darnieulles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88126-88390-darnieulles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88126-88390-darnieulles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88126-88390-darnieulles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88127-88700-deinvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88127-88700-deinvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88127-88700-deinvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88127-88700-deinvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88128-88210-denipaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88128-88210-denipaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88128-88210-denipaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88128-88210-denipaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88129-88270-derbamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88129-88270-derbamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88129-88270-derbamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88129-88270-derbamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88130-88600-destord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88130-88600-destord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88130-88600-destord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88130-88600-destord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88131-88600-deycimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88131-88600-deycimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88131-88600-deycimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88131-88600-deycimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88132-88000-deyvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88132-88000-deyvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88132-88000-deyvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88132-88000-deyvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88133-88000-dignonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88133-88000-dignonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88133-88000-dignonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88133-88000-dignonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88134-88000-dinoze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88134-88000-dinoze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88134-88000-dinoze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88134-88000-dinoze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88135-88460-docelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88135-88460-docelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88135-88460-docelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88135-88460-docelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88136-88000-dogneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88136-88000-dogneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88136-88000-dogneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88136-88000-dogneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88137-88170-dolaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88137-88170-dolaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88137-88170-dolaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88137-88170-dolaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88138-88260-dombasle_devant_darney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88138-88260-dombasle_devant_darney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88138-88260-dombasle_devant_darney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88138-88260-dombasle_devant_darney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88139-88500-dombasle_en_xaintois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88139-88500-dombasle_en_xaintois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88139-88500-dombasle_en_xaintois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88139-88500-dombasle_en_xaintois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88140-88140-dombrot_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88140-88140-dombrot_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88140-88140-dombrot_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88140-88140-dombrot_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88141-88170-dombrot_sur_vair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88141-88170-dombrot_sur_vair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88141-88170-dombrot_sur_vair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88141-88170-dombrot_sur_vair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88142-88390-domevre_sur_aviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88142-88390-domevre_sur_aviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88142-88390-domevre_sur_aviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88142-88390-domevre_sur_aviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88143-88330-domevre_sur_durbion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88143-88330-domevre_sur_durbion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88143-88330-domevre_sur_durbion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88143-88330-domevre_sur_durbion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88144-88500-domevre_sous_montfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88144-88500-domevre_sous_montfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88144-88500-domevre_sous_montfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88144-88500-domevre_sous_montfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88145-88600-domfaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88145-88600-domfaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88145-88600-domfaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88145-88600-domfaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88146-88800-domjulien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88146-88800-domjulien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88146-88800-domjulien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88146-88800-domjulien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88147-88390-dommartin_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88147-88390-dommartin_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88147-88390-dommartin_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88147-88390-dommartin_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88148-88200-dommartin_les_remiremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88148-88200-dommartin_les_remiremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88148-88200-dommartin_les_remiremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88148-88200-dommartin_les_remiremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88149-88260-dommartin_les_vallois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88149-88260-dommartin_les_vallois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88149-88260-dommartin_les_vallois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88149-88260-dommartin_les_vallois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88150-88170-dommartin_sur_vraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88150-88170-dommartin_sur_vraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88150-88170-dommartin_sur_vraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88150-88170-dommartin_sur_vraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88151-88270-dompaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88151-88270-dompaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88151-88270-dompaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88151-88270-dompaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88152-88600-dompierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88152-88600-dompierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88152-88600-dompierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88152-88600-dompierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88153-88700-domptail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88153-88700-domptail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88153-88700-domptail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88153-88700-domptail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88154-88630-domremy_la_pucelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88154-88630-domremy_la_pucelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88154-88630-domremy_la_pucelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88154-88630-domremy_la_pucelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88155-88500-domvallier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88155-88500-domvallier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88155-88500-domvallier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88155-88500-domvallier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88156-88700-doncieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88156-88700-doncieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88156-88700-doncieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88156-88700-doncieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88157-88220-dounoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88157-88220-dounoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88157-88220-dounoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88157-88220-dounoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88158-88510-eloyes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88158-88510-eloyes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88158-88510-eloyes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88158-88510-eloyes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88159-88650-entre_deux_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88159-88650-entre_deux_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88159-88650-entre_deux_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88159-88650-entre_deux_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88160-88000-epinal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88160-88000-epinal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88160-88000-epinal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88160-88000-epinal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88161-88260-escles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88161-88260-escles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88161-88260-escles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88161-88260-escles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88162-88260-esley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88162-88260-esley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88162-88260-esley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88162-88260-esley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88163-88130-essegney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88163-88130-essegney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88163-88130-essegney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88163-88130-essegney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88164-88500-estrennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88164-88500-estrennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88164-88500-estrennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88164-88500-estrennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88165-88480-etival_clairefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88165-88480-etival_clairefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88165-88480-etival_clairefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88165-88480-etival_clairefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88166-88450-evaux_et_menil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88166-88450-evaux_et_menil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88166-88450-evaux_et_menil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88166-88450-evaux_et_menil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88167-88460-faucompierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88167-88460-faucompierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88167-88460-faucompierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88167-88460-faucompierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88168-88700-fauconcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88168-88700-fauconcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88168-88700-fauconcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88168-88700-fauconcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88169-88600-fays/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88169-88600-fays/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88169-88600-fays/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88169-88600-fays/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88170-88360-ferdrupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88170-88360-ferdrupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88170-88360-ferdrupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88170-88360-ferdrupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88171-88410-fignevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88171-88410-fignevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88171-88410-fignevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88171-88410-fignevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88172-88600-fimenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88172-88600-fimenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88172-88600-fimenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88172-88600-fimenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88173-88130-floremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88173-88130-floremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88173-88130-floremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88173-88130-floremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88174-88390-fomerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88174-88390-fomerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88174-88390-fomerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88174-88390-fomerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88175-88600-fontenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88175-88600-fontenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88175-88600-fontenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88175-88600-fontenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88176-88240-fontenoy_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88176-88240-fontenoy_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88176-88240-fontenoy_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88176-88240-fontenoy_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88177-88530-la_forge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88177-88530-la_forge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88177-88530-la_forge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88177-88530-la_forge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88178-88390-les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88178-88390-les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88178-88390-les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88178-88390-les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88179-88320-fouchecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88179-88320-fouchecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88179-88320-fouchecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88179-88320-fouchecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88180-88320-frain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88180-88320-frain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88180-88320-frain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88180-88320-frain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88181-88230-fraize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88181-88230-fraize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88181-88230-fraize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88181-88230-fraize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88182-88490-frapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88182-88490-frapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88182-88490-frapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88182-88490-frapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88183-88630-frebecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88183-88630-frebecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88183-88630-frebecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88183-88630-frebecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88184-88600-fremifontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88184-88600-fremifontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88184-88600-fremifontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88184-88600-fremifontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88185-88500-frenelle_la_grande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88185-88500-frenelle_la_grande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88185-88500-frenelle_la_grande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88185-88500-frenelle_la_grande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88186-88500-frenelle_la_petite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88186-88500-frenelle_la_petite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88186-88500-frenelle_la_petite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88186-88500-frenelle_la_petite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88187-88270-frenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88187-88270-frenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88187-88270-frenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88187-88270-frenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88188-88160-fresse_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88188-88160-fresse_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88188-88160-fresse_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88188-88160-fresse_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88189-88350-freville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88189-88350-freville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88189-88350-freville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88189-88350-freville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88190-88440-frizon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88190-88440-frizon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88190-88440-frizon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88190-88440-frizon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88192-88270-gelvecourt_et_adompt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88192-88270-gelvecourt_et_adompt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88192-88270-gelvecourt_et_adompt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88192-88270-gelvecourt_et_adompt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88193-88520-gemaingoutte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88193-88520-gemaingoutte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88193-88520-gemaingoutte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88193-88520-gemaingoutte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88194-88170-gemmelaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88194-88170-gemmelaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88194-88170-gemmelaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88194-88170-gemmelaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88195-88140-gendreville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88195-88140-gendreville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88195-88140-gendreville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88195-88140-gendreville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88196-88400-gerardmer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88196-88400-gerardmer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88196-88400-gerardmer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88196-88400-gerardmer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88197-88120-gerbamont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88197-88120-gerbamont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88197-88120-gerbamont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88197-88120-gerbamont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88198-88430-gerbepal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88198-88430-gerbepal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88198-88430-gerbepal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88198-88430-gerbepal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88199-88320-gigneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88199-88320-gigneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88199-88320-gigneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88199-88320-gigneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88200-88390-gigney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88200-88390-gigney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88200-88390-gigney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88200-88390-gigney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88201-88390-girancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88201-88390-girancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88201-88390-girancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88201-88390-girancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88202-88500-gircourt_les_vieville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88202-88500-gircourt_les_vieville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88202-88500-gircourt_les_vieville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88202-88500-gircourt_les_vieville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88203-88600-girecourt_sur_durbion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88203-88600-girecourt_sur_durbion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88203-88600-girecourt_sur_durbion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88203-88600-girecourt_sur_durbion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88205-88340-girmont_val_d_ajol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88205-88340-girmont_val_d_ajol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88205-88340-girmont_val_d_ajol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88205-88340-girmont_val_d_ajol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88206-88170-gironcourt_sur_vraine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88206-88170-gironcourt_sur_vraine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88206-88170-gironcourt_sur_vraine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88206-88170-gironcourt_sur_vraine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88208-88410-godoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88208-88410-godoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88208-88410-godoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88208-88410-godoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88209-88190-golbey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88209-88190-golbey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88209-88190-golbey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88209-88190-golbey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88210-88270-gorhey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88210-88270-gorhey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88210-88270-gorhey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88210-88270-gorhey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88212-88350-grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88212-88350-grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88212-88350-grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88212-88350-grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88213-88490-la_grande_fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88213-88490-la_grande_fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88213-88490-la_grande_fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88213-88490-la_grande_fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88214-88240-grandrupt_de_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88214-88240-grandrupt_de_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88214-88240-grandrupt_de_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88214-88240-grandrupt_de_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88215-88210-grandrupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88215-88210-grandrupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88215-88210-grandrupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88215-88210-grandrupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88216-88600-grandvillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88216-88600-grandvillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88216-88600-grandvillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88216-88600-grandvillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88218-88640-granges_aumontzey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88218-88640-granges_aumontzey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88218-88640-granges_aumontzey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88218-88640-granges_aumontzey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88219-88630-greux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88219-88630-greux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88219-88630-greux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88219-88630-greux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88220-88410-grignoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88220-88410-grignoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88220-88410-grignoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88220-88410-grignoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88221-88240-gruey_les_surance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88221-88240-gruey_les_surance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88221-88240-gruey_les_surance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88221-88240-gruey_les_surance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88222-88600-gugnecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88222-88600-gugnecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88222-88600-gugnecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88222-88600-gugnecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88223-88450-gugney_aux_aulx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88223-88450-gugney_aux_aulx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88223-88450-gugney_aux_aulx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88223-88450-gugney_aux_aulx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88224-88330-hadigny_les_verrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88224-88330-hadigny_les_verrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88224-88330-hadigny_les_verrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88224-88330-hadigny_les_verrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88225-88220-hadol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88225-88220-hadol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88225-88220-hadol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88225-88220-hadol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88226-88270-hagecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88226-88270-hagecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88226-88270-hagecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88226-88270-hagecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88227-88300-hagneville_et_roncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88227-88300-hagneville_et_roncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88227-88300-hagneville_et_roncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88227-88300-hagneville_et_roncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88228-88330-haillainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88228-88330-haillainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88228-88330-haillainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88228-88330-haillainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88229-88300-harchechamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88229-88300-harchechamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88229-88300-harchechamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88229-88300-harchechamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88230-88700-hardancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88230-88700-hardancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88230-88700-hardancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88230-88700-hardancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88231-88800-hareville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88231-88800-hareville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88231-88800-hareville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88231-88800-hareville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88232-88300-harmonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88232-88300-harmonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88232-88300-harmonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88232-88300-harmonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88233-88270-harol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88233-88270-harol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88233-88270-harol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88233-88270-harol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88236-88240-la_haye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88236-88240-la_haye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88236-88240-la_haye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88236-88240-la_haye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88237-88270-hennecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88237-88270-hennecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88237-88270-hennecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88237-88270-hennecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88238-88260-hennezel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88238-88260-hennezel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88238-88260-hennezel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88238-88260-hennezel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88239-88130-hergugney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88239-88130-hergugney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88239-88130-hergugney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88239-88130-hergugney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88240-88600-herpelmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88240-88600-herpelmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88240-88600-herpelmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88240-88600-herpelmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88241-88170-houecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88241-88170-houecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88241-88170-houecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88241-88170-houecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88242-88300-houeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88242-88300-houeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88242-88300-houeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88242-88300-houeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88243-88700-housseras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88243-88700-housseras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88243-88700-housseras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88243-88700-housseras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88244-88430-la_houssiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88244-88430-la_houssiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88244-88430-la_houssiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88244-88430-la_houssiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88245-88210-hurbache/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88245-88210-hurbache/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88245-88210-hurbache/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88245-88210-hurbache/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88246-88500-hymont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88246-88500-hymont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88246-88500-hymont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88246-88500-hymont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88247-88150-igney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88247-88150-igney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88247-88150-igney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88247-88150-igney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88248-88320-isches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88248-88320-isches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88248-88320-isches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88248-88320-isches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88249-88300-jainvillotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88249-88300-jainvillotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88249-88300-jainvillotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88249-88300-jainvillotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88250-88550-jarmenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88250-88550-jarmenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88250-88550-jarmenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88250-88550-jarmenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88251-88700-jeanmenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88251-88700-jeanmenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88251-88700-jeanmenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88251-88700-jeanmenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88252-88260-jesonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88252-88260-jesonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88252-88260-jesonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88252-88260-jesonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88253-88000-jeuxey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88253-88000-jeuxey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88253-88000-jeuxey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88253-88000-jeuxey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88254-88500-jorxey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88254-88500-jorxey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88254-88500-jorxey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88254-88500-jorxey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88255-88630-jubainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88255-88630-jubainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88255-88630-jubainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88255-88630-jubainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88256-88640-jussarupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88256-88640-jussarupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88256-88640-jussarupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88256-88640-jussarupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88257-88500-juvaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88257-88500-juvaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88257-88500-juvaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88257-88500-juvaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88258-88320-lamarche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88258-88320-lamarche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88258-88320-lamarche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88258-88320-lamarche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88259-88300-landaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88259-88300-landaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88259-88300-landaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88259-88300-landaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88260-88130-langley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88260-88130-langley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88260-88130-langley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88260-88130-langley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88261-88600-laval_sur_vologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88261-88600-laval_sur_vologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88261-88600-laval_sur_vologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88261-88600-laval_sur_vologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88262-88600-laveline_devant_bruyeres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88262-88600-laveline_devant_bruyeres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88262-88600-laveline_devant_bruyeres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88262-88600-laveline_devant_bruyeres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88263-88640-laveline_du_houx/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88263-88640-laveline_du_houx/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88263-88640-laveline_du_houx/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88263-88640-laveline_du_houx/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88264-88270-legeville_et_bonfays/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88264-88270-legeville_et_bonfays/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88264-88270-legeville_et_bonfays/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88264-88270-legeville_et_bonfays/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88265-88300-lemmecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88265-88300-lemmecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88265-88300-lemmecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88265-88300-lemmecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88266-88600-lepanges_sur_vologne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88266-88600-lepanges_sur_vologne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88266-88600-lepanges_sur_vologne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88266-88600-lepanges_sur_vologne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88267-88260-lerrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88267-88260-lerrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88267-88260-lerrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88267-88260-lerrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88268-88490-lesseux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88268-88490-lesseux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88268-88490-lesseux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88268-88490-lesseux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88269-88400-liezey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88269-88400-liezey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88269-88400-liezey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88269-88400-liezey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88270-88350-liffol_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88270-88350-liffol_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88270-88350-liffol_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88270-88350-liffol_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88271-88800-ligneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88271-88800-ligneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88271-88800-ligneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88271-88800-ligneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88272-88410-lironcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88272-88410-lironcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88272-88410-lironcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88272-88410-lironcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88273-88000-longchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88273-88000-longchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88273-88000-longchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88273-88000-longchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88274-88170-longchamp_sous_chatenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88274-88170-longchamp_sous_chatenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88274-88170-longchamp_sous_chatenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88274-88170-longchamp_sous_chatenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88275-88490-lubine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88275-88490-lubine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88275-88490-lubine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88275-88490-lubine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88276-88490-lusse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88276-88490-lusse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88276-88490-lusse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88276-88490-lusse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88277-88110-luvigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88277-88110-luvigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88277-88110-luvigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88277-88110-luvigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88278-88170-maconcourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88278-88170-maconcourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88278-88170-maconcourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88278-88170-maconcourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88279-88270-madecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88279-88270-madecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88279-88270-madecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88279-88270-madecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88280-88450-madegney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88280-88450-madegney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88280-88450-madegney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88280-88450-madegney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88281-88270-madonne_et_lamerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88281-88270-madonne_et_lamerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88281-88270-madonne_et_lamerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88281-88270-madonne_et_lamerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88283-88140-malaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88283-88140-malaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88283-88140-malaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88283-88140-malaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88284-88650-mandray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88284-88650-mandray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88284-88650-mandray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88284-88650-mandray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88285-88800-mandres_sur_vair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88285-88800-mandres_sur_vair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88285-88800-mandres_sur_vair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88285-88800-mandres_sur_vair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88286-88130-marainville_sur_madon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88286-88130-marainville_sur_madon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88286-88130-marainville_sur_madon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88286-88130-marainville_sur_madon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88287-88320-marey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88287-88320-marey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88287-88320-marey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88287-88320-marey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88288-88270-maroncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88288-88270-maroncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88288-88270-maroncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88288-88270-maroncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88289-88320-martigny_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88289-88320-martigny_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88289-88320-martigny_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88289-88320-martigny_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88290-88300-martigny_les_gerbonvaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88290-88300-martigny_les_gerbonvaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88290-88300-martigny_les_gerbonvaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88290-88300-martigny_les_gerbonvaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88291-88410-martinvelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88291-88410-martinvelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88291-88410-martinvelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88291-88410-martinvelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88292-88500-mattaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88292-88500-mattaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88292-88500-mattaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88292-88500-mattaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88293-88630-maxey_sur_meuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88293-88630-maxey_sur_meuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88293-88630-maxey_sur_meuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88293-88630-maxey_sur_meuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88294-88150-mazeley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88294-88150-mazeley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88294-88150-mazeley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88294-88150-mazeley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88295-88500-mazirot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88295-88500-mazirot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88295-88500-mazirot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88295-88500-mazirot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88296-88140-medonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88296-88140-medonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88296-88140-medonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88296-88140-medonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88297-88600-memenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88297-88600-memenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88297-88600-memenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88297-88600-memenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88298-88700-menarmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88298-88700-menarmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88298-88700-menarmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88298-88700-menarmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88299-88500-menil_en_xaintois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88299-88500-menil_en_xaintois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88299-88500-menil_en_xaintois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88299-88500-menil_en_xaintois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88300-88210-menil_de_senones/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88300-88210-menil_de_senones/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88300-88210-menil_de_senones/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88300-88210-menil_de_senones/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88301-88700-menil_sur_belvitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88301-88700-menil_sur_belvitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88301-88700-menil_sur_belvitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88301-88700-menil_sur_belvitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88302-88160-le_menil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88302-88160-le_menil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88302-88160-le_menil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88302-88160-le_menil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88303-88630-midrevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88303-88630-midrevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88303-88630-midrevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88303-88630-midrevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88304-88500-mirecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88304-88500-mirecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88304-88500-mirecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88304-88500-mirecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88305-88630-moncel_sur_vair/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88305-88630-moncel_sur_vair/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88305-88630-moncel_sur_vair/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88305-88630-moncel_sur_vair/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88306-88210-le_mont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88306-88210-le_mont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88306-88210-le_mont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88306-88210-le_mont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88307-88320-mont_les_lamarche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88307-88320-mont_les_lamarche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88307-88320-mont_les_lamarche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88307-88320-mont_les_lamarche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88308-88300-mont_les_neufchateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88308-88300-mont_les_neufchateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88308-88300-mont_les_neufchateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88308-88300-mont_les_neufchateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88309-88800-monthureux_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88309-88800-monthureux_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88309-88800-monthureux_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88309-88800-monthureux_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88310-88410-monthureux_sur_saone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88310-88410-monthureux_sur_saone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88310-88410-monthureux_sur_saone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88310-88410-monthureux_sur_saone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88311-88240-montmotier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88311-88240-montmotier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88311-88240-montmotier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88311-88240-montmotier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88312-88170-morelmaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88312-88170-morelmaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88312-88170-morelmaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88312-88170-morelmaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88313-88330-moriville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88313-88330-moriville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88313-88330-moriville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88313-88330-moriville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88314-88320-morizecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88314-88320-morizecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88314-88320-morizecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88314-88320-morizecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88315-88600-mortagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88315-88600-mortagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88315-88600-mortagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88315-88600-mortagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88316-88140-morville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88316-88140-morville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88316-88140-morville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88316-88140-morville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88317-88210-moussey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88317-88210-moussey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88317-88210-moussey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88317-88210-moussey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88318-88700-moyemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88318-88700-moyemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88318-88700-moyemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88318-88700-moyemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88319-88420-moyenmoutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88319-88420-moyenmoutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88319-88420-moyenmoutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88319-88420-moyenmoutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88320-88100-nayemont_les_fosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88320-88100-nayemont_les_fosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88320-88100-nayemont_les_fosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88320-88100-nayemont_les_fosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88321-88300-neufchateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88321-88300-neufchateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88321-88300-neufchateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88321-88300-neufchateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88322-88600-la_neuveville_devant_lepanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88322-88600-la_neuveville_devant_lepanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88322-88600-la_neuveville_devant_lepanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88322-88600-la_neuveville_devant_lepanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88324-88170-la_neuveville_sous_chatenois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88324-88170-la_neuveville_sous_chatenois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88324-88170-la_neuveville_sous_chatenois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88324-88170-la_neuveville_sous_chatenois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88325-88800-la_neuveville_sous_montfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88325-88800-la_neuveville_sous_montfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88325-88800-la_neuveville_sous_montfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88325-88800-la_neuveville_sous_montfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88326-88100-neuvillers_sur_fave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88326-88100-neuvillers_sur_fave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88326-88100-neuvillers_sur_fave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88326-88100-neuvillers_sur_fave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88327-88440-nomexy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88327-88440-nomexy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88327-88440-nomexy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88327-88440-nomexy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88328-88470-nompatelize/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88328-88470-nompatelize/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88328-88470-nompatelize/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88328-88470-nompatelize/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88330-88260-nonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88330-88260-nonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88330-88260-nonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88330-88260-nonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88331-88600-nonzeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88331-88600-nonzeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88331-88600-nonzeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88331-88600-nonzeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88332-88800-norroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88332-88800-norroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88332-88800-norroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88332-88800-norroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88333-88700-nossoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88333-88700-nossoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88333-88700-nossoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88333-88700-nossoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88334-88500-oelleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88334-88500-oelleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88334-88500-oelleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88334-88500-oelleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88335-88500-offroicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88335-88500-offroicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88335-88500-offroicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88335-88500-offroicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88336-88170-ollainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88336-88170-ollainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88336-88170-ollainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88336-88170-ollainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88338-88700-ortoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88338-88700-ortoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88338-88700-ortoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88338-88700-ortoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88340-88700-padoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88340-88700-padoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88340-88700-padoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88340-88700-padoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88341-88100-pair_et_grandrupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88341-88100-pair_et_grandrupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88341-88100-pair_et_grandrupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88341-88100-pair_et_grandrupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88342-88330-pallegney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88342-88330-pallegney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88342-88330-pallegney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88342-88330-pallegney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88343-88800-parey_sous_montfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88343-88800-parey_sous_montfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88343-88800-parey_sous_montfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88343-88800-parey_sous_montfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88344-88350-pargny_sous_mureau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88344-88350-pargny_sous_mureau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88344-88350-pargny_sous_mureau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88344-88350-pargny_sous_mureau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88345-88490-la_petite_fosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88345-88490-la_petite_fosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88345-88490-la_petite_fosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88345-88490-la_petite_fosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88346-88210-la_petite_raon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88346-88210-la_petite_raon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88346-88210-la_petite_raon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88346-88210-la_petite_raon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88347-88270-pierrefitte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88347-88270-pierrefitte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88347-88270-pierrefitte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88347-88270-pierrefitte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88348-88600-pierrepont_sur_l_arentele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88348-88600-pierrepont_sur_l_arentele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88348-88600-pierrepont_sur_l_arentele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88348-88600-pierrepont_sur_l_arentele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88349-88230-plainfaing/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88349-88230-plainfaing/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88349-88230-plainfaing/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88349-88230-plainfaing/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88350-88170-pleuvezain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88350-88170-pleuvezain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88350-88170-pleuvezain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88350-88170-pleuvezain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88351-88370-plombieres_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88351-88370-plombieres_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88351-88370-plombieres_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88351-88370-plombieres_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88352-88300-pompierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88352-88300-pompierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88352-88300-pompierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88352-88300-pompierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88353-88260-pont_les_bonfays/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88353-88260-pont_les_bonfays/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88353-88260-pont_les_bonfays/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88353-88260-pont_les_bonfays/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88354-88500-pont_sur_madon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88354-88500-pont_sur_madon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88354-88500-pont_sur_madon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88354-88500-pont_sur_madon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88355-88330-portieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88355-88330-portieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88355-88330-portieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88355-88330-portieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88356-88600-les_poulieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88356-88600-les_poulieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88356-88600-les_poulieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88356-88600-les_poulieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88357-88500-poussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88357-88500-poussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88357-88500-poussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88357-88500-poussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88358-88550-pouxeux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88358-88550-pouxeux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88358-88550-pouxeux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88358-88550-pouxeux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88359-88600-prey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88359-88600-prey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88359-88600-prey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88359-88600-prey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88360-88260-provencheres_les_darney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88360-88260-provencheres_les_darney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88360-88260-provencheres_les_darney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88360-88260-provencheres_les_darney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88361-88490-provencheres_et_colroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88361-88490-provencheres_et_colroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88361-88490-provencheres_et_colroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88361-88490-provencheres_et_colroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88362-88210-le_puid/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88362-88210-le_puid/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88362-88210-le_puid/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88362-88210-le_puid/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88363-88630-punerot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88363-88630-punerot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88363-88630-punerot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88363-88630-punerot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88364-88500-puzieux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88364-88500-puzieux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88364-88500-puzieux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88364-88500-puzieux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88365-88270-racecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88365-88270-racecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88365-88270-racecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88365-88270-racecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88366-88170-rainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88366-88170-rainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88366-88170-rainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88366-88170-rainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88367-88700-rambervillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88367-88700-rambervillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88367-88700-rambervillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88367-88700-rambervillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88368-88500-ramecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88368-88500-ramecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88368-88500-ramecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88368-88500-ramecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88369-88160-ramonchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88369-88160-ramonchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88369-88160-ramonchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88369-88160-ramonchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88370-88270-rancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88370-88270-rancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88370-88270-rancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88370-88270-rancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88371-88220-raon_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88371-88220-raon_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88371-88220-raon_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88371-88220-raon_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88372-88110-raon_l_etape/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88372-88110-raon_l_etape/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88372-88110-raon_l_etape/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88372-88110-raon_l_etape/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88373-88110-raon_sur_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88373-88110-raon_sur_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88373-88110-raon_sur_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88373-88110-raon_sur_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88374-88130-rapey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88374-88130-rapey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88374-88130-rapey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88374-88130-rapey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88375-88520-raves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88375-88520-raves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88375-88520-raves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88375-88520-raves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88376-88300-rebeuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88376-88300-rebeuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88376-88300-rebeuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88376-88300-rebeuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88377-88410-regnevelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88377-88410-regnevelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88377-88410-regnevelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88377-88410-regnevelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88378-88450-regney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88378-88450-regney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88378-88450-regney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88378-88450-regney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88379-88330-rehaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88379-88330-rehaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88379-88330-rehaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88379-88330-rehaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88380-88640-rehaupal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88380-88640-rehaupal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88380-88640-rehaupal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88380-88640-rehaupal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88381-88260-relanges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88381-88260-relanges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88381-88260-relanges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88381-88260-relanges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88382-88500-remicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88382-88500-remicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88382-88500-remicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88382-88500-remicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88383-88200-remiremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88383-88200-remiremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88383-88200-remiremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88383-88200-remiremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88385-88800-remoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88385-88800-remoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88385-88800-remoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88385-88800-remoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88386-88100-remomeix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88386-88100-remomeix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88386-88100-remomeix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88386-88100-remomeix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88387-88170-removille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88387-88170-removille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88387-88170-removille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88387-88170-removille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88388-88390-renauvoid/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88388-88390-renauvoid/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88388-88390-renauvoid/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88388-88390-renauvoid/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88389-88500-repel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88389-88500-repel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88389-88500-repel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88389-88500-repel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88390-88320-robecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88390-88320-robecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88390-88320-robecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88390-88320-robecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88391-88120-rochesson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88391-88120-rochesson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88391-88120-rochesson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88391-88120-rochesson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88393-88300-rollainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88393-88300-rollainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88393-88300-rollainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88393-88300-rollainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88394-88320-romain_aux_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88394-88320-romain_aux_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88394-88320-romain_aux_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88394-88320-romain_aux_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88395-88700-romont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88395-88700-romont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88395-88700-romont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88395-88700-romont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88398-88600-les_rouges_eaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88398-88600-les_rouges_eaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88398-88600-les_rouges_eaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88398-88600-les_rouges_eaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88399-88460-le_roulier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88399-88460-le_roulier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88399-88460-le_roulier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88399-88460-le_roulier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88400-88500-rouvres_en_xaintois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88400-88500-rouvres_en_xaintois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88400-88500-rouvres_en_xaintois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88400-88500-rouvres_en_xaintois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88401-88170-rouvres_la_chetive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88401-88170-rouvres_la_chetive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88401-88170-rouvres_la_chetive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88401-88170-rouvres_la_chetive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88402-88700-roville_aux_chenes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88402-88700-roville_aux_chenes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88402-88700-roville_aux_chenes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88402-88700-roville_aux_chenes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88403-88500-rozerotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88403-88500-rozerotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88403-88500-rozerotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88403-88500-rozerotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88404-88320-rozieres_sur_mouzon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88404-88320-rozieres_sur_mouzon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88404-88320-rozieres_sur_mouzon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88404-88320-rozieres_sur_mouzon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88406-88130-rugney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88406-88130-rugney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88406-88130-rugney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88406-88130-rugney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88407-88630-ruppes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88407-88630-ruppes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88407-88630-ruppes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88407-88630-ruppes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88408-88360-rupt_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88408-88360-rupt_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88408-88360-rupt_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88408-88360-rupt_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88409-88120-saint_ame/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88409-88120-saint_ame/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88409-88120-saint_ame/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88409-88120-saint_ame/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88410-88700-sainte_barbe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88410-88700-sainte_barbe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88410-88700-sainte_barbe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88410-88700-sainte_barbe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88411-88260-saint_baslemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88411-88260-saint_baslemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88411-88260-saint_baslemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88411-88260-saint_baslemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88412-88700-saint_benoit_la_chipotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88412-88700-saint_benoit_la_chipotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88412-88700-saint_benoit_la_chipotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88412-88700-saint_benoit_la_chipotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88413-88100-saint_die_des_vosges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88413-88100-saint_die_des_vosges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88413-88100-saint_die_des_vosges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88413-88100-saint_die_des_vosges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88415-88200-saint_etienne_les_remiremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88415-88200-saint_etienne_les_remiremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88415-88200-saint_etienne_les_remiremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88415-88200-saint_etienne_les_remiremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88416-88700-saint_genest/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88416-88700-saint_genest/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88416-88700-saint_genest/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88416-88700-saint_genest/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88417-88700-saint_gorgon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88417-88700-saint_gorgon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88417-88700-saint_gorgon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88417-88700-saint_gorgon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88418-88700-sainte_helene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88418-88700-sainte_helene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88418-88700-sainte_helene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88418-88700-sainte_helene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88419-88210-saint_jean_d_ormont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88419-88210-saint_jean_d_ormont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88419-88210-saint_jean_d_ormont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88419-88210-saint_jean_d_ormont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88421-88410-saint_julien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88421-88410-saint_julien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88421-88410-saint_julien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88421-88410-saint_julien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88423-88650-saint_leonard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88423-88650-saint_leonard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88423-88650-saint_leonard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88423-88650-saint_leonard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88424-88100-sainte_marguerite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88424-88100-sainte_marguerite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88424-88100-sainte_marguerite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88424-88100-sainte_marguerite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88425-88700-saint_maurice_sur_mortagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88425-88700-saint_maurice_sur_mortagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88425-88700-saint_maurice_sur_mortagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88425-88700-saint_maurice_sur_mortagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88426-88560-saint_maurice_sur_moselle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88426-88560-saint_maurice_sur_moselle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88426-88560-saint_maurice_sur_moselle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88426-88560-saint_maurice_sur_moselle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88427-88170-saint_menge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88427-88170-saint_menge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88427-88170-saint_menge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88427-88170-saint_menge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88428-88470-saint_michel_sur_meurthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88428-88470-saint_michel_sur_meurthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88428-88470-saint_michel_sur_meurthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88428-88470-saint_michel_sur_meurthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88429-88200-saint_nabord/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88429-88200-saint_nabord/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88429-88200-saint_nabord/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88429-88200-saint_nabord/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88430-88140-saint_ouen_les_parey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88430-88140-saint_ouen_les_parey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88430-88140-saint_ouen_les_parey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88430-88140-saint_ouen_les_parey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88431-88170-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88431-88170-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88431-88170-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88431-88170-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88432-88700-saint_pierremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88432-88700-saint_pierremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88432-88700-saint_pierremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88432-88700-saint_pierremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88433-88500-saint_prancher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88433-88500-saint_prancher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88433-88500-saint_prancher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88433-88500-saint_prancher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88434-88800-saint_remimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88434-88800-saint_remimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88434-88800-saint_remimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88434-88800-saint_remimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88435-88480-saint_remy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88435-88480-saint_remy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88435-88480-saint_remy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88435-88480-saint_remy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88436-88210-saint_stail/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88436-88210-saint_stail/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88436-88210-saint_stail/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88436-88210-saint_stail/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88437-88270-saint_vallier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88437-88270-saint_vallier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88437-88270-saint_vallier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88437-88270-saint_vallier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88438-88470-la_salle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88438-88470-la_salle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88438-88470-la_salle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88438-88470-la_salle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88439-88390-sanchey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88439-88390-sanchey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88439-88390-sanchey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88439-88390-sanchey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88440-88170-sandaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88440-88170-sandaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88440-88170-sandaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88440-88170-sandaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88441-88260-sans_vallois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88441-88260-sans_vallois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88441-88260-sans_vallois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88441-88260-sans_vallois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88442-88120-sapois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88442-88120-sapois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88442-88120-sapois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88442-88120-sapois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88443-88300-sartes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88443-88300-sartes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88443-88300-sartes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88443-88300-sartes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88444-88210-le_saulcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88444-88210-le_saulcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88444-88210-le_saulcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88444-88210-le_saulcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88445-88580-saulcy_sur_meurthe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88445-88580-saulcy_sur_meurthe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88445-88580-saulcy_sur_meurthe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88445-88580-saulcy_sur_meurthe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88446-88140-saulxures_les_bulgneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88446-88140-saulxures_les_bulgneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88446-88140-saulxures_les_bulgneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88446-88140-saulxures_les_bulgneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88447-88290-saulxures_sur_moselotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88447-88290-saulxures_sur_moselotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88447-88290-saulxures_sur_moselotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88447-88290-saulxures_sur_moselotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88448-88140-sauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88448-88140-sauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88448-88140-sauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88448-88140-sauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88449-88130-savigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88449-88130-savigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88449-88130-savigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88449-88130-savigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88450-88320-senaide/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88450-88320-senaide/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88450-88320-senaide/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88450-88320-senaide/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88451-88210-senones/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88451-88210-senones/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88451-88210-senones/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88451-88210-senones/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88452-88260-senonges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88452-88260-senonges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88452-88260-senonges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88452-88260-senonges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88453-88630-seraumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88453-88630-seraumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88453-88630-seraumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88453-88630-seraumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88454-88600-sercoeur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88454-88600-sercoeur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88454-88600-sercoeur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88454-88600-sercoeur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88455-88320-serecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88455-88320-serecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88455-88320-serecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88455-88320-serecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88456-88320-serocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88456-88320-serocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88456-88320-serocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88456-88320-serocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88457-88630-sionne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88457-88630-sionne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88457-88630-sionne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88457-88630-sionne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88458-88130-socourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88458-88130-socourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88458-88130-socourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88458-88130-socourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88459-88170-soncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88459-88170-soncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88459-88170-soncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88459-88170-soncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88460-88630-soulosse_sous_saint_elophe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88460-88630-soulosse_sous_saint_elophe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88460-88630-soulosse_sous_saint_elophe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88460-88630-soulosse_sous_saint_elophe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88461-88140-suriauville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88461-88140-suriauville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88461-88140-suriauville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88461-88140-suriauville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88462-88120-le_syndicat/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88462-88120-le_syndicat/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88462-88120-le_syndicat/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88462-88120-le_syndicat/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88463-88100-taintrux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88463-88100-taintrux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88463-88100-taintrux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88463-88100-taintrux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88464-88460-tendon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88464-88460-tendon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88464-88460-tendon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88464-88460-tendon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88465-88150-capavenir_vosges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88465-88150-capavenir_vosges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88465-88150-capavenir_vosges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88465-88150-capavenir_vosges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88466-88800-they_sous_montfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88466-88800-they_sous_montfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88466-88800-they_sous_montfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88466-88800-they_sous_montfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88467-88290-thiefosse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88467-88290-thiefosse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88467-88290-thiefosse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88467-88290-thiefosse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88468-88160-le_thillot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88468-88160-le_thillot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88468-88160-le_thillot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88468-88160-le_thillot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88469-88500-thiraucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88469-88500-thiraucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88469-88500-thiraucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88469-88500-thiraucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88470-88530-le_tholy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88470-88530-le_tholy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88470-88530-le_tholy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88470-88530-le_tholy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88471-88410-les_thons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88471-88410-les_thons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88471-88410-les_thons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88471-88410-les_thons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88472-88260-thuillieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88472-88260-thuillieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88472-88260-thuillieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88472-88260-thuillieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88473-88320-tignecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88473-88320-tignecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88473-88320-tignecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88473-88320-tignecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88474-88300-tilleux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88474-88300-tilleux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88474-88300-tilleux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88474-88300-tilleux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88475-88320-tollaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88475-88320-tollaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88475-88320-tollaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88475-88320-tollaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88476-88500-totainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88476-88500-totainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88476-88500-totainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88476-88500-totainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88477-88350-trampot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88477-88350-trampot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88477-88350-trampot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88477-88350-trampot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88478-88300-tranqueville_graux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88478-88300-tranqueville_graux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88478-88300-tranqueville_graux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88478-88300-tranqueville_graux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88479-88240-tremonzey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88479-88240-tremonzey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88479-88240-tremonzey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88479-88240-tremonzey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88480-88130-ubexy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88480-88130-ubexy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88480-88130-ubexy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88480-88130-ubexy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88481-88220-urimenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88481-88220-urimenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88481-88220-urimenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88481-88220-urimenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88482-88140-urville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88482-88140-urville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88482-88140-urville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88482-88140-urville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88483-88390-uxegney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88483-88390-uxegney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88483-88390-uxegney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88483-88390-uxegney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88484-88220-uzemain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88484-88220-uzemain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88484-88220-uzemain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88484-88220-uzemain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88485-88140-la_vacheresse_et_la_rouillie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88485-88140-la_vacheresse_et_la_rouillie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88485-88140-la_vacheresse_et_la_rouillie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88485-88140-la_vacheresse_et_la_rouillie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88486-88120-vagney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88486-88120-vagney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88486-88120-vagney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88486-88120-vagney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88487-88340-le_val_d_ajol/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88487-88340-le_val_d_ajol/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88487-88340-le_val_d_ajol/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88487-88340-le_val_d_ajol/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88488-88270-valfroicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88488-88270-valfroicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88488-88270-valfroicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88488-88270-valfroicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88489-88270-valleroy_aux_saules/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88489-88270-valleroy_aux_saules/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88489-88270-valleroy_aux_saules/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88489-88270-valleroy_aux_saules/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88490-88800-valleroy_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88490-88800-valleroy_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88490-88800-valleroy_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88490-88800-valleroy_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88491-88260-les_vallois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88491-88260-les_vallois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88491-88260-les_vallois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88491-88260-les_vallois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88492-88230-le_valtin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88492-88230-le_valtin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88492-88230-le_valtin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88492-88230-le_valtin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88492-88400-le_valtin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88492-88400-le_valtin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88492-88400-le_valtin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88492-88400-le_valtin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88493-88450-varmonzey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88493-88450-varmonzey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88493-88450-varmonzey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88493-88450-varmonzey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88494-88500-vaubexy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88494-88500-vaubexy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88494-88500-vaubexy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88494-88500-vaubexy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88495-88000-vaudeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88495-88000-vaudeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88495-88000-vaudeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88495-88000-vaudeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88496-88140-vaudoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88496-88140-vaudoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88496-88140-vaudoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88496-88140-vaudoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88497-88330-vaxoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88497-88330-vaxoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88497-88330-vaxoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88497-88330-vaxoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88498-88200-vecoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88498-88200-vecoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88498-88200-vecoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88498-88200-vecoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88499-88270-velotte_et_tatignecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88499-88270-velotte_et_tatignecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88499-88270-velotte_et_tatignecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88499-88270-velotte_et_tatignecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88500-88310-ventron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88500-88310-ventron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88500-88310-ventron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88500-88310-ventron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88501-88210-le_vermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88501-88210-le_vermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88501-88210-le_vermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88501-88210-le_vermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88502-88600-vervezelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88502-88600-vervezelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88502-88600-vervezelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88502-88600-vervezelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88503-88110-vexaincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88503-88110-vexaincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88503-88110-vexaincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88503-88110-vexaincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88504-88170-vicherey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88504-88170-vicherey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88504-88170-vicherey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88504-88170-vicherey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88505-88430-vienville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88505-88430-vienville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88505-88430-vienville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88505-88430-vienville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88506-88210-vieux_moulin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88506-88210-vieux_moulin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88506-88210-vieux_moulin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88506-88210-vieux_moulin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88507-88500-villers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88507-88500-villers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88507-88500-villers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88507-88500-villers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88508-88270-ville_sur_illon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88508-88270-ville_sur_illon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88508-88270-ville_sur_illon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88508-88270-ville_sur_illon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88509-88150-villoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88509-88150-villoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88509-88150-villoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88509-88150-villoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88510-88320-villotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88510-88320-villotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88510-88320-villotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88510-88320-villotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88511-88350-villouxel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88511-88350-villouxel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88511-88350-villouxel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88511-88350-villouxel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88512-88600-vimenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88512-88600-vimenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88512-88600-vimenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88512-88600-vimenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88513-88450-vincey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88513-88450-vincey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88513-88450-vincey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88513-88450-vincey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88514-88170-viocourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88514-88170-viocourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88514-88170-viocourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88514-88170-viocourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88515-88260-viomenil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88515-88260-viomenil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88515-88260-viomenil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88515-88260-viomenil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88516-88800-vittel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88516-88800-vittel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88516-88800-vittel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88516-88800-vittel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88517-88260-viviers_le_gras/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88517-88260-viviers_le_gras/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88517-88260-viviers_le_gras/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88517-88260-viviers_le_gras/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88518-88500-viviers_les_offroicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88518-88500-viviers_les_offroicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88518-88500-viviers_les_offroicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88518-88500-viviers_les_offroicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88519-88470-la_voivre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88519-88470-la_voivre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88519-88470-la_voivre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88519-88470-la_voivre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88520-88240-les_voivres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88520-88240-les_voivres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88520-88240-les_voivres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88520-88240-les_voivres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88521-88700-vomecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88521-88700-vomecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88521-88700-vomecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88521-88700-vomecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88522-88500-vomecourt_sur_madon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88522-88500-vomecourt_sur_madon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88522-88500-vomecourt_sur_madon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88522-88500-vomecourt_sur_madon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88523-88170-vouxey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88523-88170-vouxey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88523-88170-vouxey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88523-88170-vouxey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88524-88140-vrecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88524-88140-vrecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88524-88140-vrecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88524-88140-vrecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88525-88500-vroville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88525-88500-vroville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88525-88500-vroville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88525-88500-vroville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88526-88520-wisembach/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88526-88520-wisembach/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88526-88520-wisembach/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88526-88520-wisembach/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88527-88700-xaffevillers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88527-88700-xaffevillers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88527-88700-xaffevillers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88527-88700-xaffevillers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88528-88460-xamontarupt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88528-88460-xamontarupt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88528-88460-xamontarupt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88528-88460-xamontarupt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88529-88130-xaronval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88529-88130-xaronval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88529-88130-xaronval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88529-88130-xaronval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88530-88220-xertigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88530-88220-xertigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88530-88220-xertigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88530-88220-xertigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88531-88400-xonrupt_longemer/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88531-88400-xonrupt_longemer/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88531-88400-xonrupt_longemer/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88531-88400-xonrupt_longemer/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88532-88330-zincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88532-88330-zincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88532-88330-zincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt88-vosges/commune88532-88330-zincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-89.xml
+++ b/public/sitemaps/sitemap-89.xml
@@ -5,858 +5,1712 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89002-89800-aigremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89002-89800-aigremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89002-89800-aigremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89002-89800-aigremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89003-89710-montholon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89003-89710-montholon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89003-89710-montholon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89003-89710-montholon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89003-89110-montholon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89003-89110-montholon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89003-89110-montholon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89003-89110-montholon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89004-89390-aisy_sur_armancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89004-89390-aisy_sur_armancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89004-89390-aisy_sur_armancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89004-89390-aisy_sur_armancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89005-89160-ancy_le_franc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89005-89160-ancy_le_franc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89005-89160-ancy_le_franc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89005-89160-ancy_le_franc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89006-89160-ancy_le_libre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89006-89160-ancy_le_libre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89006-89160-ancy_le_libre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89006-89160-ancy_le_libre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89007-89480-andryes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89007-89480-andryes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89007-89480-andryes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89007-89480-andryes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89008-89440-angely/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89008-89440-angely/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89008-89440-angely/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89008-89440-angely/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89009-89200-annay_la_cote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89009-89200-annay_la_cote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89009-89200-annay_la_cote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89009-89200-annay_la_cote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89010-89310-annay_sur_serein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89010-89310-annay_sur_serein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89010-89310-annay_sur_serein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89010-89310-annay_sur_serein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89011-89200-anneot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89011-89200-anneot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89011-89200-anneot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89011-89200-anneot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89012-89440-annoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89012-89440-annoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89012-89440-annoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89012-89440-annoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89013-89380-appoigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89013-89380-appoigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89013-89380-appoigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89013-89380-appoigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89014-89320-arces_dilo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89014-89320-arces_dilo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89014-89320-arces_dilo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89014-89320-arces_dilo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89015-89270-arcy_sur_cure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89015-89270-arcy_sur_cure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89015-89270-arcy_sur_cure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89015-89270-arcy_sur_cure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89016-89160-argentenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89016-89160-argentenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89016-89160-argentenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89016-89160-argentenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89017-89160-argenteuil_sur_armancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89017-89160-argenteuil_sur_armancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89017-89160-argenteuil_sur_armancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89017-89160-argenteuil_sur_armancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89018-89500-armeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89018-89500-armeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89018-89500-armeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89018-89500-armeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89019-89740-arthonnay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89019-89740-arthonnay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89019-89740-arthonnay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89019-89740-arthonnay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89020-89660-asnieres_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89020-89660-asnieres_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89020-89660-asnieres_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89020-89660-asnieres_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89021-89450-asquins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89021-89450-asquins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89021-89450-asquins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89021-89450-asquins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89022-89440-athie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89022-89440-athie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89022-89440-athie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89022-89440-athie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89023-89290-augy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89023-89290-augy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89023-89290-augy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89023-89290-augy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89024-89000-auxerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89024-89000-auxerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89024-89000-auxerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89024-89000-auxerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89025-89200-avallon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89025-89200-avallon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89025-89200-avallon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89025-89200-avallon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89027-89190-bagneaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89027-89190-bagneaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89027-89190-bagneaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89027-89190-bagneaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89028-89430-baon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89028-89430-baon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89028-89430-baon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89028-89430-baon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89029-89400-bassou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89029-89400-bassou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89029-89400-bassou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89029-89400-bassou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89030-89460-bazarnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89030-89460-bazarnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89030-89460-bazarnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89030-89460-bazarnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89031-89250-beaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89031-89250-beaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89031-89250-beaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89031-89250-beaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89032-89630-beauvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89032-89630-beauvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89032-89630-beauvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89032-89630-beauvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89033-89240-beauvoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89033-89240-beauvoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89033-89240-beauvoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89033-89240-beauvoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89034-89800-beine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89034-89800-beine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89034-89800-beine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89034-89800-beine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89035-89210-bellechaume/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89035-89210-bellechaume/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89035-89210-bellechaume/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89035-89210-bellechaume/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89036-89150-la_belliole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89036-89150-la_belliole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89036-89150-la_belliole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89036-89150-la_belliole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89037-89410-beon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89037-89410-beon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89037-89410-beon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89037-89410-beon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89038-89360-bernouil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89038-89360-bernouil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89038-89360-bernouil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89038-89360-bernouil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89039-89700-beru/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89039-89700-beru/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89039-89700-beru/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89039-89700-beru/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89040-89270-bessy_sur_cure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89040-89270-bessy_sur_cure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89040-89270-bessy_sur_cure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89040-89270-bessy_sur_cure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89041-89570-beugnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89041-89570-beugnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89041-89570-beugnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89041-89570-beugnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89042-89420-bierry_les_belles_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89042-89420-bierry_les_belles_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89042-89420-bierry_les_belles_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89042-89420-bierry_les_belles_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89043-89440-blacy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89043-89440-blacy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89043-89440-blacy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89043-89440-blacy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89044-89200-blannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89044-89200-blannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89044-89200-blannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89044-89200-blannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89045-89230-bleigny_le_carreau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89045-89230-bleigny_le_carreau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89045-89230-bleigny_le_carreau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89045-89230-bleigny_le_carreau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89046-89220-bleneau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89046-89220-bleneau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89046-89220-bleneau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89046-89220-bleneau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89048-89770-boeurs_en_othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89048-89770-boeurs_en_othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89048-89770-boeurs_en_othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89048-89770-boeurs_en_othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89049-89660-bois_d_arcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89049-89660-bois_d_arcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89049-89660-bois_d_arcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89049-89660-bois_d_arcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89050-89400-bonnard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89050-89400-bonnard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89050-89400-bonnard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89050-89400-bonnard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89051-89500-les_bordes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89051-89500-les_bordes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89051-89500-les_bordes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89051-89500-les_bordes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89053-89113-branches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89053-89113-branches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89053-89113-branches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89053-89113-branches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89054-89150-brannay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89054-89150-brannay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89054-89150-brannay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89054-89150-brannay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89055-89210-brienon_sur_armancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89055-89210-brienon_sur_armancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89055-89210-brienon_sur_armancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89055-89210-brienon_sur_armancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89056-89400-brion/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89056-89400-brion/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89056-89400-brion/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89056-89400-brion/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89057-89660-brosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89057-89660-brosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89057-89660-brosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89057-89660-brosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89058-89630-bussieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89058-89630-bussieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89058-89630-bussieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89058-89630-bussieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89059-89400-bussy_en_othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89059-89400-bussy_en_othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89059-89400-bussy_en_othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89059-89400-bussy_en_othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89060-89500-bussy_le_repos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89060-89500-bussy_le_repos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89060-89500-bussy_le_repos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89060-89500-bussy_le_repos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89061-89360-butteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89061-89360-butteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89061-89360-butteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89061-89360-butteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89062-89360-carisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89062-89360-carisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89062-89360-carisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89062-89360-carisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89063-89116-la_celle_saint_cyr/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89063-89116-la_celle_saint_cyr/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89063-89116-la_celle_saint_cyr/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89063-89116-la_celle_saint_cyr/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89064-89310-censy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89064-89310-censy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89064-89310-censy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89064-89310-censy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89065-89320-cerilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89065-89320-cerilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89065-89320-cerilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89065-89320-cerilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89066-89320-cerisiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89066-89320-cerisiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89066-89320-cerisiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89066-89320-cerisiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89067-89410-cezy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89067-89410-cezy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89067-89410-cezy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89067-89410-cezy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89068-89800-chablis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89068-89800-chablis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89068-89800-chablis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89068-89800-chablis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89069-89770-chailley/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89069-89770-chailley/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89069-89770-chailley/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89069-89770-chailley/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89071-89660-chamoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89071-89660-chamoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89071-89660-chamoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89071-89660-chamoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89072-89220-champcevrais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89072-89220-champcevrais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89072-89220-champcevrais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89072-89220-champcevrais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89073-89350-champignelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89073-89350-champignelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89073-89350-champignelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89073-89350-champignelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89074-89340-champigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89074-89340-champigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89074-89340-champigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89074-89340-champigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89075-89300-champlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89075-89300-champlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89075-89300-champlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89075-89300-champlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89076-89210-champlost/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89076-89210-champlost/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89076-89210-champlost/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89076-89210-champlost/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89077-89290-champs_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89077-89290-champs_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89077-89290-champs_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89077-89290-champs_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89079-89300-chamvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89079-89300-chamvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89079-89300-chamvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89079-89300-chamvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89080-89260-la_chapelle_sur_oreuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89080-89260-la_chapelle_sur_oreuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89080-89260-la_chapelle_sur_oreuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89080-89260-la_chapelle_sur_oreuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89081-89800-la_chapelle_vaupelteigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89081-89800-la_chapelle_vaupelteigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89081-89800-la_chapelle_vaupelteigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89081-89800-la_chapelle_vaupelteigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89083-89113-charbuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89083-89113-charbuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89083-89113-charbuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89083-89113-charbuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89084-89580-charentenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89084-89580-charentenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89084-89580-charentenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89084-89580-charentenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89085-89400-charmoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89085-89400-charmoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89085-89400-charmoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89085-89400-charmoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89086-89120-charny_oree_de_puisaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89086-89120-charny_oree_de_puisaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89086-89120-charny_oree_de_puisaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89086-89120-charny_oree_de_puisaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89087-89160-chassignelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89087-89160-chassignelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89087-89160-chassignelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89087-89160-chassignelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89088-89110-chassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89088-89110-chassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89088-89110-chassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89088-89110-chassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89089-89630-chastellux_sur_cure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89089-89630-chastellux_sur_cure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89089-89630-chastellux_sur_cure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89089-89630-chastellux_sur_cure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89091-89660-chatel_censoir/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89091-89660-chatel_censoir/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89091-89660-chatel_censoir/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89091-89660-chatel_censoir/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89092-89310-chatel_gerard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89092-89310-chatel_gerard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89092-89310-chatel_gerard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89092-89310-chatel_gerard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89093-89340-chaumont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89093-89340-chaumont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89093-89340-chaumont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89093-89340-chaumont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89094-89500-chaumot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89094-89500-chaumot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89094-89500-chaumot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89094-89500-chaumot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89095-89800-chemilly_sur_serein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89095-89800-chemilly_sur_serein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89095-89800-chemilly_sur_serein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89095-89800-chemilly_sur_serein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89096-89250-chemilly_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89096-89250-chemilly_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89096-89250-chemilly_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89096-89250-chemilly_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89098-89700-cheney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89098-89700-cheney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89098-89700-cheney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89098-89700-cheney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89099-89400-cheny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89099-89400-cheny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89099-89400-cheny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89099-89400-cheny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89100-89690-cheroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89100-89690-cheroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89100-89690-cheroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89100-89690-cheroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89101-89600-cheu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89101-89600-cheu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89101-89600-cheu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89101-89600-cheu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89102-89240-chevannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89102-89240-chevannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89102-89240-chevannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89102-89240-chevannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89104-89800-chichee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89104-89800-chichee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89104-89800-chichee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89104-89800-chichee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89105-89400-chichery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89105-89400-chichery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89105-89400-chichery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89105-89400-chichery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89108-89530-chitry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89108-89530-chitry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89108-89530-chitry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89108-89530-chitry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89111-89190-les_clerimois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89111-89190-les_clerimois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89111-89190-les_clerimois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89111-89190-les_clerimois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89112-89700-collan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89112-89700-collan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89112-89700-collan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89112-89700-collan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89113-89100-collemiers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89113-89100-collemiers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89113-89100-collemiers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89113-89100-collemiers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89115-89140-compigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89115-89140-compigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89115-89140-compigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89115-89140-compigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89116-89500-cornant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89116-89500-cornant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89116-89500-cornant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89116-89500-cornant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89117-89580-coulangeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89117-89580-coulangeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89117-89580-coulangeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89117-89580-coulangeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89118-89580-coulanges_la_vineuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89118-89580-coulanges_la_vineuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89118-89580-coulanges_la_vineuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89118-89580-coulanges_la_vineuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89119-89480-coulanges_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89119-89480-coulanges_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89119-89480-coulanges_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89119-89480-coulanges_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89120-89320-coulours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89120-89320-coulours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89120-89320-coulours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89120-89320-coulours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89122-89190-courgenay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89122-89190-courgenay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89122-89190-courgenay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89122-89190-courgenay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89123-89800-courgis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89123-89800-courgis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89123-89800-courgis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89123-89800-courgis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89124-89140-courlon_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89124-89140-courlon_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89124-89140-courlon_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89124-89140-courlon_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89125-89560-courson_les_carrieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89125-89560-courson_les_carrieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89125-89560-courson_les_carrieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89125-89560-courson_les_carrieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89126-89150-courtoin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89126-89150-courtoin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89126-89150-courtoin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89126-89150-courtoin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89127-89100-courtois_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89127-89100-courtois_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89127-89100-courtois_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89127-89100-courtois_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89128-89440-coutarnoux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89128-89440-coutarnoux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89128-89440-coutarnoux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89128-89440-coutarnoux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89129-89480-crain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89129-89480-crain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89129-89480-crain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89129-89480-crain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89130-89460-deux_rivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89130-89460-deux_rivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89130-89460-deux_rivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89130-89460-deux_rivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89131-89740-cruzy_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89131-89740-cruzy_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89131-89740-cruzy_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89131-89740-cruzy_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89132-89390-cry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89132-89390-cry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89132-89390-cry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89132-89390-cry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89133-89116-cudot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89133-89116-cudot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89133-89116-cudot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89133-89116-cudot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89134-89420-cussy_les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89134-89420-cussy_les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89134-89420-cussy_les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89134-89420-cussy_les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89136-89140-cuy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89136-89140-cuy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89136-89140-cuy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89136-89140-cuy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89137-89700-dannemoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89137-89700-dannemoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89137-89700-dannemoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89137-89700-dannemoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89139-89240-diges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89139-89240-diges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89139-89240-diges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89139-89240-diges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89141-89440-dissangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89141-89440-dissangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89141-89440-dissangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89141-89440-dissangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89142-89500-dixmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89142-89500-dixmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89142-89500-dixmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89142-89500-dixmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89143-89150-dollot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89143-89150-dollot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89143-89150-dollot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89143-89150-dollot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89144-89150-domats/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89144-89150-domats/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89144-89150-domats/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89144-89150-domats/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89145-89450-domecy_sur_cure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89145-89450-domecy_sur_cure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89145-89450-domecy_sur_cure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89145-89450-domecy_sur_cure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89146-89200-domecy_sur_le_vault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89146-89200-domecy_sur_le_vault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89146-89200-domecy_sur_le_vault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89146-89200-domecy_sur_le_vault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89147-89130-dracy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89147-89130-dracy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89147-89130-dracy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89147-89130-dracy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89148-89560-druyes_les_belles_fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89148-89560-druyes_les_belles_fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89148-89560-druyes_les_belles_fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89148-89560-druyes_les_belles_fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89149-89360-dye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89149-89360-dye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89149-89360-dye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89149-89360-dye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89150-89240-egleny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89150-89240-egleny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89150-89240-egleny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89150-89240-egleny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89151-89500-egriselles_le_bocage/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89151-89500-egriselles_le_bocage/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89151-89500-egriselles_le_bocage/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89151-89500-egriselles_le_bocage/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89152-89400-epineau_les_voves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89152-89400-epineau_les_voves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89152-89400-epineau_les_voves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89152-89400-epineau_les_voves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89153-89700-epineuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89153-89700-epineuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89153-89700-epineuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89153-89700-epineuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89154-89240-escamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89154-89240-escamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89154-89240-escamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89154-89240-escamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89155-89290-escolives_sainte_camille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89155-89290-escolives_sainte_camille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89155-89290-escolives_sainte_camille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89155-89290-escolives_sainte_camille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89156-89210-esnon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89156-89210-esnon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89156-89210-esnon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89156-89210-esnon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89158-89480-etais_la_sauvin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89158-89480-etais_la_sauvin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89158-89480-etais_la_sauvin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89158-89480-etais_la_sauvin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89159-89200-etaule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89159-89200-etaule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89159-89200-etaule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89159-89200-etaule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89160-89510-etigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89160-89510-etigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89160-89510-etigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89160-89510-etigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89161-89310-etivey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89161-89310-etivey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89161-89310-etivey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89161-89310-etivey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89162-89140-evry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89162-89140-evry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89162-89140-evry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89162-89140-evry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89163-89110-la_ferte_loupiere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89163-89110-la_ferte_loupiere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89163-89110-la_ferte_loupiere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89163-89110-la_ferte_loupiere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89164-89480-festigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89164-89480-festigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89164-89480-festigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89164-89480-festigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89165-89190-flacy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89165-89190-flacy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89165-89190-flacy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89165-89190-flacy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89167-89113-fleury_la_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89167-89113-fleury_la_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89167-89113-fleury_la_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89167-89113-fleury_la_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89168-89800-fleys/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89168-89800-fleys/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89168-89800-fleys/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89168-89800-fleys/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89169-89360-flogny_la_chapelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89169-89360-flogny_la_chapelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89169-89360-flogny_la_chapelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89169-89360-flogny_la_chapelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89170-89450-foissy_les_vezelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89170-89450-foissy_les_vezelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89170-89450-foissy_les_vezelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89170-89450-foissy_les_vezelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89171-89190-foissy_sur_vanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89171-89190-foissy_sur_vanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89171-89190-foissy_sur_vanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89171-89190-foissy_sur_vanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89172-89100-fontaine_la_gaillarde/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89172-89100-fontaine_la_gaillarde/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89172-89100-fontaine_la_gaillarde/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89172-89100-fontaine_la_gaillarde/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89173-89130-fontaines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89173-89130-fontaines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89173-89130-fontaines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89173-89130-fontaines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89175-89800-fontenay_pres_chablis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89175-89800-fontenay_pres_chablis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89175-89800-fontenay_pres_chablis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89175-89800-fontenay_pres_chablis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89176-89450-fontenay_pres_vezelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89176-89450-fontenay_pres_vezelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89176-89450-fontenay_pres_vezelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89176-89450-fontenay_pres_vezelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89177-89660-fontenay_sous_fouronnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89177-89660-fontenay_sous_fouronnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89177-89660-fontenay_sous_fouronnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89177-89660-fontenay_sous_fouronnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89179-89520-fontenoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89179-89520-fontenoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89179-89520-fontenoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89179-89520-fontenoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89180-89150-foucheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89180-89150-foucheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89180-89150-foucheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89180-89150-foucheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89181-89320-fournaudin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89181-89320-fournaudin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89181-89320-fournaudin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89181-89320-fournaudin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89182-89560-fouronnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89182-89560-fouronnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89182-89560-fouronnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89182-89560-fouronnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89183-89310-fresnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89183-89310-fresnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89183-89310-fresnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89183-89310-fresnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89184-89160-fulvy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89184-89160-fulvy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89184-89160-fulvy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89184-89160-fulvy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89186-89600-germigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89186-89600-germigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89186-89600-germigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89186-89600-germigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89187-89160-gigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89187-89160-gigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89187-89160-gigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89187-89160-gigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89188-89200-girolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89188-89200-girolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89188-89200-girolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89188-89200-girolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89189-89140-gisy_les_nobles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89189-89140-gisy_les_nobles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89189-89140-gisy_les_nobles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89189-89140-gisy_les_nobles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89190-89200-givry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89190-89200-givry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89190-89200-givry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89190-89200-givry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89191-89740-gland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89191-89740-gland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89191-89740-gland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89191-89740-gland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89194-89310-grimault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89194-89310-grimault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89194-89310-grimault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89194-89310-grimault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89195-89100-gron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89195-89100-gron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89195-89100-gron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89195-89100-gron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89196-89110-valravillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89196-89110-valravillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89196-89110-valravillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89196-89110-valravillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89196-89113-valravillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89196-89113-valravillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89196-89113-valravillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89196-89113-valravillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89197-89420-guillon_terre_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89197-89420-guillon_terre_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89197-89420-guillon_terre_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89197-89420-guillon_terre_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89198-89250-gurgy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89198-89250-gurgy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89198-89250-gurgy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89198-89250-gurgy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89199-89580-gy_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89199-89580-gy_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89199-89580-gy_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89199-89580-gy_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89200-89250-hauterive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89200-89250-hauterive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89200-89250-hauterive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89200-89250-hauterive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89201-89550-hery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89201-89550-hery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89201-89550-hery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89201-89550-hery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89202-89290-irancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89202-89290-irancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89202-89290-irancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89202-89290-irancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89203-89200-island/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89203-89200-island/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89203-89200-island/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89203-89200-island/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89204-89440-l_isle_sur_serein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89204-89440-l_isle_sur_serein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89204-89440-l_isle_sur_serein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89204-89440-l_isle_sur_serein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89205-89360-jaulges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89205-89360-jaulges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89205-89360-jaulges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89205-89360-jaulges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89206-89300-joigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89206-89300-joigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89206-89300-joigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89206-89300-joigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89207-89310-jouancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89207-89310-jouancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89207-89310-jouancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89207-89310-jouancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89208-89440-joux_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89208-89440-joux_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89208-89440-joux_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89208-89440-joux_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89209-89150-jouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89209-89150-jouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89209-89150-jouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89209-89150-jouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89210-89160-jully/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89210-89160-jully/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89210-89160-jully/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89210-89160-jully/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89211-89700-junay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89211-89700-junay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89211-89700-junay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89211-89700-junay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89212-89290-jussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89212-89290-jussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89212-89290-jussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89212-89290-jussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89214-89190-lailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89214-89190-lailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89214-89190-lailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89214-89190-lailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89215-89560-lain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89215-89560-lain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89215-89560-lain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89215-89560-lain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89216-89520-lainsecq/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89216-89520-lainsecq/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89216-89520-lainsecq/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89216-89520-lainsecq/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89217-89130-lalande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89217-89130-lalande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89217-89130-lalande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89217-89130-lalande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89218-89400-laroche_saint_cydroine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89218-89400-laroche_saint_cydroine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89218-89400-laroche_saint_cydroine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89218-89400-laroche_saint_cydroine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89219-89570-lasson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89219-89570-lasson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89219-89570-lasson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89219-89570-lasson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89220-89170-lavau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89220-89170-lavau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89220-89170-lavau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89220-89170-lavau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89221-89130-leugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89221-89130-leugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89221-89130-leugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89221-89130-leugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89222-89520-levis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89222-89520-levis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89222-89520-levis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89222-89520-levis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89223-89160-lezinnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89223-89160-lezinnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89223-89160-lezinnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89223-89160-lezinnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89224-89800-licheres_pres_aigremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89224-89800-licheres_pres_aigremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89224-89800-licheres_pres_aigremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89224-89800-licheres_pres_aigremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89225-89660-licheres_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89225-89660-licheres_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89225-89660-licheres_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89225-89660-licheres_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89226-89800-lignorelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89226-89800-lignorelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89226-89800-lignorelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89226-89800-lignorelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89227-89144-ligny_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89227-89144-ligny_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89227-89144-ligny_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89227-89144-ligny_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89228-89240-lindry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89228-89240-lindry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89228-89240-lindry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89228-89240-lindry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89229-89140-lixy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89229-89140-lixy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89229-89140-lixy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89229-89140-lixy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89230-89300-looze/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89230-89300-looze/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89230-89300-looze/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89230-89300-looze/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89232-89200-lucy_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89232-89200-lucy_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89232-89200-lucy_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89232-89200-lucy_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89233-89270-lucy_sur_cure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89233-89270-lucy_sur_cure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89233-89270-lucy_sur_cure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89233-89270-lucy_sur_cure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89234-89480-lucy_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89234-89480-lucy_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89234-89480-lucy_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89234-89480-lucy_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89235-89200-magny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89235-89200-magny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89235-89200-magny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89235-89200-magny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89236-89100-maillot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89236-89100-maillot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89236-89100-maillot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89236-89100-maillot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89237-89270-mailly_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89237-89270-mailly_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89237-89270-mailly_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89237-89270-mailly_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89238-89660-mailly_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89238-89660-mailly_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89238-89660-mailly_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89238-89660-mailly_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89239-89100-malay_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89239-89100-malay_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89239-89100-malay_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89239-89100-malay_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89240-89100-malay_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89240-89100-malay_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89240-89100-malay_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89240-89100-malay_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89242-89800-maligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89242-89800-maligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89242-89800-maligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89242-89800-maligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89244-89420-marmeaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89244-89420-marmeaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89244-89420-marmeaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89244-89420-marmeaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89245-89500-marsangy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89245-89500-marsangy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89245-89500-marsangy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89245-89500-marsangy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89246-89440-massangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89246-89440-massangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89246-89440-massangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89246-89440-massangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89247-89430-melisey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89247-89430-melisey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89247-89430-melisey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89247-89430-melisey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89248-89450-menades/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89248-89450-menades/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89248-89450-menades/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89248-89450-menades/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89249-89210-mercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89249-89210-mercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89249-89210-mercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89249-89210-mercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89250-89144-mere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89250-89144-mere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89250-89144-mere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89250-89144-mere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89251-89110-merry_la_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89251-89110-merry_la_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89251-89110-merry_la_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89251-89110-merry_la_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89252-89560-merry_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89252-89560-merry_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89252-89560-merry_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89252-89560-merry_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89253-89660-merry_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89253-89660-merry_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89253-89660-merry_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89253-89660-merry_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89254-89130-mezilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89254-89130-mezilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89254-89130-mezilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89254-89130-mezilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89255-89140-michery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89255-89140-michery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89255-89140-michery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89255-89140-michery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89256-89580-mige/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89256-89580-mige/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89256-89580-mige/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89256-89580-mige/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89257-89400-migennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89257-89400-migennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89257-89400-migennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89257-89400-migennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89259-89310-molay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89259-89310-molay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89259-89310-molay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89259-89310-molay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89261-89190-molinons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89261-89190-molinons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89261-89190-molinons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89261-89190-molinons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89262-89700-molosmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89262-89700-molosmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89262-89700-molosmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89262-89700-molosmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89263-89470-moneteau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89263-89470-moneteau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89263-89470-moneteau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89263-89470-moneteau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89264-89150-montacher_villegardin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89264-89150-montacher_villegardin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89264-89150-montacher_villegardin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89264-89150-montacher_villegardin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89265-89230-montigny_la_resle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89265-89230-montigny_la_resle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89265-89230-montigny_la_resle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89265-89230-montigny_la_resle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89266-89660-montillot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89266-89660-montillot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89266-89660-montillot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89266-89660-montillot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89267-89420-montreal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89267-89420-montreal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89267-89420-montreal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89267-89420-montreal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89268-89250-mont_saint_sulpice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89268-89250-mont_saint_sulpice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89268-89250-mont_saint_sulpice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89268-89250-mont_saint_sulpice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89270-89560-mouffy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89270-89560-mouffy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89270-89560-mouffy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89270-89560-mouffy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89271-89310-moulins_en_tonnerrois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89271-89310-moulins_en_tonnerrois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89271-89310-moulins_en_tonnerrois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89271-89310-moulins_en_tonnerrois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89272-89130-moulins_sur_ouanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89272-89130-moulins_sur_ouanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89272-89130-moulins_sur_ouanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89272-89130-moulins_sur_ouanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89273-89520-moutiers_en_puisaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89273-89520-moutiers_en_puisaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89273-89520-moutiers_en_puisaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89273-89520-moutiers_en_puisaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89274-89100-nailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89274-89100-nailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89274-89100-nailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89274-89100-nailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89276-89570-neuvy_sautour/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89276-89570-neuvy_sautour/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89276-89570-neuvy_sautour/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89276-89570-neuvy_sautour/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89277-89310-nitry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89277-89310-nitry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89277-89310-nitry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89277-89310-nitry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89278-89320-noe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89278-89320-noe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89278-89320-noe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89278-89320-noe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89279-89310-noyers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89279-89310-noyers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89279-89310-noyers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89279-89310-noyers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89280-89390-nuits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89280-89390-nuits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89280-89390-nuits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89280-89390-nuits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89281-89110-les_ormes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89281-89110-les_ormes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89281-89110-les_ormes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89281-89110-les_ormes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89282-89400-ormoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89282-89400-ormoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89282-89400-ormoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89282-89400-ormoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89283-89560-ouanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89283-89560-ouanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89283-89560-ouanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89283-89560-ouanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89284-89160-pacy_sur_armancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89284-89160-pacy_sur_armancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89284-89160-pacy_sur_armancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89284-89160-pacy_sur_armancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89285-89140-pailly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89285-89140-pailly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89285-89140-pailly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89285-89140-pailly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89286-89240-parly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89286-89240-parly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89286-89240-parly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89286-89240-parly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89287-89100-paron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89287-89100-paron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89287-89100-paron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89287-89100-paron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89288-89210-paroy_en_othe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89288-89210-paroy_en_othe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89288-89210-paroy_en_othe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89288-89210-paroy_en_othe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89289-89300-paroy_sur_tholon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89289-89300-paroy_sur_tholon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89289-89300-paroy_sur_tholon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89289-89300-paroy_sur_tholon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89290-89310-pasilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89290-89310-pasilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89290-89310-pasilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89290-89310-pasilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89291-89510-passy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89291-89510-passy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89291-89510-passy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89291-89510-passy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89292-89360-percey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89292-89360-percey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89292-89360-percey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89292-89360-percey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89295-89000-perrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89295-89000-perrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89295-89000-perrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89295-89000-perrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89296-89390-perrigny_sur_armancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89296-89390-perrigny_sur_armancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89296-89390-perrigny_sur_armancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89296-89390-perrigny_sur_armancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89297-89450-pierre_perthuis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89297-89450-pierre_perthuis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89297-89450-pierre_perthuis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89297-89450-pierre_perthuis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89298-89330-piffonds/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89298-89330-piffonds/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89298-89330-piffonds/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89298-89330-piffonds/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89299-89740-pimelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89299-89740-pimelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89299-89740-pimelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89299-89740-pimelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89300-89420-pisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89300-89420-pisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89300-89420-pisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89300-89420-pisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89302-89140-plessis_saint_jean/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89302-89140-plessis_saint_jean/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89302-89140-plessis_saint_jean/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89302-89140-plessis_saint_jean/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89303-89310-poilly_sur_serein/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89303-89310-poilly_sur_serein/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89303-89310-poilly_sur_serein/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89303-89310-poilly_sur_serein/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89304-89110-poilly_sur_tholon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89304-89110-poilly_sur_tholon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89304-89110-poilly_sur_tholon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89304-89110-poilly_sur_tholon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89306-89200-pontaubert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89306-89200-pontaubert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89306-89200-pontaubert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89306-89200-pontaubert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89307-89230-pontigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89307-89230-pontigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89307-89230-pontigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89307-89230-pontigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89308-89190-pont_sur_vanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89308-89190-pont_sur_vanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89308-89190-pont_sur_vanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89308-89190-pont_sur_vanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89309-89140-pont_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89309-89140-pont_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89309-89140-pont_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89309-89140-pont_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89310-89260-la_postolle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89310-89260-la_postolle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89310-89260-la_postolle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89310-89260-la_postolle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89311-89240-pourrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89311-89240-pourrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89311-89240-pourrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89311-89240-pourrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89312-89440-precy_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89312-89440-precy_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89312-89440-precy_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89312-89440-precy_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89313-89116-precy_sur_vrin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89313-89116-precy_sur_vrin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89313-89116-precy_sur_vrin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89313-89116-precy_sur_vrin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89314-89460-pregilbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89314-89460-pregilbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89314-89460-pregilbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89314-89460-pregilbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89315-89800-prehy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89315-89800-prehy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89315-89800-prehy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89315-89800-prehy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89316-89200-provency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89316-89200-provency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89316-89200-provency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89316-89200-provency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89318-89630-quarre_les_tombes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89318-89630-quarre_les_tombes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89318-89630-quarre_les_tombes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89318-89630-quarre_les_tombes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89319-89290-quenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89319-89290-quenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89319-89290-quenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89319-89290-quenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89320-89740-quincerot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89320-89740-quincerot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89320-89740-quincerot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89320-89740-quincerot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89321-89390-ravieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89321-89390-ravieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89321-89390-ravieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89321-89390-ravieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89323-89700-roffey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89323-89700-roffey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89323-89700-roffey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89323-89700-roffey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89324-89220-rogny_les_sept_ecluses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89324-89220-rogny_les_sept_ecluses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89324-89220-rogny_les_sept_ecluses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89324-89220-rogny_les_sept_ecluses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89325-89170-roncheres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89325-89170-roncheres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89325-89170-roncheres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89325-89170-roncheres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89326-89100-rosoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89326-89100-rosoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89326-89100-rosoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89326-89100-rosoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89327-89500-rousson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89327-89500-rousson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89327-89500-rousson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89327-89500-rousson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89328-89230-rouvray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89328-89230-rouvray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89328-89230-rouvray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89328-89230-rouvray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89329-89430-rugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89329-89430-rugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89329-89430-rugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89329-89430-rugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89331-89520-sainpuits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89331-89520-sainpuits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89331-89520-sainpuits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89331-89520-sainpuits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89332-89340-saint_agnan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89332-89340-saint_agnan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89332-89340-saint_agnan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89332-89340-saint_agnan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89333-89420-saint_andre_en_terre_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89333-89420-saint_andre_en_terre_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89333-89420-saint_andre_en_terre_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89333-89420-saint_andre_en_terre_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89334-89110-le_val_d_ocre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89334-89110-le_val_d_ocre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89334-89110-le_val_d_ocre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89334-89110-le_val_d_ocre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89335-89300-saint_aubin_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89335-89300-saint_aubin_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89335-89300-saint_aubin_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89335-89300-saint_aubin_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89336-89630-saint_brancher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89336-89630-saint_brancher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89336-89630-saint_brancher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89336-89630-saint_brancher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89337-89530-saint_bris_le_vineux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89337-89530-saint_bris_le_vineux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89337-89530-saint_bris_le_vineux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89337-89530-saint_bris_le_vineux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89338-89100-saint_clement/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89338-89100-saint_clement/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89338-89100-saint_clement/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89338-89100-saint_clement/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89339-89440-sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89339-89440-sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89339-89440-sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89339-89440-sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89341-89800-saint_cyr_les_colons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89341-89800-saint_cyr_les_colons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89341-89800-saint_cyr_les_colons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89341-89800-saint_cyr_les_colons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89342-89100-saint_denis_les_sens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89342-89100-saint_denis_les_sens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89342-89100-saint_denis_les_sens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89342-89100-saint_denis_les_sens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89344-89170-saint_fargeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89344-89170-saint_fargeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89344-89170-saint_fargeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89344-89170-saint_fargeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89345-89600-saint_florentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89345-89600-saint_florentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89345-89600-saint_florentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89345-89600-saint_florentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89346-89000-saint_georges_sur_baulche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89346-89000-saint_georges_sur_baulche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89346-89000-saint_georges_sur_baulche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89346-89000-saint_georges_sur_baulche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89347-89630-saint_germain_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89347-89630-saint_germain_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89347-89630-saint_germain_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89347-89630-saint_germain_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89348-89330-saint_julien_du_sault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89348-89330-saint_julien_du_sault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89348-89330-saint_julien_du_sault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89348-89330-saint_julien_du_sault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89349-89630-saint_leger_vauban/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89349-89630-saint_leger_vauban/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89349-89630-saint_leger_vauban/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89349-89630-saint_leger_vauban/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89350-89330-saint_loup_d_ordon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89350-89330-saint_loup_d_ordon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89350-89330-saint_loup_d_ordon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89350-89330-saint_loup_d_ordon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89351-89420-sainte_magnance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89351-89420-sainte_magnance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89351-89420-sainte_magnance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89351-89420-sainte_magnance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89352-89170-saint_martin_des_champs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89352-89170-saint_martin_des_champs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89352-89170-saint_martin_des_champs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89352-89170-saint_martin_des_champs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89353-89330-saint_martin_d_ordon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89353-89330-saint_martin_d_ordon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89353-89330-saint_martin_d_ordon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89353-89330-saint_martin_d_ordon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89354-89100-saint_martin_du_tertre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89354-89100-saint_martin_du_tertre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89354-89100-saint_martin_du_tertre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89354-89100-saint_martin_du_tertre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89355-89700-saint_martin_sur_armancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89355-89700-saint_martin_sur_armancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89355-89700-saint_martin_sur_armancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89355-89700-saint_martin_sur_armancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89359-89190-saint_maurice_aux_riches_hommes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89359-89190-saint_maurice_aux_riches_hommes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89359-89190-saint_maurice_aux_riches_hommes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89359-89190-saint_maurice_aux_riches_hommes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89360-89110-saint_maurice_le_vieil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89360-89110-saint_maurice_le_vieil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89360-89110-saint_maurice_le_vieil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89360-89110-saint_maurice_le_vieil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89361-89110-saint_maurice_thizouaille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89361-89110-saint_maurice_thizouaille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89361-89110-saint_maurice_thizouaille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89361-89110-saint_maurice_thizouaille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89362-89270-saint_more/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89362-89270-saint_more/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89362-89270-saint_more/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89362-89270-saint_more/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89363-89460-sainte_pallaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89363-89460-sainte_pallaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89363-89460-sainte_pallaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89363-89460-sainte_pallaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89364-89450-saint_pere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89364-89450-saint_pere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89364-89450-saint_pere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89364-89450-saint_pere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89365-89220-saint_prive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89365-89220-saint_prive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89365-89220-saint_prive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89365-89220-saint_prive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89367-89520-saints_en_puisaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89367-89520-saints_en_puisaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89367-89520-saints_en_puisaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89367-89520-saints_en_puisaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89368-89520-saint_sauveur_en_puisaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89368-89520-saint_sauveur_en_puisaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89368-89520-saint_sauveur_en_puisaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89368-89520-saint_sauveur_en_puisaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89369-89140-saint_serotin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89369-89140-saint_serotin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89369-89140-saint_serotin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89369-89140-saint_serotin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89370-89150-saint_valerien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89370-89150-saint_valerien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89370-89150-saint_valerien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89370-89150-saint_valerien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89371-89310-sainte_vertu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89371-89310-sainte_vertu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89371-89310-sainte_vertu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89371-89310-sainte_vertu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89373-89100-saligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89373-89100-saligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89373-89100-saligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89373-89100-saligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89374-89160-sambourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89374-89160-sambourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89374-89160-sambourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89374-89160-sambourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89375-89420-santigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89375-89420-santigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89375-89420-santigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89375-89420-santigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89376-89310-sarry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89376-89310-sarry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89376-89310-sarry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89376-89310-sarry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89377-89420-sauvigny_le_beureal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89377-89420-sauvigny_le_beureal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89377-89420-sauvigny_le_beureal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89377-89420-sauvigny_le_beureal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89378-89200-sauvigny_le_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89378-89200-sauvigny_le_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89378-89200-sauvigny_le_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89378-89200-sauvigny_le_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89379-89420-savigny_en_terre_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89379-89420-savigny_en_terre_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89379-89420-savigny_en_terre_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89379-89420-savigny_en_terre_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89380-89150-savigny_sur_clairis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89380-89150-savigny_sur_clairis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89380-89150-savigny_sur_clairis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89380-89150-savigny_sur_clairis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89382-89250-seignelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89382-89250-seignelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89382-89250-seignelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89382-89250-seignelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89383-89560-sementron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89383-89560-sementron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89383-89560-sementron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89383-89560-sementron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89384-89710-senan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89384-89710-senan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89384-89710-senan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89384-89710-senan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89385-89160-sennevoy_le_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89385-89160-sennevoy_le_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89385-89160-sennevoy_le_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89385-89160-sennevoy_le_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89386-89160-sennevoy_le_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89386-89160-sennevoy_le_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89386-89160-sennevoy_le_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89386-89160-sennevoy_le_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89387-89100-sens/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89387-89100-sens/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89387-89100-sens/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89387-89100-sens/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89388-89116-sepeaux_saint_romain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89388-89116-sepeaux_saint_romain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89388-89116-sepeaux_saint_romain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89388-89116-sepeaux_saint_romain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89390-89140-serbonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89390-89140-serbonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89390-89140-serbonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89390-89140-serbonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89391-89140-sergines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89391-89140-sergines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89391-89140-sergines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89391-89140-sergines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89392-89200-sermizelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89392-89200-sermizelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89392-89200-sermizelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89392-89200-sermizelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89393-89700-serrigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89393-89700-serrigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89393-89700-serrigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89393-89700-serrigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89394-89270-sery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89394-89270-sery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89394-89270-sery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89394-89270-sery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89395-89190-les_sieges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89395-89190-les_sieges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89395-89190-les_sieges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89395-89190-les_sieges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89397-89110-sommecaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89397-89110-sommecaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89397-89110-sommecaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89397-89110-sommecaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89398-89570-sormery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89398-89570-sormery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89398-89570-sormery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89398-89570-sormery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89399-89100-soucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89399-89100-soucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89399-89100-soucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89399-89100-soucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89400-89520-sougeres_en_puisaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89400-89520-sougeres_en_puisaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89400-89520-sougeres_en_puisaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89400-89520-sougeres_en_puisaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89402-89570-soumaintrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89402-89570-soumaintrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89402-89570-soumaintrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89402-89570-soumaintrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89403-89160-stigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89403-89160-stigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89403-89160-stigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89403-89160-stigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89404-89100-subligny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89404-89100-subligny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89404-89100-subligny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89404-89100-subligny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89405-89560-les_hauts_de_forterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89405-89560-les_hauts_de_forterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89405-89560-les_hauts_de_forterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89405-89560-les_hauts_de_forterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89406-89420-talcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89406-89420-talcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89406-89420-talcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89406-89420-talcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89407-89430-tanlay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89407-89430-tanlay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89407-89430-tanlay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89407-89430-tanlay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89408-89350-tannerre_en_puisaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89408-89350-tannerre_en_puisaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89408-89350-tannerre_en_puisaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89408-89350-tannerre_en_puisaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89409-89450-tharoiseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89409-89450-tharoiseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89409-89450-tharoiseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89409-89450-tharoiseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89410-89200-tharot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89410-89200-tharot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89410-89200-tharot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89410-89200-tharot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89411-89320-les_vallees_de_la_vanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89411-89320-les_vallees_de_la_vanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89411-89320-les_vallees_de_la_vanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89411-89320-les_vallees_de_la_vanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89411-89190-les_vallees_de_la_vanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89411-89190-les_vallees_de_la_vanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89411-89190-les_vallees_de_la_vanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89411-89190-les_vallees_de_la_vanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89412-89420-thizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89412-89420-thizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89412-89420-thizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89412-89420-thizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89413-89430-thorey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89413-89430-thorey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89413-89430-thorey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89413-89430-thorey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89414-89260-thorigny_sur_oreuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89414-89260-thorigny_sur_oreuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89414-89260-thorigny_sur_oreuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89414-89260-thorigny_sur_oreuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89415-89200-thory/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89415-89200-thory/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89415-89200-thory/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89415-89200-thory/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89416-89520-thury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89416-89520-thury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89416-89520-thury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89416-89520-thury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89417-89700-tissey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89417-89700-tissey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89417-89700-tissey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89417-89700-tissey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89418-89700-tonnerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89418-89700-tonnerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89418-89700-tonnerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89418-89700-tonnerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89419-89130-toucy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89419-89130-toucy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89419-89130-toucy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89419-89130-toucy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89420-89520-treigny_perreuse_sainte_colombe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89420-89520-treigny_perreuse_sainte_colombe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89420-89520-treigny_perreuse_sainte_colombe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89420-89520-treigny_perreuse_sainte_colombe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89422-89430-trichey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89422-89430-trichey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89422-89430-trichey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89422-89430-trichey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89423-89700-tronchoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89423-89700-tronchoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89423-89700-tronchoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89423-89700-tronchoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89424-89460-trucy_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89424-89460-trucy_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89424-89460-trucy_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89424-89460-trucy_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89425-89570-turny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89425-89570-turny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89425-89570-turny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89425-89570-turny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89426-89580-val_de_mercy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89426-89580-val_de_mercy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89426-89580-val_de_mercy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89426-89580-val_de_mercy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89427-89580-vallan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89427-89580-vallan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89427-89580-vallan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89427-89580-vallan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89428-89150-vallery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89428-89150-vallery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89428-89150-vallery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89428-89150-vallery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89430-89144-varennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89430-89144-varennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89430-89144-varennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89430-89144-varennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89431-89420-vassy_sous_pisy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89431-89420-vassy_sous_pisy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89431-89420-vassy_sous_pisy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89431-89420-vassy_sous_pisy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89432-89320-vaudeurs/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89432-89320-vaudeurs/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89432-89320-vaudeurs/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89432-89320-vaudeurs/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89433-89200-vault_de_lugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89433-89200-vault_de_lugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89433-89200-vault_de_lugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89433-89200-vault_de_lugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89434-89320-vaumort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89434-89320-vaumort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89434-89320-vaumort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89434-89320-vaumort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89436-89210-venizy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89436-89210-venizy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89436-89210-venizy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89436-89210-venizy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89437-89230-venouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89437-89230-venouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89437-89230-venouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89437-89230-venouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89438-89290-venoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89438-89290-venoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89438-89290-venoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89438-89290-venoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89439-89600-vergigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89439-89600-vergigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89439-89600-vergigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89439-89600-vergigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89440-89330-verlin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89440-89330-verlin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89440-89330-verlin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89440-89330-verlin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89441-89270-vermenton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89441-89270-vermenton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89441-89270-vermenton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89441-89270-vermenton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89442-89150-vernoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89442-89150-vernoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89442-89150-vernoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89442-89150-vernoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89443-89510-veron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89443-89510-veron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89443-89510-veron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89443-89510-veron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89445-89700-vezannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89445-89700-vezannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89445-89700-vezannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89445-89700-vezannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89446-89450-vezelay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89446-89450-vezelay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89446-89450-vezelay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89446-89450-vezelay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89447-89700-vezinnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89447-89700-vezinnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89447-89700-vezinnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89447-89700-vezinnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89449-89340-villeblevin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89449-89340-villeblevin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89449-89340-villeblevin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89449-89340-villeblevin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89450-89150-villebougis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89450-89150-villebougis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89450-89150-villebougis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89450-89150-villebougis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89451-89320-villechetive/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89451-89320-villechetive/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89451-89320-villechetive/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89451-89320-villechetive/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89452-89300-villecien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89452-89300-villecien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89452-89300-villecien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89452-89300-villecien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89453-89240-villefargeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89453-89240-villefargeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89453-89240-villefargeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89453-89240-villefargeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89456-89140-villemanoche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89456-89140-villemanoche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89456-89140-villemanoche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89456-89140-villemanoche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89458-89140-villenavotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89458-89140-villenavotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89458-89140-villenavotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89458-89140-villenavotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89459-89150-villeneuve_la_dondagre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89459-89150-villeneuve_la_dondagre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89459-89150-villeneuve_la_dondagre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89459-89150-villeneuve_la_dondagre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89460-89340-villeneuve_la_guyard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89460-89340-villeneuve_la_guyard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89460-89340-villeneuve_la_guyard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89460-89340-villeneuve_la_guyard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89461-89190-villeneuve_l_archeveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89461-89190-villeneuve_l_archeveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89461-89190-villeneuve_l_archeveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89461-89190-villeneuve_l_archeveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89462-89350-villeneuve_les_genets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89462-89350-villeneuve_les_genets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89462-89350-villeneuve_les_genets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89462-89350-villeneuve_les_genets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89463-89230-villeneuve_saint_salves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89463-89230-villeneuve_saint_salves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89463-89230-villeneuve_saint_salves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89463-89230-villeneuve_saint_salves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89464-89500-villeneuve_sur_yonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89464-89500-villeneuve_sur_yonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89464-89500-villeneuve_sur_yonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89464-89500-villeneuve_sur_yonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89465-89140-villeperrot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89465-89140-villeperrot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89465-89140-villeperrot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89465-89140-villeperrot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89466-89100-villeroy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89466-89100-villeroy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89466-89100-villeroy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89466-89100-villeroy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89467-89140-villethierry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89467-89140-villethierry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89467-89140-villethierry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89467-89140-villethierry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89468-89330-villevallier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89468-89330-villevallier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89468-89330-villevallier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89468-89330-villevallier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89469-89260-perceneige/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89469-89260-perceneige/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89469-89260-perceneige/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89469-89260-perceneige/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89470-89160-villiers_les_hauts/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89470-89160-villiers_les_hauts/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89470-89160-villiers_les_hauts/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89470-89160-villiers_les_hauts/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89471-89320-villiers_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89471-89320-villiers_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89471-89320-villiers_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89471-89320-villiers_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89472-89130-villiers_saint_benoit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89472-89130-villiers_saint_benoit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89472-89130-villiers_saint_benoit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89472-89130-villiers_saint_benoit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89474-89360-villiers_vineux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89474-89360-villiers_vineux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89474-89360-villiers_vineux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89474-89360-villiers_vineux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89475-89740-villon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89475-89740-villon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89475-89740-villon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89475-89740-villon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89477-89800-villy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89477-89800-villy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89477-89800-villy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89477-89800-villy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89478-89290-vincelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89478-89290-vincelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89478-89290-vincelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89478-89290-vincelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89479-89290-vincelottes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89479-89290-vincelottes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89479-89290-vincelottes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89479-89290-vincelottes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89480-89140-vinneuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89480-89140-vinneuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89480-89140-vinneuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89480-89140-vinneuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89481-89160-vireaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89481-89160-vireaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89481-89160-vireaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89481-89160-vireaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89482-89700-viviers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89482-89700-viviers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89482-89700-viviers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89482-89700-viviers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89483-89260-voisines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89483-89260-voisines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89483-89260-voisines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89483-89260-voisines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89485-89270-voutenay_sur_cure/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89485-89270-voutenay_sur_cure/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89485-89270-voutenay_sur_cure/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89485-89270-voutenay_sur_cure/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89486-89700-yrouerre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89486-89700-yrouerre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89486-89700-yrouerre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt89-yonne/commune89486-89700-yrouerre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-90.xml
+++ b/public/sitemaps/sitemap-90.xml
@@ -5,208 +5,412 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90001-90400-andelnans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90001-90400-andelnans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90001-90400-andelnans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90001-90400-andelnans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90002-90150-angeot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90002-90150-angeot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90002-90150-angeot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90002-90150-angeot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90003-90170-anjoutey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90003-90170-anjoutey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90003-90170-anjoutey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90003-90170-anjoutey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90004-90800-argiesans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90004-90800-argiesans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90004-90800-argiesans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90004-90800-argiesans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90005-90200-auxelles_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90005-90200-auxelles_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90005-90200-auxelles_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90005-90200-auxelles_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90006-90200-auxelles_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90006-90200-auxelles_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90006-90200-auxelles_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90006-90200-auxelles_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90007-90800-banvillars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90007-90800-banvillars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90007-90800-banvillars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90007-90800-banvillars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90008-90800-bavilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90008-90800-bavilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90008-90800-bavilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90008-90800-bavilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90009-90500-beaucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90009-90500-beaucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90009-90500-beaucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90009-90500-beaucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90010-90000-belfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90010-90000-belfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90010-90000-belfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90010-90000-belfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90011-90400-bermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90011-90400-bermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90011-90400-bermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90011-90400-bermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90012-90160-bessoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90012-90160-bessoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90012-90160-bessoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90012-90160-bessoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90013-90150-bethonvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90013-90150-bethonvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90013-90150-bethonvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90013-90150-bethonvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90014-90100-boron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90014-90100-boron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90014-90100-boron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90014-90100-boron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90015-90400-botans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90015-90400-botans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90015-90400-botans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90015-90400-botans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90016-90110-bourg_sous_chatelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90016-90110-bourg_sous_chatelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90016-90110-bourg_sous_chatelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90016-90110-bourg_sous_chatelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90017-90140-bourogne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90017-90140-bourogne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90017-90140-bourogne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90017-90140-bourogne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90018-90140-brebotte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90018-90140-brebotte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90018-90140-brebotte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90018-90140-brebotte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90019-90130-bretagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90019-90130-bretagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90019-90130-bretagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90019-90130-bretagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90020-90800-buc/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90020-90800-buc/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90020-90800-buc/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90020-90800-buc/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90021-90140-charmois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90021-90140-charmois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90021-90140-charmois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90021-90140-charmois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90022-90700-chatenois_les_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90022-90700-chatenois_les_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90022-90700-chatenois_les_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90022-90700-chatenois_les_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90023-90330-chaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90023-90330-chaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90023-90330-chaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90023-90330-chaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90024-90100-chavanatte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90024-90100-chavanatte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90024-90100-chavanatte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90024-90100-chavanatte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90025-90100-chavannes_les_grands/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90025-90100-chavannes_les_grands/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90025-90100-chavannes_les_grands/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90025-90100-chavannes_les_grands/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90026-90340-chevremont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90026-90340-chevremont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90026-90340-chevremont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90026-90340-chevremont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90027-90100-courcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90027-90100-courcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90027-90100-courcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90027-90100-courcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90028-90100-courtelevant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90028-90100-courtelevant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90028-90100-courtelevant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90028-90100-courtelevant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90029-90300-cravanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90029-90300-cravanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90029-90300-cravanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90029-90300-cravanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90030-90100-croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90030-90100-croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90030-90100-croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90030-90100-croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90031-90150-cunelieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90031-90150-cunelieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90031-90150-cunelieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90031-90150-cunelieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90032-90400-danjoutin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90032-90400-danjoutin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90032-90400-danjoutin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90032-90400-danjoutin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90033-90100-delle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90033-90100-delle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90033-90100-delle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90033-90100-delle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90034-90160-denney/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90034-90160-denney/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90034-90160-denney/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90034-90160-denney/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90035-90400-dorans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90035-90400-dorans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90035-90400-dorans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90035-90400-dorans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90036-90150-eguenigue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90036-90150-eguenigue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90036-90150-eguenigue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90036-90150-eguenigue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90037-90300-eloie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90037-90300-eloie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90037-90300-eloie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90037-90300-eloie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90039-90850-essert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90039-90850-essert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90039-90850-essert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90039-90850-essert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90041-90170-etueffont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90041-90170-etueffont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90041-90170-etueffont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90041-90170-etueffont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90042-90350-evette_salbert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90042-90350-evette_salbert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90042-90350-evette_salbert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90042-90350-evette_salbert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90043-90100-faverois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90043-90100-faverois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90043-90100-faverois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90043-90100-faverois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90044-90110-felon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90044-90110-felon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90044-90110-felon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90044-90110-felon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90045-90100-feche_l_eglise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90045-90100-feche_l_eglise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90045-90100-feche_l_eglise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90045-90100-feche_l_eglise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90046-90100-florimont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90046-90100-florimont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90046-90100-florimont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90046-90100-florimont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90047-90150-fontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90047-90150-fontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90047-90150-fontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90047-90150-fontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90048-90340-fontenelle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90048-90340-fontenelle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90048-90340-fontenelle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90048-90340-fontenelle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90049-90150-foussemagne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90049-90150-foussemagne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90049-90150-foussemagne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90049-90150-foussemagne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90050-90150-frais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90050-90150-frais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90050-90150-frais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90050-90150-frais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90051-90140-froidefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90051-90140-froidefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90051-90140-froidefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90051-90140-froidefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90052-90200-giromagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90052-90200-giromagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90052-90200-giromagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90052-90200-giromagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90053-90600-grandvillars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90053-90600-grandvillars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90053-90600-grandvillars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90053-90600-grandvillars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90054-90200-grosmagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90054-90200-grosmagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90054-90200-grosmagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90054-90200-grosmagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90055-90100-grosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90055-90100-grosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90055-90100-grosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90055-90100-grosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90056-90100-joncherey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90056-90100-joncherey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90056-90100-joncherey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90056-90100-joncherey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90057-90300-lachapelle_sous_chaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90057-90300-lachapelle_sous_chaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90057-90300-lachapelle_sous_chaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90057-90300-lachapelle_sous_chaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90058-90360-lachapelle_sous_rougemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90058-90360-lachapelle_sous_rougemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90058-90360-lachapelle_sous_rougemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90058-90360-lachapelle_sous_rougemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90059-90150-lacollonge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90059-90150-lacollonge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90059-90150-lacollonge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90059-90150-lacollonge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90060-90150-lagrange/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90060-90150-lagrange/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90060-90150-lagrange/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90060-90150-lagrange/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90061-90170-lamadeleine_val_des_anges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90061-90170-lamadeleine_val_des_anges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90061-90170-lamadeleine_val_des_anges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90061-90170-lamadeleine_val_des_anges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90062-90150-lariviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90062-90150-lariviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90062-90150-lariviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90062-90150-lariviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90063-90100-lebetain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90063-90100-lebetain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90063-90100-lebetain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90063-90100-lebetain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90064-90100-lepuix_neuf/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90064-90100-lepuix_neuf/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90064-90100-lepuix_neuf/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90064-90100-lepuix_neuf/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90065-90200-lepuix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90065-90200-lepuix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90065-90200-lepuix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90065-90200-lepuix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90066-90110-leval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90066-90110-leval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90066-90110-leval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90066-90110-leval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90067-90150-menoncourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90067-90150-menoncourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90067-90150-menoncourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90067-90150-menoncourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90068-90400-meroux_moval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90068-90400-meroux_moval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90068-90400-meroux_moval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90068-90400-meroux_moval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90069-90120-mezire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90069-90120-mezire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90069-90120-mezire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90069-90120-mezire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90070-90500-montbouton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90070-90500-montbouton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90070-90500-montbouton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90070-90500-montbouton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90071-90130-montreux_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90071-90130-montreux_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90071-90130-montreux_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90071-90130-montreux_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90072-90120-morvillars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90072-90120-morvillars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90072-90120-morvillars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90072-90120-morvillars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90074-90340-novillard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90074-90340-novillard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90074-90340-novillard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90074-90340-novillard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90075-90300-offemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90075-90300-offemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90075-90300-offemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90075-90300-offemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90076-90160-perouse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90076-90160-perouse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90076-90160-perouse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90076-90160-perouse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90077-90130-petit_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90077-90130-petit_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90077-90130-petit_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90077-90130-petit_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90078-90360-petitefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90078-90360-petitefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90078-90360-petitefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90078-90360-petitefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90079-90170-petitmagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90079-90170-petitmagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90079-90170-petitmagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90079-90170-petitmagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90080-90150-phaffans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90080-90150-phaffans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90080-90150-phaffans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90080-90150-phaffans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90081-90370-rechesy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90081-90370-rechesy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90081-90370-rechesy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90081-90370-rechesy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90082-90140-autrechene/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90082-90140-autrechene/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90082-90140-autrechene/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90082-90140-autrechene/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90083-90140-recouvrance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90083-90140-recouvrance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90083-90140-recouvrance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90083-90140-recouvrance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90084-90150-reppe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90084-90150-reppe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90084-90150-reppe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90084-90150-reppe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90085-90200-riervescemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90085-90200-riervescemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90085-90200-riervescemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90085-90200-riervescemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90086-90110-romagny_sous_rougemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90086-90110-romagny_sous_rougemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90086-90110-romagny_sous_rougemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90086-90110-romagny_sous_rougemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90087-90380-roppe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90087-90380-roppe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90087-90380-roppe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90087-90380-roppe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90088-90200-rougegoutte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90088-90200-rougegoutte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90088-90200-rougegoutte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90088-90200-rougegoutte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90089-90110-rougemont_le_chateau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90089-90110-rougemont_le_chateau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90089-90110-rougemont_le_chateau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90089-90110-rougemont_le_chateau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90090-90100-saint_dizier_l_eveque/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90090-90100-saint_dizier_l_eveque/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90090-90100-saint_dizier_l_eveque/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90090-90100-saint_dizier_l_eveque/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90091-90110-saint_germain_le_chatelet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90091-90110-saint_germain_le_chatelet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90091-90110-saint_germain_le_chatelet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90091-90110-saint_germain_le_chatelet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90093-90300-sermamagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90093-90300-sermamagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90093-90300-sermamagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90093-90300-sermamagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90094-90400-sevenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90094-90400-sevenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90094-90400-sevenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90094-90400-sevenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90095-90100-suarce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90095-90100-suarce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90095-90100-suarce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90095-90100-suarce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90096-90100-thiancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90096-90100-thiancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90096-90100-thiancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90096-90100-thiancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90097-90400-trevenans/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90097-90400-trevenans/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90097-90400-trevenans/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90097-90400-trevenans/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90098-90800-urcerey/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90098-90800-urcerey/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90098-90800-urcerey/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90098-90800-urcerey/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90099-90300-valdoie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90099-90300-valdoie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90099-90300-valdoie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90099-90300-valdoie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90100-90150-vauthiermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90100-90150-vauthiermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90100-90150-vauthiermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90100-90150-vauthiermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90101-90100-vellescot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90101-90100-vellescot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90101-90100-vellescot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90101-90100-vellescot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90102-90200-vescemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90102-90200-vescemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90102-90200-vescemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90102-90200-vescemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90103-90300-vetrigne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90103-90300-vetrigne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90103-90300-vetrigne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90103-90300-vetrigne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90104-90400-vezelois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90104-90400-vezelois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90104-90400-vezelois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90104-90400-vezelois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90105-90100-villars_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90105-90100-villars_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90105-90100-villars_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt90-territoire_de_belfort/commune90105-90100-villars_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-91.xml
+++ b/public/sitemaps/sitemap-91.xml
@@ -5,396 +5,788 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91001-91150-abbeville_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91001-91150-abbeville_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91001-91150-abbeville_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91001-91150-abbeville_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91016-91670-angerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91016-91670-angerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91016-91670-angerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91016-91670-angerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91017-91470-angervilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91017-91470-angervilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91017-91470-angervilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91017-91470-angervilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91021-91290-arpajon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91021-91290-arpajon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91021-91290-arpajon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91021-91290-arpajon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91022-91690-arrancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91022-91690-arrancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91022-91690-arrancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91022-91690-arrancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91027-91200-athis_mons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91027-91200-athis_mons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91027-91200-athis_mons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91027-91200-athis_mons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91035-91410-authon_la_plaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91035-91410-authon_la_plaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91035-91410-authon_la_plaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91035-91410-authon_la_plaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91037-91830-auvernaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91037-91830-auvernaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91037-91830-auvernaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91037-91830-auvernaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91038-91580-auvers_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91038-91580-auvers_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91038-91580-auvers_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91038-91580-auvers_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91041-91630-avrainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91041-91630-avrainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91041-91630-avrainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91041-91630-avrainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91044-91160-ballainvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91044-91160-ballainvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91044-91160-ballainvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91044-91160-ballainvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91045-91610-ballancourt_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91045-91610-ballancourt_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91045-91610-ballancourt_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91045-91610-ballancourt_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91047-91590-baulne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91047-91590-baulne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91047-91590-baulne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91047-91590-baulne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91064-91570-bievres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91064-91570-bievres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91064-91570-bievres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91064-91570-bievres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91067-91150-blandy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91067-91150-blandy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91067-91150-blandy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91067-91150-blandy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91069-91720-boigneville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91069-91720-boigneville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91069-91720-boigneville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91069-91720-boigneville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91075-91150-bois_herpin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91075-91150-bois_herpin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91075-91150-bois_herpin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91075-91150-bois_herpin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91079-91690-boissy_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91079-91690-boissy_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91079-91690-boissy_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91079-91690-boissy_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91080-91590-boissy_le_cutte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91080-91590-boissy_le_cutte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91080-91590-boissy_le_cutte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91080-91590-boissy_le_cutte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91081-91870-boissy_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91081-91870-boissy_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91081-91870-boissy_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91081-91870-boissy_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91085-91790-boissy_sous_saint_yon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91085-91790-boissy_sous_saint_yon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91085-91790-boissy_sous_saint_yon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91085-91790-boissy_sous_saint_yon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91086-91070-bondoufle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91086-91070-bondoufle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91086-91070-bondoufle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91086-91070-bondoufle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91093-91470-boullay_les_troux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91093-91470-boullay_les_troux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91093-91470-boullay_les_troux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91093-91470-boullay_les_troux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91095-91850-bouray_sur_juine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91095-91850-bouray_sur_juine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91095-91850-bouray_sur_juine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91095-91850-bouray_sur_juine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91097-91800-boussy_saint_antoine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91097-91800-boussy_saint_antoine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91097-91800-boussy_saint_antoine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91097-91800-boussy_saint_antoine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91098-91150-boutervilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91098-91150-boutervilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91098-91150-boutervilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91098-91150-boutervilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91099-91820-boutigny_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91099-91820-boutigny_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91099-91820-boutigny_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91099-91820-boutigny_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91100-91880-bouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91100-91880-bouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91100-91880-bouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91100-91880-bouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91103-91220-bretigny_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91103-91220-bretigny_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91103-91220-bretigny_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91103-91220-bretigny_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91105-91650-breuillet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91105-91650-breuillet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91105-91650-breuillet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91105-91650-breuillet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91106-91650-breux_jouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91106-91650-breux_jouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91106-91650-breux_jouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91106-91650-breux_jouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91109-91150-brieres_les_scelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91109-91150-brieres_les_scelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91109-91150-brieres_les_scelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91109-91150-brieres_les_scelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91111-91640-briis_sous_forges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91111-91640-briis_sous_forges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91111-91640-briis_sous_forges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91111-91640-briis_sous_forges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91112-91150-brouy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91112-91150-brouy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91112-91150-brouy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91112-91150-brouy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91114-91800-brunoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91114-91800-brunoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91114-91800-brunoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91114-91800-brunoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91115-91680-bruyeres_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91115-91680-bruyeres_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91115-91680-bruyeres_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91115-91680-bruyeres_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91121-91720-buno_bonnevaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91121-91720-buno_bonnevaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91121-91720-buno_bonnevaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91121-91720-buno_bonnevaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91122-91440-bures_sur_yvette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91122-91440-bures_sur_yvette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91122-91440-bures_sur_yvette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91122-91440-bures_sur_yvette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91129-91590-cerny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91129-91590-cerny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91129-91590-cerny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91129-91590-cerny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91130-91780-chalo_saint_mars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91130-91780-chalo_saint_mars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91130-91780-chalo_saint_mars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91130-91780-chalo_saint_mars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91131-91740-chalou_moulineux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91131-91740-chalou_moulineux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91131-91740-chalou_moulineux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91131-91740-chalou_moulineux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91132-91730-chamarande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91132-91730-chamarande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91132-91730-chamarande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91132-91730-chamarande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91135-91750-champcueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91135-91750-champcueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91135-91750-champcueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91135-91750-champcueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91136-91160-champlan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91136-91160-champlan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91136-91160-champlan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91136-91160-champlan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91137-91150-champmotteux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91137-91150-champmotteux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91137-91150-champmotteux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91137-91150-champmotteux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91145-91410-chatignonville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91145-91410-chatignonville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91145-91410-chatignonville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91145-91410-chatignonville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91148-91580-chauffour_les_etrechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91148-91580-chauffour_les_etrechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91148-91580-chauffour_les_etrechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91148-91580-chauffour_les_etrechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91156-91630-cheptainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91156-91630-cheptainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91156-91630-cheptainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91156-91630-cheptainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91159-91750-chevannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91159-91750-chevannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91159-91750-chevannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91159-91750-chevannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91161-91380-chilly_mazarin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91161-91380-chilly_mazarin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91161-91380-chilly_mazarin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91161-91380-chilly_mazarin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91174-91100-corbeil_essonnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91174-91100-corbeil_essonnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91174-91100-corbeil_essonnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91174-91100-corbeil_essonnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91175-91410-corbreuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91175-91410-corbreuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91175-91410-corbreuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91175-91410-corbreuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91179-91830-le_coudray_montceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91179-91830-le_coudray_montceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91179-91830-le_coudray_montceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91179-91830-le_coudray_montceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91180-91490-courances/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91180-91490-courances/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91180-91490-courances/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91180-91490-courances/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91184-91720-courdimanche_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91184-91720-courdimanche_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91184-91720-courdimanche_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91184-91720-courdimanche_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91186-91680-courson_monteloup/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91186-91680-courson_monteloup/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91186-91680-courson_monteloup/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91186-91680-courson_monteloup/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91191-91560-crosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91191-91560-crosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91191-91560-crosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91191-91560-crosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91195-91490-dannemois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91195-91490-dannemois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91195-91490-dannemois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91195-91490-dannemois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91198-91590-d_huison_longueville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91198-91590-d_huison_longueville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91198-91590-d_huison_longueville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91198-91590-d_huison_longueville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91200-91410-dourdan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91200-91410-dourdan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91200-91410-dourdan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91200-91410-dourdan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91201-91210-draveil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91201-91210-draveil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91201-91210-draveil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91201-91210-draveil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91204-91540-echarcon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91204-91540-echarcon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91204-91540-echarcon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91204-91540-echarcon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91207-91520-egly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91207-91520-egly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91207-91520-egly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91207-91520-egly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91215-91860-epinay_sous_senart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91215-91860-epinay_sous_senart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91215-91860-epinay_sous_senart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91215-91860-epinay_sous_senart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91216-91360-epinay_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91216-91360-epinay_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91216-91360-epinay_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91216-91360-epinay_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91223-91150-etampes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91223-91150-etampes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91223-91150-etampes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91223-91150-etampes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91225-91450-etiolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91225-91450-etiolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91225-91450-etiolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91225-91450-etiolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91226-91580-etrechy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91226-91580-etrechy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91226-91580-etrechy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91226-91580-etrechy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91228-91000-evry_courcouronnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91228-91000-evry_courcouronnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91228-91000-evry_courcouronnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91228-91000-evry_courcouronnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91228-91080-evry_courcouronnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91228-91080-evry_courcouronnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91228-91080-evry_courcouronnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91228-91080-evry_courcouronnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91232-91590-la_ferte_alais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91232-91590-la_ferte_alais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91232-91590-la_ferte_alais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91232-91590-la_ferte_alais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91235-91700-fleury_merogis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91235-91700-fleury_merogis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91235-91700-fleury_merogis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91235-91700-fleury_merogis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91240-91690-fontaine_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91240-91690-fontaine_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91240-91690-fontaine_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91240-91690-fontaine_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91243-91640-fontenay_les_briis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91243-91640-fontenay_les_briis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91243-91640-fontenay_les_briis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91243-91640-fontenay_les_briis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91244-91540-fontenay_le_vicomte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91244-91540-fontenay_le_vicomte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91244-91540-fontenay_le_vicomte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91244-91540-fontenay_le_vicomte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91247-91410-la_foret_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91247-91410-la_foret_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91247-91410-la_foret_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91247-91410-la_foret_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91248-91150-la_foret_sainte_croix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91248-91150-la_foret_sainte_croix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91248-91150-la_foret_sainte_croix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91248-91150-la_foret_sainte_croix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91249-91470-forges_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91249-91470-forges_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91249-91470-forges_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91249-91470-forges_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91272-91190-gif_sur_yvette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91272-91190-gif_sur_yvette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91272-91190-gif_sur_yvette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91272-91190-gif_sur_yvette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91273-91720-gironville_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91273-91720-gironville_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91273-91720-gironville_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91273-91720-gironville_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91274-91400-gometz_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91274-91400-gometz_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91274-91400-gometz_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91274-91400-gometz_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91275-91940-gometz_le_chatel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91275-91940-gometz_le_chatel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91275-91940-gometz_le_chatel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91275-91940-gometz_le_chatel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91284-91410-les_granges_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91284-91410-les_granges_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91284-91410-les_granges_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91284-91410-les_granges_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91286-91350-grigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91286-91350-grigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91286-91350-grigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91286-91350-grigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91292-91630-guibeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91292-91630-guibeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91292-91630-guibeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91292-91630-guibeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91293-91590-guigneville_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91293-91590-guigneville_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91293-91590-guigneville_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91293-91590-guigneville_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91294-91690-guillerval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91294-91690-guillerval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91294-91690-guillerval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91294-91690-guillerval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91312-91430-igny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91312-91430-igny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91312-91430-igny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91312-91430-igny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91315-91760-itteville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91315-91760-itteville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91315-91760-itteville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91315-91760-itteville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91318-91510-janville_sur_juine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91318-91510-janville_sur_juine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91318-91510-janville_sur_juine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91318-91510-janville_sur_juine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91319-91640-janvry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91319-91640-janvry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91319-91640-janvry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91319-91640-janvry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91326-91260-juvisy_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91326-91260-juvisy_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91326-91260-juvisy_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91326-91260-juvisy_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91330-91510-lardy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91330-91510-lardy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91330-91510-lardy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91330-91510-lardy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91332-91630-leudeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91332-91630-leudeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91332-91630-leudeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91332-91630-leudeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91333-91310-leuville_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91333-91310-leuville_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91333-91310-leuville_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91333-91310-leuville_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91338-91470-limours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91338-91470-limours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91338-91470-limours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91338-91470-limours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91339-91310-linas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91339-91310-linas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91339-91310-linas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91339-91310-linas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91340-91090-lisses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91340-91090-lisses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91340-91090-lisses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91340-91090-lisses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91345-91160-longjumeau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91345-91160-longjumeau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91345-91160-longjumeau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91345-91160-longjumeau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91347-91310-longpont_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91347-91310-longpont_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91347-91310-longpont_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91347-91310-longpont_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91359-91720-maisse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91359-91720-maisse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91359-91720-maisse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91359-91720-maisse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91363-91460-marcoussis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91363-91460-marcoussis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91363-91460-marcoussis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91363-91460-marcoussis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91374-91150-marolles_en_beauce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91374-91150-marolles_en_beauce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91374-91150-marolles_en_beauce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91374-91150-marolles_en_beauce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91376-91630-marolles_en_hurepoix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91376-91630-marolles_en_hurepoix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91376-91630-marolles_en_hurepoix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91376-91630-marolles_en_hurepoix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91377-91300-massy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91377-91300-massy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91377-91300-massy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91377-91300-massy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91378-91730-mauchamps/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91378-91730-mauchamps/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91378-91730-mauchamps/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91378-91730-mauchamps/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91386-91540-mennecy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91386-91540-mennecy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91386-91540-mennecy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91386-91540-mennecy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91390-91660-le_merevillois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91390-91660-le_merevillois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91390-91660-le_merevillois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91390-91660-le_merevillois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91393-91780-merobert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91393-91780-merobert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91393-91780-merobert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91393-91780-merobert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91399-91150-mespuits/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91399-91150-mespuits/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91399-91150-mespuits/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91399-91150-mespuits/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91405-91490-milly_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91405-91490-milly_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91405-91490-milly_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91405-91490-milly_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91408-91490-moigny_sur_ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91408-91490-moigny_sur_ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91408-91490-moigny_sur_ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91408-91490-moigny_sur_ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91411-91470-les_molieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91411-91470-les_molieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91411-91470-les_molieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91411-91470-les_molieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91412-91590-mondeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91412-91590-mondeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91412-91590-mondeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91412-91590-mondeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91414-91930-monnerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91414-91930-monnerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91414-91930-monnerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91414-91930-monnerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91421-91230-montgeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91421-91230-montgeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91421-91230-montgeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91421-91230-montgeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91425-91310-montlhery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91425-91310-montlhery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91425-91310-montlhery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91425-91310-montlhery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91432-91420-morangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91432-91420-morangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91432-91420-morangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91432-91420-morangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91433-91150-morigny_champigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91433-91150-morigny_champigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91433-91150-morigny_champigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91433-91150-morigny_champigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91434-91390-morsang_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91434-91390-morsang_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91434-91390-morsang_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91434-91390-morsang_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91435-91250-morsang_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91435-91250-morsang_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91435-91250-morsang_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91435-91250-morsang_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91441-91750-nainville_les_roches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91441-91750-nainville_les_roches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91441-91750-nainville_les_roches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91441-91750-nainville_les_roches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91457-91290-la_norville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91457-91290-la_norville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91457-91290-la_norville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91457-91290-la_norville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91458-91620-nozay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91458-91620-nozay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91458-91620-nozay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91458-91620-nozay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91461-91340-ollainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91461-91340-ollainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91461-91340-ollainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91461-91340-ollainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91463-91490-oncy_sur_ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91463-91490-oncy_sur_ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91463-91490-oncy_sur_ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91463-91490-oncy_sur_ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91468-91540-ormoy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91468-91540-ormoy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91468-91540-ormoy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91468-91540-ormoy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91469-91150-ormoy_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91469-91150-ormoy_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91469-91150-ormoy_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91469-91150-ormoy_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91471-91400-orsay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91471-91400-orsay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91471-91400-orsay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91471-91400-orsay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91473-91590-orveau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91473-91590-orveau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91473-91590-orveau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91473-91590-orveau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91477-91120-palaiseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91477-91120-palaiseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91477-91120-palaiseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91477-91120-palaiseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91479-91550-paray_vieille_poste/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91479-91550-paray_vieille_poste/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91479-91550-paray_vieille_poste/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91479-91550-paray_vieille_poste/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91482-91470-pecqueuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91482-91470-pecqueuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91482-91470-pecqueuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91482-91470-pecqueuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91494-91220-le_plessis_pate/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91494-91220-le_plessis_pate/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91494-91220-le_plessis_pate/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91494-91220-le_plessis_pate/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91495-91410-plessis_saint_benoist/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91495-91410-plessis_saint_benoist/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91495-91410-plessis_saint_benoist/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91495-91410-plessis_saint_benoist/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91507-91720-prunay_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91507-91720-prunay_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91507-91720-prunay_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91507-91720-prunay_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91508-91150-puiselet_le_marais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91508-91150-puiselet_le_marais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91508-91150-puiselet_le_marais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91508-91150-puiselet_le_marais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91511-91740-pussay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91511-91740-pussay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91511-91740-pussay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91511-91740-pussay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91514-91480-quincy_sous_senart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91514-91480-quincy_sous_senart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91514-91480-quincy_sous_senart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91514-91480-quincy_sous_senart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91519-91410-richarville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91519-91410-richarville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91519-91410-richarville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91519-91410-richarville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91521-91130-ris_orangis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91521-91130-ris_orangis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91521-91130-ris_orangis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91521-91130-ris_orangis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91525-91410-roinville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91525-91410-roinville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91525-91410-roinville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91525-91410-roinville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91526-91150-roinvilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91526-91150-roinvilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91526-91150-roinvilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91526-91150-roinvilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91533-91690-saclas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91533-91690-saclas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91533-91690-saclas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91533-91690-saclas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91534-91400-saclay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91534-91400-saclay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91534-91400-saclay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91534-91400-saclay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91538-91190-saint_aubin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91538-91190-saint_aubin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91538-91190-saint_aubin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91538-91190-saint_aubin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91540-91530-saint_cheron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91540-91530-saint_cheron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91540-91530-saint_cheron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91540-91530-saint_cheron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91544-91690-saint_cyr_la_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91544-91690-saint_cyr_la_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91544-91690-saint_cyr_la_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91544-91690-saint_cyr_la_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91546-91410-saint_cyr_sous_dourdan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91546-91410-saint_cyr_sous_dourdan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91546-91410-saint_cyr_sous_dourdan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91546-91410-saint_cyr_sous_dourdan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91547-91410-saint_escobille/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91547-91410-saint_escobille/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91547-91410-saint_escobille/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91547-91410-saint_escobille/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91549-91700-sainte_genevieve_des_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91549-91700-sainte_genevieve_des_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91549-91700-sainte_genevieve_des_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91549-91700-sainte_genevieve_des_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91552-91180-saint_germain_les_arpajon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91552-91180-saint_germain_les_arpajon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91552-91180-saint_germain_les_arpajon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91552-91180-saint_germain_les_arpajon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91553-91250-saint_germain_les_corbeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91553-91250-saint_germain_les_corbeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91553-91250-saint_germain_les_corbeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91553-91250-saint_germain_les_corbeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91556-91780-saint_hilaire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91556-91780-saint_hilaire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91556-91780-saint_hilaire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91556-91780-saint_hilaire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91560-91940-saint_jean_de_beauregard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91560-91940-saint_jean_de_beauregard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91560-91940-saint_jean_de_beauregard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91560-91940-saint_jean_de_beauregard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91568-91530-saint_maurice_montcouronne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91568-91530-saint_maurice_montcouronne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91568-91530-saint_maurice_montcouronne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91568-91530-saint_maurice_montcouronne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91570-91240-saint_michel_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91570-91240-saint_michel_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91570-91240-saint_michel_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91570-91240-saint_michel_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91573-91280-saint_pierre_du_perray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91573-91280-saint_pierre_du_perray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91573-91280-saint_pierre_du_perray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91573-91280-saint_pierre_du_perray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91577-91250-saintry_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91577-91250-saintry_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91577-91250-saintry_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91577-91250-saintry_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91578-91910-saint_sulpice_de_favieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91578-91910-saint_sulpice_de_favieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91578-91910-saint_sulpice_de_favieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91578-91910-saint_sulpice_de_favieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91579-91770-saint_vrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91579-91770-saint_vrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91579-91770-saint_vrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91579-91770-saint_vrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91581-91650-saint_yon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91581-91650-saint_yon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91581-91650-saint_yon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91581-91650-saint_yon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91587-91160-saulx_les_chartreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91587-91160-saulx_les_chartreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91587-91160-saulx_les_chartreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91587-91160-saulx_les_chartreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91589-91600-savigny_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91589-91600-savigny_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91589-91600-savigny_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91589-91600-savigny_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91593-91530-sermaise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91593-91530-sermaise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91593-91530-sermaise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91593-91530-sermaise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91599-91840-soisy_sur_ecole/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91599-91840-soisy_sur_ecole/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91599-91840-soisy_sur_ecole/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91599-91840-soisy_sur_ecole/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91600-91450-soisy_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91600-91450-soisy_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91600-91450-soisy_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91600-91450-soisy_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91602-91580-souzy_la_briche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91602-91580-souzy_la_briche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91602-91580-souzy_la_briche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91602-91580-souzy_la_briche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91613-91740-congerville_thionville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91613-91740-congerville_thionville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91613-91740-congerville_thionville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91613-91740-congerville_thionville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91617-91250-tigery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91617-91250-tigery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91617-91250-tigery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91617-91250-tigery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91619-91730-torfou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91619-91730-torfou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91619-91730-torfou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91619-91730-torfou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91629-91720-valpuiseaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91629-91720-valpuiseaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91629-91720-valpuiseaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91629-91720-valpuiseaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91630-91530-le_val_saint_germain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91630-91530-le_val_saint_germain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91630-91530-le_val_saint_germain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91630-91530-le_val_saint_germain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91631-91480-varennes_jarcy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91631-91480-varennes_jarcy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91631-91480-varennes_jarcy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91631-91480-varennes_jarcy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91634-91640-vaugrigneuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91634-91640-vaugrigneuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91634-91640-vaugrigneuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91634-91640-vaugrigneuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91635-91430-vauhallan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91635-91430-vauhallan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91635-91430-vauhallan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91635-91430-vauhallan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91639-91820-vayres_sur_essonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91639-91820-vayres_sur_essonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91639-91820-vayres_sur_essonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91639-91820-vayres_sur_essonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91645-91370-verrieres_le_buisson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91645-91370-verrieres_le_buisson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91645-91370-verrieres_le_buisson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91645-91370-verrieres_le_buisson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91648-91810-vert_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91648-91810-vert_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91648-91810-vert_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91648-91810-vert_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91649-91710-vert_le_petit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91649-91710-vert_le_petit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91649-91710-vert_le_petit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91649-91710-vert_le_petit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91654-91890-videlles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91654-91890-videlles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91654-91890-videlles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91654-91890-videlles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91657-91270-vigneux_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91657-91270-vigneux_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91657-91270-vigneux_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91657-91270-vigneux_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91659-91100-villabe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91659-91100-villabe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91659-91100-villabe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91659-91100-villabe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91661-91140-villebon_sur_yvette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91661-91140-villebon_sur_yvette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91661-91140-villebon_sur_yvette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91661-91140-villebon_sur_yvette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91662-91580-villeconin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91662-91580-villeconin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91662-91580-villeconin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91662-91580-villeconin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91665-91620-la_ville_du_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91665-91620-la_ville_du_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91665-91620-la_ville_du_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91665-91620-la_ville_du_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91666-91140-villejust/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91666-91140-villejust/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91666-91140-villejust/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91666-91140-villejust/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91667-91360-villemoisson_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91667-91360-villemoisson_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91667-91360-villemoisson_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91667-91360-villemoisson_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91671-91580-villeneuve_sur_auvers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91671-91580-villeneuve_sur_auvers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91671-91580-villeneuve_sur_auvers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91671-91580-villeneuve_sur_auvers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91679-91190-villiers_le_bacle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91679-91190-villiers_le_bacle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91679-91190-villiers_le_bacle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91679-91190-villiers_le_bacle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91685-91700-villiers_sur_orge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91685-91700-villiers_sur_orge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91685-91700-villiers_sur_orge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91685-91700-villiers_sur_orge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91687-91170-viry_chatillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91687-91170-viry_chatillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91687-91170-viry_chatillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91687-91170-viry_chatillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91689-91320-wissous/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91689-91320-wissous/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91689-91320-wissous/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91689-91320-wissous/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91691-91330-yerres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91691-91330-yerres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91691-91330-yerres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91691-91330-yerres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91692-91940-les_ulis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91692-91940-les_ulis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91692-91940-les_ulis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt91-essonne/commune91692-91940-les_ulis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-92.xml
+++ b/public/sitemaps/sitemap-92.xml
@@ -5,86 +5,168 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92002-92160-antony/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92002-92160-antony/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92002-92160-antony/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92002-92160-antony/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92004-92600-asnieres_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92004-92600-asnieres_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92004-92600-asnieres_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92004-92600-asnieres_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92007-92220-bagneux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92007-92220-bagneux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92007-92220-bagneux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92007-92220-bagneux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92009-92270-bois_colombes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92009-92270-bois_colombes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92009-92270-bois_colombes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92009-92270-bois_colombes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92012-92100-boulogne_billancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92012-92100-boulogne_billancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92012-92100-boulogne_billancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92012-92100-boulogne_billancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92012-75016-boulogne_billancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92012-75016-boulogne_billancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92012-75016-boulogne_billancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92012-75016-boulogne_billancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92014-92340-bourg_la_reine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92014-92340-bourg_la_reine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92014-92340-bourg_la_reine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92014-92340-bourg_la_reine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92019-92290-chatenay_malabry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92019-92290-chatenay_malabry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92019-92290-chatenay_malabry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92019-92290-chatenay_malabry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92020-92320-chatillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92020-92320-chatillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92020-92320-chatillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92020-92320-chatillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92022-92370-chaville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92022-92370-chaville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92022-92370-chaville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92022-92370-chaville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92023-92140-clamart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92023-92140-clamart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92023-92140-clamart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92023-92140-clamart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92023-92190-clamart/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92023-92190-clamart/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92023-92190-clamart/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92023-92190-clamart/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92024-92110-clichy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92024-92110-clichy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92024-92110-clichy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92024-92110-clichy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92025-92700-colombes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92025-92700-colombes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92025-92700-colombes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92025-92700-colombes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92026-92400-courbevoie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92026-92400-courbevoie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92026-92400-courbevoie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92026-92400-courbevoie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92032-92260-fontenay_aux_roses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92032-92260-fontenay_aux_roses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92032-92260-fontenay_aux_roses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92032-92260-fontenay_aux_roses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92033-92380-garches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92033-92380-garches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92033-92380-garches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92033-92380-garches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92035-92250-la_garenne_colombes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92035-92250-la_garenne_colombes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92035-92250-la_garenne_colombes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92035-92250-la_garenne_colombes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92036-92230-gennevilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92036-92230-gennevilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92036-92230-gennevilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92036-92230-gennevilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92040-92130-issy_les_moulineaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92040-92130-issy_les_moulineaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92040-92130-issy_les_moulineaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92040-92130-issy_les_moulineaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92040-75015-issy_les_moulineaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92040-75015-issy_les_moulineaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92040-75015-issy_les_moulineaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92040-75015-issy_les_moulineaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92044-92300-levallois_perret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92044-92300-levallois_perret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92044-92300-levallois_perret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92044-92300-levallois_perret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92046-92240-malakoff/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92046-92240-malakoff/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92046-92240-malakoff/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92046-92240-malakoff/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92047-92430-marnes_la_coquette/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92047-92430-marnes_la_coquette/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92047-92430-marnes_la_coquette/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92047-92430-marnes_la_coquette/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92048-92360-meudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92048-92360-meudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92048-92360-meudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92048-92360-meudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92048-92190-meudon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92048-92190-meudon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92048-92190-meudon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92048-92190-meudon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92049-92120-montrouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92049-92120-montrouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92049-92120-montrouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92049-92120-montrouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92050-92000-nanterre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92050-92000-nanterre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92050-92000-nanterre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92050-92000-nanterre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92051-92200-neuilly_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92051-92200-neuilly_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92051-92200-neuilly_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92051-92200-neuilly_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92060-92350-le_plessis_robinson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92060-92350-le_plessis_robinson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92060-92350-le_plessis_robinson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92060-92350-le_plessis_robinson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92062-92800-puteaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92062-92800-puteaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92062-92800-puteaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92062-92800-puteaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92063-92500-rueil_malmaison/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92063-92500-rueil_malmaison/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92063-92500-rueil_malmaison/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92063-92500-rueil_malmaison/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92064-92210-saint_cloud/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92064-92210-saint_cloud/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92064-92210-saint_cloud/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92064-92210-saint_cloud/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92071-92330-sceaux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92071-92330-sceaux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92071-92330-sceaux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92071-92330-sceaux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92072-92310-sevres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92072-92310-sevres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92072-92310-sevres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92072-92310-sevres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92073-92150-suresnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92073-92150-suresnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92073-92150-suresnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92073-92150-suresnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92075-92170-vanves/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92075-92170-vanves/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92075-92170-vanves/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92075-92170-vanves/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92076-92420-vaucresson/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92076-92420-vaucresson/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92076-92420-vaucresson/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92076-92420-vaucresson/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92077-92410-ville_d_avray/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92077-92410-ville_d_avray/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92077-92410-ville_d_avray/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92077-92410-ville_d_avray/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92078-92390-villeneuve_la_garenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92078-92390-villeneuve_la_garenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92078-92390-villeneuve_la_garenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt92-hauts_de_seine/commune92078-92390-villeneuve_la_garenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-93.xml
+++ b/public/sitemaps/sitemap-93.xml
@@ -5,88 +5,172 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93001-93300-aubervilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93001-93300-aubervilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93001-93300-aubervilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93001-93300-aubervilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93005-93600-aulnay_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93005-93600-aulnay_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93005-93600-aulnay_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93005-93600-aulnay_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93006-93170-bagnolet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93006-93170-bagnolet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93006-93170-bagnolet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93006-93170-bagnolet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93007-93150-le_blanc_mesnil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93007-93150-le_blanc_mesnil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93007-93150-le_blanc_mesnil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93007-93150-le_blanc_mesnil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93008-93000-bobigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93008-93000-bobigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93008-93000-bobigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93008-93000-bobigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93010-93140-bondy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93010-93140-bondy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93010-93140-bondy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93010-93140-bondy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93013-93350-le_bourget/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93013-93350-le_bourget/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93013-93350-le_bourget/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93013-93350-le_bourget/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93014-93390-clichy_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93014-93390-clichy_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93014-93390-clichy_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93014-93390-clichy_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93015-93470-coubron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93015-93470-coubron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93015-93470-coubron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93015-93470-coubron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93027-93120-la_courneuve/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93027-93120-la_courneuve/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93027-93120-la_courneuve/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93027-93120-la_courneuve/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93029-93700-drancy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93029-93700-drancy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93029-93700-drancy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93029-93700-drancy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93030-93440-dugny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93030-93440-dugny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93030-93440-dugny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93030-93440-dugny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93031-93800-epinay_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93031-93800-epinay_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93031-93800-epinay_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93031-93800-epinay_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93032-93220-gagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93032-93220-gagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93032-93220-gagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93032-93220-gagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93033-93460-gournay_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93033-93460-gournay_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93033-93460-gournay_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93033-93460-gournay_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93039-93450-l_ile_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93039-93450-l_ile_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93039-93450-l_ile_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93039-93450-l_ile_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93045-93260-les_lilas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93045-93260-les_lilas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93045-93260-les_lilas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93045-93260-les_lilas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93046-93190-livry_gargan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93046-93190-livry_gargan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93046-93190-livry_gargan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93046-93190-livry_gargan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93047-93370-montfermeil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93047-93370-montfermeil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93047-93370-montfermeil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93047-93370-montfermeil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93048-93100-montreuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93048-93100-montreuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93048-93100-montreuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93048-93100-montreuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93049-93360-neuilly_plaisance/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93049-93360-neuilly_plaisance/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93049-93360-neuilly_plaisance/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93049-93360-neuilly_plaisance/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93050-93330-neuilly_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93050-93330-neuilly_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93050-93330-neuilly_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93050-93330-neuilly_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93051-93160-noisy_le_grand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93051-93160-noisy_le_grand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93051-93160-noisy_le_grand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93051-93160-noisy_le_grand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93053-93130-noisy_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93053-93130-noisy_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93053-93130-noisy_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93053-93130-noisy_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93055-93500-pantin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93055-93500-pantin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93055-93500-pantin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93055-93500-pantin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93057-93320-les_pavillons_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93057-93320-les_pavillons_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93057-93320-les_pavillons_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93057-93320-les_pavillons_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93059-93380-pierrefitte_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93059-93380-pierrefitte_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93059-93380-pierrefitte_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93059-93380-pierrefitte_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93061-93310-le_pre_saint_gervais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93061-93310-le_pre_saint_gervais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93061-93310-le_pre_saint_gervais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93061-93310-le_pre_saint_gervais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93062-93340-le_raincy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93062-93340-le_raincy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93062-93340-le_raincy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93062-93340-le_raincy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93063-93230-romainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93063-93230-romainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93063-93230-romainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93063-93230-romainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93064-93110-rosny_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93064-93110-rosny_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93064-93110-rosny_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93064-93110-rosny_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93066-93200-saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93066-93200-saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93066-93200-saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93066-93200-saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93066-93210-saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93066-93210-saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93066-93210-saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93066-93210-saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93070-93400-saint_ouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93070-93400-saint_ouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93070-93400-saint_ouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93070-93400-saint_ouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93071-93270-sevran/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93071-93270-sevran/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93071-93270-sevran/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93071-93270-sevran/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93072-93240-stains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93072-93240-stains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93072-93240-stains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93072-93240-stains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93073-93290-tremblay_en_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93073-93290-tremblay_en_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93073-93290-tremblay_en_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93073-93290-tremblay_en_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93074-93410-vaujours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93074-93410-vaujours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93074-93410-vaujours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93074-93410-vaujours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93077-93250-villemomble/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93077-93250-villemomble/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93077-93250-villemomble/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93077-93250-villemomble/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93078-93420-villepinte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93078-93420-villepinte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93078-93420-villepinte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93078-93420-villepinte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93079-93430-villetaneuse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93079-93430-villetaneuse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93079-93430-villetaneuse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt93-seine_saint_denis/commune93079-93430-villetaneuse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-94.xml
+++ b/public/sitemaps/sitemap-94.xml
@@ -5,104 +5,204 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94001-94480-ablon_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94001-94480-ablon_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94001-94480-ablon_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94001-94480-ablon_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94002-94140-alfortville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94002-94140-alfortville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94002-94140-alfortville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94002-94140-alfortville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94003-94110-arcueil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94003-94110-arcueil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94003-94110-arcueil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94003-94110-arcueil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94004-94470-boissy_saint_leger/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94004-94470-boissy_saint_leger/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94004-94470-boissy_saint_leger/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94004-94470-boissy_saint_leger/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94011-94380-bonneuil_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94011-94380-bonneuil_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94011-94380-bonneuil_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94011-94380-bonneuil_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94015-94360-bry_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94015-94360-bry_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94015-94360-bry_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94015-94360-bry_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94016-94230-cachan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94016-94230-cachan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94016-94230-cachan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94016-94230-cachan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94017-94500-champigny_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94017-94500-champigny_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94017-94500-champigny_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94017-94500-champigny_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94018-94220-charenton_le_pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94018-94220-charenton_le_pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94018-94220-charenton_le_pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94018-94220-charenton_le_pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94019-94430-chennevieres_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94019-94430-chennevieres_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94019-94430-chennevieres_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94019-94430-chennevieres_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94021-94550-chevilly_larue/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94021-94550-chevilly_larue/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94021-94550-chevilly_larue/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94021-94550-chevilly_larue/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94022-94600-choisy_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94022-94600-choisy_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94022-94600-choisy_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94022-94600-choisy_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94028-94000-creteil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94028-94000-creteil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94028-94000-creteil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94028-94000-creteil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94033-94120-fontenay_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94033-94120-fontenay_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94033-94120-fontenay_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94033-94120-fontenay_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94034-94260-fresnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94034-94260-fresnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94034-94260-fresnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94034-94260-fresnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94037-94250-gentilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94037-94250-gentilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94037-94250-gentilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94037-94250-gentilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94038-94240-l_haÿ_les_roses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94038-94240-l_haÿ_les_roses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94038-94240-l_haÿ_les_roses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94038-94240-l_haÿ_les_roses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94041-94200-ivry_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94041-94200-ivry_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94041-94200-ivry_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94041-94200-ivry_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94042-94340-joinville_le_pont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94042-94340-joinville_le_pont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94042-94340-joinville_le_pont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94042-94340-joinville_le_pont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94043-94270-le_kremlin_bicetre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94043-94270-le_kremlin_bicetre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94043-94270-le_kremlin_bicetre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94043-94270-le_kremlin_bicetre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94044-94450-limeil_brevannes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94044-94450-limeil_brevannes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94044-94450-limeil_brevannes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94044-94450-limeil_brevannes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94046-94700-maisons_alfort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94046-94700-maisons_alfort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94046-94700-maisons_alfort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94046-94700-maisons_alfort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94047-94520-mandres_les_roses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94047-94520-mandres_les_roses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94047-94520-mandres_les_roses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94047-94520-mandres_les_roses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94048-94440-marolles_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94048-94440-marolles_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94048-94440-marolles_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94048-94440-marolles_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94052-94130-nogent_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94052-94130-nogent_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94052-94130-nogent_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94052-94130-nogent_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94053-94880-noiseau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94053-94880-noiseau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94053-94880-noiseau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94053-94880-noiseau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94054-94310-orly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94054-94310-orly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94054-94310-orly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94054-94310-orly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94055-94490-ormesson_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94055-94490-ormesson_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94055-94490-ormesson_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94055-94490-ormesson_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94056-94520-perigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94056-94520-perigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94056-94520-perigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94056-94520-perigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94058-94170-le_perreux_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94058-94170-le_perreux_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94058-94170-le_perreux_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94058-94170-le_perreux_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94059-94420-le_plessis_trevise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94059-94420-le_plessis_trevise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94059-94420-le_plessis_trevise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94059-94420-le_plessis_trevise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94060-94510-la_queue_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94060-94510-la_queue_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94060-94510-la_queue_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94060-94510-la_queue_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94065-94150-rungis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94065-94150-rungis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94065-94150-rungis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94065-94150-rungis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94067-94160-saint_mande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94067-94160-saint_mande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94067-94160-saint_mande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94067-94160-saint_mande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94100-saint_maur_des_fosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94100-saint_maur_des_fosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94100-saint_maur_des_fosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94100-saint_maur_des_fosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94210-saint_maur_des_fosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94210-saint_maur_des_fosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94210-saint_maur_des_fosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94210-saint_maur_des_fosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94340-saint_maur_des_fosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94340-saint_maur_des_fosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94340-saint_maur_des_fosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94068-94340-saint_maur_des_fosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94069-94410-saint_maurice/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94069-94410-saint_maurice/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94069-94410-saint_maurice/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94069-94410-saint_maurice/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94070-94440-santeny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94070-94440-santeny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94070-94440-santeny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94070-94440-santeny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94071-94370-sucy_en_brie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94071-94370-sucy_en_brie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94071-94370-sucy_en_brie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94071-94370-sucy_en_brie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94073-94320-thiais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94073-94320-thiais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94073-94320-thiais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94073-94320-thiais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94074-94460-valenton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94074-94460-valenton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94074-94460-valenton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94074-94460-valenton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94075-94440-villecresnes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94075-94440-villecresnes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94075-94440-villecresnes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94075-94440-villecresnes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94076-94800-villejuif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94076-94800-villejuif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94076-94800-villejuif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94076-94800-villejuif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94077-94290-villeneuve_le_roi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94077-94290-villeneuve_le_roi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94077-94290-villeneuve_le_roi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94077-94290-villeneuve_le_roi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94078-94190-villeneuve_saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94078-94190-villeneuve_saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94078-94190-villeneuve_saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94078-94190-villeneuve_saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94079-94350-villiers_sur_marne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94079-94350-villiers_sur_marne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94079-94350-villiers_sur_marne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94079-94350-villiers_sur_marne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94080-94300-vincennes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94080-94300-vincennes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94080-94300-vincennes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94080-94300-vincennes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94081-94400-vitry_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94081-94400-vitry_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94081-94400-vitry_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt94-val_de_marne/commune94081-94400-vitry_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-95.xml
+++ b/public/sitemaps/sitemap-95.xml
@@ -5,388 +5,772 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95002-95450-ableiges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95002-95450-ableiges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95002-95450-ableiges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95002-95450-ableiges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95008-95510-aincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95008-95510-aincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95008-95510-aincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95008-95510-aincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95011-95710-ambleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95011-95710-ambleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95011-95710-ambleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95011-95710-ambleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95011-95420-ambleville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95011-95420-ambleville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95011-95420-ambleville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95011-95420-ambleville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95012-95510-amenucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95012-95510-amenucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95012-95510-amenucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95012-95510-amenucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95014-95580-andilly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95014-95580-andilly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95014-95580-andilly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95014-95580-andilly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95018-95100-argenteuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95018-95100-argenteuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95018-95100-argenteuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95018-95100-argenteuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95019-95400-arnouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95019-95400-arnouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95019-95400-arnouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95019-95400-arnouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95023-95810-arronville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95023-95810-arronville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95023-95810-arronville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95023-95810-arronville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95024-95420-arthies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95024-95420-arthies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95024-95420-arthies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95024-95420-arthies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95026-95270-asnieres_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95026-95270-asnieres_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95026-95270-asnieres_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95026-95270-asnieres_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95028-95570-attainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95028-95570-attainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95028-95570-attainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95028-95570-attainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95039-95430-auvers_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95039-95430-auvers_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95039-95430-auvers_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95039-95430-auvers_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95040-95450-avernes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95040-95450-avernes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95040-95450-avernes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95040-95450-avernes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95042-95560-baillet_en_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95042-95560-baillet_en_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95042-95560-baillet_en_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95042-95560-baillet_en_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95046-95420-banthelu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95046-95420-banthelu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95046-95420-banthelu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95046-95420-banthelu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95051-95250-beauchamp/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95051-95250-beauchamp/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95051-95250-beauchamp/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95051-95250-beauchamp/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95052-95260-beaumont_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95052-95260-beaumont_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95052-95260-beaumont_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95052-95260-beaumont_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95054-95750-le_bellay_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95054-95750-le_bellay_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95054-95750-le_bellay_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95054-95750-le_bellay_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95055-95270-bellefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95055-95270-bellefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95055-95270-bellefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95055-95270-bellefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95056-95270-belloy_en_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95056-95270-belloy_en_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95056-95270-belloy_en_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95056-95270-belloy_en_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95058-95340-bernes_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95058-95340-bernes_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95058-95340-bernes_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95058-95340-bernes_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95059-95810-berville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95059-95810-berville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95059-95810-berville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95059-95810-berville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95060-95550-bessancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95060-95550-bessancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95060-95550-bessancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95060-95550-bessancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95061-95840-bethemont_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95061-95840-bethemont_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95061-95840-bethemont_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95061-95840-bethemont_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95063-95870-bezons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95063-95870-bezons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95063-95870-bezons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95063-95870-bezons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95074-95000-boisemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95074-95000-boisemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95074-95000-boisemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95074-95000-boisemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95078-95650-boissy_l_aillerie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95078-95650-boissy_l_aillerie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95078-95650-boissy_l_aillerie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95078-95650-boissy_l_aillerie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95088-95500-bonneuil_en_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95088-95500-bonneuil_en_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95088-95500-bonneuil_en_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95088-95500-bonneuil_en_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95091-95570-bouffemont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95091-95570-bouffemont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95091-95570-bouffemont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95091-95570-bouffemont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95094-95720-bouqueval/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95094-95720-bouqueval/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95094-95720-bouqueval/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95094-95720-bouqueval/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95101-95710-bray_et_lu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95101-95710-bray_et_lu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95101-95710-bray_et_lu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95101-95710-bray_et_lu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95102-95640-breancon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95102-95640-breancon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95102-95640-breancon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95102-95640-breancon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95110-95640-brignancourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95110-95640-brignancourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95110-95640-brignancourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95110-95640-brignancourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95116-95820-bruyeres_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95116-95820-bruyeres_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95116-95820-bruyeres_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95116-95820-bruyeres_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95119-95770-buhy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95119-95770-buhy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95119-95770-buhy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95119-95770-buhy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95120-95430-butry_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95120-95430-butry_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95120-95430-butry_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95120-95430-butry_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95000-cergy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95000-cergy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95000-cergy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95000-cergy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95800-cergy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95800-cergy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95800-cergy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95800-cergy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95520-cergy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95520-cergy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95520-cergy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95127-95520-cergy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95134-95660-champagne_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95134-95660-champagne_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95134-95660-champagne_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95134-95660-champagne_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95139-95420-la_chapelle_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95139-95420-la_chapelle_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95139-95420-la_chapelle_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95139-95420-la_chapelle_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95141-95420-charmont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95141-95420-charmont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95141-95420-charmont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95141-95420-charmont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95142-95750-chars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95142-95750-chars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95142-95750-chars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95142-95750-chars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95144-95190-chatenay_en_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95144-95190-chatenay_en_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95144-95190-chatenay_en_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95144-95190-chatenay_en_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95149-95270-chaumontel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95149-95270-chaumontel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95149-95270-chaumontel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95149-95270-chaumontel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95150-95710-chaussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95150-95710-chaussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95150-95710-chaussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95150-95710-chaussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95151-95560-chauvry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95151-95560-chauvry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95151-95560-chauvry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95151-95560-chauvry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95154-95380-chennevieres_les_louvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95154-95380-chennevieres_les_louvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95154-95380-chennevieres_les_louvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95154-95380-chennevieres_les_louvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95157-95510-cherence/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95157-95510-cherence/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95157-95510-cherence/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95157-95510-cherence/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95166-95420-clery_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95166-95420-clery_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95166-95420-clery_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95166-95420-clery_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95169-95450-commeny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95169-95450-commeny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95169-95450-commeny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95169-95450-commeny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95170-95450-condecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95170-95450-condecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95170-95450-condecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95170-95450-condecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95176-95240-cormeilles_en_parisis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95176-95240-cormeilles_en_parisis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95176-95240-cormeilles_en_parisis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95176-95240-cormeilles_en_parisis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95177-95830-cormeilles_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95177-95830-cormeilles_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95177-95830-cormeilles_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95177-95830-cormeilles_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95181-95650-courcelles_sur_viosne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95181-95650-courcelles_sur_viosne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95181-95650-courcelles_sur_viosne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95181-95650-courcelles_sur_viosne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95183-95800-courdimanche/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95183-95800-courdimanche/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95183-95800-courdimanche/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95183-95800-courdimanche/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95197-95170-deuil_la_barre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95197-95170-deuil_la_barre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95197-95170-deuil_la_barre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95197-95170-deuil_la_barre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95199-95330-domont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95199-95330-domont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95199-95330-domont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95199-95330-domont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95203-95600-eaubonne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95203-95600-eaubonne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95203-95600-eaubonne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95203-95600-eaubonne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95205-95440-ecouen/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95205-95440-ecouen/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95205-95440-ecouen/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95205-95440-ecouen/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95210-95880-enghien_les_bains/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95210-95880-enghien_les_bains/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95210-95880-enghien_les_bains/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95210-95880-enghien_les_bains/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95211-95300-ennery/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95211-95300-ennery/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95211-95300-ennery/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95211-95300-ennery/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95212-95380-epiais_les_louvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95212-95380-epiais_les_louvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95212-95380-epiais_les_louvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95212-95380-epiais_les_louvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95213-95810-epiais_rhus/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95213-95810-epiais_rhus/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95213-95810-epiais_rhus/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95213-95810-epiais_rhus/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95214-95270-epinay_champlatreux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95214-95270-epinay_champlatreux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95214-95270-epinay_champlatreux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95214-95270-epinay_champlatreux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95218-95610-eragny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95218-95610-eragny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95218-95610-eragny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95218-95610-eragny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95219-95120-ermont/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95219-95120-ermont/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95219-95120-ermont/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95219-95120-ermont/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95229-95460-ezanville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95229-95460-ezanville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95229-95460-ezanville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95229-95460-ezanville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95241-95190-fontenay_en_parisis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95241-95190-fontenay_en_parisis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95241-95190-fontenay_en_parisis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95241-95190-fontenay_en_parisis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95250-95470-fosses/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95250-95470-fosses/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95250-95470-fosses/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95250-95470-fosses/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95252-95130-franconville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95252-95130-franconville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95252-95130-franconville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95252-95130-franconville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95253-95450-fremainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95253-95450-fremainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95253-95450-fremainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95253-95450-fremainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95254-95830-fremecourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95254-95830-fremecourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95254-95830-fremecourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95254-95830-fremecourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95256-95740-frepillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95256-95740-frepillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95256-95740-frepillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95256-95740-frepillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95257-95530-la_frette_sur_seine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95257-95530-la_frette_sur_seine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95257-95530-la_frette_sur_seine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95257-95530-la_frette_sur_seine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95258-95690-frouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95258-95690-frouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95258-95690-frouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95258-95690-frouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95268-95140-garges_les_gonesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95268-95140-garges_les_gonesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95268-95140-garges_les_gonesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95268-95140-garges_les_gonesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95270-95420-genainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95270-95420-genainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95270-95420-genainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95270-95420-genainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95271-95650-genicourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95271-95650-genicourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95271-95650-genicourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95271-95650-genicourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95277-95500-gonesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95277-95500-gonesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95277-95500-gonesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95277-95500-gonesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95280-95190-goussainville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95280-95190-goussainville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95280-95190-goussainville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95280-95190-goussainville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95282-95450-gouzangrez/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95282-95450-gouzangrez/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95282-95450-gouzangrez/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95282-95450-gouzangrez/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95287-95810-grisy_les_platres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95287-95810-grisy_les_platres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95287-95810-grisy_les_platres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95287-95810-grisy_les_platres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95288-95410-groslay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95288-95410-groslay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95288-95410-groslay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95288-95410-groslay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95295-95450-guiry_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95295-95450-guiry_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95295-95450-guiry_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95295-95450-guiry_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95298-95640-haravilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95298-95640-haravilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95298-95640-haravilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95298-95640-haravilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95301-95780-haute_isle/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95301-95780-haute_isle/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95301-95780-haute_isle/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95301-95780-haute_isle/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95303-95640-le_heaulme/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95303-95640-le_heaulme/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95303-95640-le_heaulme/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95303-95640-le_heaulme/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95304-95690-hedouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95304-95690-hedouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95304-95690-hedouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95304-95690-hedouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95306-95220-herblay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95306-95220-herblay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95306-95220-herblay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95306-95220-herblay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95308-95300-herouville_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95308-95300-herouville_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95308-95300-herouville_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95308-95300-herouville_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95309-95420-hodent/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95309-95420-hodent/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95309-95420-hodent/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95309-95420-hodent/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95313-95290-l_isle_adam/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95313-95290-l_isle_adam/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95313-95290-l_isle_adam/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95313-95290-l_isle_adam/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95316-95850-jagny_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95316-95850-jagny_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95316-95850-jagny_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95316-95850-jagny_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95323-95280-jouy_le_moutier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95323-95280-jouy_le_moutier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95323-95280-jouy_le_moutier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95323-95280-jouy_le_moutier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95328-95690-labbeville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95328-95690-labbeville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95328-95690-labbeville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95328-95690-labbeville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95331-95270-lassy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95331-95270-lassy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95331-95270-lassy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95331-95270-lassy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95341-95300-livilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95341-95300-livilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95341-95300-livilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95341-95300-livilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95348-95450-longuesse/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95348-95450-longuesse/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95348-95450-longuesse/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95348-95450-longuesse/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95351-95380-louvres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95351-95380-louvres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95351-95380-louvres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95351-95380-louvres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95352-95270-luzarches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95352-95270-luzarches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95352-95270-luzarches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95352-95270-luzarches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95353-95560-maffliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95353-95560-maffliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95353-95560-maffliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95353-95560-maffliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95355-95420-magny_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95355-95420-magny_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95355-95420-magny_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95355-95420-magny_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95365-95850-mareil_en_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95365-95850-mareil_en_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95365-95850-mareil_en_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95365-95850-mareil_en_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95369-95580-margency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95369-95580-margency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95369-95580-margency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95369-95580-margency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95370-95640-marines/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95370-95640-marines/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95370-95640-marines/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95370-95640-marines/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95371-95670-marly_la_ville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95371-95670-marly_la_ville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95371-95670-marly_la_ville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95371-95670-marly_la_ville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95379-95420-maudetour_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95379-95420-maudetour_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95379-95420-maudetour_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95379-95420-maudetour_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95387-95810-menouville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95387-95810-menouville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95387-95810-menouville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95387-95810-menouville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95388-95180-menucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95388-95180-menucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95388-95180-menucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95388-95180-menucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95392-95630-meriel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95392-95630-meriel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95392-95630-meriel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95392-95630-meriel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95394-95540-mery_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95394-95540-mery_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95394-95540-mery_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95394-95540-mery_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95395-95720-le_mesnil_aubry/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95395-95720-le_mesnil_aubry/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95395-95720-le_mesnil_aubry/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95395-95720-le_mesnil_aubry/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95409-95570-moisselles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95409-95570-moisselles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95409-95570-moisselles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95409-95570-moisselles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95422-95650-montgeroult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95422-95650-montgeroult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95422-95650-montgeroult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95422-95650-montgeroult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95424-95370-montigny_les_cormeilles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95424-95370-montigny_les_cormeilles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95424-95370-montigny_les_cormeilles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95424-95370-montigny_les_cormeilles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95426-95680-montlignon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95426-95680-montlignon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95426-95680-montlignon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95426-95680-montlignon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95427-95360-montmagny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95427-95360-montmagny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95427-95360-montmagny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95427-95360-montmagny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95428-95160-montmorency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95428-95160-montmorency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95428-95160-montmorency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95428-95160-montmorency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95428-95330-montmorency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95428-95330-montmorency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95428-95330-montmorency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95428-95330-montmorency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95429-95770-montreuil_sur_epte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95429-95770-montreuil_sur_epte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95429-95770-montreuil_sur_epte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95429-95770-montreuil_sur_epte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95430-95560-montsoult/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95430-95560-montsoult/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95430-95560-montsoult/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95430-95560-montsoult/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95436-95260-mours/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95436-95260-mours/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95436-95260-mours/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95436-95260-mours/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95438-95640-moussy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95438-95640-moussy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95438-95640-moussy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95438-95640-moussy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95445-95590-nerville_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95445-95590-nerville_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95445-95590-nerville_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95445-95590-nerville_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95446-95690-nesles_la_vallee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95446-95690-nesles_la_vallee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95446-95690-nesles_la_vallee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95446-95690-nesles_la_vallee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95447-95640-neuilly_en_vexin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95447-95640-neuilly_en_vexin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95447-95640-neuilly_en_vexin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95447-95640-neuilly_en_vexin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95450-95000-neuville_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95450-95000-neuville_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95450-95000-neuville_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95450-95000-neuville_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95452-95590-nointel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95452-95590-nointel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95452-95590-nointel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95452-95590-nointel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95456-95270-noisy_sur_oise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95456-95270-noisy_sur_oise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95456-95270-noisy_sur_oise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95456-95270-noisy_sur_oise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95459-95420-nucourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95459-95420-nucourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95459-95420-nucourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95459-95420-nucourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95462-95420-omerville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95462-95420-omerville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95462-95420-omerville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95462-95420-omerville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95476-95520-osny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95476-95520-osny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95476-95520-osny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95476-95520-osny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95480-95620-parmain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95480-95620-parmain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95480-95620-parmain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95480-95620-parmain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95483-95450-le_perchay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95483-95450-le_perchay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95483-95450-le_perchay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95483-95450-le_perchay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95487-95340-persan/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95487-95340-persan/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95487-95340-persan/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95487-95340-persan/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95488-95480-pierrelaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95488-95480-pierrelaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95488-95480-pierrelaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95488-95480-pierrelaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95488-95220-pierrelaye/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95488-95220-pierrelaye/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95488-95220-pierrelaye/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95488-95220-pierrelaye/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95489-95350-piscop/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95489-95350-piscop/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95489-95350-piscop/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95489-95350-piscop/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95491-95130-le_plessis_bouchard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95491-95130-le_plessis_bouchard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95491-95130-le_plessis_bouchard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95491-95130-le_plessis_bouchard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95492-95720-le_plessis_gassot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95492-95720-le_plessis_gassot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95492-95720-le_plessis_gassot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95492-95720-le_plessis_gassot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95493-95270-le_plessis_luzarches/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95493-95270-le_plessis_luzarches/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95493-95270-le_plessis_luzarches/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95493-95270-le_plessis_luzarches/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95000-pontoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95000-pontoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95000-pontoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95000-pontoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95300-pontoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95300-pontoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95300-pontoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95300-pontoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95520-pontoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95520-pontoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95520-pontoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95500-95520-pontoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95504-95590-presles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95504-95590-presles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95504-95590-presles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95504-95590-presles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95509-95380-puiseux_en_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95509-95380-puiseux_en_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95509-95380-puiseux_en_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95509-95380-puiseux_en_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95510-95650-puiseux_pontoise/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95510-95650-puiseux_pontoise/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95510-95650-puiseux_pontoise/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95510-95650-puiseux_pontoise/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95523-95780-la_roche_guyon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95523-95780-la_roche_guyon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95523-95780-la_roche_guyon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95523-95780-la_roche_guyon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95527-95700-roissy_en_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95527-95700-roissy_en_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95527-95700-roissy_en_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95527-95700-roissy_en_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95529-95340-ronquerolles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95529-95340-ronquerolles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95529-95340-ronquerolles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95529-95340-ronquerolles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95535-95450-sagy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95535-95450-sagy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95535-95450-sagy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95535-95450-sagy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95539-95350-saint_brice_sous_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95539-95350-saint_brice_sous_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95539-95350-saint_brice_sous_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95539-95350-saint_brice_sous_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95541-95770-saint_clair_sur_epte/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95541-95770-saint_clair_sur_epte/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95541-95770-saint_clair_sur_epte/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95541-95770-saint_clair_sur_epte/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95543-95510-saint_cyr_en_arthies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95543-95510-saint_cyr_en_arthies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95543-95510-saint_cyr_en_arthies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95543-95510-saint_cyr_en_arthies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95554-95420-saint_gervais/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95554-95420-saint_gervais/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95554-95420-saint_gervais/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95554-95420-saint_gervais/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95555-95210-saint_gratien/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95555-95210-saint_gratien/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95555-95210-saint_gratien/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95555-95210-saint_gratien/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95563-95320-saint_leu_la_foret/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95563-95320-saint_leu_la_foret/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95563-95320-saint_leu_la_foret/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95563-95320-saint_leu_la_foret/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95566-95270-saint_martin_du_tertre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95566-95270-saint_martin_du_tertre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95566-95270-saint_martin_du_tertre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95566-95270-saint_martin_du_tertre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95572-95310-saint_ouen_l_aumone/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95572-95310-saint_ouen_l_aumone/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95572-95310-saint_ouen_l_aumone/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95572-95310-saint_ouen_l_aumone/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95574-95390-saint_prix/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95574-95390-saint_prix/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95574-95390-saint_prix/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95574-95390-saint_prix/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95580-95470-saint_witz/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95580-95470-saint_witz/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95580-95470-saint_witz/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95580-95470-saint_witz/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95582-95110-sannois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95582-95110-sannois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95582-95110-sannois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95582-95110-sannois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95584-95640-santeuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95584-95640-santeuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95584-95640-santeuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95584-95640-santeuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95585-95200-sarcelles/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95585-95200-sarcelles/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95585-95200-sarcelles/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95585-95200-sarcelles/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95592-95450-seraincourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95592-95450-seraincourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95592-95450-seraincourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95592-95450-seraincourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95594-95270-seugy/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95594-95270-seugy/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95594-95270-seugy/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95594-95270-seugy/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95598-95230-soisy_sous_montmorency/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95598-95230-soisy_sous_montmorency/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95598-95230-soisy_sous_montmorency/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95598-95230-soisy_sous_montmorency/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95604-95470-survilliers/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95604-95470-survilliers/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95604-95470-survilliers/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95604-95470-survilliers/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95607-95150-taverny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95607-95150-taverny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95607-95150-taverny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95607-95150-taverny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95610-95450-themericourt/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95610-95450-themericourt/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95610-95450-themericourt/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95610-95450-themericourt/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95611-95810-theuville/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95611-95810-theuville/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95611-95810-theuville/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95611-95810-theuville/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95612-95500-le_thillay/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95612-95500-le_thillay/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95612-95500-le_thillay/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95612-95500-le_thillay/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95625-95450-us/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95625-95450-us/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95625-95450-us/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95625-95450-us/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95627-95810-vallangoujard/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95627-95810-vallangoujard/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95627-95810-vallangoujard/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95627-95810-vallangoujard/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95628-95760-valmondois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95628-95760-valmondois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95628-95760-valmondois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95628-95760-valmondois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95633-95500-vaudherland/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95633-95500-vaudherland/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95633-95500-vaudherland/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95633-95500-vaudherland/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95637-95490-vaureal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95637-95490-vaureal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95637-95490-vaureal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95637-95490-vaureal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95641-95470-vemars/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95641-95470-vemars/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95641-95470-vemars/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95641-95470-vemars/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95651-95510-vetheuil/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95651-95510-vetheuil/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95651-95510-vetheuil/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95651-95510-vetheuil/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95652-95270-viarmes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95652-95270-viarmes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95652-95270-viarmes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95652-95270-viarmes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95656-95510-vienne_en_arthies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95656-95510-vienne_en_arthies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95656-95510-vienne_en_arthies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95656-95510-vienne_en_arthies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95658-95450-vigny/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95658-95450-vigny/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95658-95450-vigny/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95658-95450-vigny/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95660-95570-villaines_sous_bois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95660-95570-villaines_sous_bois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95660-95570-villaines_sous_bois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95660-95570-villaines_sous_bois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95675-95380-villeron/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95675-95380-villeron/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95675-95380-villeron/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95675-95380-villeron/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95676-95510-villers_en_arthies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95676-95510-villers_en_arthies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95676-95510-villers_en_arthies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95676-95510-villers_en_arthies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95678-95840-villiers_adam/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95678-95840-villiers_adam/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95678-95840-villiers_adam/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95678-95840-villiers_adam/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95680-95400-villiers_le_bel/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95680-95400-villiers_le_bel/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95680-95400-villiers_le_bel/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95680-95400-villiers_le_bel/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95682-95720-villiers_le_sec/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95682-95720-villiers_le_sec/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95682-95720-villiers_le_sec/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95682-95720-villiers_le_sec/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95690-95420-wy_dit_joli_village/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95690-95420-wy_dit_joli_village/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95690-95420-wy_dit_joli_village/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt95-val_d_oise/commune95690-95420-wy_dit_joli_village/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-971.xml
+++ b/public/sitemaps/sitemap-971.xml
@@ -5,70 +5,136 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97101-97139-les_abymes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97101-97139-les_abymes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97101-97139-les_abymes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97101-97139-les_abymes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97102-97121-anse_bertrand/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97102-97121-anse_bertrand/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97102-97121-anse_bertrand/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97102-97121-anse_bertrand/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97103-97122-baie_mahault/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97103-97122-baie_mahault/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97103-97122-baie_mahault/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97103-97122-baie_mahault/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97104-97123-baillif/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97104-97123-baillif/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97104-97123-baillif/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97104-97123-baillif/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97105-97100-basse_terre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97105-97100-basse_terre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97105-97100-basse_terre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97105-97100-basse_terre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97106-97125-bouillante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97106-97125-bouillante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97106-97125-bouillante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97106-97125-bouillante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97107-97130-capesterre_belle_eau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97107-97130-capesterre_belle_eau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97107-97130-capesterre_belle_eau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97107-97130-capesterre_belle_eau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97108-97140-capesterre_de_marie_galante/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97108-97140-capesterre_de_marie_galante/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97108-97140-capesterre_de_marie_galante/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97108-97140-capesterre_de_marie_galante/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97109-97113-gourbeyre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97109-97113-gourbeyre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97109-97113-gourbeyre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97109-97113-gourbeyre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97110-97127-la_desirade/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97110-97127-la_desirade/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97110-97127-la_desirade/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97110-97127-la_desirade/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97111-97126-deshaies/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97111-97126-deshaies/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97111-97126-deshaies/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97111-97126-deshaies/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97112-97112-grand_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97112-97112-grand_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97112-97112-grand_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97112-97112-grand_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97113-97190-le_gosier/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97113-97190-le_gosier/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97113-97190-le_gosier/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97113-97190-le_gosier/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97114-97128-goyave/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97114-97128-goyave/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97114-97128-goyave/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97114-97128-goyave/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97115-97129-lamentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97115-97129-lamentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97115-97129-lamentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97115-97129-lamentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97116-97111-morne_a_l_eau/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97116-97111-morne_a_l_eau/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97116-97111-morne_a_l_eau/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97116-97111-morne_a_l_eau/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97117-97160-le_moule/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97117-97160-le_moule/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97117-97160-le_moule/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97117-97160-le_moule/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97118-97170-petit_bourg/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97118-97170-petit_bourg/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97118-97170-petit_bourg/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97118-97170-petit_bourg/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97119-97131-petit_canal/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97119-97131-petit_canal/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97119-97131-petit_canal/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97119-97131-petit_canal/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97120-97110-pointe_a_pitre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97120-97110-pointe_a_pitre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97120-97110-pointe_a_pitre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97120-97110-pointe_a_pitre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97121-97116-pointe_noire/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97121-97116-pointe_noire/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97121-97116-pointe_noire/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97121-97116-pointe_noire/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97122-97117-port_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97122-97117-port_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97122-97117-port_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97122-97117-port_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97124-97120-saint_claude/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97124-97120-saint_claude/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97124-97120-saint_claude/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97124-97120-saint_claude/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97125-97118-saint_francois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97125-97118-saint_francois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97125-97118-saint_francois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97125-97118-saint_francois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97126-97134-saint_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97126-97134-saint_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97126-97134-saint_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97126-97134-saint_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97128-97180-sainte_anne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97128-97180-sainte_anne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97128-97180-sainte_anne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97128-97180-sainte_anne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97129-97115-sainte_rose/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97129-97115-sainte_rose/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97129-97115-sainte_rose/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97129-97115-sainte_rose/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97130-97136-terre_de_bas/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97130-97136-terre_de_bas/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97130-97136-terre_de_bas/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97130-97136-terre_de_bas/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97131-97137-terre_de_haut/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97131-97137-terre_de_haut/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97131-97137-terre_de_haut/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97131-97137-terre_de_haut/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97132-97114-trois_rivieres/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97132-97114-trois_rivieres/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97132-97114-trois_rivieres/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97132-97114-trois_rivieres/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97133-97141-vieux_fort/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97133-97141-vieux_fort/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97133-97141-vieux_fort/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97133-97141-vieux_fort/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97134-97119-vieux_habitants/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97134-97119-vieux_habitants/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97134-97119-vieux_habitants/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt971-guadeloupe/commune97134-97119-vieux_habitants/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-972.xml
+++ b/public/sitemaps/sitemap-972.xml
@@ -5,78 +5,152 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97201-97216-l_ajoupa_bouillon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97201-97216-l_ajoupa_bouillon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97201-97216-l_ajoupa_bouillon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97201-97216-l_ajoupa_bouillon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97202-97217-les_anses_d_arlet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97202-97217-les_anses_d_arlet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97202-97217-les_anses_d_arlet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97202-97217-les_anses_d_arlet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97203-97218-basse_pointe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97203-97218-basse_pointe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97203-97218-basse_pointe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97203-97218-basse_pointe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97204-97221-le_carbet/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97204-97221-le_carbet/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97204-97221-le_carbet/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97204-97221-le_carbet/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97205-97222-case_pilote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97205-97222-case_pilote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97205-97222-case_pilote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97205-97222-case_pilote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97206-97223-le_diamant/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97206-97223-le_diamant/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97206-97223-le_diamant/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97206-97223-le_diamant/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97207-97224-ducos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97207-97224-ducos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97207-97224-ducos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97207-97224-ducos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97208-97250-fonds_saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97208-97250-fonds_saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97208-97250-fonds_saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97208-97250-fonds_saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97200-fort_de_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97200-fort_de_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97200-fort_de_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97200-fort_de_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97234-fort_de_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97234-fort_de_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97234-fort_de_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97234-fort_de_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97212-fort_de_france/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97212-fort_de_france/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97212-fort_de_france/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97209-97212-fort_de_france/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97210-97240-le_francois/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97210-97240-le_francois/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97210-97240-le_francois/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97210-97240-le_francois/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97211-97218-grand_riviere/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97211-97218-grand_riviere/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97211-97218-grand_riviere/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97211-97218-grand_riviere/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97212-97213-gros_morne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97212-97213-gros_morne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97212-97213-gros_morne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97212-97213-gros_morne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97213-97232-le_lamentin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97213-97232-le_lamentin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97213-97232-le_lamentin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97213-97232-le_lamentin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97214-97214-le_lorrain/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97214-97214-le_lorrain/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97214-97214-le_lorrain/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97214-97214-le_lorrain/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97215-97218-macouba/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97215-97218-macouba/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97215-97218-macouba/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97215-97218-macouba/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97216-97225-le_marigot/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97216-97225-le_marigot/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97216-97225-le_marigot/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97216-97225-le_marigot/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97217-97290-le_marin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97217-97290-le_marin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97217-97290-le_marin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97217-97290-le_marin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97218-97260-le_morne_rouge/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97218-97260-le_morne_rouge/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97218-97260-le_morne_rouge/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97218-97260-le_morne_rouge/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97219-97250-le_precheur/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97219-97250-le_precheur/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97219-97250-le_precheur/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97219-97250-le_precheur/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97220-97211-riviere_pilote/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97220-97211-riviere_pilote/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97220-97211-riviere_pilote/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97220-97211-riviere_pilote/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97221-97215-riviere_salee/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97221-97215-riviere_salee/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97221-97215-riviere_salee/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97221-97215-riviere_salee/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97222-97231-le_robert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97222-97231-le_robert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97222-97231-le_robert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97222-97231-le_robert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97223-97270-saint_esprit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97223-97270-saint_esprit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97223-97270-saint_esprit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97223-97270-saint_esprit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97224-97212-saint_joseph/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97224-97212-saint_joseph/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97224-97212-saint_joseph/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97224-97212-saint_joseph/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97225-97250-saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97225-97250-saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97225-97250-saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97225-97250-saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97226-97227-sainte_anne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97226-97227-sainte_anne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97226-97227-sainte_anne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97226-97227-sainte_anne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97227-97228-sainte_luce/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97227-97228-sainte_luce/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97227-97228-sainte_luce/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97227-97228-sainte_luce/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97228-97230-sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97228-97230-sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97228-97230-sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97228-97230-sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97229-97233-schoelcher/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97229-97233-schoelcher/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97229-97233-schoelcher/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97229-97233-schoelcher/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97230-97220-la_trinite/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97230-97220-la_trinite/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97230-97220-la_trinite/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97230-97220-la_trinite/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97231-97229-les_trois_ilets/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97231-97229-les_trois_ilets/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97231-97229-les_trois_ilets/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97231-97229-les_trois_ilets/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97232-97280-le_vauclin/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97232-97280-le_vauclin/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97232-97280-le_vauclin/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97232-97280-le_vauclin/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97233-97226-le_morne_vert/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97233-97226-le_morne_vert/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97233-97226-le_morne_vert/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97233-97226-le_morne_vert/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97234-97222-bellefontaine/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97234-97222-bellefontaine/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97234-97222-bellefontaine/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt972-martinique/commune97234-97222-bellefontaine/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-973.xml
+++ b/public/sitemaps/sitemap-973.xml
@@ -5,50 +5,96 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97301-97390-regina/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97301-97390-regina/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97301-97390-regina/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97301-97390-regina/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97302-97300-cayenne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97302-97300-cayenne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97302-97300-cayenne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97302-97300-cayenne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97303-97350-iracoubo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97303-97350-iracoubo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97303-97350-iracoubo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97303-97350-iracoubo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97304-97310-kourou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97304-97310-kourou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97304-97310-kourou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97304-97310-kourou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97305-97355-macouria/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97305-97355-macouria/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97305-97355-macouria/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97305-97355-macouria/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97306-97360-mana/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97306-97360-mana/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97306-97360-mana/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97306-97360-mana/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97307-97351-matoury/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97307-97351-matoury/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97307-97351-matoury/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97307-97351-matoury/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97308-97313-saint_georges/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97308-97313-saint_georges/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97308-97313-saint_georges/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97308-97313-saint_georges/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97309-97354-remire_montjoly/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97309-97354-remire_montjoly/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97309-97354-remire_montjoly/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97309-97354-remire_montjoly/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97310-97311-roura/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97310-97311-roura/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97310-97311-roura/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97310-97311-roura/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97311-97320-saint_laurent_du_maroni/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97311-97320-saint_laurent_du_maroni/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97311-97320-saint_laurent_du_maroni/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97311-97320-saint_laurent_du_maroni/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97312-97315-sinnamary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97312-97315-sinnamary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97312-97315-sinnamary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97312-97315-sinnamary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97313-97356-montsinery_tonnegrande/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97313-97356-montsinery_tonnegrande/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97313-97356-montsinery_tonnegrande/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97313-97356-montsinery_tonnegrande/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97314-97380-ouanary/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97314-97380-ouanary/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97314-97380-ouanary/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97314-97380-ouanary/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97352-97314-saul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97352-97314-saul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97352-97314-saul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97352-97314-saul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97353-97370-maripasoula/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97353-97370-maripasoula/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97353-97370-maripasoula/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97353-97370-maripasoula/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97356-97330-camopi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97356-97330-camopi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97356-97330-camopi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97356-97330-camopi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97357-97340-grand_santi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97357-97340-grand_santi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97357-97340-grand_santi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97357-97340-grand_santi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97358-97312-saint_elie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97358-97312-saint_elie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97358-97312-saint_elie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97358-97312-saint_elie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97360-97317-apatou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97360-97317-apatou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97360-97317-apatou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97360-97317-apatou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97361-97319-awala_yalimapo/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97361-97319-awala_yalimapo/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97361-97319-awala_yalimapo/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97361-97319-awala_yalimapo/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97362-97316-papaichton/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97362-97316-papaichton/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97362-97316-papaichton/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt973-guyane/commune97362-97316-papaichton/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-974.xml
+++ b/public/sitemaps/sitemap-974.xml
@@ -5,90 +5,176 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97401-97425-les_avirons/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97401-97425-les_avirons/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97401-97425-les_avirons/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97401-97425-les_avirons/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97402-97412-bras_panon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97402-97412-bras_panon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97402-97412-bras_panon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97402-97412-bras_panon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97403-97414-entre_deux/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97403-97414-entre_deux/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97403-97414-entre_deux/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97403-97414-entre_deux/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97404-97427-l_etang_sale/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97404-97427-l_etang_sale/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97404-97427-l_etang_sale/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97404-97427-l_etang_sale/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97405-97429-petite_ile/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97405-97429-petite_ile/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97405-97429-petite_ile/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97405-97429-petite_ile/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97406-97431-la_plaine_des_palmistes/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97406-97431-la_plaine_des_palmistes/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97406-97431-la_plaine_des_palmistes/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97406-97431-la_plaine_des_palmistes/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97407-97420-le_port/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97407-97420-le_port/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97407-97420-le_port/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97407-97420-le_port/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97408-97419-la_possession/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97408-97419-la_possession/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97408-97419-la_possession/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97408-97419-la_possession/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97408-97433-la_possession/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97408-97433-la_possession/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97408-97433-la_possession/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97408-97433-la_possession/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97409-97440-saint_andre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97409-97440-saint_andre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97409-97440-saint_andre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97409-97440-saint_andre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97410-97470-saint_benoit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97410-97470-saint_benoit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97410-97470-saint_benoit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97410-97470-saint_benoit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97410-97437-saint_benoit/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97410-97437-saint_benoit/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97410-97437-saint_benoit/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97410-97437-saint_benoit/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97400-saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97400-saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97400-saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97400-saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97417-saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97417-saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97417-saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97417-saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97490-saint_denis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97490-saint_denis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97490-saint_denis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97411-97490-saint_denis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97412-97480-saint_joseph/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97412-97480-saint_joseph/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97412-97480-saint_joseph/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97412-97480-saint_joseph/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97424-saint_leu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97424-saint_leu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97424-saint_leu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97424-saint_leu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97436-saint_leu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97436-saint_leu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97436-saint_leu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97436-saint_leu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97416-saint_leu/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97416-saint_leu/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97416-saint_leu/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97413-97416-saint_leu/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97414-97421-saint_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97414-97421-saint_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97414-97421-saint_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97414-97421-saint_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97414-97450-saint_louis/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97414-97450-saint_louis/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97414-97450-saint_louis/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97414-97450-saint_louis/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97434-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97434-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97434-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97434-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97422-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97422-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97422-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97422-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97460-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97460-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97460-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97460-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97411-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97411-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97411-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97411-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97435-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97435-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97435-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97435-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97423-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97423-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97423-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97423-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97419-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97419-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97419-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97419-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97433-saint_paul/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97433-saint_paul/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97433-saint_paul/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97415-97433-saint_paul/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97432-saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97432-saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97432-saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97432-saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97410-saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97410-saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97410-saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97410-saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97430-saint_pierre/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97430-saint_pierre/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97430-saint_pierre/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97416-97430-saint_pierre/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97417-97442-saint_philippe/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97417-97442-saint_philippe/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97417-97442-saint_philippe/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97417-97442-saint_philippe/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97418-97438-sainte_marie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97418-97438-sainte_marie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97418-97438-sainte_marie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97418-97438-sainte_marie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97419-97439-sainte_rose/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97419-97439-sainte_rose/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97419-97439-sainte_rose/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97419-97439-sainte_rose/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97420-97441-sainte_suzanne/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97420-97441-sainte_suzanne/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97420-97441-sainte_suzanne/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97420-97441-sainte_suzanne/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97421-97433-salazie/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97421-97433-salazie/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97421-97433-salazie/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97421-97433-salazie/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97418-le_tampon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97418-le_tampon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97418-le_tampon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97418-le_tampon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97430-le_tampon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97430-le_tampon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97430-le_tampon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97430-le_tampon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97432-le_tampon/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97432-le_tampon/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97432-le_tampon/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97422-97432-le_tampon/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97423-97426-les_trois_bassins/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97423-97426-les_trois_bassins/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97423-97426-les_trois_bassins/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97423-97426-les_trois_bassins/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97424-97413-cilaos/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97424-97413-cilaos/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97424-97413-cilaos/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt974-la_reunion/commune97424-97413-cilaos/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/public/sitemaps/sitemap-976.xml
+++ b/public/sitemaps/sitemap-976.xml
@@ -5,40 +5,76 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/recherche-standard</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/recherche-18_55</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/recherche-dose_rappel</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/recherche-dose_1_ou_2</loc><changefreq>always</changefreq><priority>0.1</priority></url>
     
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97601-97630-acoua/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97601-97630-acoua/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97601-97630-acoua/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97601-97630-acoua/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97602-97650-bandraboua/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97602-97650-bandraboua/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97602-97650-bandraboua/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97602-97650-bandraboua/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97603-97660-bandrele/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97603-97660-bandrele/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97603-97660-bandrele/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97603-97660-bandrele/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97604-97620-boueni/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97604-97620-boueni/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97604-97620-boueni/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97604-97620-boueni/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97605-97670-chiconi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97605-97670-chiconi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97605-97670-chiconi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97605-97670-chiconi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97606-97620-chirongui/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97606-97620-chirongui/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97606-97620-chirongui/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97606-97620-chirongui/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97607-97660-dembeni/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97607-97660-dembeni/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97607-97660-dembeni/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97607-97660-dembeni/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97608-97615-dzaoudzi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97608-97615-dzaoudzi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97608-97615-dzaoudzi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97608-97615-dzaoudzi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97609-97625-kani_keli/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97609-97625-kani_keli/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97609-97625-kani_keli/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97609-97625-kani_keli/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97610-97600-koungou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97610-97600-koungou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97610-97600-koungou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97610-97600-koungou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97611-97600-mamoudzou/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97611-97600-mamoudzou/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97611-97600-mamoudzou/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97611-97600-mamoudzou/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97612-97630-mtsamboro/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97612-97630-mtsamboro/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97612-97630-mtsamboro/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97612-97630-mtsamboro/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97613-97650-m_tsangamouji/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97613-97650-m_tsangamouji/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97613-97650-m_tsangamouji/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97613-97650-m_tsangamouji/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97614-97670-ouangani/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97614-97670-ouangani/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97614-97670-ouangani/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97614-97670-ouangani/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97615-97615-pamandzi/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97615-97615-pamandzi/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97615-97615-pamandzi/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97615-97615-pamandzi/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97616-97640-sada/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97616-97640-sada/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97616-97640-sada/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97616-97640-sada/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>,
     <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97617-97680-tsingoni/recherche-standard/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
-    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97617-97680-tsingoni/recherche-18_55/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97617-97680-tsingoni/recherche-dose_rappel/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
+    <url><loc>https://vitemadose.covidtracker.fr/centres-vaccination-covid-dpt976-mayotte/commune97617-97680-tsingoni/recherche-dose_1_ou_2/en-triant-par-distance</loc><changefreq>always</changefreq><priority>0.1</priority></url>
 </urlset>

--- a/src/components/vmd-search.component.ts
+++ b/src/components/vmd-search.component.ts
@@ -1,5 +1,5 @@
 import {css, customElement, html, LitElement, internalProperty, property } from 'lit-element';
-import {SearchRequest, SearchType} from '../state/State'
+import {SearchRequest, SearchType, TYPE_RECHERCHE_PAR_DEFAUT} from '../state/State'
 import {
     Commune,
     Departement,
@@ -57,14 +57,14 @@ export class VmdSearchComponent extends LitElement {
     private onCommuneSelected (commune: Commune) {
       this.currentSelection = commune
       this.dispatchEvent(new CustomEvent<SearchRequest.ByCommune>('on-search', {
-        detail: SearchRequest.ByCommune(commune, this.currentSearchType || 'standard', this.currentValue?.date)
+        detail: SearchRequest.ByCommune(commune, this.currentSearchType || TYPE_RECHERCHE_PAR_DEFAUT, this.currentValue?.date)
       }))
     }
 
     private onDepartementSelected (departement: Departement) {
       this.currentSelection = departement
       this.dispatchEvent(new CustomEvent<SearchRequest.ByDepartement>('on-search', {
-        detail: SearchRequest.ByDepartement(departement, this.currentSearchType || 'standard', this.currentValue?.date)
+        detail: SearchRequest.ByDepartement(departement, this.currentSearchType || TYPE_RECHERCHE_PAR_DEFAUT, this.currentValue?.date)
       }))
     }
 }

--- a/src/routing/DynamicURLs.ts
+++ b/src/routing/DynamicURLs.ts
@@ -4,7 +4,7 @@ import {Strings} from "../utils/Strings";
 export const rechercheDepartementDescriptor = {
     routerUrl: '/centres-vaccination-covid-dpt:codeDpt-:nomDpt/recherche-:typeRecherche',
     urlGenerator: ({codeDepartement, nomDepartement}: {codeDepartement: string, nomDepartement: string}) => {
-        return ['standard', /* '18_55' */].map(typeRecherche => {
+        return ['standard', /* '18_55' */, 'dose_rappel', 'dose_1_ou_2'].map(typeRecherche => {
             return `/centres-vaccination-covid-dpt${codeDepartement}-${Strings.toReadableURLPathValue(nomDepartement)}/recherche-${typeRecherche}`;
         });
     }
@@ -13,7 +13,7 @@ export const rechercheDepartementDescriptor = {
 export const rechercheCommuneDescriptor = {
     routerUrl: '/centres-vaccination-covid-dpt:codeDpt-:nomDpt/commune:codeCommune-:codePostal-:nomCommune/recherche-:typeRecherche/en-triant-par-:codeTriCentre',
     urlGenerator: ({codeDepartement, nomDepartement, codeCommune, codePostal, nomCommune, tri}: {codeDepartement: string, nomDepartement: string, codeCommune: string, codePostal: string, nomCommune: string, tri: CodeTriCentre}) => {
-        return ['standard', /* '18_55' */].map(typeRecherche => {
+        return ['standard', /* '18_55' */, 'dose_rappel', 'dose_1_ou_2'].map(typeRecherche => {
             return `/centres-vaccination-covid-dpt${codeDepartement}-${Strings.toReadableURLPathValue(nomDepartement)}/commune${codeCommune}-${codePostal}-${Strings.toReadableURLPathValue(nomCommune)}/recherche-${typeRecherche}/en-triant-par-${tri}`;
         })
     }

--- a/src/routing/DynamicURLs.ts
+++ b/src/routing/DynamicURLs.ts
@@ -4,7 +4,7 @@ import {Strings} from "../utils/Strings";
 export const rechercheDepartementDescriptor = {
     routerUrl: '/centres-vaccination-covid-dpt:codeDpt-:nomDpt/recherche-:typeRecherche',
     urlGenerator: ({codeDepartement, nomDepartement}: {codeDepartement: string, nomDepartement: string}) => {
-        return ['standard', '18_55'].map(typeRecherche => {
+        return ['standard', /* '18_55' */].map(typeRecherche => {
             return `/centres-vaccination-covid-dpt${codeDepartement}-${Strings.toReadableURLPathValue(nomDepartement)}/recherche-${typeRecherche}`;
         });
     }
@@ -13,7 +13,7 @@ export const rechercheDepartementDescriptor = {
 export const rechercheCommuneDescriptor = {
     routerUrl: '/centres-vaccination-covid-dpt:codeDpt-:nomDpt/commune:codeCommune-:codePostal-:nomCommune/recherche-:typeRecherche/en-triant-par-:codeTriCentre',
     urlGenerator: ({codeDepartement, nomDepartement, codeCommune, codePostal, nomCommune, tri}: {codeDepartement: string, nomDepartement: string, codeCommune: string, codePostal: string, nomCommune: string, tri: CodeTriCentre}) => {
-        return ['standard', '18_55'].map(typeRecherche => {
+        return ['standard', /* '18_55' */].map(typeRecherche => {
             return `/centres-vaccination-covid-dpt${codeDepartement}-${Strings.toReadableURLPathValue(nomDepartement)}/commune${codeCommune}-${codePostal}-${Strings.toReadableURLPathValue(nomCommune)}/recherche-${typeRecherche}/en-triant-par-${tri}`;
         })
     }

--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -151,7 +151,7 @@ function transformLieu(rawLieu: any): Lieu {
 
 export type Coordinates = { latitude: number, longitude: number }
 export type Location = Coordinates & {city: string, cp: string}
-export type TagCreneau = "preco18_55"|"all";
+export type TagCreneau = /*"preco18_55"|*/"all";
 export type StatsCreneauxQuotidienParTag = {
     tag: TagCreneau;
     creneaux: number;
@@ -284,16 +284,18 @@ export const libelleUrlPathDeCommune = (commune: Commune) => {
     return Strings.toReadableURLPathValue(commune.nom);
 }
 
+/*
 type VaccineCategory = {code: SearchType, libelle: string};
 export const VACCINE_CATEGORIES: VaccineCategory[] = [
     { code: "18_55", libelle: "Préconisé pour les 18-55 ans" },
     // { code: "16_18", libelle: "Préconisé pour les 16-18 ans" },
     { code: "standard", libelle: "Tous" },
 ];
+ */
 
+export type SearchType = "standard"/*| "18_55"*/;
 export const TYPE_RECHERCHE_PAR_DEFAUT: SearchType = "standard";
 
-export type SearchType = "standard"|"18_55";
 export type SearchTypeConfig = {
     tagCreneau: TagCreneau;
     cardAppointmentsExtractor: (lieu: Lieu, daySelectorDisponible: boolean, creneauxParLieux: CreneauxParLieu[]) => number;
@@ -326,6 +328,7 @@ const SEARCH_TYPE_CONFIGS: {[type in SearchType]: SearchTypeConfig & {type: type
             searchResultsByCity: 'search_results_by_city'
         }
     },
+    /*
     '18_55': {
         type: '18_55',
         tagCreneau: "preco18_55",
@@ -346,6 +349,7 @@ const SEARCH_TYPE_CONFIGS: {[type in SearchType]: SearchTypeConfig & {type: type
             searchResultsByCity: 'search_results_by_city_18_55'
         }
     },
+     */
 };
 export function searchTypeConfigFromPathParam(pathParams: Record<string,string>): SearchTypeConfig & {type: SearchType} {
     const config = Object.values(SEARCH_TYPE_CONFIGS).find(config => pathParams && config.pathParam === pathParams['typeRecherche']);

--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -151,7 +151,7 @@ function transformLieu(rawLieu: any): Lieu {
 
 export type Coordinates = { latitude: number, longitude: number }
 export type Location = Coordinates & {city: string, cp: string}
-export type TagCreneau = /*"preco18_55"|*/"all";
+export type TagCreneau = /*"preco18_55"|*/"all"|"first_or_second_dose"|"third_dose";
 export type StatsCreneauxQuotidienParTag = {
     tag: TagCreneau;
     creneaux: number;
@@ -293,8 +293,8 @@ export const VACCINE_CATEGORIES: VaccineCategory[] = [
 ];
  */
 
-export type SearchType = "standard"/*| "18_55"*/;
-export const TYPE_RECHERCHE_PAR_DEFAUT: SearchType = "standard";
+export type SearchType = "standard" /*| "18_55"|*/ |"dose_rappel"|"dose_1_ou_2";
+export const TYPE_RECHERCHE_PAR_DEFAUT: SearchType = "dose_rappel";
 
 export type SearchTypeConfig = {
     tagCreneau: TagCreneau;
@@ -350,6 +350,40 @@ const SEARCH_TYPE_CONFIGS: {[type in SearchType]: SearchTypeConfig & {type: type
         }
     },
      */
+    'dose_rappel': {
+        type: 'dose_rappel',
+        tagCreneau: 'third_dose',
+        cardAppointmentsExtractor: (lieu, daySelectorDisponible, creneauxParLieux) => daySelectorDisponible
+            ?creneauxParLieux.find(cpl => cpl.lieu === lieu.internal_id)?.creneaux || 0
+            :lieu.appointment_count,
+        lieuConsidereCommeDisponible: (lieu, creneauxParLieu) => lieu.appointment_by_phone_only || (creneauxParLieu?.creneaux || 0) > 0,
+        pathParam: 'dose_rappel',
+        standardTabSelected: true,
+        excludeAppointmentByPhoneOnly: false,
+        jourSelectionnable: true,
+        theme: 'standard',
+        analytics: {
+            searchResultsByDepartement: 'search_results_by_department_third_shot',
+            searchResultsByCity: 'search_results_by_city_third_shot'
+        }
+    },
+    'dose_1_ou_2': {
+        type: 'dose_1_ou_2',
+        tagCreneau: 'first_or_second_dose',
+        cardAppointmentsExtractor: (lieu, daySelectorDisponible, creneauxParLieux) => daySelectorDisponible
+            ?creneauxParLieux.find(cpl => cpl.lieu === lieu.internal_id)?.creneaux || 0
+            :lieu.appointment_count,
+        lieuConsidereCommeDisponible: (lieu, creneauxParLieu) => lieu.appointment_by_phone_only || (creneauxParLieu?.creneaux || 0) > 0,
+        pathParam: 'dose_1_ou_2',
+        standardTabSelected: true,
+        excludeAppointmentByPhoneOnly: false,
+        jourSelectionnable: true,
+        theme: 'standard',
+        analytics: {
+            searchResultsByDepartement: 'search_results_by_department_first_or_second_shot',
+            searchResultsByCity: 'search_results_by_city_first_or_second_shot'
+        }
+    }
 };
 export function searchTypeConfigFromPathParam(pathParams: Record<string,string>): SearchTypeConfig & {type: SearchType} {
     const config = Object.values(SEARCH_TYPE_CONFIGS).find(config => pathParams && config.pathParam === pathParams['typeRecherche']);

--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -291,6 +291,8 @@ export const VACCINE_CATEGORIES: VaccineCategory[] = [
     { code: "standard", libelle: "Tous" },
 ];
 
+export const TYPE_RECHERCHE_PAR_DEFAUT: SearchType = "standard";
+
 export type SearchType = "standard"|"18_55";
 export type SearchTypeConfig = {
     tagCreneau: TagCreneau;

--- a/src/views/vmd-home.view.ts
+++ b/src/views/vmd-home.view.ts
@@ -6,7 +6,7 @@ import {
     PLATEFORMES, SearchType,
     SearchRequest,
     State,
-    StatsLieu, Departement,
+    StatsLieu, Departement, TYPE_RECHERCHE_PAR_DEFAUT,
 } from "../state/State";
 import {CSS_Global, CSS_Home} from "../styles/ConstructibleStyleSheets";
 
@@ -28,7 +28,7 @@ export class VmdHomeView extends LitElement {
     @property({type: Array, attribute: false}) statsLieu: StatsLieu|undefined = undefined;
 
     private async onSearch (event: CustomEvent<SearchRequest>) {
-      const searchType: SearchType = 'standard';
+      const searchType: SearchType = TYPE_RECHERCHE_PAR_DEFAUT;
       if (SearchRequest.isByDepartement(event.detail)) {
         const departement = event.detail.departement
         Router.navigateToRendezVousAvecDepartement(departement.code_departement, libelleUrlPathDuDepartement(departement), searchType)

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -31,7 +31,7 @@ import {
     SearchTypeConfig,
     RendezVousDuJour,
     StatsCreneauxLieuxParJour,
-    countCreneauxFromCreneauxParTag
+    countCreneauxFromCreneauxParTag, TYPE_RECHERCHE_PAR_DEFAUT
 } from "../state/State";
 import {formatDistanceToNow, parseISO} from 'date-fns'
 import { fr } from 'date-fns/locale'
@@ -230,7 +230,7 @@ export abstract class AbstractVmdRdvView extends LitElement {
     }
 
     get searchTypeConfig() {
-        return searchTypeConfigFromSearch(this.currentSearch, 'standard')
+        return searchTypeConfigFromSearch(this.currentSearch, TYPE_RECHERCHE_PAR_DEFAUT)
     }
 
     async onSearchSelected (event: CustomEvent<SearchRequest>) {

--- a/src/views/vmd-rdv.view.ts
+++ b/src/views/vmd-rdv.view.ts
@@ -282,6 +282,18 @@ export abstract class AbstractVmdRdvView extends LitElement {
                   <button class="btn btn-primary">+</button>
                 </div>
               </div>`:html``}
+                <div class="rdvForm-fields row align-items-center mb-3 mb-md-5">
+                    <label class="col-sm-24 col-md-auto mb-md-1 label-for-search p-3 ps-1">
+                        Vous recherchez :
+                    </label>
+                    <div class="col">
+                        <vmd-button-switch class="mb-3" style="display: inline-block"
+                                           codeSelectionne="dose_rappel"
+                                           .options="${[{code: 'dose_rappel', libelle: 'Une dose de rappel'}, {code: 'dose_1_ou_2', libelle: 'Une 1ère dose de vaccin'}]}"
+                                           @changed="${(e: CustomEvent<{value: SearchType}>) => this.updateSearchTypeTo(e.detail.value)}">
+                        </vmd-button-switch>
+                    </div>
+                </div>
             </div>
 
             <div class="spacer mt-5 mb-5"></div>

--- a/tools/README.md
+++ b/tools/README.md
@@ -8,7 +8,7 @@ Installer les dépendances : `npm ci`
 
 # Exécution
 
-Une fois les dépendances installées, lancer la commande suivante : `npx ts-node communes-import.ts `
+Une fois les dépendances installées, lancer la commande suivante : `npx ts-node communes-import.ts`
 
 Sous IntelliJ IDEA, il faudra configurer le launcher avec les options suivantes :
 - Working directory : current `tools` directory


### PR DESCRIPTION
Cette Pull Request est

- Une nouvelle fonctionnalité (dans le prolongement de la réflexion sur #270)

### Checklist

- Cette PR vise la branche `dev`
- Elle n'est pas en conflit avec la branche `dev`

### Description

Rajout d'un filtre permettant de rechercher soit les doses de rappel, soit les 1ère doses (et aussi, mais on ne l'évoque pas pour éviter du bruit/de l'ambiguité, les 2ndes doses)

Visible ici : https://dev.vitemado.se/dose-rappel-et-1ere-dose/
<img width="1381" alt="Vaccination_COVID-19_à_Villenave-d_Ornon_33140" src="https://user-images.githubusercontent.com/603815/144011168-c283556b-9d75-44f4-bd58-7fc30f09265c.png">


Quelques précisions : 

- Par rapport au choix de la dose de rappel par défaut : 
> 88% de la population vaccinnable a actuellement un chemin vaccinal complet (et 2% a un chemin vaccinal entamé) (source: vaccin tracker)
> => il reste seulement 10% de la population vaccinable non vaccinée, et ce n'est pas à priori celle qui va être le plus susceptible d'aller sur VMD pour rechercher une dose de vaccin.
> 
> C'est pour ces raisons que j'encouragerais à pré-selectionner le choix "dose de rappel" lors de la recherche.

- Par rapport au fait de ne pas afficher que le choix "1ère dose de vaccin" couvre aussi les secondes doses : 

> => La notion de "2ème dose" disparaît car elle est très ambigüe vis à vis de ceux qui ont eu le COVID (et donc 1 seule dose) ou ceux qui ont reçu un JJ à 1 seule dose aussi.
> De plus, les rdv 2nde dose étant très généralement pris au moment où on se fait injecter la 1ère dose, je pense que vraiment très peu de personnes viendront sur VMD à la recherche d'une 2nde dose (inutile, donc, de venir rajouter du bruit/ambiguité avec cette notion dans le filtre de recherche).
> 
> On peut toutefois garder le filtre sur le tag 1+2 lorsqu'on sélectionne 1ère dose de vaccin car je ne pense pas qu'il y ait beaucoup de créneaux qui soient compatible 2ème dose sans être compatibles 1ère dose.

- Par rapport au fait qu'on n'affichait pas les créneaux indéterminés : 

> Je pense qu'on va pouvoir laisser tomber les indéterminés car nous n'en avons que très peu actuellement en prod (les 2 plateformes concernées sont des plateformes qui sont en cours de migration (une fois qu'elles auront été migrées, les doses de rappel apparaîtront)) :
> <img width="1267" alt="Vaccination_COVID-19_en_Aisne_02" src="https://user-images.githubusercontent.com/603815/144012461-eb639187-ea51-4b0e-88f2-43e458971c2a.png">

PS:
- Merci @nhumblot pour le taf fait en amont :)
- Merci @grubounet pour le taf fait sur le back ❤️ 